### PR TITLE
fix: replace misleading buy-confirm snackbar with generic message

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -26,7 +26,7 @@
   "buyExecutedTitle": "Vielen Dank.",
   "buyMinAmount": "Mindestbetrag: ${amount} ${currency}",
   "buyPaymentConfirm": "Klicken Sie hier, sobald Sie die Überweisung getätigt haben",
-  "buyPaymentConfirmFailed": "Es gibt ein technisches Problem. Bitte überprüfen Sie Ihr E-Mail-Postfach, möglicherweise fehlt noch eine Bestätigung Ihrer Blockchain-Adresse. Andernfalls versuchen Sie es zu einem späteren Zeitpunkt nochmals. Falls der Fehler weiterhin besteht, kontaktieren Sie unseren Support.",
+  "buyPaymentConfirmFailed": "Es gibt ein technisches Problem. Bitte versuchen Sie es später erneut. Falls der Fehler weiterhin besteht, kontaktieren Sie unseren Support.",
   "buyPaymentInformation": "Zahlungsinformationen",
   "buyPaymentInformationDescription": "Bitte überweisen Sie den Kaufbetrag mit diesen Angaben über Ihre Bankanwendung. Der Verwendungszweck ist wichtig!",
   "buyRealu": "RealUnit Token kaufen",

--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -27,6 +27,7 @@
   "buyMinAmount": "Mindestbetrag: ${amount} ${currency}",
   "buyPaymentConfirm": "Klicken Sie hier, sobald Sie die Überweisung getätigt haben",
   "buyPaymentConfirmFailed": "Es gibt ein technisches Problem. Bitte versuchen Sie es später erneut. Falls der Fehler weiterhin besteht, kontaktieren Sie unseren Support.",
+  "buyPaymentConfirmFailedAktionariat": "Bitte überprüfen Sie Ihr E-Mail-Postfach, möglicherweise fehlt noch eine Bestätigung Ihrer Blockchain-Adresse. Andernfalls versuchen Sie es zu einem späteren Zeitpunkt nochmals. Falls der Fehler weiterhin besteht, kontaktieren Sie unseren Support.",
   "buyPaymentInformation": "Zahlungsinformationen",
   "buyPaymentInformationDescription": "Bitte überweisen Sie den Kaufbetrag mit diesen Angaben über Ihre Bankanwendung. Der Verwendungszweck ist wichtig!",
   "buyRealu": "RealUnit Token kaufen",

--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -27,7 +27,7 @@
   "buyMinAmount": "Mindestbetrag: ${amount} ${currency}",
   "buyPaymentConfirm": "Klicken Sie hier, sobald Sie die Überweisung getätigt haben",
   "buyPaymentConfirmFailed": "Es gibt ein technisches Problem. Bitte versuchen Sie es später erneut. Falls der Fehler weiterhin besteht, kontaktieren Sie unseren Support.",
-  "buyPaymentConfirmFailedAktionariat": "Bitte überprüfen Sie Ihr E-Mail-Postfach, möglicherweise fehlt noch eine Bestätigung Ihrer Blockchain-Adresse. Andernfalls versuchen Sie es zu einem späteren Zeitpunkt nochmals. Falls der Fehler weiterhin besteht, kontaktieren Sie unseren Support.",
+  "buyPaymentConfirmFailedAktionariat": "Es gibt ein technisches Problem. Bitte überprüfen Sie Ihr E-Mail-Postfach, möglicherweise fehlt noch eine Bestätigung Ihrer Blockchain-Adresse. Andernfalls versuchen Sie es später erneut. Falls der Fehler weiterhin besteht, kontaktieren Sie unseren Support.",
   "buyPaymentInformation": "Zahlungsinformationen",
   "buyPaymentInformationDescription": "Bitte überweisen Sie den Kaufbetrag mit diesen Angaben über Ihre Bankanwendung. Der Verwendungszweck ist wichtig!",
   "buyRealu": "RealUnit Token kaufen",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -27,6 +27,7 @@
   "buyMinAmount": "Minimum amount: ${amount} ${currency}",
   "buyPaymentConfirm": "Click here once you have made the transfer",
   "buyPaymentConfirmFailed": "There is a technical problem. Please try again later. If the error persists, contact our support team.",
+  "buyPaymentConfirmFailedAktionariat": "Please check your email inbox — you may still need to confirm your blockchain address. Otherwise, please try again later. If the error persists, contact our support team.",
   "buyPaymentInformation": "Payment information",
   "buyPaymentInformationDescription": "Please transfer the purchase amount using your banking app with these details. The purpose of payment is important!",
   "buyRealu": "Buy RealUnit Token",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -26,7 +26,7 @@
   "buyExecutedTitle": "Thank you.",
   "buyMinAmount": "Minimum amount: ${amount} ${currency}",
   "buyPaymentConfirm": "Click here once you have made the transfer",
-  "buyPaymentConfirmFailed": "There is a technical problem. Please check your email inbox — you may still need to confirm your blockchain address. Otherwise, please try again later. If the error persists, contact our support team.",
+  "buyPaymentConfirmFailed": "There is a technical problem. Please try again later. If the error persists, contact our support team.",
   "buyPaymentInformation": "Payment information",
   "buyPaymentInformationDescription": "Please transfer the purchase amount using your banking app with these details. The purpose of payment is important!",
   "buyRealu": "Buy RealUnit Token",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -27,7 +27,7 @@
   "buyMinAmount": "Minimum amount: ${amount} ${currency}",
   "buyPaymentConfirm": "Click here once you have made the transfer",
   "buyPaymentConfirmFailed": "There is a technical problem. Please try again later. If the error persists, contact our support team.",
-  "buyPaymentConfirmFailedAktionariat": "Please check your email inbox — you may still need to confirm your blockchain address. Otherwise, please try again later. If the error persists, contact our support team.",
+  "buyPaymentConfirmFailedAktionariat": "There is a technical problem. Please check your email inbox — you may still need to confirm your blockchain address. Otherwise, please try again later. If the error persists, contact our support team.",
   "buyPaymentInformation": "Payment information",
   "buyPaymentInformationDescription": "Please transfer the purchase amount using your banking app with these details. The purpose of payment is important!",
   "buyRealu": "Buy RealUnit Token",

--- a/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
@@ -71,7 +71,8 @@ class RealUnitBuyPaymentInfoService {
     );
 
     if (response.statusCode != 200 && response.statusCode != 201) {
-      throw Exception('Failed to confirm payment: ${response.statusCode} ${response.body}');
+      final errorJson = jsonDecode(response.body) as Map<String, dynamic>;
+      throw ApiException.fromJson(errorJson);
     }
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;

--- a/lib/screens/buy/cubits/buy_confirm/buy_confirm_cubit.dart
+++ b/lib/screens/buy/cubits/buy_confirm/buy_confirm_cubit.dart
@@ -2,6 +2,7 @@ import 'dart:developer' as developer;
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
 
 part 'buy_confirm_state.dart';
@@ -18,9 +19,19 @@ class BuyConfirmCubit extends Cubit<BuyConfirmState> {
       emit(BuyConfirmLoading());
       final reference = await _buyPaymentInfoService.confirmPayment(paymentInfoId);
       emit(BuyConfirmSuccess(reference));
+    } on ApiException catch (e) {
+      developer.log(e.toString());
+      emit(
+        BuyConfirmFailure(
+          kind: e.statusCode == 503
+              ? BuyConfirmFailureKind.aktionariat
+              : BuyConfirmFailureKind.generic,
+          error: e.toString(),
+        ),
+      );
     } catch (e) {
       developer.log(e.toString());
-      emit(BuyConfirmFailure(e.toString()));
+      emit(BuyConfirmFailure(kind: BuyConfirmFailureKind.generic, error: e.toString()));
     }
   }
 }

--- a/lib/screens/buy/cubits/buy_confirm/buy_confirm_cubit.dart
+++ b/lib/screens/buy/cubits/buy_confirm/buy_confirm_cubit.dart
@@ -12,26 +12,23 @@ class BuyConfirmCubit extends Cubit<BuyConfirmState> {
 
   BuyConfirmCubit(RealUnitBuyPaymentInfoService buyPaymentInfoService)
     : _buyPaymentInfoService = buyPaymentInfoService,
-      super(BuyConfirmInitial());
+      super(const BuyConfirmInitial());
 
   Future<void> confirmPayment(int paymentInfoId) async {
     try {
-      emit(BuyConfirmLoading());
+      emit(const BuyConfirmLoading());
       final reference = await _buyPaymentInfoService.confirmPayment(paymentInfoId);
       emit(BuyConfirmSuccess(reference));
     } on ApiException catch (e) {
       developer.log(e.toString());
       emit(
         BuyConfirmFailure(
-          kind: e.statusCode == 503
-              ? BuyConfirmFailureKind.aktionariat
-              : BuyConfirmFailureKind.generic,
-          error: e.toString(),
+          e.statusCode == 503 ? BuyConfirmError.aktionariat : BuyConfirmError.unknown,
         ),
       );
     } catch (e) {
       developer.log(e.toString());
-      emit(BuyConfirmFailure(kind: BuyConfirmFailureKind.generic, error: e.toString()));
+      emit(const BuyConfirmFailure(BuyConfirmError.unknown));
     }
   }
 }

--- a/lib/screens/buy/cubits/buy_confirm/buy_confirm_state.dart
+++ b/lib/screens/buy/cubits/buy_confirm/buy_confirm_state.dart
@@ -1,5 +1,7 @@
 part of 'buy_confirm_cubit.dart';
 
+enum BuyConfirmFailureKind { aktionariat, generic }
+
 abstract class BuyConfirmState extends Equatable {
   @override
   List<Object?> get props => [];
@@ -19,10 +21,11 @@ class BuyConfirmSuccess extends BuyConfirmState {
 }
 
 class BuyConfirmFailure extends BuyConfirmState {
+  final BuyConfirmFailureKind kind;
   final String error;
 
-  BuyConfirmFailure(this.error);
+  BuyConfirmFailure({required this.kind, required this.error});
 
   @override
-  List<Object?> get props => [error];
+  List<Object?> get props => [kind, error];
 }

--- a/lib/screens/buy/cubits/buy_confirm/buy_confirm_state.dart
+++ b/lib/screens/buy/cubits/buy_confirm/buy_confirm_state.dart
@@ -1,31 +1,36 @@
 part of 'buy_confirm_cubit.dart';
 
-enum BuyConfirmFailureKind { aktionariat, generic }
+enum BuyConfirmError { aktionariat, unknown }
 
 abstract class BuyConfirmState extends Equatable {
+  const BuyConfirmState();
+
   @override
   List<Object?> get props => [];
 }
 
-class BuyConfirmInitial extends BuyConfirmState {}
+class BuyConfirmInitial extends BuyConfirmState {
+  const BuyConfirmInitial();
+}
 
-class BuyConfirmLoading extends BuyConfirmState {}
+class BuyConfirmLoading extends BuyConfirmState {
+  const BuyConfirmLoading();
+}
 
 class BuyConfirmSuccess extends BuyConfirmState {
   final String reference;
 
-  BuyConfirmSuccess(this.reference);
+  const BuyConfirmSuccess(this.reference);
 
   @override
   List<Object?> get props => [reference];
 }
 
 class BuyConfirmFailure extends BuyConfirmState {
-  final BuyConfirmFailureKind kind;
-  final String error;
+  final BuyConfirmError error;
 
-  BuyConfirmFailure({required this.kind, required this.error});
+  const BuyConfirmFailure(this.error);
 
   @override
-  List<Object?> get props => [kind, error];
+  List<Object?> get props => [error];
 }

--- a/lib/screens/buy/widgets/payment_information_details.dart
+++ b/lib/screens/buy/widgets/payment_information_details.dart
@@ -70,10 +70,12 @@ class PaymentInformationDetailsView extends StatelessWidget {
         }
         if (state is BuyConfirmFailure) {
           if (context.mounted) {
+            final text = switch (state.kind) {
+              BuyConfirmFailureKind.aktionariat => S.of(context).buyPaymentConfirmFailedAktionariat,
+              BuyConfirmFailureKind.generic => S.of(context).buyPaymentConfirmFailed,
+            };
             ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(S.of(context).buyPaymentConfirmFailed),
-              ),
+              SnackBar(content: Text(text)),
             );
           }
         }

--- a/lib/screens/buy/widgets/payment_information_details.dart
+++ b/lib/screens/buy/widgets/payment_information_details.dart
@@ -70,9 +70,9 @@ class PaymentInformationDetailsView extends StatelessWidget {
         }
         if (state is BuyConfirmFailure) {
           if (context.mounted) {
-            final text = switch (state.kind) {
-              BuyConfirmFailureKind.aktionariat => S.of(context).buyPaymentConfirmFailedAktionariat,
-              BuyConfirmFailureKind.generic => S.of(context).buyPaymentConfirmFailed,
+            final text = switch (state.error) {
+              BuyConfirmError.aktionariat => S.of(context).buyPaymentConfirmFailedAktionariat,
+              BuyConfirmError.unknown => S.of(context).buyPaymentConfirmFailed,
             };
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(content: Text(text)),

--- a/test/packages/service/dfx/real_unit_buy_payment_info_service_test.dart
+++ b/test/packages/service/dfx/real_unit_buy_payment_info_service_test.dart
@@ -6,6 +6,7 @@ import 'package:realunit_wallet/packages/config/api_config.dart';
 import 'package:realunit_wallet/packages/config/network_mode.dart';
 import 'package:realunit_wallet/packages/repository/cache_repository.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
 
@@ -65,16 +66,39 @@ void main() {
         expect(reference, equals(referenceText));
       });
 
-      test('throws exception on non-200/201 status code', () async {
+      test('throws ApiException on non-200/201 status code', () async {
         final appStore = buildAppStore(
-          (request) async => http.Response('{"error": "Not found"}', 404),
+          (request) async => http.Response(
+            '{"statusCode": 404, "message": "Not found"}',
+            404,
+          ),
         );
 
         final service = RealUnitBuyPaymentInfoService(appStore);
 
         expect(
           () => service.confirmPayment(999),
-          throwsA(isA<Exception>()),
+          throwsA(
+            isA<ApiException>().having((e) => e.statusCode, 'statusCode', 404),
+          ),
+        );
+      });
+
+      test('throws ApiException with statusCode 503 on Aktionariat failure', () async {
+        final appStore = buildAppStore(
+          (request) async => http.Response(
+            '{"statusCode": 503, "message": "Aktionariat API error: upstream"}',
+            503,
+          ),
+        );
+
+        final service = RealUnitBuyPaymentInfoService(appStore);
+
+        expect(
+          () => service.confirmPayment(999),
+          throwsA(
+            isA<ApiException>().having((e) => e.statusCode, 'statusCode', 503),
+          ),
         );
       });
 


### PR DESCRIPTION
## Background — what the user actually sees today

When a user taps **Confirm** on the buy-payment screen and the API call fails for *any* reason (network drop, 5xx, timeout, expired session, expired transaction request, …), the app currently shows this snackbar:

> Es gibt ein technisches Problem. Bitte überprüfen Sie Ihr E-Mail-Postfach, möglicherweise fehlt noch eine Bestätigung Ihrer Blockchain-Adresse. Andernfalls versuchen Sie es zu einem späteren Zeitpunkt nochmals. Falls der Fehler weiterhin besteht, kontaktieren Sie unseren Support.

The mailbox hint was originally written for one specific scenario: Aktionariat throws an NPE on `Person.getPrimaryEmail()` for users who have no email registered there. In that scenario the user genuinely needs to confirm their blockchain address via an email Aktionariat sends to their DFX address.

For any other failure — and that's the vast majority of buy-confirm failures — the hint is misleading. It tells the user to check an inbox that has nothing to find, and creates a support load on something the user can't actually act on.

## Why we can do better now

[DFXswiss/api#3377](https://github.com/DFXswiss/api/pull/3377) wrapped the Aktionariat NPE on the API side and made the genuine Aktionariat case identifiable: the `confirmBuy` endpoint now emits HTTP `503` exclusively from the Aktionariat try-catch. The other failure modes inside that endpoint throw 400/404/409. So `statusCode == 503` is a clean marker for "this is the Aktionariat path" — no fragile message-string matching needed.

Before this PR the app couldn't take advantage of that, because the service layer threw a generic `Exception` with the status code embedded in the message — unparseable from the cubit. So even the typed exception infrastructure (`ApiException`, `ApiException.fromJson`) that exists for the other endpoints was dead code on this path.

## What this PR does

Three layers, smallest scope per layer:

**Service** — `real_unit_buy_payment_info_service.dart`
`confirmPayment` now throws `ApiException.fromJson(response.body)` on any non-2xx response, mirroring the pattern used everywhere in `dfx_kyc_service.dart`. Without this, the typed cubit handler below would never fire. Network errors (no response at all) still surface as the underlying SocketException/ClientException and fall into the generic catch — that's intentional, the API hasn't responded so we have no structured error to read.

**Cubit + state** — `buy_confirm_cubit.dart`, `buy_confirm_state.dart`
The cubit now catches `ApiException` typed and classifies `statusCode == 503` as `BuyConfirmError.aktionariat`, everything else as `BuyConfirmError.unknown`. While touching this file the state was aligned with the surrounding `BuyPaymentInfoState` pattern: typed error enum instead of an unused `error: String` field, `<Context>Error` naming (matches `PaymentInfoError`), `const` constructors throughout. Internal cleanup, no behaviour change beyond the new classification.

**UI + i18n** — `payment_information_details.dart`, `strings_de.arb`, `strings_en.arb`
The snackbar listener now picks the matching i18n key via an exhaustive `switch` over the typed error. Two keys: `buyPaymentConfirmFailed` (generic — technical problem, try again later, contact support) and `buyPaymentConfirmFailedAktionariat` (technical problem + the original mailbox hint). Both share the same opening sentence so the user gets context regardless of which branch fires.

## Result

| Failure type                                | Before                               | After                                |
| ------------------------------------------- | ------------------------------------ | ------------------------------------ |
| Aktionariat NPE (API 503)                   | Mailbox hint shown — correct         | Mailbox hint shown — correct         |
| Network drop, 5xx upstream, timeout, etc.   | Mailbox hint shown — **misleading**  | Generic technical-problem text       |
| Expired transaction request (400)           | Mailbox hint shown — **misleading**  | Generic technical-problem text       |
| Already-confirmed (409), invalid (404)      | Mailbox hint shown — **misleading**  | Generic technical-problem text       |

## Out of scope

- Sell-confirm pendant (P3 in #280) — same Tot-Pattern in `SellConfirmState`, separate fix.
- Cubit-übergreifender error-handling refactor (P4 in #280) — needs the same treatment in settings cubits and a shared `mapApiException` helper.
- `getPaymentInfo` in the same service has the same generic-Exception fallback for non-403 codes — separate bug, not on the buy-confirm path.

## Test plan

- [ ] Trigger a buy-confirm with the network offline → generic text shown
- [ ] Trigger a buy-confirm where the API returns 503 (Aktionariat path) → mailbox-hint text shown
- [ ] Trigger a buy-confirm with an expired/invalid request (400/404/409) → generic text shown (no mailbox hint)
- [ ] Both DE and EN render correctly

## References

- Closes the P1 acceptance bullets in #280
- Builds on [DFXswiss/api#3377](https://github.com/DFXswiss/api/pull/3377)