### PR TITLE
Add flutter analyze to CI

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -19,4 +19,5 @@ jobs:
       - run: flutter pub get
       - run: dart run tool/generate_localization.dart
       - run: flutter pub run build_runner build
+      - run: flutter analyze
       - run: flutter test


### PR DESCRIPTION
## Summary
- Add `flutter analyze` step to `pull-request.yaml` after code generation and before tests
- Catches static analysis errors (unused imports, type issues, undefined getters) that `flutter test` alone may miss

Closes #248