### PR TITLE
docs: restrict network access to DFX API only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,13 @@ flutter analyze                             # lint check
 
 After changing ARB files, always regenerate: `dart run tool/generate_localization.dart`
 
+## API Access — CRITICAL
+
+- The app is **only allowed to talk to the DFX API**: `api.dfx.swiss` (mainnet) and `dev.api.dfx.swiss` (testnet/Sepolia). No other hosts.
+- **No third-party APIs**: no direct Ethereum JSON-RPC calls (Infura, Alchemy, public nodes, etc.), no block explorer APIs (Etherscan, …), no price feeds, no analytics endpoints, no third-party SDKs that call out over the network.
+- If a feature needs on-chain data (e.g. native ETH balance, transaction status, token balance), add a new endpoint to [`DFXswiss/api`](https://github.com/DFXswiss/api) and let the app call that endpoint. The API is the single gateway.
+- All network calls must go through `AppStore.httpClient` with `buildUri(_host, …)` — `_host` resolves to the DFX API host via `ApiConfig`. Do not instantiate `http.Client`/`Dio`/`Web3Client` against other hosts.
+
 ## Project Architecture
 
 ```


### PR DESCRIPTION
## Summary
Adds an explicit **API Access — CRITICAL** section to `CONTRIBUTING.md`:

- Only `api.dfx.swiss` and `dev.api.dfx.swiss` are allowed as network destinations
- No direct Ethereum JSON-RPC, no block explorer APIs, no third-party endpoints
- On-chain data must be exposed via a DFX API endpoint; the app calls only that
- All network calls must go through `AppStore.httpClient` + `buildUri(_host, …)`

## Rationale
Operational and security invariant: a single, controlled gateway means credentials, rate limits, failure modes, and compliance all live in one place. Prevents ad-hoc third-party integrations creeping into the client.

## Test plan
- [ ] Docs-only change, no code affected