### PR TITLE
feat: add beta APK release on develop merge

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -2,7 +2,7 @@ name: Auto Tag on Merge
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: write
@@ -48,6 +48,7 @@ jobs:
         id: next-version
         run: |
           LATEST_TAG="${{ steps.get-tag.outputs.latest_tag }}"
+          BRANCH="${{ github.ref_name }}"
 
           # Remove 'v' prefix and split into parts
           VERSION="${LATEST_TAG#v}"
@@ -55,9 +56,25 @@ jobs:
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           PATCH=$(echo "$VERSION" | cut -d. -f3)
 
-          # Increment patch version
+          # Next release version
           NEW_PATCH=$((PATCH + 1))
-          NEW_TAG="v${MAJOR}.${MINOR}.${NEW_PATCH}"
+          NEXT_VERSION="v${MAJOR}.${MINOR}.${NEW_PATCH}"
+
+          if [ "$BRANCH" = "main" ]; then
+            NEW_TAG="$NEXT_VERSION"
+          else
+            # For develop: find latest beta tag for the next version
+            LATEST_BETA=$(git tag -l --sort=-v:refname "${NEXT_VERSION}-beta.*" | head -n 1)
+
+            if [ -z "$LATEST_BETA" ]; then
+              NEW_TAG="${NEXT_VERSION}-beta.1"
+            else
+              # Extract beta number and increment
+              BETA_NUM=$(echo "$LATEST_BETA" | sed "s/${NEXT_VERSION}-beta\.//")
+              NEW_BETA=$((BETA_NUM + 1))
+              NEW_TAG="${NEXT_VERSION}-beta.${NEW_BETA}"
+            fi
+          fi
 
           echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
           echo "::notice::New tag: $NEW_TAG"

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   android-deploy:
+    if: ${{ !contains(github.ref_name, 'beta') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -107,6 +108,7 @@ jobs:
           path: build/app/outputs/flutter-apk/realunit-*.apk
 
   ios-deploy:
+    if: ${{ !contains(github.ref_name, 'beta') }}
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
@@ -200,6 +202,7 @@ jobs:
           path: ios/realunit-*.ipa
 
   github-release:
+    if: ${{ !contains(github.ref_name, 'beta') }}
     needs: [android-deploy, ios-deploy]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/develop-release.yaml
+++ b/.github/workflows/develop-release.yaml
@@ -1,0 +1,171 @@
+name: Develop Beta Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*-beta*"
+
+permissions:
+  contents: write
+
+jobs:
+  android-apk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      # -------------------
+      # Setup Environment
+      # -------------------
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - uses: android-actions/setup-android@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.6"
+          channel: "stable"
+          cache: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.5"
+
+      - name: Init GoMobile
+        run: |
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          go install golang.org/x/mobile/cmd/gomobile@latest
+          gomobile init
+        working-directory: ${{ github.workspace }}
+
+      - name: Decode Secrets
+        env:
+          ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          echo "$ANDROID_KEYSTORE" | base64 --decode > android/app/upload-keystore.jks
+
+      - name: Create key.properties
+        env:
+          STORE_PWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_PWD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          cat <<EOF > android/key.properties
+          storeFile=upload-keystore.jks
+          storePassword=$STORE_PWD
+          keyAlias=$KEY_ALIAS
+          keyPassword=$KEY_PWD
+          EOF
+
+      - name: Install Flutter Dependencies
+        run: |
+          flutter pub get
+          dart run tool/generate_localization.dart
+          dart run build_runner build --delete-conflicting-outputs
+        working-directory: ${{ github.workspace }}
+
+      # -------------------
+      # Build APK
+      # -------------------
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION_NAME="${{ github.ref_name }}"
+          VERSION_NAME="${VERSION_NAME#v}"
+          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
+
+      - name: Build APK
+        run: |
+          flutter build apk \
+            --release \
+            --build-name=${{ steps.version.outputs.version_name }} \
+            --no-tree-shake-icons \
+            --obfuscate \
+            --split-debug-info=build/debug_info
+
+      - name: Rename APK
+        run: |
+          mv build/app/outputs/flutter-apk/app-release.apk \
+             build/app/outputs/flutter-apk/realunit-${{ steps.version.outputs.version_name }}.apk
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: build/app/outputs/flutter-apk/realunit-*.apk
+
+  github-release:
+    needs: [android-apk]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v6.0.1
+        with:
+          configurationJson: |
+            {
+              "template": "#{{CHANGELOG}}",
+              "categories": [
+                {
+                  "title": "## Features",
+                  "labels": ["feat", "feature"]
+                },
+                {
+                  "title": "## Fixes",
+                  "labels": ["fix", "bug"]
+                },
+                {
+                  "title": "## Refactor",
+                  "labels": ["refactor"]
+                },
+                {
+                  "title": "## Others",
+                  "labels": ["chore"]
+                },
+                {
+                  "title": "## Not labelled",
+                  "labels": []
+                }
+              ],
+              "label_extractor": [
+                {
+                  "method": "match",
+                  "pattern": "^([\\w\\-]+)",
+                  "target": "$1",
+                  "on_property": "title"
+                }
+              ]
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk
+          path: .
+
+      - name: Create Pre-Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          files: realunit-*.apk
+          generate_release_notes: false
+          draft: false
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Auto-tag develop merges with `vX.Y.Z-beta.N` tags (incremental beta numbering)
- New `develop-release.yaml` workflow: builds signed APK and creates GitHub pre-release on beta tags
- Existing `beta-release.yaml` skips all jobs for beta tags to avoid duplicate builds

## Test plan
- [ ] Merge a PR into develop and verify `v0.0.41-beta.1` tag is created
- [ ] Verify `develop-release.yaml` triggers and builds APK successfully
- [ ] Verify `beta-release.yaml` jobs are skipped for the beta tag
- [ ] Verify GitHub pre-release is created with APK attached
- [ ] Merge to main and verify full release pipeline still works unchanged