### PR TITLE
Pin web3dart fork to commit hash (NEW-14)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -166,10 +166,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -915,18 +915,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -1408,26 +1408,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:
@@ -1584,7 +1584,7 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: cake
+      ref: aa3f932dbf54eda651b7bd01ad00204acf998bd0
       resolved-ref: aa3f932dbf54eda651b7bd01ad00204acf998bd0
       url: "https://github.com/cake-tech/web3dart.git"
     source: git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,7 +96,7 @@ dependency_overrides:
   web3dart:
     git:
       url: https://github.com/cake-tech/web3dart.git
-      ref: cake
+      ref: aa3f932dbf54eda651b7bd01ad00204acf998bd0
 
 hooks:
   user_defines:


### PR DESCRIPTION
## Summary

Pin the `web3dart` dependency override from branch name `cake` to the exact commit hash `aa3f932`.

## Why

Branch references can resolve to a different commit on each `flutter pub get`. If the upstream branch is force-pushed or compromised, the app silently pulls in different code. Pinning to the commit hash that `pubspec.lock` already resolved to ensures reproducible builds without changing any actual dependency code.

## Test plan
- [ ] `flutter pub get` resolves to same version
- [ ] Signing operations work correctly