### PR TITLE
chore: pin bitbox_flutter to v0.0.1 release tag

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,7 +73,7 @@ dependencies:
   bitbox_flutter:
     git:
       url: https://github.com/DFXswiss/bitbox_flutter.git
-      ref: main
+      ref: v0.0.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,7 +73,7 @@ dependencies:
   bitbox_flutter:
     git:
       url: https://github.com/DFXswiss/bitbox_flutter.git
-      ref: feature/ios-ble-pairing
+      ref: main
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Switch bitbox_flutter git dependency from `feature/ios-ble-pairing` branch to `v0.0.1` release tag

## Why
Dependencies should reference immutable release tags, not branches. This ensures reproducible builds and explicit version control. The `feature/ios-ble-pairing` branch content has been merged and released as `v0.0.1`.