### PR TITLE
Gate debug auth route behind kDebugMode (NEW-18)

### DIFF
--- a/lib/setup/routing/router_config.dart
+++ b/lib/setup/routing/router_config.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:go_router/go_router.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
@@ -84,11 +85,12 @@ final GoRouter routerConfig = GoRouter(
       builder: (_, _) => const OnboardingCompletedPage(),
     ),
 
-    GoRoute(
-      name: OnboardingRoutes.debugAuth,
-      path: '/debugAuth',
-      builder: (_, _) => const DebugAuthPage(),
-    ),
+    if (kDebugMode)
+      GoRoute(
+        name: OnboardingRoutes.debugAuth,
+        path: '/debugAuth',
+        builder: (_, _) => const DebugAuthPage(),
+      ),
 
     GoRoute(
       name: PinRoutes.gate,


### PR DESCRIPTION
## Summary

The `/debugAuth` GoRoute was unconditionally registered, making it reachable via deep-link (`realunit-wallet:///debugAuth`) even in release builds. Now only registered when `kDebugMode == true`.

## Test plan
- [ ] Debug build: verify debug auth button and route work
- [ ] Release build: verify `/debugAuth` route is not reachable