### PR TITLE
Run build check for PRs to main

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - develop
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Adds `main` branch to pull-request.yaml trigger so build check runs for PRs to main.

## Why
- PR ruleset now protects both `develop` and `main`
- Ruleset requires `build` check
- Without this fix, PRs to main are blocked (like PR #40)

## Fix
```yaml
pull_request:
  branches:
    - develop
    - main  # ← added
```