### PR TITLE
fix: add scroll support for small screens

### DIFF
--- a/lib/screens/create_wallet/create_wallet_view.dart
+++ b/lib/screens/create_wallet/create_wallet_view.dart
@@ -28,98 +28,99 @@ class CreateWalletView extends StatelessWidget {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.start,
                       children: [
-                      Padding(
-                        padding: const EdgeInsets.only(top: 20, bottom: 20),
-                        child: SvgPicture.asset(
-                          'assets/images/backup_seed.svg',
-                          width: 124,
+                        Padding(
+                          padding: const EdgeInsets.only(top: 20, bottom: 20),
+                          child: SvgPicture.asset(
+                            'assets/images/backup_seed.svg',
+                            width: 124,
+                          ),
                         ),
-                      ),
-                      Text(
-                        S.of(context).createWalletTitle,
-                        style: const TextStyle(
-                          fontSize: 26,
-                          fontWeight: FontWeight.w700,
-                          color: RealUnitColors.realUnitBlack,
+                        Text(
+                          S.of(context).createWalletTitle,
+                          style: const TextStyle(
+                            fontSize: 26,
+                            fontWeight: FontWeight.w700,
+                            color: RealUnitColors.realUnitBlack,
+                          ),
                         ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 3, bottom: 12),
-                        child: Text(
-                          S.of(context).createWalletSubtitle,
-                          textAlign: TextAlign.center,
-                          style: kSubtitleTextStyle,
+                        Padding(
+                          padding: const EdgeInsets.only(top: 3, bottom: 12),
+                          child: Text(
+                            S.of(context).createWalletSubtitle,
+                            textAlign: TextAlign.center,
+                            style: kSubtitleTextStyle,
+                          ),
                         ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 12.0),
-                        child: Row(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            const Padding(
-                              padding: EdgeInsets.only(right: 10, top: 5),
-                              child: RecoveryKeyIcon(
-                                size: 20,
-                                color: RealUnitColors.realUnitBlue,
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 12.0),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const Padding(
+                                padding: EdgeInsets.only(right: 10, top: 5),
+                                child: RecoveryKeyIcon(
+                                  size: 20,
+                                  color: RealUnitColors.realUnitBlue,
+                                ),
                               ),
-                            ),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Padding(
-                                    padding: const EdgeInsets.only(bottom: 3),
-                                    child: Text(
-                                      S.of(context).createWalletRecoveryKeyTitle,
-                                      textAlign: TextAlign.center,
-                                      style: const TextStyle(
-                                        fontSize: 18,
-                                        color: RealUnitColors.realUnitBlack,
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Padding(
+                                      padding: const EdgeInsets.only(bottom: 3),
+                                      child: Text(
+                                        S.of(context).createWalletRecoveryKeyTitle,
+                                        textAlign: TextAlign.center,
+                                        style: const TextStyle(
+                                          fontSize: 18,
+                                          color: RealUnitColors.realUnitBlack,
+                                        ),
                                       ),
                                     ),
-                                  ),
-                                  Text(
-                                    S.of(context).createWalletRecoveryKeySubtitle,
-                                    style: kSubtitleTextStyle,
-                                  ),
-                                ],
+                                    Text(
+                                      S.of(context).createWalletRecoveryKeySubtitle,
+                                      style: kSubtitleTextStyle,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        SeedBlurCard(
+                          seed: state.wallet!.seed,
+                          onTap: context.read<CreateWalletCubit>().toggleShowSeed,
+                          blur: state.hideSeed,
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(top: 5),
+                          child: CupertinoButton(
+                            onPressed: () => _copySeed(state.wallet!.seed),
+                            child: Text(
+                              S.of(context).copySeed,
+                              style:
+                                  kPageTitleTextStyle.copyWith(color: RealUnitColors.realUnitBlue),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 20),
+                        Padding(
+                          padding: const EdgeInsets.only(top: 20, bottom: 20),
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: TextButton(
+                              onPressed: () =>
+                                  context.read<HomeBloc>().add(LoadWalletEvent(state.wallet!)),
+                              style: kFullwidthBlueButtonStyle,
+                              child: Text(
+                                S.of(context).createWalletConfirm,
+                                textAlign: TextAlign.center,
+                                style: kFullwidthBlueButtonTextStyle,
                               ),
                             ),
-                          ],
-                        ),
-                      ),
-                      SeedBlurCard(
-                        seed: state.wallet!.seed,
-                        onTap: context.read<CreateWalletCubit>().toggleShowSeed,
-                        blur: state.hideSeed,
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 5),
-                        child: CupertinoButton(
-                          onPressed: () => _copySeed(state.wallet!.seed),
-                          child: Text(
-                            S.of(context).copySeed,
-                            style: kPageTitleTextStyle.copyWith(color: RealUnitColors.realUnitBlue),
                           ),
                         ),
-                      ),
-                      const SizedBox(height: 20),
-                      Padding(
-                        padding: const EdgeInsets.only(top: 20, bottom: 20),
-                        child: SizedBox(
-                          width: double.infinity,
-                          child: TextButton(
-                            onPressed: () =>
-                                context.read<HomeBloc>().add(LoadWalletEvent(state.wallet!)),
-                            style: kFullwidthBlueButtonStyle,
-                            child: Text(
-                              S.of(context).createWalletConfirm,
-                              textAlign: TextAlign.center,
-                              style: kFullwidthBlueButtonTextStyle,
-                            ),
-                          ),
-                        ),
-                      ),
                       ],
                     ),
                   );

--- a/lib/screens/onboarding/onboarding_completed_page.dart
+++ b/lib/screens/onboarding/onboarding_completed_page.dart
@@ -30,88 +30,88 @@ class _OnboardingCompletedPageState extends State<OnboardingCompletedPage> {
           child: SingleChildScrollView(
             child: Column(
               children: [
-              Image.asset(
-                'assets/images/realu_tokens.png',
-                height: 280,
-              ),
-              const SizedBox(height: 40.0),
-              Column(
-                spacing: 8.0,
-                children: [
-                  Text(
-                    s.onboardingCompletedTitle,
-                    style: const TextStyle(
-                      fontWeight: FontWeight.bold,
-                      fontSize: 26,
-                      letterSpacing: 26 * -0.02,
-                      height: 30 / 26,
-                    ),
-                  ),
-                  Text(
-                    s.onboardingCompletedSubtitle,
-                    textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      height: 18 / 14,
-                      letterSpacing: 0.0,
-                      color: RealUnitColors.neutral500,
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 20),
-              Row(
-                spacing: 12,
-                children: [
-                  SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: Checkbox(
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(4),
+                Image.asset(
+                  'assets/images/realu_tokens.png',
+                  height: 280,
+                ),
+                const SizedBox(height: 40.0),
+                Column(
+                  spacing: 8.0,
+                  children: [
+                    Text(
+                      s.onboardingCompletedTitle,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 26,
+                        letterSpacing: 26 * -0.02,
+                        height: 30 / 26,
                       ),
-                      checkColor: Colors.white,
-                      activeColor: RealUnitColors.green,
-                      value: isChecked,
-                      onChanged: (value) => setState(() => isChecked = value ?? false),
                     ),
-                  ),
-                  Expanded(
-                    child: RichText(
-                      text: TextSpan(
-                        style: const TextStyle(
-                          fontSize: 12,
-                          color: Colors.black,
-                          height: 16 / 12,
+                    Text(
+                      s.onboardingCompletedSubtitle,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        height: 18 / 14,
+                        letterSpacing: 0.0,
+                        color: RealUnitColors.neutral500,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                Row(
+                  spacing: 12,
+                  children: [
+                    SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: Checkbox(
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(4),
                         ),
-                        children: [
-                          TextSpan(text: '${s.terms1} '),
-                          TextLinkSpan.link(context,
-                              text: s.privacyPolicy,
-                              uri: Uri.parse('https://realunit.ch/datenschutzerklaerung/')),
-                          TextSpan(text: ' ${s.terms2} '),
-                          TextLinkSpan.link(context,
-                              text: s.termsAndConditions,
-                              uri: Uri.parse('https://realunit.ch/nutzungsbedingungen/')),
-                          TextSpan(text: ' ${s.terms3} ${s.realunitAg} ${s.terms4}'),
-                        ],
+                        checkColor: Colors.white,
+                        activeColor: RealUnitColors.green,
+                        value: isChecked,
+                        onChanged: (value) => setState(() => isChecked = value ?? false),
                       ),
                     ),
-                  ),
-                ],
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 20, bottom: 20),
-                child: SizedBox(
-                  width: double.infinity,
-                  child: FilledButton(
-                    onPressed: isChecked
-                        ? () => context.read<HomeBloc>().add((const CompleteOnboardingEvent()))
-                        : null,
-                    child: Text(s.next),
+                    Expanded(
+                      child: RichText(
+                        text: TextSpan(
+                          style: const TextStyle(
+                            fontSize: 12,
+                            color: Colors.black,
+                            height: 16 / 12,
+                          ),
+                          children: [
+                            TextSpan(text: '${s.terms1} '),
+                            TextLinkSpan.link(context,
+                                text: s.privacyPolicy,
+                                uri: Uri.parse('https://realunit.ch/datenschutzerklaerung/')),
+                            TextSpan(text: ' ${s.terms2} '),
+                            TextLinkSpan.link(context,
+                                text: s.termsAndConditions,
+                                uri: Uri.parse('https://realunit.ch/nutzungsbedingungen/')),
+                            TextSpan(text: ' ${s.terms3} ${s.realunitAg} ${s.terms4}'),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 20, bottom: 20),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: isChecked
+                          ? () => context.read<HomeBloc>().add((const CompleteOnboardingEvent()))
+                          : null,
+                      child: Text(s.next),
+                    ),
                   ),
                 ),
-              ),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- Add `SingleChildScrollView` to prevent overflow on smaller devices (e.g. iPhone 13 mini)
- Replace `Spacer()` with `SizedBox(height: 20)` for scrollable layouts
- Affected screens:
  - Create Wallet ("Wallet sichern")
  - Onboarding Completed ("Ihre Wallet ist bereit")

## Test plan
- [x] Tested on iPhone 13 mini simulator
- [x] All 73 unit tests pass
- [x] Content is now scrollable on small screens
- [x] Button is accessible by scrolling down