### PR TITLE
fix: prevent orphaned timer leak on BitBox modal dismiss

### DIFF
--- a/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
+++ b/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
@@ -50,8 +50,9 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
 
       String channelHash = '';
       final deadline = DateTime.now().add(const Duration(seconds: 90));
-      while (channelHash.isEmpty && DateTime.now().isBefore(deadline)) {
+      while (channelHash.isEmpty && DateTime.now().isBefore(deadline) && !isClosed) {
         await Future.delayed(const Duration(milliseconds: 500));
+        if (isClosed) return;
         if (initFailed) throw Exception('init failed');
         try {
           final hash = await _service.getChannelHash().timeout(const Duration(seconds: 2));
@@ -59,12 +60,15 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
         } catch (_) {}
       }
 
+      if (isClosed) return;
+
       if (channelHash.isEmpty) throw TimeoutException('no channel hash within 90s');
 
       emit(BitboxCheckHash(device, channelHash));
     } catch (e) {
       developer.log(e.toString(), name: '$ConnectBitboxCubit');
       _pendingInit = null;
+      if (isClosed) return;
       emit(BitboxNotConnected());
       _checkForTimer = Timer.periodic(const Duration(milliseconds: 500), (_) => checkForBitbox());
     }
@@ -88,6 +92,7 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
     } catch (e) {
       developer.log(e.toString(), name: '$ConnectBitboxCubit');
       _pendingInit = null;
+      if (isClosed) return;
       emit(BitboxNotConnected());
       _checkForTimer = Timer.periodic(const Duration(milliseconds: 500), (_) => checkForBitbox());
     }
@@ -102,6 +107,7 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
   @override
   Future<void> close() async {
     _checkForTimer?.cancel();
+    _pendingInit = null;
     super.close();
   }
 }

--- a/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
+++ b/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
@@ -106,9 +106,9 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
   }
 
   @override
-  Future<void> close() async {
+  Future<void> close() {
     _checkForTimer?.cancel();
     _pendingInit = null;
-    super.close();
+    return super.close();
   }
 }

--- a/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
+++ b/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
@@ -27,6 +27,7 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
 
   Future<void> checkForBitbox() async {
     final devices = await _service.getAllUsbDevices();
+    if (isClosed) return;
     if (devices.isNotEmpty) {
       emit(BitboxFound(devices.first));
       _checkForTimer?.cancel();


### PR DESCRIPTION
## Summary
- Add `isClosed` guards to all async methods in `ConnectBitboxCubit` to prevent resource leaks on disposal
- Align `close()` with the project convention (`return super.close()` instead of `async` + bare `super.close()`)

## Problem
`ConnectBitboxCubit` lives inside a `showModalBottomSheet` without `isDismissible: false`. During the `BitboxConnecting` state there is no cancel button — the only way to abort is swiping the modal down.

When the user swipes during the 90-second polling loop introduced in #301:

1. `BlocProvider` removes the widget → `close()` runs → `_checkForTimer` is cancelled
2. But `connectToBitbox()` is an in-flight async method — it keeps running
3. When the loop eventually times out or `init` fails, the `catch` block creates a **new `Timer.periodic`** that is never cancelled (because `close()` already ran)
4. This timer holds a reference to the cubit, preventing garbage collection, and calls `checkForBitbox()` every 500ms indefinitely

The same issue exists in the `confirmPairing()` catch block.

## Fix
- `checkForBitbox()`: `if (isClosed) return` after `await getAllUsbDevices()` — prevents starting a connection flow on a disposed cubit
- `connectToBitbox()` `while` condition: `&& !isClosed` — stops polling immediately on dispose
- `connectToBitbox()` after `await Future.delayed`: `if (isClosed) return` — catches the edge case where close happens during the delay
- `connectToBitbox()` after loop exit: `if (isClosed) return` — prevents `emit` on a closed cubit
- Both `catch` blocks: `if (isClosed) return` — prevents creating orphaned timers
- `close()`: `_pendingInit = null` — drops the future reference
- `close()`: aligned with project convention — non-async with `return super.close()`

## Test plan
- [x] `flutter analyze` — 0 errors
- [x] `flutter test` — 182/182 passed
- [ ] Manual: open BitBox modal → swipe down during "connecting" spinner → verify no timer leak in DevTools