### PR TITLE
feat: dashboard empty state when balance is zero

### DIFF
--- a/lib/screens/dashboard/dashboard_page.dart
+++ b/lib/screens/dashboard/dashboard_page.dart
@@ -26,21 +26,20 @@ class DashboardPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final appStore = getIt<AppStore>();
     return MultiBlocProvider(
       providers: [
         BlocProvider(
           create: (context) => DashboardBloc(
             getIt<DFXPriceService>(),
-            asset: appStore.apiConfig.asset,
+            asset: getIt<AppStore>().apiConfig.asset,
             initialCurrency: context.read<SettingsBloc>().state.currency,
           ),
         ),
         BlocProvider(
           create: (context) => BalanceCubit(
             getIt<BalanceRepository>(),
-            asset: appStore.apiConfig.asset,
-            walletAddress: appStore.primaryAddress,
+            asset: getIt<AppStore>().apiConfig.asset,
+            walletAddress: getIt<AppStore>().primaryAddress,
           ),
         ),
       ],

--- a/lib/screens/dashboard/widgets/sections/dashboard_portfolio.dart
+++ b/lib/screens/dashboard/widgets/sections/dashboard_portfolio.dart
@@ -14,17 +14,6 @@ class DashboardPortfolio extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DashboardPortfolioView(price: price);
-  }
-}
-
-class DashboardPortfolioView extends StatelessWidget {
-  final BigInt price;
-
-  const DashboardPortfolioView({super.key, required this.price});
-
-  @override
-  Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       spacing: 8.0,


### PR DESCRIPTION
## Summary
- Show an empty state on the dashboard when the user's balance is zero
- Display the `add-realu-token-visual.svg` graphic centered on screen
- Add a full-width "Kaufen" (Buy) button at the bottom that navigates to the buy flow
- Hide portfolio, transaction history, and buy/sell action buttons when balance is zero
- Lift `BalanceCubit` from `DashboardPortfolio` to `DashboardPage` so the balance state is accessible for conditional rendering

## Test plan
- [ ] Open app with balance = 0 → SVG graphic and "Kaufen" button visible, no portfolio/transactions/actions
- [ ] Tap "Kaufen" button → navigates to buy page
- [ ] Open app with balance > 0 → normal dashboard with all sections visible