### PR TITLE
fix: missing return in payment information unknown error branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,13 @@ flutter analyze                             # lint check
 
 After changing ARB files, always regenerate: `dart run tool/generate_localization.dart`
 
+## API Access — CRITICAL
+
+- The app is **only allowed to talk to the DFX API**: `api.dfx.swiss` (mainnet) and `dev.api.dfx.swiss` (testnet/Sepolia). No other hosts.
+- **No third-party APIs**: no direct Ethereum JSON-RPC calls (Infura, Alchemy, public nodes, etc.), no block explorer APIs (Etherscan, …), no price feeds, no analytics endpoints, no third-party SDKs that call out over the network.
+- If a feature needs on-chain data (e.g. native ETH balance, transaction status, token balance), add a new endpoint to [`DFXswiss/api`](https://github.com/DFXswiss/api) and let the app call that endpoint. The API is the single gateway.
+- All network calls must go through `AppStore.httpClient` with `buildUri(_host, …)` — `_host` resolves to the DFX API host via `ApiConfig`. Do not instantiate `http.Client`/`Dio`/`Web3Client` against other hosts.
+
 ## Project Architecture
 
 ```

--- a/lib/screens/buy/widgets/payment_information.dart
+++ b/lib/screens/buy/widgets/payment_information.dart
@@ -39,7 +39,7 @@ class PaymentInformation extends StatelessWidget {
               description: S.of(context).identityCheckDescription,
             );
           } else if (error == PaymentInfoError.unknown) {
-            PaymentActionRequired(
+            return PaymentActionRequired(
               title: S.of(context).paymentInformationFailed,
               description: S.of(context).paymentInformationFailedDescription,
             );


### PR DESCRIPTION
## Summary
- Fixes the `PaymentInfoError.unknown` branch in `PaymentInformation` (lib/screens/buy/widgets/payment_information.dart:42) which constructed a `PaymentActionRequired` widget but never returned it
- Without the `return`, the build fell through to `SizedBox.shrink()`, so users saw a blank screen instead of an error message

## Context
Identified as bug #1 in #241. Severity is higher than originally noted: `BuyPaymentInfoCubit._runGetPaymentInfo()` maps every unexpected exception (403, 503, network errors, token expiry) onto `PaymentInfoError.unknown`, so the blank-screen path is the standard error path — not a rare edge case.

Refs: #241

## Test plan
- [ ] Trigger a non-KYC, non-registration failure in the buy flow (e.g. force a network error or 503) and verify the error widget renders with title + description instead of a blank area
- [ ] Verify the registration-required and KYC-required branches still render correctly