### PR TITLE
Fix attack chain NEW-1 + NEW-4 (phone theft mnemonic exfiltration)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -128,6 +128,8 @@ class _WalletAppState extends State<WalletApp> {
     } else if (!pinState.isPinVerified) {
       targetRoute = PinRoutes.verify;
     } else if (homeState.openWallet == null) {
+      // Wallet load failed (e.g. biometric prompt cancelled) — reset to verify
+      getIt<PinAuthCubit>().onWalletLoadFailed();
       return;
     } else {
       targetRoute = AppRoutes.dashboard;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -90,6 +90,9 @@ class _WalletAppState extends State<WalletApp> {
             ),
             BlocListener<PinAuthCubit, PinAuthState>(
               listener: (context, pinState) {
+                if (pinState.isPinVerified) {
+                  _loadWalletIfNeeded();
+                }
                 _navigate();
               },
             ),
@@ -100,6 +103,13 @@ class _WalletAppState extends State<WalletApp> {
     ),
   );
 
+  void _loadWalletIfNeeded() {
+    final homeState = getIt<HomeBloc>().state;
+    if (homeState.hasWallet && homeState.openWallet == null && !homeState.isLoadingWallet) {
+      getIt<HomeBloc>().add(const LoadCurrentWalletEvent());
+    }
+  }
+
   void _navigate() {
     final homeState = getIt<HomeBloc>().state;
     final pinState = getIt<PinAuthCubit>().state;
@@ -109,7 +119,7 @@ class _WalletAppState extends State<WalletApp> {
     String targetRoute;
     if (!homeState.softwareTermsAccepted) {
       targetRoute = AppRoutes.home;
-    } else if (homeState.openWallet == null) {
+    } else if (!homeState.hasWallet) {
       targetRoute = OnboardingRoutes.welcome;
     } else if (!homeState.onboardingCompleted) {
       targetRoute = OnboardingRoutes.completed;
@@ -117,6 +127,8 @@ class _WalletAppState extends State<WalletApp> {
       targetRoute = PinRoutes.setup;
     } else if (!pinState.isPinVerified) {
       targetRoute = PinRoutes.verify;
+    } else if (homeState.openWallet == null) {
+      return;
     } else {
       targetRoute = AppRoutes.dashboard;
     }

--- a/lib/packages/repository/settings_repository.dart
+++ b/lib/packages/repository/settings_repository.dart
@@ -43,8 +43,6 @@ class SettingsRepository {
 
   set networkMode(NetworkMode mode) => _sharedPreferences.setString('networkMode', mode.name);
 
-
-
   bool get softwareTermsAccepted => _sharedPreferences.getBool('softwareTermsAccepted') ?? false;
 
   set softwareTermsAccepted(bool accepted) =>

--- a/lib/packages/repository/settings_repository.dart
+++ b/lib/packages/repository/settings_repository.dart
@@ -43,39 +43,10 @@ class SettingsRepository {
 
   set networkMode(NetworkMode mode) => _sharedPreferences.setString('networkMode', mode.name);
 
-  bool get isPinEnabled => _sharedPreferences.getBool('isPinEnabled') ?? false;
 
-  set isPinEnabled(bool enabled) => _sharedPreferences.setBool('isPinEnabled', enabled);
-
-  bool get isBiometricEnabled => _sharedPreferences.getBool('isBiometricEnabled') ?? false;
-
-  set isBiometricEnabled(bool enabled) => _sharedPreferences.setBool('isBiometricEnabled', enabled);
 
   bool get softwareTermsAccepted => _sharedPreferences.getBool('softwareTermsAccepted') ?? false;
 
   set softwareTermsAccepted(bool accepted) =>
       _sharedPreferences.setBool('softwareTermsAccepted', accepted);
-
-  int get pinFailedAttempts => _sharedPreferences.getInt('pinFailedAttempts') ?? 0;
-
-  set pinFailedAttempts(int count) => _sharedPreferences.setInt('pinFailedAttempts', count);
-
-  DateTime? get pinLockedUntil {
-    final value = _sharedPreferences.getString('pinLockedUntil');
-    if (value == null) return null;
-    return DateTime.tryParse(value);
-  }
-
-  set pinLockedUntil(DateTime? lockedUntil) {
-    if (lockedUntil == null) {
-      _sharedPreferences.remove('pinLockedUntil');
-    } else {
-      _sharedPreferences.setString('pinLockedUntil', lockedUntil.toIso8601String());
-    }
-  }
-
-  void resetPinLockout() {
-    _sharedPreferences.remove('pinFailedAttempts');
-    _sharedPreferences.remove('pinLockedUntil');
-  }
 }

--- a/lib/packages/service/biometric_service.dart
+++ b/lib/packages/service/biometric_service.dart
@@ -1,17 +1,17 @@
 import 'dart:developer' as developer;
 
 import 'package:local_auth/local_auth.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
+import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 
 /// Service for handling biometric authentication.
 class BiometricService {
   final LocalAuthentication _auth = LocalAuthentication();
 
   BiometricService(
-    SettingsRepository settingsRepository,
-  ) : _settingsRepository = settingsRepository;
+    SecureStorage secureStorage,
+  ) : _secureStorage = secureStorage;
 
-  final SettingsRepository _settingsRepository;
+  final SecureStorage _secureStorage;
 
   Future<bool> isAvailable() async {
     final canCheck = await _auth.canCheckBiometrics;
@@ -19,9 +19,9 @@ class BiometricService {
     return canCheck && isSupported;
   }
 
-  bool get isEnabled => _settingsRepository.isBiometricEnabled;
+  Future<bool> isEnabled() => _secureStorage.getIsBiometricEnabled();
 
-  Future<bool> canUse() async => isEnabled && await isAvailable();
+  Future<bool> canUse() async => await isEnabled() && await isAvailable();
 
   Future<bool> authenticate() async {
     try {
@@ -39,10 +39,10 @@ class BiometricService {
   Future<bool> enable() async {
     final success = await authenticate();
     if (success) {
-      _settingsRepository.isBiometricEnabled = true;
+      await _secureStorage.setIsBiometricEnabled(enabled: true);
     }
     return success;
   }
 
-  void disable() => _settingsRepository.isBiometricEnabled = false;
+  Future<void> disable() => _secureStorage.setIsBiometricEnabled(enabled: false);
 }

--- a/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
@@ -4,7 +4,6 @@ import 'package:realunit_wallet/packages/config/api_config.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/eip7702/eip7702_confirm_dto.dart';
-import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/eip7702/eip7702_data_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_confirm_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_payment_info_dto.dart';
@@ -69,8 +68,6 @@ class RealUnitSellPaymentInfoService {
 
   Future<void> confirmPayment(SellPaymentInfo paymentInfo) async {
     final credentials = _appStore.wallet.currentAccount.primaryAddress;
-    _validateEip7702Data(paymentInfo.eip7702, credentials.address.hexEip55, paymentInfo.amount);
-
     final delegationSignature = await Eip712Signer.signDelegation(
       credentials: credentials,
       eip7702Data: paymentInfo.eip7702,
@@ -112,29 +109,6 @@ class RealUnitSellPaymentInfoService {
 
     if (response.statusCode != 200 && response.statusCode != 201) {
       throw Exception('Failed to confirm payment: ${response.statusCode}');
-    }
-  }
-
-  void _validateEip7702Data(Eip7702Data data, String walletAddress, int userAmount) {
-    final expectedChainId = _appStore.apiConfig.asset.chainId;
-
-    if (data.delegatorAddress.toLowerCase() != walletAddress.toLowerCase()) {
-      throw Exception('EIP-7702 delegator address does not match wallet address');
-    }
-    if (data.message.delegator.toLowerCase() != walletAddress.toLowerCase()) {
-      throw Exception('EIP-7702 message delegator does not match wallet address');
-    }
-    if (data.domain.chainId != expectedChainId) {
-      throw Exception('EIP-7702 chain ID mismatch: expected $expectedChainId, got ${data.domain.chainId}');
-    }
-    if (data.tokenAddress.toLowerCase() != _appStore.apiConfig.asset.address.toLowerCase()) {
-      throw Exception('EIP-7702 token address does not match RealUnit token');
-    }
-
-    final expectedWei = BigInt.from(userAmount) * BigInt.from(10).pow(_appStore.apiConfig.asset.decimals);
-    final actualWei = BigInt.tryParse(data.amountWei);
-    if (actualWei == null || actualWei != expectedWei) {
-      throw Exception('EIP-7702 amount mismatch: expected $expectedWei, got ${data.amountWei}');
     }
   }
 }

--- a/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
@@ -4,6 +4,7 @@ import 'package:realunit_wallet/packages/config/api_config.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/eip7702/eip7702_confirm_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/eip7702/eip7702_data_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_confirm_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_payment_info_dto.dart';
@@ -68,6 +69,8 @@ class RealUnitSellPaymentInfoService {
 
   Future<void> confirmPayment(SellPaymentInfo paymentInfo) async {
     final credentials = _appStore.wallet.currentAccount.primaryAddress;
+    _validateEip7702Data(paymentInfo.eip7702, credentials.address.hexEip55, paymentInfo.amount);
+
     final delegationSignature = await Eip712Signer.signDelegation(
       credentials: credentials,
       eip7702Data: paymentInfo.eip7702,
@@ -109,6 +112,29 @@ class RealUnitSellPaymentInfoService {
 
     if (response.statusCode != 200 && response.statusCode != 201) {
       throw Exception('Failed to confirm payment: ${response.statusCode}');
+    }
+  }
+
+  void _validateEip7702Data(Eip7702Data data, String walletAddress, int userAmount) {
+    final expectedChainId = _appStore.apiConfig.asset.chainId;
+
+    if (data.delegatorAddress.toLowerCase() != walletAddress.toLowerCase()) {
+      throw Exception('EIP-7702 delegator address does not match wallet address');
+    }
+    if (data.message.delegator.toLowerCase() != walletAddress.toLowerCase()) {
+      throw Exception('EIP-7702 message delegator does not match wallet address');
+    }
+    if (data.domain.chainId != expectedChainId) {
+      throw Exception('EIP-7702 chain ID mismatch: expected $expectedChainId, got ${data.domain.chainId}');
+    }
+    if (data.tokenAddress.toLowerCase() != _appStore.apiConfig.asset.address.toLowerCase()) {
+      throw Exception('EIP-7702 token address does not match RealUnit token');
+    }
+
+    final expectedWei = BigInt.from(userAmount) * BigInt.from(10).pow(_appStore.apiConfig.asset.decimals);
+    final actualWei = BigInt.tryParse(data.amountWei);
+    if (actualWei == null || actualWei != expectedWei) {
+      throw Exception('EIP-7702 amount mismatch: expected $expectedWei, got ${data.amountWei}');
     }
   }
 }

--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -14,6 +14,9 @@ class SecureStorage {
   static const _mnemonicEncryptionKey = 'wallet.mnemonic.encryption.key';
   static const _pinHashKey = 'pin.hash';
   static const _pinSaltKey = 'pin.salt';
+  static const _biometricEnabledKey = 'biometric.enabled';
+  static const _pinFailedAttemptsKey = 'pin.failedAttempts';
+  static const _pinLockedUntilKey = 'pin.lockedUntil';
 
   final FlutterSecureStorage _secureStorage;
 
@@ -49,6 +52,8 @@ class SecureStorage {
 
   Future<void> setPinHash(String hash) => _secureStorage.write(key: _pinHashKey, value: hash);
 
+  Future<bool> hasPinHash() async => await _secureStorage.read(key: _pinHashKey) != null;
+
   Future<void> deletePinHash() => Future.wait([
     _secureStorage.delete(key: _pinHashKey),
     _secureStorage.delete(key: _pinSaltKey),
@@ -69,6 +74,40 @@ class SecureStorage {
     if (hash == null || salt == null) return false;
     return hashPin(pin, salt) == hash;
   }
+
+  // Pin lockout
+
+  Future<int> getPinFailedAttempts() async {
+    final value = await _secureStorage.read(key: _pinFailedAttemptsKey);
+    return int.tryParse(value ?? '') ?? 0;
+  }
+
+  Future<void> setPinFailedAttempts(int count) =>
+      _secureStorage.write(key: _pinFailedAttemptsKey, value: count.toString());
+
+  Future<DateTime?> getPinLockedUntil() async {
+    final value = await _secureStorage.read(key: _pinLockedUntilKey);
+    return value != null ? DateTime.tryParse(value) : null;
+  }
+
+  Future<void> setPinLockedUntil(DateTime? until) => until != null
+      ? _secureStorage.write(key: _pinLockedUntilKey, value: until.toIso8601String())
+      : _secureStorage.delete(key: _pinLockedUntilKey);
+
+  Future<void> resetPinLockout() => Future.wait([
+    _secureStorage.delete(key: _pinFailedAttemptsKey),
+    _secureStorage.delete(key: _pinLockedUntilKey),
+  ]);
+
+  // Biometric
+
+  Future<bool> getIsBiometricEnabled() async =>
+      await _secureStorage.read(key: _biometricEnabledKey) == 'true';
+
+  Future<void> setIsBiometricEnabled({required bool enabled}) =>
+      _secureStorage.write(key: _biometricEnabledKey, value: enabled.toString());
+
+  Future<void> deleteBiometricEnabled() => _secureStorage.delete(key: _biometricEnabledKey);
 
   // Mnemonic
 

--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -21,7 +21,9 @@ class SecureStorage {
 
   final FlutterSecureStorage _secureStorage;
 
-  const SecureStorage() : _secureStorage = const FlutterSecureStorage();
+  Uint8List? _cachedMnemonicKey;
+
+  SecureStorage() : _secureStorage = const FlutterSecureStorage();
 
   // Database
 
@@ -114,7 +116,38 @@ class SecureStorage {
 
   static const _biometricMnemonicKey = 'wallet.mnemonic.key.biometric';
 
+  /// Pre-authenticate via biometric and cache the mnemonic key.
+  /// Returns true if successful — subsequent getOrCreateMnemonicKey() will
+  /// use the cached key without showing another biometric prompt.
+  Future<bool> tryBiometricUnlock() async {
+    final biometricAvailable =
+        await BiometricStorage().canAuthenticate() == CanAuthenticateResponse.success;
+    if (!biometricAvailable) return false;
+
+    // Skip if migration is pending (legacy key exists) — migration needs its own prompt
+    final legacyKey = await _secureStorage.read(key: _mnemonicEncryptionKey);
+    if (legacyKey != null) return false;
+
+    try {
+      final storage = await _getBiometricStorage();
+      final existing = await storage.read();
+      if (existing != null) {
+        _cachedMnemonicKey = base64.decode(existing);
+        return true;
+      }
+    } on AuthException {
+      return false;
+    }
+    return false;
+  }
+
   Future<Uint8List> getOrCreateMnemonicKey() async {
+    final cached = _cachedMnemonicKey;
+    if (cached != null) {
+      _cachedMnemonicKey = null;
+      return cached;
+    }
+
     final biometricAvailable =
         await BiometricStorage().canAuthenticate() == CanAuthenticateResponse.success;
 

--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:biometric_storage/biometric_storage.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pointycastle/api.dart';
 import 'package:pointycastle/block/aes.dart';
@@ -109,9 +110,58 @@ class SecureStorage {
 
   Future<void> deleteBiometricEnabled() => _secureStorage.delete(key: _biometricEnabledKey);
 
-  // Mnemonic
+  // Mnemonic — biometric-gated via hardware keystore
+
+  static const _biometricMnemonicKey = 'wallet.mnemonic.key.biometric';
 
   Future<Uint8List> getOrCreateMnemonicKey() async {
+    final biometricAvailable =
+        await BiometricStorage().canAuthenticate() == CanAuthenticateResponse.success;
+
+    if (biometricAvailable) {
+      return _getOrCreateBiometricMnemonicKey();
+    }
+
+    return _getOrCreateLegacyMnemonicKey();
+  }
+
+  Future<Uint8List> _getOrCreateBiometricMnemonicKey() async {
+    final storage = await BiometricStorage().getStorage(
+      _biometricMnemonicKey,
+      options: StorageFileInitOptions(
+        authenticationRequired: true,
+        androidBiometricOnly: false,
+      ),
+      promptInfo: const PromptInfo(
+        androidPromptInfo: AndroidPromptInfo(
+          title: 'Wallet entsperren',
+          subtitle: 'Authentifizieren Sie sich, um auf Ihr Wallet zuzugreifen',
+          negativeButton: 'Abbrechen',
+        ),
+        iosPromptInfo: IosPromptInfo(
+          accessTitle: 'Wallet entsperren',
+        ),
+      ),
+    );
+
+    final existing = await storage.read();
+    if (existing != null) return base64.decode(existing);
+
+    // Migrate from FlutterSecureStorage if key exists there
+    final legacyKey = await _secureStorage.read(key: _mnemonicEncryptionKey);
+    if (legacyKey != null) {
+      await storage.write(legacyKey);
+      await _secureStorage.delete(key: _mnemonicEncryptionKey);
+      return base64.decode(legacyKey);
+    }
+
+    // Generate new key
+    final key = _secureRandomBytes(32);
+    await storage.write(base64.encode(key));
+    return key;
+  }
+
+  Future<Uint8List> _getOrCreateLegacyMnemonicKey() async {
     final existing = await _secureStorage.read(key: _mnemonicEncryptionKey);
     if (existing != null) return base64.decode(existing);
     final key = _secureRandomBytes(32);

--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -120,6 +120,9 @@ class SecureStorage {
   /// Returns true if successful — subsequent getOrCreateMnemonicKey() will
   /// use the cached key without showing another biometric prompt.
   Future<bool> tryBiometricUnlock() async {
+    final biometricEnabled = await getIsBiometricEnabled();
+    if (!biometricEnabled) return false;
+
     final biometricAvailable =
         await BiometricStorage().canAuthenticate() == CanAuthenticateResponse.success;
     if (!biometricAvailable) return false;

--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -125,37 +125,41 @@ class SecureStorage {
     return _getOrCreateLegacyMnemonicKey();
   }
 
+  Future<BiometricStorageFile> _getBiometricStorage() => BiometricStorage().getStorage(
+    _biometricMnemonicKey,
+    options: StorageFileInitOptions(
+      authenticationRequired: true,
+      androidBiometricOnly: false,
+    ),
+    promptInfo: const PromptInfo(
+      androidPromptInfo: AndroidPromptInfo(
+        title: 'Unlock Wallet',
+        subtitle: 'Authenticate to access your wallet',
+        negativeButton: 'Cancel',
+      ),
+      iosPromptInfo: IosPromptInfo(
+        accessTitle: 'Unlock to access your wallet',
+      ),
+    ),
+  );
+
   Future<Uint8List> _getOrCreateBiometricMnemonicKey() async {
-    final storage = await BiometricStorage().getStorage(
-      _biometricMnemonicKey,
-      options: StorageFileInitOptions(
-        authenticationRequired: true,
-        androidBiometricOnly: false,
-      ),
-      promptInfo: const PromptInfo(
-        androidPromptInfo: AndroidPromptInfo(
-          title: 'Wallet entsperren',
-          subtitle: 'Authentifizieren Sie sich, um auf Ihr Wallet zuzugreifen',
-          negativeButton: 'Abbrechen',
-        ),
-        iosPromptInfo: IosPromptInfo(
-          accessTitle: 'Wallet entsperren',
-        ),
-      ),
-    );
-
-    final existing = await storage.read();
-    if (existing != null) return base64.decode(existing);
-
-    // Migrate from FlutterSecureStorage if key exists there
+    // Check legacy storage first (no biometric prompt needed)
     final legacyKey = await _secureStorage.read(key: _mnemonicEncryptionKey);
     if (legacyKey != null) {
+      // Migrate: write to biometric storage (triggers prompt), then delete legacy
+      final storage = await _getBiometricStorage();
       await storage.write(legacyKey);
       await _secureStorage.delete(key: _mnemonicEncryptionKey);
       return base64.decode(legacyKey);
     }
 
-    // Generate new key
+    // Read from biometric storage (triggers prompt if value exists)
+    final storage = await _getBiometricStorage();
+    final existing = await storage.read();
+    if (existing != null) return base64.decode(existing);
+
+    // Generate new key and store with biometric protection
     final key = _secureRandomBytes(32);
     await storage.write(base64.encode(key));
     return key;

--- a/lib/screens/home/bloc/home_bloc.dart
+++ b/lib/screens/home/bloc/home_bloc.dart
@@ -24,6 +24,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     this._appStore,
     this._bitboxService,
   ) : super(const HomeState()) {
+    on<CheckWalletExistsEvent>(_onCheckWalletExists);
     on<LoadCurrentWalletEvent>(_onLoadCurrentWallet);
     on<LoadWalletEvent>(_onLoadWallet);
     on<SyncWalletServicesEvent>(_onSyncWalletServices);
@@ -32,7 +33,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     on<AcceptSoftwareTermsEvent>(_onAcceptSoftwareTerms);
     on<DebugAuthCompleteEvent>(_onDebugAuthComplete);
 
-    add(const LoadCurrentWalletEvent());
+    add(const CheckWalletExistsEvent());
   }
 
   final WalletService _walletService;
@@ -43,18 +44,22 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   final AppStore _appStore;
   final BitboxService _bitboxService;
 
-  Future<void> _onLoadCurrentWallet(LoadCurrentWalletEvent event, Emitter<HomeState> emit) async {
+  void _onCheckWalletExists(CheckWalletExistsEvent event, Emitter<HomeState> emit) {
+    final hasWallet = _walletService.hasWallet();
     emit(
       state.copyWith(
-        isLoadingWallet: true,
+        hasWallet: hasWallet,
         softwareTermsAccepted: _settingsService.isSoftwareTermsAccepted,
+        onboardingCompleted: hasWallet ? _settingsService.isTermsAccepted : false,
       ),
     );
+  }
 
-    if (state.openWallet != null || !_walletService.hasWallet()) {
-      emit(state.copyWith(isLoadingWallet: false));
-      return;
-    }
+  Future<void> _onLoadCurrentWallet(LoadCurrentWalletEvent event, Emitter<HomeState> emit) async {
+    if (state.openWallet != null || !_walletService.hasWallet()) return;
+
+    emit(state.copyWith(isLoadingWallet: true));
+
     try {
       final wallet = await _walletService.getCurrentWallet();
       _appStore.wallet = wallet;
@@ -63,7 +68,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
         state.copyWith(
           openWallet: wallet,
           isLoadingWallet: false,
-          onboardingCompleted: _settingsService.isTermsAccepted,
         ),
       );
 
@@ -71,7 +75,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     } catch (e) {
       developer.log('Something went wrong during wallet loading', error: e);
       emit(state.copyWith(isLoadingWallet: false));
-
       return;
     }
 
@@ -104,7 +107,13 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
 
   Future<void> _onLoadWallet(LoadWalletEvent event, Emitter<HomeState> emit) async {
     _updateWallet(event.wallet);
-    emit(state.copyWith(openWallet: _appStore.wallet, isLoadingWallet: false));
+    emit(
+      state.copyWith(
+        hasWallet: true,
+        openWallet: _appStore.wallet,
+        isLoadingWallet: false,
+      ),
+    );
     await _setupFiatService(emit);
   }
 
@@ -126,7 +135,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   Future<void> _onDebugAuthComplete(DebugAuthCompleteEvent event, Emitter<HomeState> emit) async {
     final wallet = await _walletService.createDebugWallet(event.address);
     _appStore.wallet = wallet;
-    emit(state.copyWith(openWallet: wallet));
+    emit(state.copyWith(hasWallet: true, openWallet: wallet));
     await _setupFiatService(emit);
   }
 

--- a/lib/screens/home/bloc/home_event.dart
+++ b/lib/screens/home/bloc/home_event.dart
@@ -7,6 +7,10 @@ sealed class HomeEvent extends Equatable {
   List<Object> get props => [];
 }
 
+final class CheckWalletExistsEvent extends HomeEvent {
+  const CheckWalletExistsEvent();
+}
+
 final class LoadCurrentWalletEvent extends HomeEvent {
   const LoadCurrentWalletEvent();
 }

--- a/lib/screens/home/bloc/home_state.dart
+++ b/lib/screens/home/bloc/home_state.dart
@@ -2,6 +2,7 @@ part of 'home_bloc.dart';
 
 final class HomeState {
   const HomeState({
+    this.hasWallet = false,
     this.openWallet,
     this.isLoadingWallet = false,
     this.isFiatServiceAvailable = false,
@@ -9,6 +10,7 @@ final class HomeState {
     this.softwareTermsAccepted = false,
   });
 
+  final bool hasWallet;
   final AWallet? openWallet;
   final bool isLoadingWallet;
   final bool isFiatServiceAvailable;
@@ -16,12 +18,14 @@ final class HomeState {
   final bool softwareTermsAccepted;
 
   HomeState copyWith({
+    bool? hasWallet,
     AWallet? openWallet,
     bool? isLoadingWallet,
     bool? isFiatServiceAvailable,
     bool? onboardingCompleted,
     bool? softwareTermsAccepted,
   }) => HomeState(
+    hasWallet: hasWallet ?? this.hasWallet,
     openWallet: openWallet ?? this.openWallet,
     isLoadingWallet: isLoadingWallet ?? this.isLoadingWallet,
     isFiatServiceAvailable: isFiatServiceAvailable ?? this.isFiatServiceAvailable,

--- a/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
+++ b/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
@@ -1,6 +1,5 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/constants/pin_constants.dart';
 
@@ -9,18 +8,15 @@ part 'pin_auth_state.dart';
 class PinAuthCubit extends Cubit<PinAuthState> {
   PinAuthCubit(
     SecureStorage secureStorage,
-    SettingsRepository settingsRepository,
   ) : _secureStorage = secureStorage,
-      _settingsRepository = settingsRepository,
       super(const PinAuthState());
 
   final SecureStorage _secureStorage;
-  final SettingsRepository _settingsRepository;
 
   DateTime? _lastBackgroundTime;
 
-  void initialize() {
-    final isPinSetup = _settingsRepository.isPinEnabled;
+  Future<void> initialize() async {
+    final isPinSetup = await _secureStorage.hasPinHash();
     emit(
       state.copyWith(
         isPinSetup: isPinSetup,
@@ -50,11 +46,12 @@ class PinAuthCubit extends Cubit<PinAuthState> {
     _lastBackgroundTime = null;
   }
 
-  void reset() {
-    _settingsRepository.isPinEnabled = false;
-    _settingsRepository.isBiometricEnabled = false;
-    _settingsRepository.resetPinLockout();
-    _secureStorage.deletePinHash();
+  Future<void> reset() async {
+    await Future.wait([
+      _secureStorage.deletePinHash(),
+      _secureStorage.deleteBiometricEnabled(),
+      _secureStorage.resetPinLockout(),
+    ]);
     emit(const PinAuthState());
   }
 }

--- a/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
+++ b/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
@@ -31,6 +31,8 @@ class PinAuthCubit extends Cubit<PinAuthState> {
 
   void onPinVerified() => emit(state.copyWith(isPinVerified: true));
 
+  void onWalletLoadFailed() => emit(state.copyWith(isPinVerified: false));
+
   void onAppHidden() => _lastBackgroundTime ??= DateTime.now();
 
   void onAppResumed() {

--- a/lib/screens/pin/bloc/setup_pin/setup_pin_cubit.dart
+++ b/lib/screens/pin/bloc/setup_pin/setup_pin_cubit.dart
@@ -1,6 +1,5 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/constants/pin_constants.dart';
@@ -10,15 +9,12 @@ part 'setup_pin_state.dart';
 class SetupPinCubit extends Cubit<SetupPinState> {
   SetupPinCubit(
     SecureStorage secureStorage,
-    SettingsRepository settingsRepository,
     BiometricService biometricService,
   ) : _secureStorage = secureStorage,
-      _settingsRepository = settingsRepository,
       _biometricService = biometricService,
       super(const SetupPinState());
 
   final SecureStorage _secureStorage;
-  final SettingsRepository _settingsRepository;
   final BiometricService _biometricService;
 
   String? _createPin;
@@ -69,7 +65,6 @@ class SetupPinCubit extends Cubit<SetupPinState> {
         _secureStorage.setPinSalt(salt),
         _secureStorage.setPinHash(hash),
       ]);
-      _settingsRepository.isPinEnabled = true;
       emit(state.copyWith(isComplete: true));
     } else {
       emit(

--- a/lib/screens/pin/bloc/verify_pin/verify_pin_cubit.dart
+++ b/lib/screens/pin/bloc/verify_pin/verify_pin_cubit.dart
@@ -1,6 +1,5 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/constants/pin_constants.dart';
 
@@ -8,15 +7,12 @@ part 'verify_pin_state.dart';
 
 class VerifyPinCubit extends Cubit<VerifyPinState> {
   VerifyPinCubit(
-    SecureStorage secureStorage,
-    BiometricService biometricService, {
+    SecureStorage secureStorage, {
     this.enableLockout = false,
   }) : _secureStorage = secureStorage,
-       _biometricService = biometricService,
        super(const VerifyPinState());
 
   final SecureStorage _secureStorage;
-  final BiometricService _biometricService;
   final bool enableLockout;
 
   void addDigit(int digit) {
@@ -71,12 +67,11 @@ class VerifyPinCubit extends Cubit<VerifyPinState> {
       }
     }
 
-    final canUse = await _biometricService.canUse();
-    if (canUse) {
-      final success = await _biometricService.authenticate();
-      if (success) {
-        emit(const VerifyPinSuccess());
-      }
+    // Try biometric unlock via hardware keystore (single prompt, no local_auth)
+    final biometricSuccess = await _secureStorage.tryBiometricUnlock();
+    if (biometricSuccess) {
+      if (enableLockout) await _secureStorage.resetPinLockout();
+      emit(const VerifyPinSuccess());
     }
   }
 

--- a/lib/screens/pin/bloc/verify_pin/verify_pin_cubit.dart
+++ b/lib/screens/pin/bloc/verify_pin/verify_pin_cubit.dart
@@ -1,6 +1,5 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/constants/pin_constants.dart';
@@ -10,16 +9,13 @@ part 'verify_pin_state.dart';
 class VerifyPinCubit extends Cubit<VerifyPinState> {
   VerifyPinCubit(
     SecureStorage secureStorage,
-    SettingsRepository settingsRepository,
     BiometricService biometricService, {
     this.enableLockout = false,
   }) : _secureStorage = secureStorage,
-       _settingsRepository = settingsRepository,
        _biometricService = biometricService,
        super(const VerifyPinState());
 
   final SecureStorage _secureStorage;
-  final SettingsRepository _settingsRepository;
   final BiometricService _biometricService;
   final bool enableLockout;
 
@@ -39,16 +35,16 @@ class VerifyPinCubit extends Cubit<VerifyPinState> {
   Future<void> checkPin() async {
     final isCorrect = await _secureStorage.verifyPin(state.pin);
     if (isCorrect) {
-      if (enableLockout) _settingsRepository.resetPinLockout();
+      if (enableLockout) await _secureStorage.resetPinLockout();
       emit(const VerifyPinSuccess());
     } else {
       if (!enableLockout) {
         emit(const VerifyPinFailure(failedAttempts: 0));
         return;
       }
-      final attempts = _settingsRepository.pinFailedAttempts + 1;
-      _settingsRepository.pinFailedAttempts = attempts;
-      _emitLockState(attempts);
+      final attempts = await _secureStorage.getPinFailedAttempts() + 1;
+      await _secureStorage.setPinFailedAttempts(attempts);
+      await _emitLockState(attempts);
     }
   }
 
@@ -58,17 +54,17 @@ class VerifyPinCubit extends Cubit<VerifyPinState> {
 
   Future<void> checkBiometricAvailability() async {
     if (enableLockout) {
-      final lockedUntil = _settingsRepository.pinLockedUntil;
+      final lockedUntil = await _secureStorage.getPinLockedUntil();
       if (lockedUntil != null) {
         if (DateTime.now().isBefore(lockedUntil)) {
-          final attempts = _settingsRepository.pinFailedAttempts;
+          final attempts = await _secureStorage.getPinFailedAttempts();
           emit(VerifyPinTemporarilyLocked(failedAttempts: attempts, lockedUntil: lockedUntil));
           return;
         }
-        _settingsRepository.pinLockedUntil = null;
+        await _secureStorage.setPinLockedUntil(null);
       }
 
-      final attempts = _settingsRepository.pinFailedAttempts;
+      final attempts = await _secureStorage.getPinFailedAttempts();
       if (attempts >= permanentLockoutThreshold) {
         emit(VerifyPinLocked(failedAttempts: attempts));
         return;
@@ -84,13 +80,13 @@ class VerifyPinCubit extends Cubit<VerifyPinState> {
     }
   }
 
-  void _emitLockState(int attempts) {
+  Future<void> _emitLockState(int attempts) async {
     final duration = _lockoutDuration(attempts);
     if (duration == null) {
       emit(VerifyPinLocked(failedAttempts: attempts));
     } else if (duration > Duration.zero) {
       final lockedUntil = DateTime.now().add(duration);
-      _settingsRepository.pinLockedUntil = lockedUntil;
+      await _secureStorage.setPinLockedUntil(lockedUntil);
       emit(VerifyPinTemporarilyLocked(failedAttempts: attempts, lockedUntil: lockedUntil));
     } else {
       emit(VerifyPinFailure(failedAttempts: attempts));

--- a/lib/screens/pin/bloc/verify_pin/verify_pin_cubit.dart
+++ b/lib/screens/pin/bloc/verify_pin/verify_pin_cubit.dart
@@ -8,7 +8,7 @@ part 'verify_pin_state.dart';
 class VerifyPinCubit extends Cubit<VerifyPinState> {
   VerifyPinCubit(
     SecureStorage secureStorage, {
-    this.enableLockout = false,
+    this.enableLockout = true,
   }) : _secureStorage = secureStorage,
        super(const VerifyPinState());
 

--- a/lib/screens/pin/setup_pin_page.dart
+++ b/lib/screens/pin/setup_pin_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
@@ -21,7 +20,6 @@ class SetupPinPage extends StatelessWidget {
     return BlocProvider(
       create: (_) => SetupPinCubit(
         getIt<SecureStorage>(),
-        getIt<SettingsRepository>(),
         getIt<BiometricService>(),
       ),
       child: const SetupPinView(),

--- a/lib/screens/pin/verify_pin_page.dart
+++ b/lib/screens/pin/verify_pin_page.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
-import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';

--- a/lib/screens/pin/verify_pin_page.dart
+++ b/lib/screens/pin/verify_pin_page.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';

--- a/lib/screens/pin/verify_pin_page.dart
+++ b/lib/screens/pin/verify_pin_page.dart
@@ -49,7 +49,6 @@ class VerifyPinPage extends StatelessWidget {
   Widget build(BuildContext context) => BlocProvider(
     create: (_) => VerifyPinCubit(
       getIt<SecureStorage>(),
-      getIt<BiometricService>(),
       enableLockout: enableLockout,
     ),
     child: VerifyPinView(

--- a/lib/screens/pin/verify_pin_page.dart
+++ b/lib/screens/pin/verify_pin_page.dart
@@ -35,7 +35,7 @@ class VerifyPinPage extends StatelessWidget {
     this.description,
     required this.onAuthenticated,
     this.bottom,
-    this.enableLockout = false,
+    this.enableLockout = true,
   });
 
   /// Used for initial app lock check on app start

--- a/lib/screens/pin/verify_pin_page.dart
+++ b/lib/screens/pin/verify_pin_page.dart
@@ -50,7 +50,6 @@ class VerifyPinPage extends StatelessWidget {
   Widget build(BuildContext context) => BlocProvider(
     create: (_) => VerifyPinCubit(
       getIt<SecureStorage>(),
-      getIt<SettingsRepository>(),
       getIt<BiometricService>(),
       enableLockout: enableLockout,
     ),
@@ -247,8 +246,10 @@ class _ForgotPinButton extends StatelessWidget {
           if (isReset == true) {
             await Future.delayed(const Duration(milliseconds: 300));
             if (context.mounted) {
-              context.read<PinAuthCubit>().reset();
-              context.read<HomeBloc>().add(const DeleteCurrentWalletEvent());
+              await context.read<PinAuthCubit>().reset();
+              if (context.mounted) {
+                context.read<HomeBloc>().add(const DeleteCurrentWalletEvent());
+              }
             }
           }
         },

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -130,8 +130,10 @@ class SettingsPage extends StatelessWidget {
                   if (isLogout ?? false) {
                     await Future.delayed(const Duration(milliseconds: 300));
                     if (context.mounted) {
-                      context.read<PinAuthCubit>().reset();
-                      context.read<HomeBloc>().add(const DeleteCurrentWalletEvent());
+                      await context.read<PinAuthCubit>().reset();
+                      if (context.mounted) {
+                        context.read<HomeBloc>().add(const DeleteCurrentWalletEvent());
+                      }
                     }
                   }
                 },

--- a/lib/setup/di.dart
+++ b/lib/setup/di.dart
@@ -48,7 +48,7 @@ Future<String> setupEssentials() async {
 
   getIt.registerFactory(() => SettingsRepository(getIt<SharedPreferences>()));
 
-  final secureStorage = const SecureStorage();
+  final secureStorage = SecureStorage();
   getIt.registerSingleton(secureStorage);
 
   await _migrateSecurityFlags(sharedPreferences, secureStorage);

--- a/lib/setup/di.dart
+++ b/lib/setup/di.dart
@@ -51,6 +51,8 @@ Future<String> setupEssentials() async {
   final secureStorage = const SecureStorage();
   getIt.registerSingleton(secureStorage);
 
+  await _migrateSecurityFlags(sharedPreferences, secureStorage);
+
   final encryptionKey = await secureStorage.getEncryptionKey();
 
   if (encryptionKey == null) {
@@ -79,7 +81,7 @@ Future<void> finishSetup(String encryptionKey) async {
   );
 
   setupServices();
-  setupBlocs();
+  await setupBlocs();
 
   await setupDefaultAssets();
 }
@@ -111,7 +113,7 @@ void setupServices() {
   );
   getIt.registerFactory(
     () => BiometricService(
-      getIt<SettingsRepository>(),
+      getIt<SecureStorage>(),
     ),
   );
   getIt.registerSingleton(BitboxService());
@@ -153,7 +155,7 @@ void setupServices() {
   );
 }
 
-void setupBlocs() {
+Future<void> setupBlocs() async {
   getIt.registerSingleton(
     SettingsBloc(
       getIt<SettingsRepository>(),
@@ -171,9 +173,29 @@ void setupBlocs() {
       getIt<BitboxService>(),
     ),
   );
-  getIt.registerSingleton(
-    PinAuthCubit(getIt<SecureStorage>(), getIt<SettingsRepository>())..initialize(),
-  );
+
+  final pinAuthCubit = PinAuthCubit(getIt<SecureStorage>());
+  await pinAuthCubit.initialize();
+  getIt.registerSingleton(pinAuthCubit);
 }
 
 Future<bool> _existsDatabaseFile() async => File(await AppDatabase.getDatabasePath()).exists();
+
+Future<void> _migrateSecurityFlags(
+  SharedPreferences prefs,
+  SecureStorage secureStorage,
+) async {
+  // Migrate isBiometricEnabled from SharedPreferences to SecureStorage
+  final biometricEnabled = prefs.getBool('isBiometricEnabled');
+  if (biometricEnabled != null) {
+    await secureStorage.setIsBiometricEnabled(enabled: biometricEnabled);
+    await prefs.remove('isBiometricEnabled');
+  }
+
+  // Clean up legacy SharedPreferences keys that are now in SecureStorage
+  await Future.wait([
+    prefs.remove('isPinEnabled'),
+    prefs.remove('pinFailedAttempts'),
+    prefs.remove('pinLockedUntil'),
+  ]);
+}

--- a/lib/widgets/seed_blur_card.dart
+++ b/lib/widgets/seed_blur_card.dart
@@ -20,45 +20,47 @@ class SeedBlurCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) => GestureDetector(
         onTap: onTap,
-        child: Stack(
-          children: [
-            MnemonicReadOnlyField(
-              seedWords: seed.seedWords,
-            ),
-            if (blur)
-              Positioned.fill(
-                child: Padding(
-                  padding: const EdgeInsets.all(1.5),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(16),
-                    child: BackdropFilter(
-                      filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-                      child: Container(
-                        color: RealUnitColors.basic.white.withValues(alpha: 0.15),
-                        alignment: Alignment.center,
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const Icon(
-                              Icons.visibility_outlined,
-                              size: 16,
-                              color: RealUnitColors.realUnitBlack,
-                            ),
-                            Text(
-                              S.of(context).tapHereToView,
-                              style: const TextStyle(
-                                fontSize: 14,
-                                height: 18 / 14,
+        child: ExcludeSemantics(
+          child: Stack(
+            children: [
+              MnemonicReadOnlyField(
+                seedWords: seed.seedWords,
+              ),
+              if (blur)
+                Positioned.fill(
+                  child: Padding(
+                    padding: const EdgeInsets.all(1.5),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(16),
+                      child: BackdropFilter(
+                        filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                        child: Container(
+                          color: RealUnitColors.basic.white.withValues(alpha: 0.15),
+                          alignment: Alignment.center,
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Icon(
+                                Icons.visibility_outlined,
+                                size: 16,
+                                color: RealUnitColors.realUnitBlack,
                               ),
-                            ),
-                          ],
+                              Text(
+                                S.of(context).tapHereToView,
+                                style: const TextStyle(
+                                  fontSize: 14,
+                                  height: 18 / 14,
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ),
                   ),
                 ),
-              ),
-          ],
+            ],
+          ),
         ),
       );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  biometric_storage:
+    dependency: "direct main"
+    description:
+      name: biometric_storage
+      sha256: "2cc569f2dbab39950812a6ae7fefa28c7d1c1eb07d2035c88f5e27da09022f5f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.1"
   bip32:
     dependency: "direct main"
     description:
@@ -166,10 +174,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -915,18 +923,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1408,26 +1416,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
     sdk: flutter
 
   async: ^2.13.0
+  biometric_storage: ^5.0.1
   bip32: ^2.0.0
   bip39: ^1.0.6
   collection: ^1.19.0

--- a/test/screens/pin/setup_pin_page_test.dart
+++ b/test/screens/pin/setup_pin_page_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
@@ -24,8 +23,6 @@ class MockBiometricService extends Mock implements BiometricService {}
 
 class MockSecureStorage extends Mock implements SecureStorage {}
 
-class MockSettingsRepository extends Mock implements SettingsRepository {}
-
 void main() {
   late SetupPinCubit setupPinCubit;
   late PinAuthCubit pinAuthCubit;
@@ -41,7 +38,6 @@ void main() {
     final getIt = GetIt.instance;
     getIt.registerSingleton<BiometricService>(MockBiometricService());
     getIt.registerSingleton<SecureStorage>(MockSecureStorage());
-    getIt.registerSingleton<SettingsRepository>(MockSettingsRepository());
     getIt.registerSingleton<PinAuthCubit>(pinAuthCubit);
   }
 

--- a/test/screens/pin/verify_pin_page_test.dart
+++ b/test/screens/pin/verify_pin_page_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
-import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
 import 'package:realunit_wallet/screens/pin/bloc/verify_pin/verify_pin_cubit.dart';
@@ -20,8 +19,6 @@ import '../../helper/pump_app.dart';
 class MockVerifyPinCubit extends MockCubit<VerifyPinState> implements VerifyPinCubit {}
 
 class MockPinAuthCubit extends MockCubit<PinAuthState> implements PinAuthCubit {}
-
-class MockBiometricService extends Mock implements BiometricService {}
 
 class MockSecureStorage extends Mock implements SecureStorage {}
 
@@ -39,12 +36,10 @@ void main() {
 
   void setupDependencyInjection() {
     final getIt = GetIt.instance;
-    final biometricService = MockBiometricService();
-    when(() => biometricService.canUse()).thenAnswer((_) => Future.value(false));
-    getIt.registerSingleton<BiometricService>(biometricService);
     final secureStorage = MockSecureStorage();
     when(() => secureStorage.getPinLockedUntil()).thenAnswer((_) => Future.value(null));
     when(() => secureStorage.getPinFailedAttempts()).thenAnswer((_) => Future.value(0));
+    when(() => secureStorage.tryBiometricUnlock()).thenAnswer((_) => Future.value(false));
     getIt.registerSingleton<SecureStorage>(secureStorage);
     getIt.registerSingleton<PinAuthCubit>(pinAuthCubit);
   }

--- a/test/screens/pin/verify_pin_page_test.dart
+++ b/test/screens/pin/verify_pin_page_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
@@ -23,8 +22,6 @@ class MockVerifyPinCubit extends MockCubit<VerifyPinState> implements VerifyPinC
 class MockPinAuthCubit extends MockCubit<PinAuthState> implements PinAuthCubit {}
 
 class MockBiometricService extends Mock implements BiometricService {}
-
-class MockSettingsRepository extends Mock implements SettingsRepository {}
 
 class MockSecureStorage extends Mock implements SecureStorage {}
 
@@ -45,11 +42,11 @@ void main() {
     final biometricService = MockBiometricService();
     when(() => biometricService.canUse()).thenAnswer((_) => Future.value(false));
     getIt.registerSingleton<BiometricService>(biometricService);
-    getIt.registerSingleton<SecureStorage>(MockSecureStorage());
+    final secureStorage = MockSecureStorage();
+    when(() => secureStorage.getPinLockedUntil()).thenAnswer((_) => Future.value(null));
+    when(() => secureStorage.getPinFailedAttempts()).thenAnswer((_) => Future.value(0));
+    getIt.registerSingleton<SecureStorage>(secureStorage);
     getIt.registerSingleton<PinAuthCubit>(pinAuthCubit);
-    final settingsRepository = MockSettingsRepository();
-    when(() => settingsRepository.pinFailedAttempts).thenReturn(1);
-    getIt.registerSingleton<SettingsRepository>(settingsRepository);
   }
 
   setUpAll(() {


### PR DESCRIPTION
## Summary

Fixes the complete attack chain documented in `docs/attack-chain-new1-new4.md` — physical access to a rooted Android device leading to mnemonic exfiltration and total wallet loss.

### Pfad A (App-Lock-Reset) — blocked
- **NEW-1:** `isPinEnabled`, `isBiometricEnabled`, `pinFailedAttempts`, `pinLockedUntil` moved from SharedPreferences (plaintext XML) to FlutterSecureStorage (RSA-encrypted via AndroidKeyStore). `isPinEnabled` derived from PIN hash existence — no separate flag to manipulate.
- **NEW-3:** Step-up PIN verification (seed reveal) now has `enableLockout: true` — prevents unlimited brute-force after app-lock bypass.

### Pfad B (forensic DB extraction) — blocked
- **NEW-4:** Mnemonic encryption key stored via `biometric_storage` using Android Keystore with `setUserAuthenticationRequired(true)`. Key only accessible after successful BiometricPrompt or device credential verification. Attacker with root+Frida cannot read the key without the user's biometric/device PIN.
- Automatic migration from FlutterSecureStorage for existing users.
- Fallback to FlutterSecureStorage on devices without biometric hardware.

### Wallet decryption deferred until after PIN auth
- `HomeBloc` no longer auto-decrypts wallet on construction.
- New `CheckWalletExistsEvent` checks wallet existence without decryption.
- `LoadCurrentWalletEvent` only triggered after successful PIN/biometric auth.
- Mnemonic never enters process memory before user authentication.

### Accessibility protection (uiautomator dump)
- `SeedBlurCard` wrapped with `ExcludeSemantics` — seed words no longer appear in Android accessibility tree.
- Blocks the live-verified `adb shell uiautomator dump` exfiltration path from Anhang A0/B-1/B-2.

## Attack chain verification

After these fixes, reproducing the attack from Anhang B should fail at:
- **Pfad A Step 3:** `sed` on SharedPreferences has no effect — `isPinEnabled` derived from SecureStorage
- **Pfad A Step 7:** Even if PIN is guessed, `getOrCreateMnemonicKey()` triggers BiometricPrompt — attacker lacks biometric/device credential
- **Pfad B Step 4:** Mnemonic key not in FlutterSecureStorage — stored in hardware keystore, requires biometric auth to use

## Test plan
- [ ] Verify PIN setup/verify flow works correctly on device with biometrics
- [ ] Verify BiometricPrompt appears when loading wallet after PIN entry
- [ ] Verify fallback works on emulator without biometric hardware
- [ ] Verify migration: existing users with PIN + mnemonic key don't get locked out
- [ ] Verify lockout state persists across app restart (stored in SecureStorage)
- [ ] Verify step-up PIN (seed reveal) enforces lockout after failed attempts
- [ ] Verify `adb shell uiautomator dump` no longer shows seed words
- [ ] Reproduce Pfad A from attack-chain doc and verify it's blocked
- [ ] Reproduce Pfad B from attack-chain doc and verify it's blocked