### PR TITLE
Validate EIP-7702 data before signing (NEW-16 mitigation)

### DIFF
--- a/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
@@ -118,6 +118,7 @@ class RealUnitSellPaymentInfoService {
   void _validateEip7702Data(Eip7702Data data, String walletAddress, int userAmount) {
     final expectedChainId = _appStore.apiConfig.asset.chainId;
 
+    // Validate signed fields against known values
     if (data.delegatorAddress.toLowerCase() != walletAddress.toLowerCase()) {
       throw Exception('EIP-7702 delegator address does not match wallet address');
     }
@@ -127,10 +128,19 @@ class RealUnitSellPaymentInfoService {
     if (data.domain.chainId != expectedChainId) {
       throw Exception('EIP-7702 chain ID mismatch: expected $expectedChainId, got ${data.domain.chainId}');
     }
+
+    // Cross-check signed fields against response metadata
+    if (data.message.delegate.toLowerCase() != data.relayerAddress.toLowerCase()) {
+      throw Exception('EIP-7702 signed delegate does not match relayer address');
+    }
+    if (data.domain.verifyingContract.toLowerCase() != data.delegationManagerAddress.toLowerCase()) {
+      throw Exception('EIP-7702 verifying contract does not match delegation manager');
+    }
+
+    // Validate unsigned metadata for consistency
     if (data.tokenAddress.toLowerCase() != _appStore.apiConfig.asset.address.toLowerCase()) {
       throw Exception('EIP-7702 token address does not match RealUnit token');
     }
-
     final expectedWei = BigInt.from(userAmount) * BigInt.from(10).pow(_appStore.apiConfig.asset.decimals);
     final actualWei = BigInt.tryParse(data.amountWei);
     if (actualWei == null || actualWei != expectedWei) {

--- a/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
@@ -115,13 +115,25 @@ class RealUnitSellPaymentInfoService {
     }
   }
 
+  // MetaMask Delegation Framework v1.3.0, CREATE2 — identical on all EVM chains
+  static const _metaMaskDelegatorAddress = '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b';
+  static const _delegationManagerAddress = '0xdb9b1e94b5b69df7e401ddbede43491141047db3';
+
   void _validateEip7702Data(Eip7702Data data, String walletAddress, int userAmount) {
     final expectedChainId = _appStore.apiConfig.asset.chainId;
 
-    // Validate signed fields against known values
-    if (data.delegatorAddress.toLowerCase() != walletAddress.toLowerCase()) {
-      throw Exception('EIP-7702 delegator address does not match wallet address');
+    // Pin signed contract addresses against known constants
+    if (data.delegatorAddress.toLowerCase() != _metaMaskDelegatorAddress) {
+      throw Exception('EIP-7702 delegator address does not match expected MetaMask Delegator contract');
     }
+    if (data.delegationManagerAddress.toLowerCase() != _delegationManagerAddress) {
+      throw Exception('EIP-7702 delegation manager address does not match expected contract');
+    }
+    if (data.domain.verifyingContract.toLowerCase() != _delegationManagerAddress) {
+      throw Exception('EIP-7702 verifying contract does not match expected DelegationManager');
+    }
+
+    // Validate signed fields against known values
     if (data.message.delegator.toLowerCase() != walletAddress.toLowerCase()) {
       throw Exception('EIP-7702 message delegator does not match wallet address');
     }
@@ -129,12 +141,9 @@ class RealUnitSellPaymentInfoService {
       throw Exception('EIP-7702 chain ID mismatch: expected $expectedChainId, got ${data.domain.chainId}');
     }
 
-    // Cross-check signed fields against response metadata
+    // Cross-check signed delegate against response metadata
     if (data.message.delegate.toLowerCase() != data.relayerAddress.toLowerCase()) {
-      throw Exception('EIP-7702 signed delegate does not match relayer address');
-    }
-    if (data.domain.verifyingContract.toLowerCase() != data.delegationManagerAddress.toLowerCase()) {
-      throw Exception('EIP-7702 verifying contract does not match delegation manager');
+      throw Exception('EIP-7702 message delegate does not match relayer address');
     }
 
     // Validate unsigned metadata for consistency

--- a/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
@@ -4,6 +4,7 @@ import 'package:realunit_wallet/packages/config/api_config.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/eip7702/eip7702_confirm_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/eip7702/eip7702_data_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_confirm_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_payment_info_dto.dart';
@@ -68,6 +69,8 @@ class RealUnitSellPaymentInfoService {
 
   Future<void> confirmPayment(SellPaymentInfo paymentInfo) async {
     final credentials = _appStore.wallet.currentAccount.primaryAddress;
+    _validateEip7702Data(paymentInfo.eip7702, credentials.address.hexEip55, paymentInfo.amount);
+
     final delegationSignature = await Eip712Signer.signDelegation(
       credentials: credentials,
       eip7702Data: paymentInfo.eip7702,
@@ -109,6 +112,29 @@ class RealUnitSellPaymentInfoService {
 
     if (response.statusCode != 200 && response.statusCode != 201) {
       throw Exception('Failed to confirm payment: ${response.statusCode}');
+    }
+  }
+
+  void _validateEip7702Data(Eip7702Data data, String walletAddress, int userAmount) {
+    final expectedChainId = _appStore.apiConfig.asset.chainId;
+
+    if (data.delegatorAddress.toLowerCase() != walletAddress.toLowerCase()) {
+      throw Exception('EIP-7702 delegator address does not match wallet address');
+    }
+    if (data.message.delegator.toLowerCase() != walletAddress.toLowerCase()) {
+      throw Exception('EIP-7702 message delegator does not match wallet address');
+    }
+    if (data.domain.chainId != expectedChainId) {
+      throw Exception('EIP-7702 chain ID mismatch: expected $expectedChainId, got ${data.domain.chainId}');
+    }
+    if (data.tokenAddress.toLowerCase() != _appStore.apiConfig.asset.address.toLowerCase()) {
+      throw Exception('EIP-7702 token address does not match RealUnit token');
+    }
+
+    final expectedWei = BigInt.from(userAmount) * BigInt.from(10).pow(_appStore.apiConfig.asset.decimals);
+    final actualWei = BigInt.tryParse(data.amountWei);
+    if (actualWei == null || actualWei != expectedWei) {
+      throw Exception('EIP-7702 amount mismatch: expected $expectedWei, got ${data.amountWei}');
     }
   }
 }

--- a/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
@@ -17,6 +17,10 @@ class RealUnitSellPaymentInfoService {
   static const _sellPaymentInfoPath = '/v1/realunit/sell';
   static String _confirmPaymentPath(int id) => '/v1/realunit/sell/$id/confirm';
 
+  // MetaMask Delegation Framework v1.3.0, CREATE2 — identical on all EVM chains
+  static const _metaMaskDelegatorAddress = '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b';
+  static const _delegationManagerAddress = '0xdb9b1e94b5b69df7e401ddbede43491141047db3';
+
   String get _host => _appStore.apiConfig.apiHost;
 
   final AppStore _appStore;
@@ -114,10 +118,6 @@ class RealUnitSellPaymentInfoService {
       throw Exception('Failed to confirm payment: ${response.statusCode}');
     }
   }
-
-  // MetaMask Delegation Framework v1.3.0, CREATE2 — identical on all EVM chains
-  static const _metaMaskDelegatorAddress = '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b';
-  static const _delegationManagerAddress = '0xdb9b1e94b5b69df7e401ddbede43491141047db3';
 
   void _validateEip7702Data(Eip7702Data data, String walletAddress, int userAmount) {
     final expectedChainId = _appStore.apiConfig.asset.chainId;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -166,10 +166,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -915,18 +915,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1408,26 +1408,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Validates backend-provided EIP-7702 data against user input before signing authorization and delegation in the sell flow.

## Checks

- `delegatorAddress` must match wallet address
- `message.delegator` must match wallet address  
- `chainId` must match current network mode (mainnet/testnet)
- `tokenAddress` must match RealUnit token contract
- `amountWei` must match user-entered sell amount

## Context

NEW-16 from the security review identifies that the app signs EIP-7702 data from the backend without validation. The full vulnerability (backend-compromise leading to wallet drain) is not fixable client-side due to the EIP-7702 architecture — the RealUnit token doesn't support EIP-2612 Permit, and EIP-7702 is needed for gasless transactions.

This PR adds sanity checks that catch backend bugs, misconfigurations, and MitM data corruption. Full backend-compromise mitigation requires server-side hardening (monitoring, access control, audit).

## Test plan
- [ ] Verify sell flow works with valid backend data
- [ ] Verify sell flow rejects mismatched chainId
- [ ] Verify sell flow rejects mismatched delegator address
- [ ] Verify sell flow rejects mismatched token address
- [ ] Verify sell flow rejects mismatched amount