### PR TITLE
fix: BitBox pairing flow shows code in app and survives Home auth

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -46,7 +46,7 @@
   "completed": "Abgeschlossen",
   "confirm": "Bestätigen",
   "connectBitboxCheckPairingCode": "Überprüfen Sie, ob dieser Code mit dem auf Ihrem BitBox-Gerät angezeigten übereinstimmt, und bestätigen Sie anschließend.",
-  "connectBitboxConnecting": "Gerät gefunden. Bitte überprüfen Sie Ihre Bitbox, befolgen Sie die Anweisungen und merken Sie sich den angezeigten Kopplungscode.",
+  "connectBitboxConnecting": "Gerät gefunden. Auf Ihrer BitBox erscheint in Kürze ein Kopplungscode. Bitte lassen Sie ihn stehen – derselbe Code erscheint anschließend auch hier zum Vergleich.",
   "connectBitboxContent": "Bitte verbinden Sie Ihre BitBox02 mit Ihrem Smartphone.",
   "connectBitboxContentIos": "Bitte verbinden Sie Ihre BitBox02 mit Ihrem Smartphone und aktivieren Sie zusätzlich Bluetooth.",
   "connectBitboxFailed": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -46,7 +46,7 @@
   "completed": "Completed",
   "confirm": "Confirm",
   "connectBitboxCheckPairingCode": "Verify this code matches the one shown on your BitBox device, then confirm.",
-  "connectBitboxConnecting": "Device found, please check your Bitbox, follow the instructions and memorise the shown pairing code.",
+  "connectBitboxConnecting": "Device found. A pairing code will appear on your BitBox shortly. Please keep it visible – the same code will appear here for comparison.",
   "connectBitboxContent": "Please connect your BitBox02 with your Smartphone.",
   "connectBitboxContentIos": "Please connect your BitBox02 with your Smartphone and activate Bluetooth.",
   "connectBitboxFailed": "Something went wrong. Please try to connect again.",

--- a/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
+++ b/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
@@ -23,6 +23,7 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
   final BitboxService _service;
   final WalletService _walletService;
   Timer? _checkForTimer;
+  Future<bool>? _pendingInit;
 
   Future<void> checkForBitbox() async {
     final devices = await _service.getAllUsbDevices();
@@ -37,11 +38,33 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
     if (state is BitboxConnecting) return;
     emit(BitboxConnecting(device));
     try {
-      await _service.init(device);
-      final channelHash = await _service.getChannelHash();
+      var initFailed = false;
+      _pendingInit = _service.init(device).then((success) {
+        if (!success) initFailed = true;
+        return success;
+      }).catchError((Object e) {
+        developer.log('init error: $e', name: '$ConnectBitboxCubit');
+        initFailed = true;
+        return false;
+      });
+
+      String channelHash = '';
+      final deadline = DateTime.now().add(const Duration(seconds: 90));
+      while (channelHash.isEmpty && DateTime.now().isBefore(deadline)) {
+        await Future.delayed(const Duration(milliseconds: 500));
+        if (initFailed) throw Exception('init failed');
+        try {
+          final hash = await _service.getChannelHash().timeout(const Duration(seconds: 2));
+          if (hash.isNotEmpty) channelHash = hash;
+        } catch (_) {}
+      }
+
+      if (channelHash.isEmpty) throw TimeoutException('no channel hash within 90s');
+
       emit(BitboxCheckHash(device, channelHash));
     } catch (e) {
       developer.log(e.toString(), name: '$ConnectBitboxCubit');
+      _pendingInit = null;
       emit(BitboxNotConnected());
       _checkForTimer = Timer.periodic(const Duration(milliseconds: 500), (_) => checkForBitbox());
     }
@@ -53,12 +76,18 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
 
     try {
       emit(BitboxPairing(currentState.device));
+      final initOk = await (_pendingInit ?? Future.value(true)).timeout(
+        const Duration(seconds: 120),
+        onTimeout: () => false,
+      );
+      if (!initOk) throw Exception('pairing not confirmed on device');
       await _service.confirmPairing();
       final wallet = await _walletService.createBitboxWallet('Luke-Skywallet');
       _service.startConnectionStatusObserver();
       emit(BitboxConnected(wallet));
     } catch (e) {
       developer.log(e.toString(), name: '$ConnectBitboxCubit');
+      _pendingInit = null;
       emit(BitboxNotConnected());
       _checkForTimer = Timer.periodic(const Duration(milliseconds: 500), (_) => checkForBitbox());
     }

--- a/lib/screens/home/bloc/home_bloc.dart
+++ b/lib/screens/home/bloc/home_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/balance_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
@@ -135,6 +136,11 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   }
 
   Future<void> _setupFiatService(Emitter<HomeState> emit) async {
+    if (_appStore.wallet.currentAccount.primaryAddress is BitboxCredentials) {
+      // bitbox_flutter's ETHSignMessage panics on a NACK and crashes the engine.
+      emit(state.copyWith(isFiatServiceAvailable: false));
+      return;
+    }
     try {
       await _dfxService.getAuthToken();
       emit(state.copyWith(isFiatServiceAvailable: _dfxService.isAvailable));


### PR DESCRIPTION
## Summary
- Run `BitboxService.init()` in the background and poll `getChannelHash()` in parallel so the app shows the pairing code at the same time as the BitBox does
- `confirmPairing()` awaits the in-flight `init()` future before calling `channelHashVerify()`, so the host-side verify (and `createBitboxWallet` after it) cannot run before the device-side verify has landed
- Guard every async step on `isClosed` and clear `_pendingInit` in `close()` — dismissing the modal during pairing no longer leaks the re-scan timer or emits on a disposed cubit (incorporates the dispose-leak hardening from #303)
- Skip the automatic DFX auth call in `HomeBloc._setupFiatService` for BitBox-backed wallets — `bitbox_flutter`'s `ETHSignMessage` panics on a NACK and crashes the engine, which previously killed the app right after pairing
- DE/EN copy on the connecting screen reworded to make the compare-step expectation clearer

## Why
**Pairing code never shown in app.** `bitbox02-api-go`'s `pair()` sets `device.channelHash` before issuing `opICanHasPairinVerificashun`, which blocks until the user confirms the pairing on the device. The previous flow `await init()` first, so the BitBox displayed the pairing code while the app stayed on its spinner indefinitely — there was no way to compare the codes. Calling `channelHashVerify()` before `init()` returned also crashed `createBitboxWallet` because the noise channel was not yet considered verified on the device side.

`bitbox.ChannelHash()` is a plain field read on the Go-side `Device`, so polling it concurrently with the still-running `init()` is safe.

**Modal-dismiss timer leak.** The cubit lives inside a `showModalBottomSheet`. Dismissing the sheet during the 90 s polling loop ran `close()` while `connectToBitbox()` was still in flight; the `catch` block then armed a fresh `Timer.periodic` on the disposed cubit and emitted onto a closed bloc. The `isClosed` guards stop the loop on disposal, prevent the catch path from arming a new timer, and let `close()` drop the `_pendingInit` reference cleanly.

**Engine crash on first Home load.** Right after a fresh pairing, `HomeBloc._setupFiatService` asks the wallet to sign a challenge so the DFX backend can verify ownership. For BitBox-backed wallets this goes through `bitbox_flutter`, and the SDK's `ETHSignMessage` panics with `unexpected NACK response` when the device rejects the request. Go panics in gomobile bindings cannot be caught from Dart, so the engine dies. Skipping the automatic call for BitBox wallets keeps the app alive — signing is then triggered explicitly by user-initiated flows that can present a clearer error.

## Changes
- `lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart`: parallel-poll for the channel hash, gate `confirmPairing()` on the init future, isClosed guards on every async path, drop `_pendingInit` in `close()`
- `lib/screens/home/bloc/home_bloc.dart`: skip auto-auth when the active credentials are `BitboxCredentials`
- `assets/languages/strings_de.arb`, `assets/languages/strings_en.arb`: reworded `connectBitboxConnecting`

## Test plan
Devices: iPhone with USB-C cable, BitBox02 Plus, debug-mode build, console open for `developer.log` output.

### 1. Happy path — fresh first pairing
- [ ] Hot-restart, Welcome → BitBox flow, plug BitBox in
- [ ] Within 1–2 s the same pairing code appears on BitBox **and** in the app
- [ ] Codes match
- [ ] Tap confirm in app → spinner appears
- [ ] Confirm on BitBox → app moves to Connected, wallet is created, onboarding continues

### 2. Cancel from `BitboxCheckHash`
- [ ] Steps 1–4 of test 1, then tap cancel in the app instead of confirm
- [ ] Sheet closes, no crash, no stuck spinner
- [ ] Restarting the BitBox flow immediately can re-pair

### 3. Modal-dismiss during `BitboxConnecting`
- [ ] Start BitBox flow, plug in, swipe sheet down while still on the spinner
- [ ] Sheet closes, no `Cannot emit new states after calling close` and no orphan timer in DevTools

### 4. Decline / timeout on the device
- [ ] Steps 1–5 of test 1, then either reject the pairing on the BitBox or do nothing
- [ ] Within ≤ 120 s the app shows the failure snackbar and returns to Welcome
- [ ] Re-pair works

### 5. Reach Home with a BitBox wallet
- [ ] Complete the pairing flow, set PIN and biometric on the device
- [ ] App lands on Home without crashing
- [ ] Fiat-service banner is hidden / disabled (the auth call is intentionally skipped)