### PR TITLE
perf: snappier BitBox channel-hash poll after PIN unlock

### DIFF
--- a/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
+++ b/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
@@ -40,19 +40,29 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
     emit(BitboxConnecting(device));
     try {
       var initFailed = false;
-      _pendingInit = _service.init(device).then((success) {
-        if (!success) initFailed = true;
-        return success;
-      }).catchError((Object e) {
-        developer.log('init error: $e', name: '$ConnectBitboxCubit');
-        initFailed = true;
-        return false;
-      });
+      _pendingInit = _service
+          .init(device)
+          .then((success) {
+            if (!success) initFailed = true;
+            return success;
+          })
+          .catchError((Object e) {
+            developer.log('init error: $e', name: '$ConnectBitboxCubit');
+            initFailed = true;
+            return false;
+          });
 
       String channelHash = '';
       final deadline = DateTime.now().add(const Duration(seconds: 90));
+      var firstIteration = true;
       while (channelHash.isEmpty && DateTime.now().isBefore(deadline) && !isClosed) {
-        await Future.delayed(const Duration(milliseconds: 500));
+        // First sleep is longer so the SDK can finish setting up its Go-side
+        // device pointer before we call into it; subsequent iterations stay
+        // tight so the post-PIN handover feels snappy.
+        await Future.delayed(
+          firstIteration ? const Duration(milliseconds: 500) : const Duration(milliseconds: 100),
+        );
+        firstIteration = false;
         if (isClosed) return;
         if (initFailed) throw Exception('init failed');
         try {


### PR DESCRIPTION
## Summary
- Check the channel hash at the start of every poll iteration instead of sleeping first; break out as soon as a non-empty value comes back
- Drop the inter-poll sleep from 500 ms to 100 ms

## Why
After the PIN is entered on the device, `pair()`'s noise handshake sets `device.channelHash` within a couple of BLE round-trips. Before this PR the poll loop slept 500 ms at the top of each iteration, so once the hash became available the app could still lag up to half a second behind the device's display — users perceived a noticeable hang \"after the last PIN digit\".

`bitbox.ChannelHash()` is a plain field read on the Go side, so the tighter cadence (100 ms) costs effectively nothing and the immediate first read removes the leading 500 ms of dead time.

## Test plan
- [ ] Pair a BitBox, enter the PIN — the pairing code appears in the app within ~100 ms of being shown on the device
- [ ] Cancel during connecting still returns to the welcome flow cleanly
- [ ] Re-pair without restarting the app still works