### PR TITLE
fix: gate sensitive KYC steps behind BitBox EIP-712 sign

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -195,6 +195,7 @@
   "registerEmailInvalid": "E-Mail ist ungültig",
   "registerEmailRequired": "E-Mail ist erforderlich",
   "registerEmailVerification": "E-Mail Bestätigung",
+  "registerEmailVerificationBitboxSignHint": "Bitte bestätigen Sie die Signatur auf Ihrer BitBox — die Nachricht erstreckt sich über mehrere Seiten, halten Sie den Touchsensor zum Weiterblättern.",
   "registerEmailVerificationButton": "Ich habe meine E-Mail bestätigt",
   "registerEmailVerificationDescription": "Wie es aussieht, haben Sie bereits ein Konto. Wir haben Ihnen gerade eine E-Mail geschickt. Um mit Ihrem bestehenden Konto fortzufahren, bestätigen Sie bitte Ihre E-Mail-Adresse, indem Sie auf den zugesandten Link klicken.",
   "registerEmailVerificationFailed": "Sie haben Ihre E-Mail noch nicht bestätigt.",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -195,6 +195,7 @@
   "registerEmailInvalid": "Email is invalid",
   "registerEmailRequired": "Email is required",
   "registerEmailVerification": "Email verification",
+  "registerEmailVerificationBitboxSignHint": "Confirm the signature on your BitBox — the message spans multiple pages, hold the touch sensor to advance.",
   "registerEmailVerificationButton": "I have confirmed my email address",
   "registerEmailVerificationDescription": "It looks like you already have an account. We have just sent you an email. To continue with your existing account, please confirm your email address by clicking on the link in the email.",
   "registerEmailVerificationFailed": "You have not yet confirmed your email address.",

--- a/lib/packages/service/dfx/dfx_auth_service.dart
+++ b/lib/packages/service/dfx/dfx_auth_service.dart
@@ -1,12 +1,14 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:realunit_wallet/packages/config/api_config.dart';
-import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 
 abstract class DFXAuthService {
   static const walletName = 'RealUnit';
+  static const _signMessageTimeout = Duration(minutes: 3);
+  static const _httpTimeout = Duration(seconds: 20);
 
   final String signMessagePath = '/v1/auth/signMessage';
   final String authPath = '/v1/auth';
@@ -23,7 +25,9 @@ abstract class DFXAuthService {
   Future<String> getSignMessage() async {
     final uri = buildUri(host, signMessagePath, {'address': walletAddress});
 
-    final response = await appStore.httpClient.get(uri, headers: {'accept': 'application/json'});
+    final response = await appStore.httpClient
+        .get(uri, headers: {'accept': 'application/json'})
+        .timeout(_httpTimeout);
 
     if (response.statusCode == 200) {
       final responseBody = jsonDecode(response.body);
@@ -42,7 +46,10 @@ abstract class DFXAuthService {
       return cached;
     }
 
-    final signature = await wallet.signMessage(message);
+    final signature = await wallet.signMessage(message).timeout(_signMessageTimeout);
+    if (signature.isEmpty || signature == '0x') {
+      throw Exception('Wallet returned an empty signature');
+    }
     await appStore.sessionCache.saveSignature(walletAddress, signature);
 
     return signature;
@@ -65,11 +72,9 @@ abstract class DFXAuthService {
     );
 
     final uri = buildUri(host, authPath);
-    final response = await appStore.httpClient.post(
-      uri,
-      headers: {'Content-Type': 'application/json'},
-      body: requestBody,
-    );
+    final response = await appStore.httpClient
+        .post(uri, headers: {'Content-Type': 'application/json'}, body: requestBody)
+        .timeout(_httpTimeout);
 
     if (response.statusCode == 201) {
       final responseBody = jsonDecode(response.body);
@@ -83,11 +88,11 @@ abstract class DFXAuthService {
     }
   }
 
+  // The BitBox-credentials skip introduced in PR #304 is no longer needed:
+  // bitbox_flutter v0.0.2 fixed the BLE force-unwrap and dedup hang, the
+  // empty-signature guard in `getSignature` covers the cancel/disconnect
+  // case gracefully, and the SDK no longer panics on NACK.
   Future<String?> getAuthToken() async {
-    // bitbox_flutter's ETHSignMessage panics on a NACK and crashes the engine,
-    // so don't trigger backend auth that requires a fresh signature for
-    // BitBox-backed wallets until the SDK returns the error gracefully.
-    if (wallet.primaryAddress is BitboxCredentials) return null;
     if (appStore.sessionCache.authToken == null) {
       await appStore.sessionCache.loadSignature();
       final response = await getAuthResponse();

--- a/lib/packages/wallet/eip712_signer.dart
+++ b/lib/packages/wallet/eip712_signer.dart
@@ -109,15 +109,25 @@ class Eip712Signer {
     CredentialsWithKnownAddress credentials,
     int chainId,
     String jsonData,
-  ) => switch (credentials) {
-    BitboxCredentials() => credentials.signTypedDataV4(chainId, jsonData),
-    EthPrivateKey() => Future.value(
-      EthSigUtil.signTypedData(
-        privateKey: bytesToHex(credentials.privateKey, include0x: true),
-        jsonData: jsonData,
-        version: TypedDataVersion.V4,
+  ) async {
+    final signature = await switch (credentials) {
+      BitboxCredentials() => credentials.signTypedDataV4(chainId, jsonData),
+      EthPrivateKey() => Future.value(
+        EthSigUtil.signTypedData(
+          privateKey: bytesToHex(credentials.privateKey, include0x: true),
+          jsonData: jsonData,
+          version: TypedDataVersion.V4,
+        ),
       ),
-    ),
-    _ => throw UnsupportedError('Unsupported credentials type: ${credentials.runtimeType}'),
-  };
+      _ => throw UnsupportedError('Unsupported credentials type: ${credentials.runtimeType}'),
+    };
+    // The BitBox swift wrapper returns empty bytes ('0x') when the user
+    // cancels on the device or the BLE link drops mid-sign; without this
+    // guard the empty sig would be sent to the backend and the abort would
+    // be misread as a successful sign.
+    if (signature.isEmpty || signature == '0x') {
+      throw Exception('Signature was empty — wallet may have been cancelled or disconnected');
+    }
+    return signature;
+  }
 }

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -36,6 +36,10 @@ class KycCubit extends Cubit<KycState> {
   // forces a fresh hardware-wallet confirmation before sensitive steps.
   bool _bitboxConfirmed = false;
 
+  // `Future.timeout` does not cancel the underlying work — this flag lets
+  // late HTTP responses bail out instead of overwriting the failure state.
+  bool _timedOut = false;
+
   KycCubit(
     DfxKycService kycService,
     RealUnitRegistrationService registrationService, {
@@ -46,9 +50,11 @@ class KycCubit extends Cubit<KycState> {
        super(const KycInitial());
 
   Future<void> checkKyc() async {
+    _timedOut = false;
     try {
       await _runCheckKyc().timeout(_checkKycTimeout);
     } on TimeoutException {
+      _timedOut = true;
       if (!isClosed) emit(const KycFailure('KYC backend did not respond in time'));
     } catch (e) {
       if (!isClosed) emit(KycFailure(e.toString()));
@@ -64,10 +70,7 @@ class KycCubit extends Cubit<KycState> {
         _kycService.getUser(),
       ]);
 
-      // `Future.timeout` does not cancel the underlying work — guard against
-      // a slow API response landing after the outer timeout fired and
-      // overwriting the failure state.
-      if (isClosed) return;
+      if (isClosed || _timedOut) return;
 
       final kycStatus = results.elementAt(0) as KycLevelDto;
       final user = results.elementAt(1) as UserDto;
@@ -163,6 +166,7 @@ class KycCubit extends Cubit<KycState> {
   /// should only be called after realunit registration was completed
   Future<void> _continueKyc() async {
     final kycStatus = await _kycService.continueKyc();
+    if (isClosed || _timedOut) return;
     final currentStep = kycStatus.kycSteps.firstWhere((step) => step.isCurrent);
 
     final kycStep = _mapStepName(currentStep.name);

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -6,9 +8,7 @@ import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.da
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_level_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/user/dto/user_dto.dart';
-import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_wallet_status_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
-import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
 
 part 'kyc_state.dart';
 
@@ -22,38 +22,55 @@ class KycCubit extends Cubit<KycState> {
   };
 
   static const _minLevelForActions = 30;
+  static const _checkKycTimeout = Duration(seconds: 30);
 
   final DfxKycService _kycService;
-  final RealUnitWalletService _walletService;
   final RealUnitRegistrationService _registrationService;
   final int _requiredLevel;
 
   bool _legalDisclaimerAccepted = false;
+  bool _emailRegistrationAttempted = false;
+
+  // Per-cubit-instance gate. Reset on every KYC entry because `KycPageManager`
+  // creates a fresh `KycCubit` via `BlocProvider(create:)`, so each entry
+  // forces a fresh hardware-wallet confirmation before sensitive steps.
+  bool _bitboxConfirmed = false;
 
   KycCubit(
     DfxKycService kycService,
-    RealUnitWalletService walletService,
     RealUnitRegistrationService registrationService, {
     int? requiredLevel,
   }) : _kycService = kycService,
-       _walletService = walletService,
        _registrationService = registrationService,
        _requiredLevel = requiredLevel ?? _minLevelForActions,
        super(const KycInitial());
 
   Future<void> checkKyc() async {
     try {
+      await _runCheckKyc().timeout(_checkKycTimeout);
+    } on TimeoutException {
+      if (!isClosed) emit(const KycFailure('KYC backend did not respond in time'));
+    } catch (e) {
+      if (!isClosed) emit(KycFailure(e.toString()));
+    }
+  }
+
+  Future<void> _runCheckKyc() async {
+    try {
       emit(const KycLoading());
 
       final results = await Future.wait([
-        _walletService.getWalletStatus(),
         _kycService.getKycStatus(),
         _kycService.getUser(),
       ]);
 
-      final status = results.elementAt(0) as RealUnitWalletStatusDto;
-      final kycStatus = results.elementAt(1) as KycLevelDto;
-      final user = results.elementAt(2) as UserDto;
+      // `Future.timeout` does not cancel the underlying work — guard against
+      // a slow API response landing after the outer timeout fired and
+      // overwriting the failure state.
+      if (isClosed) return;
+
+      final kycStatus = results.elementAt(0) as KycLevelDto;
+      final user = results.elementAt(1) as UserDto;
       final level = kycStatus.kycLevel.value;
 
       if (user.mail == null) {
@@ -63,20 +80,31 @@ class KycCubit extends Cubit<KycState> {
 
       // edge case, where email exists but level is <10. In this case email is automatically registered for RealUnit
       if (user.mail != null && level < 10) {
+        if (_emailRegistrationAttempted) {
+          // Backend did not bump the level after registration; surface the
+          // current state instead of recursing forever.
+          emit(const KycSuccess(currentStep: KycStep.email));
+          return;
+        }
+        _emailRegistrationAttempted = true;
         await _registrationService.registerEmail(user.mail!);
-        await checkKyc();
+        await _runCheckKyc();
         return;
       }
 
-      if (!status.isRegistered) {
-        if (!_legalDisclaimerAccepted) {
-          emit(const KycSuccess(currentStep: KycStep.legalDisclaimer));
-          return;
-        }
-        if (level < 20) {
-          emit(const KycSuccess(currentStep: KycStep.registration));
-          return;
-        }
+      // Disclaimer + form (name/address) + EIP-712 13-step sign always
+      // precede every state past the email step, even when the user is
+      // already at `>= requiredLevel`. The hardware-wallet ceremony is the
+      // security gate, not the backend KYC level — without the sign a
+      // returning user with a high level would otherwise be granted
+      // sensitive actions on this device without ever touching the BitBox.
+      if (!_legalDisclaimerAccepted) {
+        emit(const KycSuccess(currentStep: KycStep.legalDisclaimer));
+        return;
+      }
+      if (!_bitboxConfirmed) {
+        emit(const KycSuccess(currentStep: KycStep.registration));
+        return;
       }
 
       if (level < _requiredLevel) {
@@ -98,7 +126,11 @@ class KycCubit extends Cubit<KycState> {
 
         if (pendingStep != null) {
           final step = _mapStepName(pendingStep.name);
-          if (step != null) emit(KycPending(step));
+          if (step != null) {
+            emit(KycPending(step));
+          } else {
+            emit(KycUnsupportedStepFailure(pendingStep.name));
+          }
           return;
         }
 
@@ -108,8 +140,9 @@ class KycCubit extends Cubit<KycState> {
 
       emit(const KycCompleted());
     } on ApiException catch (e) {
-      // API returns 403 when 2FA verification is required before proceeding
-      if (e.statusCode == 403) {
+      // API returns 403 / code TFA_REQUIRED when 2FA verification is required
+      // before proceeding.
+      if (e.statusCode == 403 || e.code == 'TFA_REQUIRED') {
         emit(const KycSuccess(currentStep: KycStep.twoFa));
       } else {
         rethrow;
@@ -121,6 +154,10 @@ class KycCubit extends Cubit<KycState> {
 
   void markLegalDisclaimerAccepted() {
     _legalDisclaimerAccepted = true;
+  }
+
+  void markBitboxConfirmed() {
+    _bitboxConfirmed = true;
   }
 
   /// should only be called after realunit registration was completed

--- a/lib/screens/kyc/kyc_page_manager.dart
+++ b/lib/screens/kyc/kyc_page_manager.dart
@@ -4,7 +4,6 @@ import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
-import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
 import 'package:realunit_wallet/screens/kyc/cubits/kyc/kyc_cubit.dart';
 import 'package:realunit_wallet/screens/kyc/steps/2fa/kyc_2fa_page.dart';
 import 'package:realunit_wallet/screens/kyc/steps/email/kyc_email_page.dart';
@@ -30,7 +29,6 @@ class KycPageManager extends StatelessWidget {
     return BlocProvider(
       create: (context) => KycCubit(
         getIt<DfxKycService>(),
-        getIt<RealUnitWalletService>(),
         getIt<RealUnitRegistrationService>(),
         requiredLevel: requiredLevel,
       )..checkKyc(),

--- a/lib/screens/kyc/steps/email/subpages/kyc_email_verification_page.dart
+++ b/lib/screens/kyc/steps/email/subpages/kyc_email_verification_page.dart
@@ -3,9 +3,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
+import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
 import 'package:realunit_wallet/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart';
 import 'package:realunit_wallet/setup/di.dart';
 import 'package:realunit_wallet/styles/colors.dart';
@@ -90,12 +92,32 @@ class KycEmailVerificationView extends StatelessWidget {
                         padding: const .symmetric(vertical: 16.0),
                         child: BlocBuilder<KycEmailVerificationCubit, KycEmailVerificationState>(
                           builder: (context, state) {
-                            return AppFilledButton(
-                              state: state is KycEmailVerificationLoading ? .loading : .idle,
-                              onPressed: () => context
-                                  .read<KycEmailVerificationCubit>()
-                                  .checkEmailVerification(),
-                              label: S.of(context).registerEmailVerificationButton,
+                            final isLoading = state is KycEmailVerificationLoading;
+                            final isBitbox = context
+                                    .read<HomeBloc>()
+                                    .state
+                                    .openWallet
+                                    ?.currentAccount
+                                    .primaryAddress is BitboxCredentials;
+                            return Column(
+                              spacing: 12,
+                              children: [
+                                AppFilledButton(
+                                  state: isLoading ? .loading : .idle,
+                                  onPressed: () => context
+                                      .read<KycEmailVerificationCubit>()
+                                      .checkEmailVerification(),
+                                  label: S.of(context).registerEmailVerificationButton,
+                                ),
+                                if (isLoading && isBitbox)
+                                  Text(
+                                    S.of(context).registerEmailVerificationBitboxSignHint,
+                                    textAlign: .center,
+                                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                      color: RealUnitColors.neutral500,
+                                    ),
+                                  ),
+                              ],
                             );
                           },
                         ),

--- a/lib/screens/kyc/steps/registration/cubits/registration_submit/kyc_registration_submit_cubit.dart
+++ b/lib/screens/kyc/steps/registration/cubits/registration_submit/kyc_registration_submit_cubit.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/country/country.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/registration.dart';
@@ -78,6 +79,17 @@ class KycRegistrationSubmitCubit extends Cubit<KycRegistrationSubmitState> {
       emit(
         KycRegistrationSubmitBitboxRequired(registration: registration),
       );
+    } on ApiException catch (e) {
+      // The EIP-712 13-step sign already succeeded on the device — the user
+      // has proven hardware-wallet control. The backend's logical rejection
+      // (already registered / wallet linked to another account / merge
+      // required) is informational, not a signal that the ceremony failed.
+      // Treat the sign as completed and let `KycCubit.checkKyc()` resolve
+      // the next step from the refreshed KYC status (merge page, ident,
+      // ...). Network / parse errors throw a different exception type and
+      // still surface as a failure below.
+      developer.log('completeRegistration backend rejected after sign: $e');
+      emit(const KycRegistrationSubmitSuccess(RegistrationStatus.completed));
     } catch (e) {
       developer.log(e.toString());
       emit(KycRegistrationSubmitFailure(e.toString()));

--- a/lib/screens/kyc/steps/registration/kyc_registration_page.dart
+++ b/lib/screens/kyc/steps/registration/kyc_registration_page.dart
@@ -102,6 +102,9 @@ class _KycRegistrationViewState extends State<KycRegistrationView> {
         listener: (context, state) async {
           if (state is KycRegistrationSubmitSuccess) {
             if (state.status == RegistrationStatus.completed) {
+              // completeRegistration already produced the BitBox 13-step sign,
+              // so skip the security ceremony on the next checkKyc.
+              context.read<KycCubit>().markBitboxConfirmed();
               context.read<KycCubit>().checkKyc();
             }
           }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,8 +69,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "feature/ios-ble-pairing"
-      resolved-ref: dd7a45ce29fc425d769b33c6dc8ec81b53f785de
+      ref: "v0.0.3"
+      resolved-ref: "1807d51fc93e215b5860cb9888b6409aea5bba67"
       url: "https://github.com/DFXswiss/bitbox_flutter.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,7 +73,7 @@ dependencies:
   bitbox_flutter:
     git:
       url: https://github.com/DFXswiss/bitbox_flutter.git
-      ref: v0.0.2
+      ref: v0.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge-blocked on DFXswiss/bitbox_flutter#11.** Without that SDK PR's per-message scoped dedup + 60 s BLE read timeout, the EIP-712 sign aborts at step 1→2 (BLE-layer retransmit corrupts the U2F HID frame stream) and / or after the 10 s timeout fires mid-confirmation. Sequence: merge #11 → tag `v0.0.3` → bump this PR's `pubspec.yaml` from `v0.0.2` to `v0.0.3` → merge here.

## Summary
- `KycCubit` hoists the disclaimer + form (name/address) + EIP-712 13-step BitBox sign in front of every state past the email step. Returning users at `level >= requiredLevel` previously dropped straight into `KycCompleted` without ever touching the BitBox; the hardware-wallet ceremony is the security gate, not the backend KYC level. `_bitboxConfirmed` is per-`KycCubit` instance and resets on every KYC entry, so each entry forces a fresh confirmation.
- `KycRegistrationSubmitCubit` treats every `ApiException` raised after a successful EIP-712 sign as `RegistrationStatus.completed`. The user has proven hardware-wallet control on the device — the backend's logical reply (already registered, wallet linked to another account, merge required, …) is informational. `KycCubit.checkKyc()` then resolves the next state from the refreshed status, including the existing `KycAccountMergeRequested` page when the wallet is bound to another DFX user. Network / parse / sign errors raise non-`ApiException` types and still surface as a `KycRegistrationSubmitFailure` SnackBar.
- `Eip712Signer._signTypedData` now throws when the signature comes back empty or `'0x'`. The bitbox_flutter iOS bridge returns empty bytes when the user cancels mid-sign or the BLE link drops; before this PR the empty signature was POSTed and silently accepted as a successful sign.
- TFA handling: the cubit recognises both `statusCode == 403` and `code == 'TFA_REQUIRED'` as the trigger for routing to the 2FA step (paired with #310's `httpStatusCode` fallback so the code path is reachable).
- `checkKyc` is wrapped in a 30 s top-level timeout. The email-auto-registration recursion has a one-shot guard so a backend that does not bump the level after `registerEmail` cannot keep the loading spinner alive forever. An `isClosed` guard after the API fetch in `_runCheckKyc` prevents a slow response from overwriting a timeout failure.
- `DFXAuthService`: removed the BitBox auth skip from #304 (no longer needed after the v0.0.2 SDK fixes — see inline comment for context). Added a 3 min sign timeout for the BitBox 13-step ceremony, 20 s HTTP timeouts, and an empty-signature guard for personal-message signing.
- Email verification shows a localized BitBox sign hint (`registerEmailVerificationBitboxSignHint`) below the confirm button while the signature ceremony is running.

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 188 tests pass
- [ ] Fresh wallet without RealUnit registration: email → disclaimer → form → BitBox 13 fields + sign → ident
- [ ] Wallet already attached to the same RealUnit user, KYC level < 30: disclaimer → form → BitBox 13 fields + sign → ident (backend's already-registered reply tolerated, KYC continues)
- [ ] **Wallet attached to a different DFX user**: disclaimer → form → BitBox 13 fields + sign → `KycAccountMergePage` ("Identität in anderem Konto gefunden, Merge per Email bestätigen") instead of the generic failure screen
- [ ] Returning user already at `level >= 30`: disclaimer + form + BitBox sign first, then `KycCompleted` (no silent grant)
- [ ] Cancel the BitBox sign mid-ceremony → `Signature was empty` SnackBar, no silent success
- [ ] BitBox not connected on submit → existing modal sheet pops (light theme), reconnect → retry
- [ ] Backend response with `code: TFA_REQUIRED` → cubit emits `KycSuccess(twoFa)` instead of `KycFailure`