### PR TITLE
fix: skip blocking on in-review KYC steps

### DIFF
--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -45,21 +45,23 @@ class KycCubit extends Cubit<KycState> {
       }
 
       if (level < 30) {
-        final requiredSteps = kycStatus.kycSteps.where(
-          (step) => _requiredStepNames.contains(step.name),
-        );
+        try {
+          await _continueKyc();
+        } catch (_) {
+          // If continue fails (e.g. no next step available), show pending for in-review steps
+          final pendingStep = kycStatus.kycSteps
+              .where((step) => _requiredStepNames.contains(step.name))
+              .firstWhereOrNull((step) => step.status == KycStepStatus.inReview);
 
-        final pendingStep = requiredSteps.firstWhereOrNull(
-          (step) => step.status == KycStepStatus.inReview,
-        );
-
-        if (pendingStep != null) {
-          final step = _mapStepName(pendingStep.name);
-          if (step != null) emit(KycPending(step));
-          return;
+          if (pendingStep != null) {
+            final step = _mapStepName(pendingStep.name);
+            if (step != null) {
+              emit(KycPending(step));
+              return;
+            }
+          }
+          rethrow;
         }
-
-        await _continueKyc();
         return;
       }
 


### PR DESCRIPTION
## Summary
- Instead of showing the "Daten werden geprüft" pending screen when a KYC step (e.g. nationality) is in-review, the app now calls `continueKyc` first to proceed to the next step
- The backend considers in-review steps as "done" and will initiate the next step (e.g. IDENT)
- Falls back to the pending screen only if `continueKyc` fails (no next step available)
- Companion PR: https://github.com/DFXswiss/api/pull/3226

## Test plan
- [ ] Complete nationality step during onboarding and verify the app immediately proceeds to IDENT (no ~1 min wait)
- [ ] Verify the pending screen still appears as fallback when no next step is available