### PR TITLE
feat: change default network to mainnet

### DIFF
--- a/lib/packages/repository/settings_repository.dart
+++ b/lib/packages/repository/settings_repository.dart
@@ -29,7 +29,7 @@ class SettingsRepository {
     final value = _sharedPreferences.getString('networkMode');
     return NetworkMode.values.firstWhere(
       (network) => network.name == value,
-      orElse: () => NetworkMode.testnet,
+      orElse: () => NetworkMode.mainnet,
     );
   }
 

--- a/lib/screens/settings/bloc/settings_state.dart
+++ b/lib/screens/settings/bloc/settings_state.dart
@@ -5,7 +5,7 @@ final class SettingsState {
     this.hideAmounts = false,
     this.language = Language.en,
     this.currency = Currency.chf,
-    this.networkMode = NetworkMode.testnet,
+    this.networkMode = NetworkMode.mainnet,
   });
 
   final bool hideAmounts;


### PR DESCRIPTION
## Summary
- Change the default network mode from **testnet** to **mainnet** for new users
- Applies to both the initial `SettingsState` and the `SettingsRepository` fallback when no preference is stored

## Test plan
- [x] `flutter analyze` passes with no issues
- [x] All 98 tests pass
- [ ] Manual: Start app fresh → verify dashboard shows mainnet data (`api.dfx.swiss`)