### PR TITLE
fix: refresh JWT token on 401 response

### DIFF
--- a/lib/packages/service/dfx/dfx_auth_service.dart
+++ b/lib/packages/service/dfx/dfx_auth_service.dart
@@ -77,4 +77,9 @@ abstract class DFXAuthService {
   }
 
   void invalidateAuthToken() => appStore.dfxAuthToken = null;
+
+  Future<String?> refreshAuthToken() async {
+    invalidateAuthToken();
+    return getAuthToken();
+  }
 }

--- a/lib/packages/service/dfx/dfx_kyc_service.dart
+++ b/lib/packages/service/dfx/dfx_kyc_service.dart
@@ -26,13 +26,24 @@ class DfxKycService extends DFXAuthService {
     final authToken = appStore.dfxAuthToken;
 
     final uri = buildUri(_host, _userPath);
-    final response = await appStore.httpClient.get(
+    var response = await appStore.httpClient.get(
       uri,
       headers: {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer $authToken',
       },
     );
+
+    if (response.statusCode == 401) {
+      final newToken = await refreshAuthToken();
+      response = await appStore.httpClient.get(
+        uri,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $newToken',
+        },
+      );
+    }
 
     if (response.statusCode != 200 && response.statusCode != 201) {
       final errorJson = jsonDecode(response.body) as Map<String, dynamic>;


### PR DESCRIPTION
## Summary
- Add `refreshAuthToken()` method to `DFXAuthService` (invalidate + re-acquire)
- In `DfxKycService.getUser()`: on HTTP 401, refresh the token and retry the request
- Since all KYC methods (`getKycStatus()`, `continueKyc()`, `setData()`, etc.) call `getUser()` first, this covers all KYC API calls generically
- Fixes the 401 "User is merged" error after a successful account merge

## Test plan
- [ ] After account merge: KYC status page loads correctly (no 401 error)
- [ ] After account merge: KYC flow works with the new token
- [ ] Normal KYC flow (no merge) still works as before