### PR TITLE
feat: add terms acceptance screen as first onboarding step

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
 import 'package:realunit_wallet/screens/pin/setup_pin_page.dart';
 import 'package:realunit_wallet/screens/pin/verify_pin_page.dart';
 import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
+import 'package:realunit_wallet/screens/terms/terms_page.dart';
 import 'package:realunit_wallet/styles/themes.dart';
 
 Future<void> main() async {
@@ -148,7 +149,9 @@ class _WalletAppState extends State<WalletApp> {
     if (homeState.isLoadingWallet) return;
 
     String targetRoute;
-    if (homeState.openWallet == null) {
+    if (!homeState.softwareTermsAccepted) {
+      targetRoute = TermsPage.route;
+    } else if (homeState.openWallet == null) {
       targetRoute = '/welcome';
     } else if (!homeState.onboardingCompleted) {
       targetRoute = OnboardingCompletedPage.route;

--- a/lib/packages/repository/settings_repository.dart
+++ b/lib/packages/repository/settings_repository.dart
@@ -27,8 +27,10 @@ class SettingsRepository {
 
   NetworkMode get networkMode {
     final value = _sharedPreferences.getString('networkMode');
-    return NetworkMode.values
-        .firstWhere((network) => network.name == value, orElse: () => NetworkMode.testnet);
+    return NetworkMode.values.firstWhere(
+      (network) => network.name == value,
+      orElse: () => NetworkMode.testnet,
+    );
   }
 
   set networkMode(NetworkMode mode) => _sharedPreferences.setString('networkMode', mode.name);
@@ -40,4 +42,9 @@ class SettingsRepository {
   bool get isBiometricEnabled => _sharedPreferences.getBool('isBiometricEnabled') ?? false;
 
   set isBiometricEnabled(bool enabled) => _sharedPreferences.setBool('isBiometricEnabled', enabled);
+
+  bool get softwareTermsAccepted => _sharedPreferences.getBool('softwareTermsAccepted') ?? false;
+
+  set softwareTermsAccepted(bool accepted) =>
+      _sharedPreferences.setBool('softwareTermsAccepted', accepted);
 }

--- a/lib/packages/service/settings_service.dart
+++ b/lib/packages/service/settings_service.dart
@@ -10,4 +10,10 @@ class SettingsService {
   void setTermsAccepted(bool value) {
     _repository.termsAccepted = value;
   }
+
+  bool get isSoftwareTermsAccepted => _repository.softwareTermsAccepted;
+
+  void setSoftwareTermsAccepted(bool value) {
+    _repository.softwareTermsAccepted = value;
+  }
 }

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -24,6 +24,7 @@ import 'package:realunit_wallet/screens/settings_network/settings_network_page.d
 import 'package:realunit_wallet/screens/settings_nodes/settings_nodes_page.dart';
 import 'package:realunit_wallet/screens/settings_seed/settings_seed_page.dart';
 import 'package:realunit_wallet/screens/settings_tax_report/settings_tax_report_page.dart';
+import 'package:realunit_wallet/screens/terms/terms_page.dart';
 import 'package:realunit_wallet/screens/transaction_history/transaction_history_page.dart';
 import 'package:realunit_wallet/screens/transaction_sent/transaction_sent_page.dart';
 import 'package:realunit_wallet/screens/web_view/web_view_page.dart';
@@ -43,6 +44,10 @@ void setupRouter() {
         GoRoute(
           path: '/',
           builder: (context, state) => const HomePage(),
+        ),
+        GoRoute(
+          path: TermsPage.route,
+          builder: (context, state) => const TermsPage(),
         ),
         GoRoute(
           path: '/welcome',

--- a/lib/screens/home/bloc/home_bloc.dart
+++ b/lib/screens/home/bloc/home_bloc.dart
@@ -14,13 +14,19 @@ part 'home_event.dart';
 part 'home_state.dart';
 
 class HomeBloc extends Bloc<HomeEvent, HomeState> {
-  HomeBloc(this._walletService, this._balanceService, this._transactionHistoryService,
-      this._dfxService, this._settingsService, this._appStore)
-      : super(const HomeState()) {
+  HomeBloc(
+    this._walletService,
+    this._balanceService,
+    this._transactionHistoryService,
+    this._dfxService,
+    this._settingsService,
+    this._appStore,
+  ) : super(const HomeState()) {
     on<LoadCurrentWalletEvent>(_onLoadCurrentWallet);
     on<LoadWalletEvent>(_onLoadWallet);
     on<DeleteCurrentWalletEvent>(_onDeleteCurrentWallet);
     on<CompleteOnboardingEvent>(_onCompleteOnboarding);
+    on<AcceptSoftwareTermsEvent>(_onAcceptSoftwareTerms);
   }
 
   final WalletService _walletService;
@@ -31,7 +37,12 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   final AppStore _appStore;
 
   Future<void> _onLoadCurrentWallet(LoadCurrentWalletEvent event, Emitter<HomeState> emit) async {
-    emit(state.copyWith(isLoadingWallet: true));
+    emit(
+      state.copyWith(
+        isLoadingWallet: true,
+        softwareTermsAccepted: _settingsService.isSoftwareTermsAccepted,
+      ),
+    );
 
     if (state.openWallet != null || !_walletService.hasWallet()) {
       emit(state.copyWith(isLoadingWallet: false));
@@ -41,11 +52,13 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
       final wallet = await _walletService.getCurrentWallet();
       _appStore.wallet = wallet;
 
-      emit(state.copyWith(
-        openWallet: wallet,
-        isLoadingWallet: false,
-        onboardingCompleted: _settingsService.isTermsAccepted,
-      ));
+      emit(
+        state.copyWith(
+          openWallet: wallet,
+          isLoadingWallet: false,
+          onboardingCompleted: _settingsService.isTermsAccepted,
+        ),
+      );
 
       await setupFiatService(emit);
     } catch (e) {
@@ -63,17 +76,20 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   }
 
   Future<void> _onDeleteCurrentWallet(
-      DeleteCurrentWalletEvent event, Emitter<HomeState> emit) async {
+    DeleteCurrentWalletEvent event,
+    Emitter<HomeState> emit,
+  ) async {
     emit(state.copyWith(isLoadingWallet: true));
 
     _dfxService.invalidateAuthToken();
     await _walletService.deleteCurrentWallet();
     _settingsService.setTermsAccepted(false);
     emit(
-      const HomeState(
+      HomeState(
         openWallet: null,
         isLoadingWallet: false,
         isFiatServiceAvailable: false,
+        softwareTermsAccepted: state.softwareTermsAccepted,
       ),
     );
   }
@@ -102,5 +118,10 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   void _onCompleteOnboarding(HomeEvent event, Emitter<HomeState> emit) {
     _settingsService.setTermsAccepted(true);
     emit(state.copyWith(onboardingCompleted: true));
+  }
+
+  void _onAcceptSoftwareTerms(AcceptSoftwareTermsEvent event, Emitter<HomeState> emit) {
+    _settingsService.setSoftwareTermsAccepted(true);
+    emit(state.copyWith(softwareTermsAccepted: true));
   }
 }

--- a/lib/screens/home/bloc/home_event.dart
+++ b/lib/screens/home/bloc/home_event.dart
@@ -27,3 +27,7 @@ final class LoadWalletEvent extends HomeEvent {
 final class CompleteOnboardingEvent extends HomeEvent {
   const CompleteOnboardingEvent();
 }
+
+final class AcceptSoftwareTermsEvent extends HomeEvent {
+  const AcceptSoftwareTermsEvent();
+}

--- a/lib/screens/home/bloc/home_state.dart
+++ b/lib/screens/home/bloc/home_state.dart
@@ -6,23 +6,26 @@ final class HomeState {
     this.isLoadingWallet = false,
     this.isFiatServiceAvailable = false,
     this.onboardingCompleted = false,
+    this.softwareTermsAccepted = false,
   });
 
   final AWallet? openWallet;
   final bool isLoadingWallet;
   final bool isFiatServiceAvailable;
   final bool onboardingCompleted;
+  final bool softwareTermsAccepted;
 
   HomeState copyWith({
     AWallet? openWallet,
     bool? isLoadingWallet,
     bool? isFiatServiceAvailable,
     bool? onboardingCompleted,
-  }) =>
-      HomeState(
-        openWallet: openWallet ?? this.openWallet,
-        isLoadingWallet: isLoadingWallet ?? this.isLoadingWallet,
-        isFiatServiceAvailable: isFiatServiceAvailable ?? this.isFiatServiceAvailable,
-        onboardingCompleted: onboardingCompleted ?? this.onboardingCompleted,
-      );
+    bool? softwareTermsAccepted,
+  }) => HomeState(
+    openWallet: openWallet ?? this.openWallet,
+    isLoadingWallet: isLoadingWallet ?? this.isLoadingWallet,
+    isFiatServiceAvailable: isFiatServiceAvailable ?? this.isFiatServiceAvailable,
+    onboardingCompleted: onboardingCompleted ?? this.onboardingCompleted,
+    softwareTermsAccepted: softwareTermsAccepted ?? this.softwareTermsAccepted,
+  );
 }

--- a/lib/screens/terms/terms_page.dart
+++ b/lib/screens/terms/terms_page.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:realunit_wallet/generated/i18n.dart';
+import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
+import 'package:realunit_wallet/styles/colors.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class TermsPage extends StatelessWidget {
+  static const route = '/terms';
+
+  const TermsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final s = S.of(context);
+
+    return Scaffold(
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          Image.asset(
+            'assets/images/splash/splash_background.png',
+            fit: BoxFit.cover,
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: Container(
+              decoration: const BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Color(0x00FFFFFF),
+                    Color(0xFFFFFFFF),
+                  ],
+                ),
+              ),
+              padding: const EdgeInsets.only(
+                left: 24,
+                right: 24,
+                top: 80,
+                bottom: 40,
+              ),
+              child: SafeArea(
+                top: false,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _buildTermsText(s),
+                    const SizedBox(height: 24),
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton(
+                        onPressed: () =>
+                            context.read<HomeBloc>().add(const AcceptSoftwareTermsEvent()),
+                        child: Text(s.next),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTermsText(S s) => Text.rich(
+    TextSpan(
+      style: const TextStyle(
+        fontSize: 14,
+        height: 20 / 14,
+        color: RealUnitColors.neutral600,
+      ),
+      children: [
+        TextSpan(text: '${s.softwareTermsText} '),
+        WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: GestureDetector(
+            onTap: () => _openUrl('https://realunit.ch/app/nutzungsbedingungen'),
+            child: Text(
+              s.termsAndConditions,
+              style: const TextStyle(
+                fontSize: 14,
+                height: 20 / 14,
+                color: RealUnitColors.realUnitBlue,
+                decoration: TextDecoration.underline,
+                decorationColor: RealUnitColors.realUnitBlue,
+              ),
+            ),
+          ),
+        ),
+        TextSpan(text: ' ${s.terms2} '),
+        WidgetSpan(
+          alignment: PlaceholderAlignment.baseline,
+          baseline: TextBaseline.alphabetic,
+          child: GestureDetector(
+            onTap: () => _openUrl('https://realunit.ch/app/haftungsausschluss'),
+            child: Text(
+              s.privacyPolicy,
+              style: const TextStyle(
+                fontSize: 14,
+                height: 20 / 14,
+                color: RealUnitColors.realUnitBlue,
+                decoration: TextDecoration.underline,
+                decorationColor: RealUnitColors.realUnitBlue,
+              ),
+            ),
+          ),
+        ),
+        TextSpan(text: ' ${s.softwareTermsSuffix}.'),
+      ],
+    ),
+    textAlign: TextAlign.center,
+  );
+
+  Future<void> _openUrl(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a new terms acceptance screen shown on first app launch before the welcome screen
- Users must accept terms & conditions and disclaimer via clickable links before proceeding
- Screen uses the splash background image with a gradient overlay, terms text, and a "Continue" button
- Acceptance is persisted via SharedPreferences and survives wallet resets

## Test plan
- [ ] Fresh install → Terms screen appears as first screen
- [ ] Tap "Continue" → Welcome screen appears
- [ ] Links to Nutzungsbedingungen and Haftungsausschluss are clickable and open in browser
- [ ] Close and reopen app → Terms screen does NOT appear again
- [ ] Delete wallet → Terms screen does NOT reappear (only Welcome)
- [ ] `dart analyze` and `flutter build ios --simulator` pass cleanly