### PR TITLE
Fix: Auto-register wallet for existing users

### DIFF
--- a/lib/screens/buy/buy_page.dart
+++ b/lib/screens/buy/buy_page.dart
@@ -4,6 +4,8 @@ import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_brokerbot_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
 import 'package:realunit_wallet/screens/buy/cubits/buy_converter/buy_converter_cubit.dart';
 import 'package:realunit_wallet/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart';
 import 'package:realunit_wallet/screens/buy/widgets/payment_additional_action_needed_button.dart';
@@ -27,6 +29,8 @@ class BuyPage extends StatelessWidget {
           create: (_) => BuyPaymentInfoCubit(
             getIt<RealUnitBuyPaymentInfoService>(),
             getIt<DFXPriceService>(),
+            getIt<RealUnitWalletService>(),
+            getIt<RealUnitRegistrationService>(),
           ),
         ),
       ],

--- a/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
+++ b/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
@@ -51,8 +51,7 @@ class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
 
   Future<BuyPaymentInfoState> _runGetPaymentInfo(String amount, Currency currency) async {
     try {
-      final sanitizedAmount = amount.isEmpty ? '0' : amount.replaceAll(',', '.');
-      final parsedAmount = double.parse(sanitizedAmount);
+      final parsedAmount = _parseAmount(amount);
 
       double minAmount = _minAmountChf;
       if (currency == Currency.eur) {
@@ -66,11 +65,8 @@ class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
           minAmount: minAmount,
         );
       }
-      final paymentInfo = await _buyPaymentInfoService.getPaymentInfo(
-        parsedAmount.round(),
-        currency: currency,
-      );
-      return BuyPaymentInfoSuccess(paymentInfo);
+
+      return await _fetchPaymentInfo(parsedAmount, currency);
     } on KycLevelRequiredException catch (e) {
       return BuyPaymentInfoFailure(
         PaymentInfoError.kycRequired,
@@ -95,17 +91,24 @@ class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
 
       await _registrationService.registerWallet(userData);
 
-      final sanitizedAmount = amount.isEmpty ? '0' : amount.replaceAll(',', '.');
-      final parsedAmount = double.parse(sanitizedAmount);
-      final paymentInfo = await _buyPaymentInfoService.getPaymentInfo(
-        parsedAmount.round(),
-        currency: currency,
-      );
-      return BuyPaymentInfoSuccess(paymentInfo);
+      return await _fetchPaymentInfo(_parseAmount(amount), currency);
     } catch (e) {
       developer.log('Auto wallet registration failed: $e');
       return const BuyPaymentInfoFailure(PaymentInfoError.registrationRequired);
     }
+  }
+
+  double _parseAmount(String amount) {
+    final sanitized = amount.isEmpty ? '0' : amount.replaceAll(',', '.');
+    return double.parse(sanitized);
+  }
+
+  Future<BuyPaymentInfoSuccess> _fetchPaymentInfo(double amount, Currency currency) async {
+    final paymentInfo = await _buyPaymentInfoService.getPaymentInfo(
+      amount.round(),
+      currency: currency,
+    );
+    return BuyPaymentInfoSuccess(paymentInfo);
   }
 
   @override

--- a/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
+++ b/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
@@ -8,6 +8,8 @@ import 'package:realunit_wallet/packages/service/dfx/exceptions/payment/buy_exce
 import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/buy_payment_info.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/payment_info_error.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
 import 'package:realunit_wallet/styles/currency.dart';
 
 part 'buy_payment_info_state.dart';
@@ -17,13 +19,19 @@ const double _minAmountChf = 100;
 class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
   final RealUnitBuyPaymentInfoService _buyPaymentInfoService;
   final DFXPriceService _priceService;
+  final RealUnitWalletService _walletService;
+  final RealUnitRegistrationService _registrationService;
   CancelableOperation<BuyPaymentInfoState>? _completer;
 
   BuyPaymentInfoCubit(
     RealUnitBuyPaymentInfoService buyPaymentInfoService,
     DFXPriceService priceService,
+    RealUnitWalletService walletService,
+    RealUnitRegistrationService registrationService,
   ) : _buyPaymentInfoService = buyPaymentInfoService,
       _priceService = priceService,
+      _walletService = walletService,
+      _registrationService = registrationService,
       super(const BuyPaymentInfoInitial());
 
   Future<void> getPaymentInfo({String amount = '300', Currency currency = Currency.chf}) async {
@@ -69,10 +77,34 @@ class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
         requiredLevel: e.requiredLevel,
       );
     } on RegistrationRequiredException {
-      return const BuyPaymentInfoFailure(PaymentInfoError.registrationRequired);
+      return await _tryAutoRegisterWallet(amount, currency);
     } catch (e) {
       developer.log(e.toString());
       return const BuyPaymentInfoFailure(PaymentInfoError.unknown);
+    }
+  }
+
+  Future<BuyPaymentInfoState> _tryAutoRegisterWallet(String amount, Currency currency) async {
+    try {
+      final walletStatus = await _walletService.getWalletStatus();
+      final userData = walletStatus.realUnitUserDataDto;
+
+      if (userData == null) {
+        return const BuyPaymentInfoFailure(PaymentInfoError.registrationRequired);
+      }
+
+      await _registrationService.registerWallet(userData);
+
+      final sanitizedAmount = amount.isEmpty ? '0' : amount.replaceAll(',', '.');
+      final parsedAmount = double.parse(sanitizedAmount);
+      final paymentInfo = await _buyPaymentInfoService.getPaymentInfo(
+        parsedAmount.round(),
+        currency: currency,
+      );
+      return BuyPaymentInfoSuccess(paymentInfo);
+    } catch (e) {
+      developer.log('Auto wallet registration failed: $e');
+      return const BuyPaymentInfoFailure(PaymentInfoError.registrationRequired);
     }
   }
 

--- a/test/screens/buy/buy_page_test.dart
+++ b/test/screens/buy/buy_page_test.dart
@@ -13,6 +13,8 @@ import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/buy_payment_info.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/payment_info_error.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
 import 'package:realunit_wallet/screens/buy/buy_page.dart';
 import 'package:realunit_wallet/screens/buy/cubits/buy_converter/buy_converter_cubit.dart';
 import 'package:realunit_wallet/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart';
@@ -35,6 +37,10 @@ class MockDfxBrokerbotService extends Mock implements DfxBrokerbotService {}
 class MockRealUnitBuyPaymentInfoService extends Mock implements RealUnitBuyPaymentInfoService {}
 
 class MockDfxPriceService extends Mock implements DFXPriceService {}
+
+class MockRealUnitWalletService extends Mock implements RealUnitWalletService {}
+
+class MockRealUnitRegistrationService extends Mock implements RealUnitRegistrationService {}
 
 class MockApiConfig extends Mock implements ApiConfig {}
 
@@ -62,6 +68,8 @@ void main() {
     getIt.registerSingleton<DfxBrokerbotService>(MockDfxBrokerbotService());
     getIt.registerSingleton<RealUnitBuyPaymentInfoService>(MockRealUnitBuyPaymentInfoService());
     getIt.registerSingleton<DFXPriceService>(MockDfxPriceService());
+    getIt.registerSingleton<RealUnitWalletService>(MockRealUnitWalletService());
+    getIt.registerSingleton<RealUnitRegistrationService>(MockRealUnitRegistrationService());
   }
 
   setUpAll(() {

--- a/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
+++ b/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
@@ -1,0 +1,169 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/payment/buy_exceptions.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/buy_payment_info.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/payment_info_error.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/registration/kyc/kyc_personal_data.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/registration/registration_status.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/user/dto/real_unit_user_data_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_wallet_status_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
+import 'package:realunit_wallet/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart';
+import 'package:realunit_wallet/styles/currency.dart';
+
+class MockRealUnitBuyPaymentInfoService extends Mock implements RealUnitBuyPaymentInfoService {}
+
+class MockDfxPriceService extends Mock implements DFXPriceService {}
+
+class MockRealUnitWalletService extends Mock implements RealUnitWalletService {}
+
+class MockRealUnitRegistrationService extends Mock implements RealUnitRegistrationService {}
+
+void main() {
+  late MockRealUnitBuyPaymentInfoService mockBuyPaymentInfoService;
+  late MockDfxPriceService mockPriceService;
+  late MockRealUnitWalletService mockWalletService;
+  late MockRealUnitRegistrationService mockRegistrationService;
+
+  const testAmount = '300';
+  const testCurrency = Currency.chf;
+
+  final testUserData = RealUnitUserDataDto(
+    email: 'test@example.com',
+    name: 'Test User',
+    type: 'Personal',
+    phoneNumber: '+41791234567',
+    birthday: '1990-01-01',
+    nationality: 'CH',
+    addressStreet: 'Test Street 1',
+    addressPostalCode: '8000',
+    addressCity: 'Zurich',
+    addressCountry: 'CH',
+    swissTaxResidence: true,
+    lang: 'DE',
+    kycData: const KycPersonalData(
+      accountType: KycAccountType.personal,
+      firstName: 'Test',
+      lastName: 'User',
+      phone: '+41791234567',
+      address: KycAddress(
+        street: 'Test Street',
+        houseNumber: '1',
+        zip: '8000',
+        city: 'Zurich',
+        country: 756, // Switzerland country ID
+      ),
+    ),
+  );
+
+  const testPaymentInfo = BuyPaymentInfo(
+    id: 1,
+    iban: 'CH1234567890',
+    bic: 'TESTBIC',
+    name: 'Test Bank',
+    street: 'Bank Street',
+    number: '1',
+    zip: '8000',
+    city: 'Zurich',
+    country: 'CH',
+    currency: Currency.chf,
+  );
+
+  setUp(() {
+    mockBuyPaymentInfoService = MockRealUnitBuyPaymentInfoService();
+    mockPriceService = MockDfxPriceService();
+    mockWalletService = MockRealUnitWalletService();
+    mockRegistrationService = MockRealUnitRegistrationService();
+  });
+
+  setUpAll(() {
+    registerFallbackValue(testUserData);
+    registerFallbackValue(Currency.chf);
+  });
+
+  BuyPaymentInfoCubit createCubit() => BuyPaymentInfoCubit(
+        mockBuyPaymentInfoService,
+        mockPriceService,
+        mockWalletService,
+        mockRegistrationService,
+      );
+
+  group('BuyPaymentInfoCubit', () {
+    group('auto wallet registration', () {
+      blocTest<BuyPaymentInfoCubit, BuyPaymentInfoState>(
+        'auto-registers wallet when user data exists and returns success',
+        setUp: () {
+          var callCount = 0;
+          when(() => mockBuyPaymentInfoService.getPaymentInfo(any(), currency: any(named: 'currency')))
+              .thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) {
+              throw const RegistrationRequiredException(code: 'REGISTRATION_REQUIRED', message: 'Registration required');
+            }
+            return testPaymentInfo;
+          });
+          when(() => mockWalletService.getWalletStatus())
+              .thenAnswer((_) async => RealUnitWalletStatusDto(isRegistered: false, realUnitUserDataDto: testUserData));
+          when(() => mockRegistrationService.registerWallet(any()))
+              .thenAnswer((_) async => RegistrationStatus.completed);
+        },
+        build: createCubit,
+        act: (cubit) => cubit.getPaymentInfo(amount: testAmount, currency: testCurrency),
+        expect: () => [
+          const BuyPaymentInfoLoading(),
+          const BuyPaymentInfoSuccess(testPaymentInfo),
+        ],
+        verify: (_) {
+          verify(() => mockWalletService.getWalletStatus()).called(1);
+          verify(() => mockRegistrationService.registerWallet(testUserData)).called(1);
+        },
+      );
+
+      blocTest<BuyPaymentInfoCubit, BuyPaymentInfoState>(
+        'returns registration required error when user data is null',
+        setUp: () {
+          when(() => mockBuyPaymentInfoService.getPaymentInfo(any(), currency: any(named: 'currency')))
+              .thenThrow(const RegistrationRequiredException(code: 'REGISTRATION_REQUIRED', message: 'Registration required'));
+          when(() => mockWalletService.getWalletStatus())
+              .thenAnswer((_) async => RealUnitWalletStatusDto(isRegistered: false, realUnitUserDataDto: null));
+        },
+        build: createCubit,
+        act: (cubit) => cubit.getPaymentInfo(amount: testAmount, currency: testCurrency),
+        expect: () => [
+          const BuyPaymentInfoLoading(),
+          const BuyPaymentInfoFailure(PaymentInfoError.registrationRequired),
+        ],
+        verify: (_) {
+          verify(() => mockWalletService.getWalletStatus()).called(1);
+          verifyNever(() => mockRegistrationService.registerWallet(any()));
+        },
+      );
+
+      blocTest<BuyPaymentInfoCubit, BuyPaymentInfoState>(
+        'returns registration required error when wallet registration fails',
+        setUp: () {
+          when(() => mockBuyPaymentInfoService.getPaymentInfo(any(), currency: any(named: 'currency')))
+              .thenThrow(const RegistrationRequiredException(code: 'REGISTRATION_REQUIRED', message: 'Registration required'));
+          when(() => mockWalletService.getWalletStatus())
+              .thenAnswer((_) async => RealUnitWalletStatusDto(isRegistered: false, realUnitUserDataDto: testUserData));
+          when(() => mockRegistrationService.registerWallet(any()))
+              .thenThrow(Exception('Registration failed'));
+        },
+        build: createCubit,
+        act: (cubit) => cubit.getPaymentInfo(amount: testAmount, currency: testCurrency),
+        expect: () => [
+          const BuyPaymentInfoLoading(),
+          const BuyPaymentInfoFailure(PaymentInfoError.registrationRequired),
+        ],
+        verify: (_) {
+          verify(() => mockWalletService.getWalletStatus()).called(1);
+          verify(() => mockRegistrationService.registerWallet(testUserData)).called(1);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Bug

When a user has multiple wallets or creates a new wallet, they may encounter the "Registrierung erforderlich" (Registration required) error on the Buy page, even though they already have completed registration with another wallet.

**Root cause:** Registration in the DFX system works on two levels:
- **Account level:** User data (name, address, email, etc.) - stored once per user
- **Wallet level:** Each wallet must be individually registered with DFX

When a user with existing account data tries to buy with a new/unregistered wallet, the API returns `REGISTRATION_REQUIRED`. Previously, the app would show an error message and require the user to manually go through the KYC/registration flow again - even though all their data is already in the system.

## Solution

When the `REGISTRATION_REQUIRED` error is returned:
1. Check if user data already exists via `getWalletStatus()`
2. If `userData` exists → automatically call `registerWallet()` to register the current wallet
3. If successful → retry getting payment info (seamless UX)
4. If no user data exists or registration fails → fall back to showing the original error

This provides a seamless experience for existing users adding new wallets.

## Changes

- `BuyPaymentInfoCubit`: Added `_tryAutoRegisterWallet()` method that attempts automatic wallet registration
- `BuyPage`: Added required service dependencies
- Tests: Updated mocks for new dependencies

## Test plan

- [ ] Existing user with registered wallet: Buy flow works as before
- [ ] Existing user with new/unregistered wallet: Wallet is auto-registered, buy flow continues without interruption
- [ ] New user without account data: Shows "Registrierung erforderlich" as before