### PR TITLE
fix: missing return in payment information unknown error branch

### DIFF
--- a/lib/screens/buy/widgets/payment_information.dart
+++ b/lib/screens/buy/widgets/payment_information.dart
@@ -39,7 +39,7 @@ class PaymentInformation extends StatelessWidget {
               description: S.of(context).identityCheckDescription,
             );
           } else if (error == PaymentInfoError.unknown) {
-            PaymentActionRequired(
+            return PaymentActionRequired(
               title: S.of(context).paymentInformationFailed,
               description: S.of(context).paymentInformationFailedDescription,
             );


### PR DESCRIPTION
## Summary
- Fixes the `PaymentInfoError.unknown` branch in `PaymentInformation` (`lib/screens/buy/widgets/payment_information.dart:42`) which constructed a `PaymentActionRequired` widget but never returned it.
- Without the `return`, the build fell through to `SizedBox.shrink()`, so users saw a blank screen instead of an error message.

## Context
Identified as bug #1 in #241. Severity is higher than originally noted: `BuyPaymentInfoCubit._runGetPaymentInfo()` maps every unexpected exception (403, 503, network errors, token expiry) onto `PaymentInfoError.unknown`, so the blank-screen path is the standard error path — not a rare edge case.

Replaces #271 (which had an unrelated `CONTRIBUTING.md` commit that has since landed on `develop` via #267).

Refs: #241

## Test plan
- [ ] Trigger a non-KYC, non-registration failure in the buy flow (e.g. force a network error or 503) and verify the error widget renders with title + description instead of a blank area
- [ ] Verify the registration-required and KYC-required branches still render correctly