### PR TITLE
Enable R8 obfuscation for release builds (NEW-6)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,6 +46,8 @@ android {
 
     buildTypes {
         release {
+            minifyEnabled true
+            shrinkResources true
             signingConfig signingConfigs.release
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }


### PR DESCRIPTION
## Summary

Add `minifyEnabled true` and `shrinkResources true` to the Android release build type. Without these flags, the existing `proguard-rules.pro` was never executed — release APKs contained cleartext class/method names.

## Test plan
- [ ] Build release APK and verify it starts correctly
- [ ] Verify flutter_secure_storage works (ProGuard rules keep Tink/EncryptedSharedPreferences)
- [ ] Verify SumSub SDK works (ProGuard rules keep com.sumsub.*)
- [ ] Verify biometric authentication works