### PR TITLE
Harden PIN storage: move security flags from SharedPreferences to SecureStorage

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -128,8 +128,8 @@ class _WalletAppState extends State<WalletApp> {
     } else if (!pinState.isPinVerified) {
       targetRoute = PinRoutes.verify;
     } else if (homeState.openWallet == null) {
-      // Wallet load failed (e.g. decryption error) — reset to verify
-      getIt<PinAuthCubit>().onWalletLoadFailed();
+      // Wallet not loaded yet — trigger load and wait for HomeBloc update
+      _loadWalletIfNeeded();
       return;
     } else {
       targetRoute = AppRoutes.dashboard;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -90,6 +90,9 @@ class _WalletAppState extends State<WalletApp> {
             ),
             BlocListener<PinAuthCubit, PinAuthState>(
               listener: (context, pinState) {
+                if (pinState.isPinVerified) {
+                  _loadWalletIfNeeded();
+                }
                 _navigate();
               },
             ),
@@ -100,6 +103,13 @@ class _WalletAppState extends State<WalletApp> {
     ),
   );
 
+  void _loadWalletIfNeeded() {
+    final homeState = getIt<HomeBloc>().state;
+    if (homeState.hasWallet && homeState.openWallet == null && !homeState.isLoadingWallet) {
+      getIt<HomeBloc>().add(const LoadCurrentWalletEvent());
+    }
+  }
+
   void _navigate() {
     final homeState = getIt<HomeBloc>().state;
     final pinState = getIt<PinAuthCubit>().state;
@@ -109,7 +119,7 @@ class _WalletAppState extends State<WalletApp> {
     String targetRoute;
     if (!homeState.softwareTermsAccepted) {
       targetRoute = AppRoutes.home;
-    } else if (homeState.openWallet == null) {
+    } else if (!homeState.hasWallet) {
       targetRoute = OnboardingRoutes.welcome;
     } else if (!homeState.onboardingCompleted) {
       targetRoute = OnboardingRoutes.completed;
@@ -117,6 +127,10 @@ class _WalletAppState extends State<WalletApp> {
       targetRoute = PinRoutes.setup;
     } else if (!pinState.isPinVerified) {
       targetRoute = PinRoutes.verify;
+    } else if (homeState.openWallet == null) {
+      // Wallet load failed (e.g. decryption error) — reset to verify
+      getIt<PinAuthCubit>().onWalletLoadFailed();
+      return;
     } else {
       targetRoute = AppRoutes.dashboard;
     }

--- a/lib/packages/repository/settings_repository.dart
+++ b/lib/packages/repository/settings_repository.dart
@@ -43,39 +43,8 @@ class SettingsRepository {
 
   set networkMode(NetworkMode mode) => _sharedPreferences.setString('networkMode', mode.name);
 
-  bool get isPinEnabled => _sharedPreferences.getBool('isPinEnabled') ?? false;
-
-  set isPinEnabled(bool enabled) => _sharedPreferences.setBool('isPinEnabled', enabled);
-
-  bool get isBiometricEnabled => _sharedPreferences.getBool('isBiometricEnabled') ?? false;
-
-  set isBiometricEnabled(bool enabled) => _sharedPreferences.setBool('isBiometricEnabled', enabled);
-
   bool get softwareTermsAccepted => _sharedPreferences.getBool('softwareTermsAccepted') ?? false;
 
   set softwareTermsAccepted(bool accepted) =>
       _sharedPreferences.setBool('softwareTermsAccepted', accepted);
-
-  int get pinFailedAttempts => _sharedPreferences.getInt('pinFailedAttempts') ?? 0;
-
-  set pinFailedAttempts(int count) => _sharedPreferences.setInt('pinFailedAttempts', count);
-
-  DateTime? get pinLockedUntil {
-    final value = _sharedPreferences.getString('pinLockedUntil');
-    if (value == null) return null;
-    return DateTime.tryParse(value);
-  }
-
-  set pinLockedUntil(DateTime? lockedUntil) {
-    if (lockedUntil == null) {
-      _sharedPreferences.remove('pinLockedUntil');
-    } else {
-      _sharedPreferences.setString('pinLockedUntil', lockedUntil.toIso8601String());
-    }
-  }
-
-  void resetPinLockout() {
-    _sharedPreferences.remove('pinFailedAttempts');
-    _sharedPreferences.remove('pinLockedUntil');
-  }
 }

--- a/lib/packages/service/biometric_service.dart
+++ b/lib/packages/service/biometric_service.dart
@@ -1,17 +1,17 @@
 import 'dart:developer' as developer;
 
 import 'package:local_auth/local_auth.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
+import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 
 /// Service for handling biometric authentication.
 class BiometricService {
   final LocalAuthentication _auth = LocalAuthentication();
 
   BiometricService(
-    SettingsRepository settingsRepository,
-  ) : _settingsRepository = settingsRepository;
+    SecureStorage secureStorage,
+  ) : _secureStorage = secureStorage;
 
-  final SettingsRepository _settingsRepository;
+  final SecureStorage _secureStorage;
 
   Future<bool> isAvailable() async {
     final canCheck = await _auth.canCheckBiometrics;
@@ -19,9 +19,9 @@ class BiometricService {
     return canCheck && isSupported;
   }
 
-  bool get isEnabled => _settingsRepository.isBiometricEnabled;
+  Future<bool> isEnabled() => _secureStorage.getIsBiometricEnabled();
 
-  Future<bool> canUse() async => isEnabled && await isAvailable();
+  Future<bool> canUse() async => await isEnabled() && await isAvailable();
 
   Future<bool> authenticate() async {
     try {
@@ -39,10 +39,10 @@ class BiometricService {
   Future<bool> enable() async {
     final success = await authenticate();
     if (success) {
-      _settingsRepository.isBiometricEnabled = true;
+      await _secureStorage.setIsBiometricEnabled(enabled: true);
     }
     return success;
   }
 
-  void disable() => _settingsRepository.isBiometricEnabled = false;
+  Future<void> disable() => _secureStorage.setIsBiometricEnabled(enabled: false);
 }

--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -14,6 +14,9 @@ class SecureStorage {
   static const _mnemonicEncryptionKey = 'wallet.mnemonic.encryption.key';
   static const _pinHashKey = 'pin.hash';
   static const _pinSaltKey = 'pin.salt';
+  static const _biometricEnabledKey = 'biometric.enabled';
+  static const _pinFailedAttemptsKey = 'pin.failedAttempts';
+  static const _pinLockedUntilKey = 'pin.lockedUntil';
 
   final FlutterSecureStorage _secureStorage;
 
@@ -52,6 +55,8 @@ class SecureStorage {
 
   Future<void> setPinHash(String hash) => _secureStorage.write(key: _pinHashKey, value: hash);
 
+  Future<bool> hasPinHash() async => await _secureStorage.read(key: _pinHashKey) != null;
+
   Future<void> deletePinHash() => Future.wait([
     _secureStorage.delete(key: _pinHashKey),
     _secureStorage.delete(key: _pinSaltKey),
@@ -82,6 +87,40 @@ class SecureStorage {
 
     return false;
   }
+
+  // Pin lockout
+
+  Future<int> getPinFailedAttempts() async {
+    final value = await _secureStorage.read(key: _pinFailedAttemptsKey);
+    return int.tryParse(value ?? '') ?? 0;
+  }
+
+  Future<void> setPinFailedAttempts(int count) =>
+      _secureStorage.write(key: _pinFailedAttemptsKey, value: count.toString());
+
+  Future<DateTime?> getPinLockedUntil() async {
+    final value = await _secureStorage.read(key: _pinLockedUntilKey);
+    return value != null ? DateTime.tryParse(value) : null;
+  }
+
+  Future<void> setPinLockedUntil(DateTime? until) => until != null
+      ? _secureStorage.write(key: _pinLockedUntilKey, value: until.toIso8601String())
+      : _secureStorage.delete(key: _pinLockedUntilKey);
+
+  Future<void> resetPinLockout() => Future.wait([
+    _secureStorage.delete(key: _pinFailedAttemptsKey),
+    _secureStorage.delete(key: _pinLockedUntilKey),
+  ]);
+
+  // Biometric
+
+  Future<bool> getIsBiometricEnabled() async =>
+      await _secureStorage.read(key: _biometricEnabledKey) == 'true';
+
+  Future<void> setIsBiometricEnabled({required bool enabled}) =>
+      _secureStorage.write(key: _biometricEnabledKey, value: enabled.toString());
+
+  Future<void> deleteBiometricEnabled() => _secureStorage.delete(key: _biometricEnabledKey);
 
   // Mnemonic
 

--- a/lib/screens/home/bloc/home_bloc.dart
+++ b/lib/screens/home/bloc/home_bloc.dart
@@ -97,6 +97,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     }
     emit(
       HomeState(
+        hasWallet: false,
         openWallet: null,
         isLoadingWallet: false,
         isFiatServiceAvailable: false,

--- a/lib/screens/home/bloc/home_bloc.dart
+++ b/lib/screens/home/bloc/home_bloc.dart
@@ -24,6 +24,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     this._appStore,
     this._bitboxService,
   ) : super(const HomeState()) {
+    on<CheckWalletExistsEvent>(_onCheckWalletExists);
     on<LoadCurrentWalletEvent>(_onLoadCurrentWallet);
     on<LoadWalletEvent>(_onLoadWallet);
     on<SyncWalletServicesEvent>(_onSyncWalletServices);
@@ -32,7 +33,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     on<AcceptSoftwareTermsEvent>(_onAcceptSoftwareTerms);
     on<DebugAuthCompleteEvent>(_onDebugAuthComplete);
 
-    add(const LoadCurrentWalletEvent());
+    add(const CheckWalletExistsEvent());
   }
 
   final WalletService _walletService;
@@ -43,18 +44,21 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   final AppStore _appStore;
   final BitboxService _bitboxService;
 
-  Future<void> _onLoadCurrentWallet(LoadCurrentWalletEvent event, Emitter<HomeState> emit) async {
+  void _onCheckWalletExists(CheckWalletExistsEvent event, Emitter<HomeState> emit) {
+    final hasWallet = _walletService.hasWallet();
     emit(
       state.copyWith(
-        isLoadingWallet: true,
+        hasWallet: hasWallet,
         softwareTermsAccepted: _settingsService.isSoftwareTermsAccepted,
+        onboardingCompleted: hasWallet ? _settingsService.isTermsAccepted : false,
       ),
     );
+  }
 
-    if (state.openWallet != null || !_walletService.hasWallet()) {
-      emit(state.copyWith(isLoadingWallet: false));
-      return;
-    }
+  Future<void> _onLoadCurrentWallet(LoadCurrentWalletEvent event, Emitter<HomeState> emit) async {
+    if (state.openWallet != null || !_walletService.hasWallet()) return;
+
+    emit(state.copyWith(isLoadingWallet: true));
     try {
       final wallet = await _walletService.getCurrentWallet();
       _appStore.wallet = wallet;
@@ -63,7 +67,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
         state.copyWith(
           openWallet: wallet,
           isLoadingWallet: false,
-          onboardingCompleted: _settingsService.isTermsAccepted,
         ),
       );
 
@@ -104,7 +107,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
 
   Future<void> _onLoadWallet(LoadWalletEvent event, Emitter<HomeState> emit) async {
     _updateWallet(event.wallet);
-    emit(state.copyWith(openWallet: _appStore.wallet, isLoadingWallet: false));
+    emit(state.copyWith(hasWallet: true, openWallet: _appStore.wallet, isLoadingWallet: false));
     await _setupFiatService(emit);
   }
 
@@ -126,7 +129,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   Future<void> _onDebugAuthComplete(DebugAuthCompleteEvent event, Emitter<HomeState> emit) async {
     final wallet = await _walletService.createDebugWallet(event.address);
     _appStore.wallet = wallet;
-    emit(state.copyWith(openWallet: wallet));
+    emit(state.copyWith(hasWallet: true, openWallet: wallet));
     await _setupFiatService(emit);
   }
 

--- a/lib/screens/home/bloc/home_event.dart
+++ b/lib/screens/home/bloc/home_event.dart
@@ -7,6 +7,10 @@ sealed class HomeEvent extends Equatable {
   List<Object> get props => [];
 }
 
+final class CheckWalletExistsEvent extends HomeEvent {
+  const CheckWalletExistsEvent();
+}
+
 final class LoadCurrentWalletEvent extends HomeEvent {
   const LoadCurrentWalletEvent();
 }

--- a/lib/screens/home/bloc/home_state.dart
+++ b/lib/screens/home/bloc/home_state.dart
@@ -2,6 +2,7 @@ part of 'home_bloc.dart';
 
 final class HomeState {
   const HomeState({
+    this.hasWallet = false,
     this.openWallet,
     this.isLoadingWallet = false,
     this.isFiatServiceAvailable = false,
@@ -9,6 +10,7 @@ final class HomeState {
     this.softwareTermsAccepted = false,
   });
 
+  final bool hasWallet;
   final AWallet? openWallet;
   final bool isLoadingWallet;
   final bool isFiatServiceAvailable;
@@ -16,12 +18,14 @@ final class HomeState {
   final bool softwareTermsAccepted;
 
   HomeState copyWith({
+    bool? hasWallet,
     AWallet? openWallet,
     bool? isLoadingWallet,
     bool? isFiatServiceAvailable,
     bool? onboardingCompleted,
     bool? softwareTermsAccepted,
   }) => HomeState(
+    hasWallet: hasWallet ?? this.hasWallet,
     openWallet: openWallet ?? this.openWallet,
     isLoadingWallet: isLoadingWallet ?? this.isLoadingWallet,
     isFiatServiceAvailable: isFiatServiceAvailable ?? this.isFiatServiceAvailable,

--- a/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
+++ b/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
@@ -31,8 +31,6 @@ class PinAuthCubit extends Cubit<PinAuthState> {
 
   void onPinVerified() => emit(state.copyWith(isPinVerified: true));
 
-  void onWalletLoadFailed() => emit(state.copyWith(isPinVerified: false));
-
   void onAppHidden() => _lastBackgroundTime ??= DateTime.now();
 
   void onAppResumed() {

--- a/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
+++ b/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
@@ -1,6 +1,5 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/constants/pin_constants.dart';
 
@@ -9,18 +8,15 @@ part 'pin_auth_state.dart';
 class PinAuthCubit extends Cubit<PinAuthState> {
   PinAuthCubit(
     SecureStorage secureStorage,
-    SettingsRepository settingsRepository,
   ) : _secureStorage = secureStorage,
-      _settingsRepository = settingsRepository,
       super(const PinAuthState());
 
   final SecureStorage _secureStorage;
-  final SettingsRepository _settingsRepository;
 
   DateTime? _lastBackgroundTime;
 
-  void initialize() {
-    final isPinSetup = _settingsRepository.isPinEnabled;
+  Future<void> initialize() async {
+    final isPinSetup = await _secureStorage.hasPinHash();
     emit(
       state.copyWith(
         isPinSetup: isPinSetup,
@@ -34,6 +30,8 @@ class PinAuthCubit extends Cubit<PinAuthState> {
   );
 
   void onPinVerified() => emit(state.copyWith(isPinVerified: true));
+
+  void onWalletLoadFailed() => emit(state.copyWith(isPinVerified: false));
 
   void onAppHidden() => _lastBackgroundTime ??= DateTime.now();
 
@@ -50,11 +48,12 @@ class PinAuthCubit extends Cubit<PinAuthState> {
     _lastBackgroundTime = null;
   }
 
-  void reset() {
-    _settingsRepository.isPinEnabled = false;
-    _settingsRepository.isBiometricEnabled = false;
-    _settingsRepository.resetPinLockout();
-    _secureStorage.deletePinHash();
+  Future<void> reset() async {
+    await Future.wait([
+      _secureStorage.deletePinHash(),
+      _secureStorage.deleteBiometricEnabled(),
+      _secureStorage.resetPinLockout(),
+    ]);
     emit(const PinAuthState());
   }
 }

--- a/lib/screens/pin/bloc/setup_pin/setup_pin_cubit.dart
+++ b/lib/screens/pin/bloc/setup_pin/setup_pin_cubit.dart
@@ -1,6 +1,5 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/constants/pin_constants.dart';
@@ -10,15 +9,12 @@ part 'setup_pin_state.dart';
 class SetupPinCubit extends Cubit<SetupPinState> {
   SetupPinCubit(
     SecureStorage secureStorage,
-    SettingsRepository settingsRepository,
     BiometricService biometricService,
   ) : _secureStorage = secureStorage,
-      _settingsRepository = settingsRepository,
       _biometricService = biometricService,
       super(const SetupPinState());
 
   final SecureStorage _secureStorage;
-  final SettingsRepository _settingsRepository;
   final BiometricService _biometricService;
 
   String? _createPin;
@@ -69,7 +65,6 @@ class SetupPinCubit extends Cubit<SetupPinState> {
         _secureStorage.setPinSalt(salt),
         _secureStorage.setPinHash(hash),
       ]);
-      _settingsRepository.isPinEnabled = true;
       emit(state.copyWith(isComplete: true));
     } else {
       emit(

--- a/lib/screens/pin/bloc/verify_pin/verify_pin_cubit.dart
+++ b/lib/screens/pin/bloc/verify_pin/verify_pin_cubit.dart
@@ -1,6 +1,5 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/constants/pin_constants.dart';
@@ -10,16 +9,13 @@ part 'verify_pin_state.dart';
 class VerifyPinCubit extends Cubit<VerifyPinState> {
   VerifyPinCubit(
     SecureStorage secureStorage,
-    SettingsRepository settingsRepository,
     BiometricService biometricService, {
-    this.enableLockout = false,
+    this.enableLockout = true,
   }) : _secureStorage = secureStorage,
-       _settingsRepository = settingsRepository,
        _biometricService = biometricService,
        super(const VerifyPinState());
 
   final SecureStorage _secureStorage;
-  final SettingsRepository _settingsRepository;
   final BiometricService _biometricService;
   final bool enableLockout;
 
@@ -39,16 +35,16 @@ class VerifyPinCubit extends Cubit<VerifyPinState> {
   Future<void> checkPin() async {
     final isCorrect = await _secureStorage.verifyPin(state.pin);
     if (isCorrect) {
-      if (enableLockout) _settingsRepository.resetPinLockout();
+      if (enableLockout) await _secureStorage.resetPinLockout();
       emit(const VerifyPinSuccess());
     } else {
       if (!enableLockout) {
         emit(const VerifyPinFailure(failedAttempts: 0));
         return;
       }
-      final attempts = _settingsRepository.pinFailedAttempts + 1;
-      _settingsRepository.pinFailedAttempts = attempts;
-      _emitLockState(attempts);
+      final attempts = await _secureStorage.getPinFailedAttempts() + 1;
+      await _secureStorage.setPinFailedAttempts(attempts);
+      await _emitLockState(attempts);
     }
   }
 
@@ -58,17 +54,17 @@ class VerifyPinCubit extends Cubit<VerifyPinState> {
 
   Future<void> checkBiometricAvailability() async {
     if (enableLockout) {
-      final lockedUntil = _settingsRepository.pinLockedUntil;
+      final lockedUntil = await _secureStorage.getPinLockedUntil();
       if (lockedUntil != null) {
         if (DateTime.now().isBefore(lockedUntil)) {
-          final attempts = _settingsRepository.pinFailedAttempts;
+          final attempts = await _secureStorage.getPinFailedAttempts();
           emit(VerifyPinTemporarilyLocked(failedAttempts: attempts, lockedUntil: lockedUntil));
           return;
         }
-        _settingsRepository.pinLockedUntil = null;
+        await _secureStorage.setPinLockedUntil(null);
       }
 
-      final attempts = _settingsRepository.pinFailedAttempts;
+      final attempts = await _secureStorage.getPinFailedAttempts();
       if (attempts >= permanentLockoutThreshold) {
         emit(VerifyPinLocked(failedAttempts: attempts));
         return;
@@ -79,18 +75,19 @@ class VerifyPinCubit extends Cubit<VerifyPinState> {
     if (canUse) {
       final success = await _biometricService.authenticate();
       if (success) {
+        if (enableLockout) await _secureStorage.resetPinLockout();
         emit(const VerifyPinSuccess());
       }
     }
   }
 
-  void _emitLockState(int attempts) {
+  Future<void> _emitLockState(int attempts) async {
     final duration = _lockoutDuration(attempts);
     if (duration == null) {
       emit(VerifyPinLocked(failedAttempts: attempts));
     } else if (duration > Duration.zero) {
       final lockedUntil = DateTime.now().add(duration);
-      _settingsRepository.pinLockedUntil = lockedUntil;
+      await _secureStorage.setPinLockedUntil(lockedUntil);
       emit(VerifyPinTemporarilyLocked(failedAttempts: attempts, lockedUntil: lockedUntil));
     } else {
       emit(VerifyPinFailure(failedAttempts: attempts));

--- a/lib/screens/pin/setup_pin_page.dart
+++ b/lib/screens/pin/setup_pin_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
@@ -21,7 +20,6 @@ class SetupPinPage extends StatelessWidget {
     return BlocProvider(
       create: (_) => SetupPinCubit(
         getIt<SecureStorage>(),
-        getIt<SettingsRepository>(),
         getIt<BiometricService>(),
       ),
       child: const SetupPinView(),

--- a/lib/screens/pin/verify_pin_page.dart
+++ b/lib/screens/pin/verify_pin_page.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
@@ -36,7 +35,7 @@ class VerifyPinPage extends StatelessWidget {
     this.description,
     required this.onAuthenticated,
     this.bottom,
-    this.enableLockout = false,
+    this.enableLockout = true,
   });
 
   /// Used for initial app lock check on app start
@@ -50,7 +49,6 @@ class VerifyPinPage extends StatelessWidget {
   Widget build(BuildContext context) => BlocProvider(
     create: (_) => VerifyPinCubit(
       getIt<SecureStorage>(),
-      getIt<SettingsRepository>(),
       getIt<BiometricService>(),
       enableLockout: enableLockout,
     ),
@@ -247,8 +245,10 @@ class _ForgotPinButton extends StatelessWidget {
           if (isReset == true) {
             await Future.delayed(const Duration(milliseconds: 300));
             if (context.mounted) {
-              context.read<PinAuthCubit>().reset();
-              context.read<HomeBloc>().add(const DeleteCurrentWalletEvent());
+              await context.read<PinAuthCubit>().reset();
+              if (context.mounted) {
+                context.read<HomeBloc>().add(const DeleteCurrentWalletEvent());
+              }
             }
           }
         },

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -130,8 +130,10 @@ class SettingsPage extends StatelessWidget {
                   if (isLogout ?? false) {
                     await Future.delayed(const Duration(milliseconds: 300));
                     if (context.mounted) {
-                      context.read<PinAuthCubit>().reset();
-                      context.read<HomeBloc>().add(const DeleteCurrentWalletEvent());
+                      await context.read<PinAuthCubit>().reset();
+                      if (context.mounted) {
+                        context.read<HomeBloc>().add(const DeleteCurrentWalletEvent());
+                      }
                     }
                   }
                 },

--- a/lib/setup/di.dart
+++ b/lib/setup/di.dart
@@ -51,6 +51,8 @@ Future<String> setupEssentials() async {
   final secureStorage = const SecureStorage();
   getIt.registerSingleton(secureStorage);
 
+  await _migrateSecurityFlags(sharedPreferences, secureStorage);
+
   final encryptionKey = await secureStorage.getEncryptionKey();
 
   if (encryptionKey == null) {
@@ -79,7 +81,7 @@ Future<void> finishSetup(String encryptionKey) async {
   );
 
   setupServices();
-  setupBlocs();
+  await setupBlocs();
 
   await setupDefaultAssets();
 }
@@ -111,7 +113,7 @@ void setupServices() {
   );
   getIt.registerFactory(
     () => BiometricService(
-      getIt<SettingsRepository>(),
+      getIt<SecureStorage>(),
     ),
   );
   getIt.registerSingleton(BitboxService());
@@ -153,7 +155,7 @@ void setupServices() {
   );
 }
 
-void setupBlocs() {
+Future<void> setupBlocs() async {
   getIt.registerSingleton(
     SettingsBloc(
       getIt<SettingsRepository>(),
@@ -171,9 +173,39 @@ void setupBlocs() {
       getIt<BitboxService>(),
     ),
   );
-  getIt.registerSingleton(
-    PinAuthCubit(getIt<SecureStorage>(), getIt<SettingsRepository>())..initialize(),
-  );
+
+  final pinAuthCubit = PinAuthCubit(getIt<SecureStorage>());
+  await pinAuthCubit.initialize();
+  getIt.registerSingleton(pinAuthCubit);
 }
 
 Future<bool> _existsDatabaseFile() async => File(await AppDatabase.getDatabasePath()).exists();
+
+Future<void> _migrateSecurityFlags(
+  SharedPreferences prefs,
+  SecureStorage secureStorage,
+) async {
+  // Migrate isBiometricEnabled from SharedPreferences to SecureStorage
+  final biometricEnabled = prefs.getBool('isBiometricEnabled');
+  if (biometricEnabled != null) {
+    await secureStorage.setIsBiometricEnabled(enabled: biometricEnabled);
+    await prefs.remove('isBiometricEnabled');
+  }
+
+  // Migrate lockout state from SharedPreferences to SecureStorage
+  final failedAttempts = prefs.getInt('pinFailedAttempts');
+  if (failedAttempts != null) {
+    await secureStorage.setPinFailedAttempts(failedAttempts);
+    await prefs.remove('pinFailedAttempts');
+  }
+
+  final lockedUntil = prefs.getString('pinLockedUntil');
+  if (lockedUntil != null) {
+    final parsed = DateTime.tryParse(lockedUntil);
+    if (parsed != null) await secureStorage.setPinLockedUntil(parsed);
+    await prefs.remove('pinLockedUntil');
+  }
+
+  // Clean up legacy isPinEnabled flag (now derived from PIN hash existence)
+  await prefs.remove('isPinEnabled');
+}

--- a/lib/widgets/seed_blur_card.dart
+++ b/lib/widgets/seed_blur_card.dart
@@ -28,37 +28,37 @@ class SeedBlurCard extends StatelessWidget {
               ),
               if (blur)
                 Positioned.fill(
-                child: Padding(
-                  padding: const EdgeInsets.all(1.5),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(16),
-                    child: BackdropFilter(
-                      filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-                      child: Container(
-                        color: RealUnitColors.basic.white.withValues(alpha: 0.15),
-                        alignment: Alignment.center,
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            const Icon(
-                              Icons.visibility_outlined,
-                              size: 16,
-                              color: RealUnitColors.realUnitBlack,
-                            ),
-                            Text(
-                              S.of(context).tapHereToView,
-                              style: const TextStyle(
-                                fontSize: 14,
-                                height: 18 / 14,
+                  child: Padding(
+                    padding: const EdgeInsets.all(1.5),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(16),
+                      child: BackdropFilter(
+                        filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                        child: Container(
+                          color: RealUnitColors.basic.white.withValues(alpha: 0.15),
+                          alignment: Alignment.center,
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Icon(
+                                Icons.visibility_outlined,
+                                size: 16,
+                                color: RealUnitColors.realUnitBlack,
                               ),
-                            ),
-                          ],
+                              Text(
+                                S.of(context).tapHereToView,
+                                style: const TextStyle(
+                                  fontSize: 14,
+                                  height: 18 / 14,
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ),
                   ),
                 ),
-              ),
             ],
           ),
         ),

--- a/lib/widgets/seed_blur_card.dart
+++ b/lib/widgets/seed_blur_card.dart
@@ -20,13 +20,14 @@ class SeedBlurCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) => GestureDetector(
         onTap: onTap,
-        child: Stack(
-          children: [
-            MnemonicReadOnlyField(
-              seedWords: seed.seedWords,
-            ),
-            if (blur)
-              Positioned.fill(
+        child: ExcludeSemantics(
+          child: Stack(
+            children: [
+              MnemonicReadOnlyField(
+                seedWords: seed.seedWords,
+              ),
+              if (blur)
+                Positioned.fill(
                 child: Padding(
                   padding: const EdgeInsets.all(1.5),
                   child: ClipRRect(
@@ -58,7 +59,8 @@ class SeedBlurCard extends StatelessWidget {
                   ),
                 ),
               ),
-          ],
+            ],
+          ),
         ),
       );
 }

--- a/test/screens/pin/setup_pin_page_test.dart
+++ b/test/screens/pin/setup_pin_page_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
@@ -24,8 +23,6 @@ class MockBiometricService extends Mock implements BiometricService {}
 
 class MockSecureStorage extends Mock implements SecureStorage {}
 
-class MockSettingsRepository extends Mock implements SettingsRepository {}
-
 void main() {
   late SetupPinCubit setupPinCubit;
   late PinAuthCubit pinAuthCubit;
@@ -41,7 +38,6 @@ void main() {
     final getIt = GetIt.instance;
     getIt.registerSingleton<BiometricService>(MockBiometricService());
     getIt.registerSingleton<SecureStorage>(MockSecureStorage());
-    getIt.registerSingleton<SettingsRepository>(MockSettingsRepository());
     getIt.registerSingleton<PinAuthCubit>(pinAuthCubit);
   }
 

--- a/test/screens/pin/verify_pin_page_test.dart
+++ b/test/screens/pin/verify_pin_page_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
-import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/service/biometric_service.dart';
 import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
@@ -22,11 +21,9 @@ class MockVerifyPinCubit extends MockCubit<VerifyPinState> implements VerifyPinC
 
 class MockPinAuthCubit extends MockCubit<PinAuthState> implements PinAuthCubit {}
 
-class MockBiometricService extends Mock implements BiometricService {}
-
-class MockSettingsRepository extends Mock implements SettingsRepository {}
-
 class MockSecureStorage extends Mock implements SecureStorage {}
+
+class MockBiometricService extends Mock implements BiometricService {}
 
 void main() {
   late VerifyPinCubit verifyPinCubit;
@@ -42,14 +39,14 @@ void main() {
 
   void setupDependencyInjection() {
     final getIt = GetIt.instance;
+    final secureStorage = MockSecureStorage();
+    when(() => secureStorage.getPinLockedUntil()).thenAnswer((_) => Future.value(null));
+    when(() => secureStorage.getPinFailedAttempts()).thenAnswer((_) => Future.value(0));
+    getIt.registerSingleton<SecureStorage>(secureStorage);
     final biometricService = MockBiometricService();
     when(() => biometricService.canUse()).thenAnswer((_) => Future.value(false));
     getIt.registerSingleton<BiometricService>(biometricService);
-    getIt.registerSingleton<SecureStorage>(MockSecureStorage());
     getIt.registerSingleton<PinAuthCubit>(pinAuthCubit);
-    final settingsRepository = MockSettingsRepository();
-    when(() => settingsRepository.pinFailedAttempts).thenReturn(1);
-    getIt.registerSingleton<SettingsRepository>(settingsRepository);
   }
 
   setUpAll(() {


### PR DESCRIPTION
## Summary
- Move `isPinEnabled`, `isBiometricEnabled`, `pinFailedAttempts`, `pinLockedUntil` from SharedPreferences (plaintext XML) to FlutterSecureStorage (RSA-encrypted via AndroidKeyStore)
- Derive `isPinEnabled` from PIN hash existence — no separate flag to manipulate
- Defer wallet decryption until after PIN verification (mnemonic never enters memory before auth)
- Enable lockout by default on all PIN verification flows including seed reveal step-up
- Block seed extraction via `adb shell uiautomator dump` (ExcludeSemantics)
- Full migration of existing user data including active lockout state

## What this fixes
On a rooted Android device, an attacker could:
1. Edit SharedPreferences XML: `isPinEnabled = false` → app skips PIN screen
2. Reset `pinFailedAttempts = 0` → unlimited brute-force
3. Delete `pinLockedUntil` → bypass active lockout

After this PR, all security-critical flags are in encrypted storage that cannot be trivially modified via filesystem access.

## What this does NOT include
Hardware keystore integration (`biometric_storage` with `setUserAuthenticationRequired`) — to be evaluated separately.

## Test plan
- [ ] Verify PIN setup/verify flow works correctly
- [ ] Verify biometric enable/disable works correctly
- [ ] Verify lockout state persists across app restart
- [ ] Verify migration: existing users with PIN + biometric + active lockout don't lose state
- [ ] Verify `adb shell uiautomator dump` no longer shows seed words
- [ ] Verify wallet only loads after successful PIN/biometric auth
- [ ] Verify "forgot PIN" reset works (async reset + context.mounted)