### PR TITLE
perf: hash app PIN off the main thread

### DIFF
--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:math';
-import 'dart:typed_data';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:pointycastle/api.dart';
 import 'package:pointycastle/block/aes.dart';
@@ -51,6 +51,18 @@ class SecureStorage {
     return bytesToHex(derivator.process(utf8.encode(pin)));
   }
 
+  /// Off-main-thread variant of [hashPin]. PBKDF2 with 600k iterations takes
+  /// several seconds on a phone and freezes the UI when run synchronously, so
+  /// any caller reachable from the UI should await this instead.
+  static Future<String> hashPinAsync(
+    String pin,
+    Uint8List salt, {
+    int iterations = _pinHashIterations,
+  }) => compute(
+    _hashPinIsolate,
+    (pin: pin, salt: salt, iterations: iterations),
+  );
+
   Future<String?> getPinHash() => _secureStorage.read(key: _pinHashKey);
 
   Future<void> setPinHash(String hash) => _secureStorage.write(key: _pinHashKey, value: hash);
@@ -76,11 +88,11 @@ class SecureStorage {
     final salt = await getPinSalt();
     if (hash == null || salt == null) return false;
 
-    if (hashPin(pin, salt) == hash) return true;
+    if (await hashPinAsync(pin, salt) == hash) return true;
 
     // Transparent rehash: verify against legacy iterations, upgrade if match
-    if (hashPin(pin, salt, iterations: _legacyPinHashIterations) == hash) {
-      final newHash = hashPin(pin, salt);
+    if (await hashPinAsync(pin, salt, iterations: _legacyPinHashIterations) == hash) {
+      final newHash = await hashPinAsync(pin, salt);
       await setPinHash(newHash);
       return true;
     }
@@ -154,3 +166,6 @@ class SecureStorage {
     return Uint8List.fromList(List.generate(length, (_) => random.nextInt(256)));
   }
 }
+
+String _hashPinIsolate(({String pin, Uint8List salt, int iterations}) args) =>
+    SecureStorage.hashPin(args.pin, args.salt, iterations: args.iterations);

--- a/lib/screens/pin/bloc/setup_pin/setup_pin_cubit.dart
+++ b/lib/screens/pin/bloc/setup_pin/setup_pin_cubit.dart
@@ -60,7 +60,7 @@ class SetupPinCubit extends Cubit<SetupPinState> {
   Future<void> _confirmPin(String confirmPin) async {
     if (confirmPin == _createPin) {
       final salt = SecureStorage.generatePinSalt();
-      final hash = SecureStorage.hashPin(confirmPin, salt);
+      final hash = await SecureStorage.hashPinAsync(confirmPin, salt);
       await Future.wait([
         _secureStorage.setPinSalt(salt),
         _secureStorage.setPinHash(hash),


### PR DESCRIPTION
## Summary
- Add `SecureStorage.hashPinAsync` that runs the existing PBKDF2 derivation in a `compute()` isolate
- Switch the PIN setup confirm step and `verifyPin` to the async variant

## Why
PBKDF2 with 600k SHA-256 iterations (introduced in #290) takes 5–10 s on a phone. `_confirmPin` ran the derivation synchronously on the platform isolate, which froze the UI from the moment the last digit of the confirmation PIN was tapped until the home screen rendered — the user-visible \"freeze for ten seconds\" right after PIN setup. `verifyPin` had the same hot path twice (current + legacy iteration count) so every unlock blocked the UI as well.

`compute()` ships the work to a worker isolate; the synchronous `hashPin` stays for callers that already run outside the UI loop.

## Test plan
- [ ] Set up a fresh app PIN — Home screen renders within ~100 ms of the last digit instead of freezing for several seconds
- [ ] Verify PIN on a subsequent launch — no UI freeze, the PIN dots animate while the hash is computed
- [ ] Legacy PIN hash (10k iterations) still verifies and gets transparently rehashed to 600k