### PR TITLE
Move database out of iCloud backup path (NEW-20)

### DIFF
--- a/lib/packages/storage/database.dart
+++ b/lib/packages/storage/database.dart
@@ -67,8 +67,20 @@ class AppDatabase extends _$AppDatabase {
   );
 
   static Future<String> getDatabasePath() async {
-    final path = await getApplicationDocumentsDirectory();
-    return p.join(path.path, _databaseFileName);
+    final dir = await getApplicationSupportDirectory();
+    final newPath = p.join(dir.path, _databaseFileName);
+
+    // Migrate from Documents/ (backed up to iCloud) to Application Support/ (not backed up)
+    if (!File(newPath).existsSync()) {
+      final legacyDir = await getApplicationDocumentsDirectory();
+      final legacyPath = p.join(legacyDir.path, _databaseFileName);
+      if (File(legacyPath).existsSync()) {
+        await Directory(dir.path).create(recursive: true);
+        await File(legacyPath).rename(newPath);
+      }
+    }
+
+    return newPath;
   }
 }
 


### PR DESCRIPTION
## Summary

Move the SQLCipher database from `Documents/` to `Library/Application Support/` on iOS. Existing databases are automatically migrated on first launch after update.

## Why

On iOS, `getApplicationDocumentsDirectory()` maps to `Documents/` which is included in iCloud backups by default. The encrypted wallet database was therefore uploaded to Apple servers. Combined with the Keychain entry for the DB encryption key (which can also be included in encrypted iCloud backups depending on accessibility settings), this creates a risk if the user's iCloud account is compromised.

`Library/Application Support/` is excluded from iCloud backups by default.

## Test plan
- [ ] Fresh install on iOS: verify DB created in Application Support
- [ ] Existing install on iOS: verify DB migrated from Documents to Application Support
- [ ] Verify app works normally after migration
- [ ] Android: verify no behavioral change