### PR TITLE
Reduce app lock timeout to 60 seconds (NEW-7)

### DIFF
--- a/lib/screens/pin/constants/pin_constants.dart
+++ b/lib/screens/pin/constants/pin_constants.dart
@@ -1,3 +1,3 @@
-const lockoutDuration = Duration(minutes: 5);
+const lockoutDuration = Duration(seconds: 60);
 const pinLength = 6;
 const permanentLockoutThreshold = 9;


### PR DESCRIPTION
## Summary

Reduce background lock timeout from 5 minutes to 60 seconds. Banking apps typically use 30-60 seconds. A 5-minute window leaves the app unlocked too long after backgrounding.

## Test plan
- [ ] Background app for >60s, verify PIN/biometric prompt on resume
- [ ] Background app for <60s, verify no prompt on resume