### PR TITLE
chore: bump bitbox_flutter to v0.0.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,7 +73,7 @@ dependencies:
   bitbox_flutter:
     git:
       url: https://github.com/DFXswiss/bitbox_flutter.git
-      ref: v0.0.1
+      ref: v0.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Bump bitbox_flutter from `v0.0.1` to `v0.0.2`

## What's in v0.0.2
- Remove broken packet deduplication from BLE read path (could cause hangs)
- Fix force-unwrap crash in BLE write on disconnect race condition