### PR TITLE
fix: render error widget for unknown payment info failures

### DIFF
--- a/lib/screens/buy/widgets/payment_information.dart
+++ b/lib/screens/buy/widgets/payment_information.dart
@@ -39,7 +39,7 @@ class PaymentInformation extends StatelessWidget {
               description: S.of(context).identityCheckDescription,
             );
           } else if (error == PaymentInfoError.unknown) {
-            PaymentActionRequired(
+            return PaymentActionRequired(
               title: S.of(context).paymentInformationFailed,
               description: S.of(context).paymentInformationFailedDescription,
             );


### PR DESCRIPTION
## Summary
Adds the missing `return` in `PaymentInformation` so the `PaymentInfoError.unknown` branch actually renders the `PaymentActionRequired` widget instead of silently falling through to `SizedBox.shrink()` (`lib/screens/buy/widgets/payment_information.dart:42`).

## Why this is needed

The `unknown` branch is **not a rare edge case** — it is the catch-all for every non-specific failure in the buy payment info flow. `BuyPaymentInfoCubit._runGetPaymentInfo()` only treats `KycLevelRequiredException` and `RegistrationRequiredException` specifically; everything else lands in `catch (e) → PaymentInfoError.unknown` (`buy_payment_info_cubit.dart:74-77`). That includes:

- `503` from Aktionariat being down
- Generic `403`s (e.g. 2FA required, until a dedicated handler is added)
- Network errors / timeouts
- Token expiry
- JSON parse errors / unexpected response shapes

Without the `return`, all of these produced a **blank screen** with no indication that anything went wrong. The user just saw an empty payment-information area and would reasonably assume the app froze.

The two companion strings `paymentInformationFailed` and `paymentInformationFailedDescription` already exist in `i18n.dart` for exactly this case — the branch was meant to render an error widget. The `return` was simply forgotten when the branch was added; nothing else about the surrounding code suggests this state was intentional.

## Out of scope (intentionally)

This PR is deliberately minimal — only the missing `return`. Related issues from #241 are **not** fixed here:

- Buy/Sell cubits do not specifically catch 2FA-required `403`s — they still get mapped to `PaymentInfoError.unknown`. After this PR they at least show a generic error widget instead of a blank screen, but a dedicated `TfaRequiredException` + cubit handler is the proper fix.
- Settings cubits (`SettingsEditAddressCubit`, `SettingsEditNameCubit`, `SettingsEditPhoneNumberCubit`) have no 2FA handling at all; they emit raw exception strings.

Both belong in a separate refactor that introduces `TfaRequiredException` end-to-end and decides on the settings-level 2FA UI flow. Tracked in #241.

Refs: #241

## Test plan
- [ ] Force the buy flow into the `unknown` error path (e.g. block the API with a 503 or kill the network) and verify the error widget renders with title + description instead of a blank area
- [ ] Verify the registration-required and KYC-required branches still render correctly
- [ ] Verify `minAmountNotMet` still shows the min-amount text + disabled button via `PaymentAdditionalActionNeededButton` (handled in a sibling widget by design, unchanged here)