### PR TITLE
chore: rename CLAUDE.md to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# RealUnit App — Claude Code Guidelines
+# RealUnit App — Contributing Guidelines
 
 ## Build & Test Commands
 


### PR DESCRIPTION
## Summary
Renames `CLAUDE.md` → `CONTRIBUTING.md` and updates the internal title accordingly. Tool-neutral filename, works as standard contributor docs and can still be referenced by any AI assistant manually.

Rename via `git mv`, so history is preserved.

## Test plan
- [ ] File shows up as rename (not delete + add) on the PR
- [ ] Internal title no longer mentions Claude