### PR TITLE
fix: add missing WidgetsLocalizations methods for Flutter compatibility

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -908,10 +908,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1401,26 +1401,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/tool/localization/localization_constants.dart
+++ b/tool/localization/localization_constants.dart
@@ -66,6 +66,12 @@ class S implements WidgetsLocalizations {
 
   @override
   String get shareButtonLabel => throw UnimplementedError();
+
+  @override
+  String get noResultsFound => 'No results found';
+
+  @override
+  String get searchResultsFound => 'Search results found';
 ''';
 
 const part2 = '''


### PR DESCRIPTION
## Summary
- Add `noResultsFound` and `searchResultsFound` getters to the localization generator
- These methods are required by Flutter's updated `WidgetsLocalizations` interface
- Without this fix, the app fails to compile with recent Flutter versions

## Test plan
- [x] Run `flutter test` - all 73 tests pass
- [x] Run `dart run tool/generate_localization.dart` - generates valid i18n.dart
- [x] Run app locally on iOS simulator - builds and runs successfully