### PR TITLE
fix: drop stale BitBox channel hash on re-pair

### DIFF
--- a/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
+++ b/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
@@ -20,6 +20,11 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
     _checkForTimer = Timer.periodic(const Duration(milliseconds: 500), (_) => checkForBitbox());
   }
 
+  // Tracks whether the SDK's Go-side device pointer has been initialised in
+  // this process. Until it has, calling getChannelHash dereferences nil and
+  // crashes the engine, so we only read the cached hash for re-pairings.
+  static bool _sdkInitialised = false;
+
   final BitboxService _service;
   final WalletService _walletService;
   Timer? _checkForTimer;
@@ -39,15 +44,25 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
     if (state is BitboxConnecting) return;
     emit(BitboxConnecting(device));
     try {
+      // The SDK's Go-side device singleton survives across pairings, so on a
+      // re-pair the previous channel hash is still cached until the new noise
+      // handshake replaces it. Capture that stale value first and reject it
+      // during the poll so the user never sees a code that does not match the
+      // BitBox display.
+      final priorHash = _sdkInitialised ? await _readChannelHash() : '';
+
       var initFailed = false;
-      _pendingInit = _service.init(device).then((success) {
-        if (!success) initFailed = true;
-        return success;
-      }).catchError((Object e) {
-        developer.log('init error: $e', name: '$ConnectBitboxCubit');
-        initFailed = true;
-        return false;
-      });
+      _pendingInit = _service
+          .init(device)
+          .then((success) {
+            if (!success) initFailed = true;
+            return success;
+          })
+          .catchError((Object e) {
+            developer.log('init error: $e', name: '$ConnectBitboxCubit');
+            initFailed = true;
+            return false;
+          });
 
       String channelHash = '';
       final deadline = DateTime.now().add(const Duration(seconds: 90));
@@ -55,16 +70,15 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
         await Future.delayed(const Duration(milliseconds: 500));
         if (isClosed) return;
         if (initFailed) throw Exception('init failed');
-        try {
-          final hash = await _service.getChannelHash().timeout(const Duration(seconds: 2));
-          if (hash.isNotEmpty) channelHash = hash;
-        } catch (_) {}
+        final hash = await _readChannelHash();
+        if (hash.isNotEmpty && hash != priorHash) channelHash = hash;
       }
 
       if (isClosed) return;
 
       if (channelHash.isEmpty) throw TimeoutException('no channel hash within 90s');
 
+      _sdkInitialised = true;
       emit(BitboxCheckHash(device, channelHash));
     } catch (e) {
       developer.log(e.toString(), name: '$ConnectBitboxCubit');
@@ -72,6 +86,14 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
       if (isClosed) return;
       emit(BitboxNotConnected());
       _checkForTimer = Timer.periodic(const Duration(milliseconds: 500), (_) => checkForBitbox());
+    }
+  }
+
+  Future<String> _readChannelHash() async {
+    try {
+      return await _service.getChannelHash().timeout(const Duration(seconds: 2));
+    } catch (_) {
+      return '';
     }
   }
 


### PR DESCRIPTION
## Summary
- Capture `getChannelHash` once before kicking off `init()` and reject that value as the poll's stale baseline
- Gate the prior-hash read on a static `_sdkInitialised` flag that flips once we have observed a real hash, so the very first pairing — where the SDK's Go-side device pointer is still nil — does not nil-deref

## Why
`bitbox_flutter`'s Go-side `Device` is a process-wide singleton; `device.channelHash` keeps the previous pairing's value until the next noise handshake overwrites it. When the user starts a second connect within the same app session, the cubit's poll picks up the old hash before the new handshake completes and shows it in the app — the BitBox then displays a different code, the user notices the mismatch, and the pairing has to be cancelled.

The fix records the stale value first and rejects it during the poll. The `_sdkInitialised` flag keeps the first-pair path unchanged: until we have received any hash, calling into the SDK would crash the engine on a nil pointer.

## Test plan
- [ ] Pair a BitBox successfully (first pairing in the session)
- [ ] Without restarting the app, start a second pairing while the BitBox is still booting — the app waits for the new code instead of showing the old one
- [ ] Codes on BitBox and app match in both pairings
- [ ] Cold-start pair still works (no nil-deref crash)