### PR TITLE
Fix signMessage key derivation and encoding (NEW-11, NEW-12)

### DIFF
--- a/lib/packages/wallet/wallet_account.dart
+++ b/lib/packages/wallet/wallet_account.dart
@@ -1,4 +1,4 @@
-import 'dart:convert';
+import 'dart:convert' show utf8;
 
 import 'package:bip32/bip32.dart';
 import 'package:convert/convert.dart';
@@ -29,7 +29,7 @@ class WalletAccount extends AWalletAccount {
 
   @override
   Future<String> signMessage(String message, {int addressIndex = 0}) async =>
-      '0x${hex.encode(_getPrivateKeyAt(root, addressIndex, addressIndex).signPersonalMessageToUint8List(ascii.encode(message)))}';
+      '0x${hex.encode(_getPrivateKeyAt(root, accountIndex, addressIndex).signPersonalMessageToUint8List(utf8.encode(message)))}';
 }
 
 class BitboxWalletAccount extends AWalletAccount {
@@ -37,5 +37,5 @@ class BitboxWalletAccount extends AWalletAccount {
 
   @override
   Future<String> signMessage(String message, {int addressIndex = 0}) async =>
-      '0x${hex.encode(await primaryAddress.signPersonalMessage(ascii.encode(message)))}';
+      '0x${hex.encode(await primaryAddress.signPersonalMessage(utf8.encode(message)))}';
 }


### PR DESCRIPTION
## Summary

Two bugs in `WalletAccount.signMessage`:

**NEW-11:** `_getPrivateKeyAt(root, addressIndex, addressIndex)` used `addressIndex` for both parameters instead of `accountIndex` for the first. Would derive the wrong private key when `accountIndex != 0` — currently latent since only account 0 is used, but would produce invalid signatures with multi-account support.

**NEW-12:** `ascii.encode(message)` throws `ArgumentError` on non-ASCII characters (umlauts, emojis, UTF-8). Replaced with `utf8.encode` per EIP-191 specification.

## Test plan
- [ ] Verify personal_sign authentication flow still works
- [ ] Verify sell flow signing still produces valid signatures