### PR TITLE
Use deploy key for tag push

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -22,6 +22,14 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Setup SSH for Deploy Key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TAG_DEPLOY_KEY }}
+
+      - name: Configure Git for SSH
+        run: git remote set-url origin git@github.com:DFXswiss/realunit-app.git
+
       - name: Get latest tag
         id: get-tag
         run: |


### PR DESCRIPTION
## Summary
Uses dedicated SSH deploy key instead of GITHUB_TOKEN to push tags.

## Why
- Tag ruleset blocks GITHUB_TOKEN from pushing tags
- Deploy Key is already a bypass actor in the ruleset
- More secure than adding blanket GitHub Actions bypass

## Changes
- Added `webfactory/ssh-agent` to load deploy key
- Configure git to use SSH remote URL
- Tag push now uses deploy key authentication

## Setup done
- ✅ Deploy Key created (write access)
- ✅ Secret `TAG_DEPLOY_KEY` stored