### PR TITLE
fix: gate DFX auth at the source instead of HomeBloc only

### DIFF
--- a/lib/packages/service/dfx/dfx_auth_service.dart
+++ b/lib/packages/service/dfx/dfx_auth_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 
@@ -83,6 +84,10 @@ abstract class DFXAuthService {
   }
 
   Future<String?> getAuthToken() async {
+    // bitbox_flutter's ETHSignMessage panics on a NACK and crashes the engine,
+    // so don't trigger backend auth that requires a fresh signature for
+    // BitBox-backed wallets until the SDK returns the error gracefully.
+    if (wallet.primaryAddress is BitboxCredentials) return null;
     if (appStore.sessionCache.authToken == null) {
       await appStore.sessionCache.loadSignature();
       final response = await getAuthResponse();

--- a/lib/screens/home/bloc/home_bloc.dart
+++ b/lib/screens/home/bloc/home_bloc.dart
@@ -3,7 +3,6 @@ import 'dart:developer' as developer;
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
-import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/balance_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
@@ -136,11 +135,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   }
 
   Future<void> _setupFiatService(Emitter<HomeState> emit) async {
-    if (_appStore.wallet.currentAccount.primaryAddress is BitboxCredentials) {
-      // bitbox_flutter's ETHSignMessage panics on a NACK and crashes the engine.
-      emit(state.copyWith(isFiatServiceAvailable: false));
-      return;
-    }
     try {
       await _dfxService.getAuthToken();
       emit(state.copyWith(isFiatServiceAvailable: _dfxService.isAvailable));


### PR DESCRIPTION
## Summary
- Move the BitBox short-circuit out of `HomeBloc._setupFiatService` and into `DFXAuthService.getAuthToken()` so every caller is covered
- `getAuthToken()` returns `null` for `BitboxCredentials` wallets, which the existing callers already treat as \"not authenticated\"

## Why
`bitbox_flutter`'s `ETHSignMessage` panics on a NACK from the device and crashes the Flutter engine (panics in gomobile bindings cannot be caught from Dart). #301 added a guard inside `HomeBloc._setupFiatService` so the auto-auth on Home would not crash a BitBox-backed wallet, but the same `getAuthToken()` path is reachable from `DfxKycService`, `DfxSupportService`, `DfxWidgetService`, and every future `DFXAuthService` consumer — each one would still crash the app the moment the user touched that feature.

Putting the check at the source means the workaround can stay in one place until the SDK returns the error gracefully (tracked in DFXswiss/bitbox_flutter).

## Changes
- `lib/packages/service/dfx/dfx_auth_service.dart`: `getAuthToken()` short-circuits to `null` when the active credentials are `BitboxCredentials`
- `lib/screens/home/bloc/home_bloc.dart`: drop the now-redundant guard and the `bitbox_credentials` import

## Test plan
- [ ] Pair a BitBox, land on Home — no crash, fiat banner stays disabled (same as #301)
- [ ] Open Settings → Contact / KYC entry while BitBox-paired — no crash, the affected screens treat the user as unauthenticated
- [ ] Software wallet on Home still authenticates against DFX (regression check)