### PR TITLE
fix(kyc): prevent stale state leak in KycCubit on retry

### DIFF
--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -36,9 +36,12 @@ class KycCubit extends Cubit<KycState> {
   // forces a fresh hardware-wallet confirmation before sensitive steps.
   bool _bitboxConfirmed = false;
 
-  // `Future.timeout` does not cancel the underlying work — this flag lets
-  // late HTTP responses bail out instead of overwriting the failure state.
-  bool _timedOut = false;
+  // `Future.timeout` does not cancel the underlying work, so a late HTTP
+  // response from an earlier call can still resume and emit state after a
+  // retry. Each `checkKyc()` captures its own generation; the run body and
+  // any continuations bail when their generation no longer matches the
+  // current one. Acts as a cancellation token for non-cancellable work.
+  int _runGeneration = 0;
 
   KycCubit(
     DfxKycService kycService,
@@ -50,19 +53,23 @@ class KycCubit extends Cubit<KycState> {
        super(const KycInitial());
 
   Future<void> checkKyc() async {
-    _timedOut = false;
+    final generation = ++_runGeneration;
     try {
-      await _runCheckKyc().timeout(_checkKycTimeout);
+      await _runCheckKyc(generation).timeout(_checkKycTimeout);
     } on TimeoutException {
-      _timedOut = true;
-      if (!isClosed) emit(const KycFailure('KYC backend did not respond in time'));
+      if (generation == _runGeneration && !isClosed) {
+        emit(const KycFailure('KYC backend did not respond in time'));
+      }
     } catch (e) {
-      if (!isClosed) emit(KycFailure(e.toString()));
+      if (generation == _runGeneration && !isClosed) {
+        emit(KycFailure(e.toString()));
+      }
     }
   }
 
-  Future<void> _runCheckKyc() async {
+  Future<void> _runCheckKyc(int generation) async {
     try {
+      if (isClosed || generation != _runGeneration) return;
       emit(const KycLoading());
 
       final results = await Future.wait([
@@ -70,7 +77,7 @@ class KycCubit extends Cubit<KycState> {
         _kycService.getUser(),
       ]);
 
-      if (isClosed || _timedOut) return;
+      if (isClosed || generation != _runGeneration) return;
 
       final kycStatus = results.elementAt(0) as KycLevelDto;
       final user = results.elementAt(1) as UserDto;
@@ -91,7 +98,8 @@ class KycCubit extends Cubit<KycState> {
         }
         _emailRegistrationAttempted = true;
         await _registrationService.registerEmail(user.mail!);
-        await _runCheckKyc();
+        if (isClosed || generation != _runGeneration) return;
+        await _runCheckKyc(generation);
         return;
       }
 
@@ -137,12 +145,13 @@ class KycCubit extends Cubit<KycState> {
           return;
         }
 
-        await _continueKyc();
+        await _continueKyc(generation);
         return;
       }
 
       emit(const KycCompleted());
     } on ApiException catch (e) {
+      if (generation != _runGeneration || isClosed) return;
       // API returns 403 / code TFA_REQUIRED when 2FA verification is required
       // before proceeding.
       if (e.statusCode == 403 || e.code == 'TFA_REQUIRED') {
@@ -151,6 +160,7 @@ class KycCubit extends Cubit<KycState> {
         rethrow;
       }
     } catch (e) {
+      if (generation != _runGeneration || isClosed) return;
       emit(KycFailure(e.toString()));
     }
   }
@@ -164,9 +174,9 @@ class KycCubit extends Cubit<KycState> {
   }
 
   /// should only be called after realunit registration was completed
-  Future<void> _continueKyc() async {
+  Future<void> _continueKyc(int generation) async {
     final kycStatus = await _kycService.continueKyc();
-    if (isClosed || _timedOut) return;
+    if (isClosed || generation != _runGeneration) return;
     final currentStep = kycStatus.kycSteps.firstWhere((step) => step.isCurrent);
 
     final kycStep = _mapStepName(currentStep.name);

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -57,13 +57,11 @@ class KycCubit extends Cubit<KycState> {
     try {
       await _runCheckKyc(generation).timeout(_checkKycTimeout);
     } on TimeoutException {
-      if (generation == _runGeneration && !isClosed) {
-        emit(const KycFailure('KYC backend did not respond in time'));
-      }
+      if (isClosed || generation != _runGeneration) return;
+      emit(const KycFailure('KYC backend did not respond in time'));
     } catch (e) {
-      if (generation == _runGeneration && !isClosed) {
-        emit(KycFailure(e.toString()));
-      }
+      if (isClosed || generation != _runGeneration) return;
+      emit(KycFailure(e.toString()));
     }
   }
 
@@ -151,7 +149,7 @@ class KycCubit extends Cubit<KycState> {
 
       emit(const KycCompleted());
     } on ApiException catch (e) {
-      if (generation != _runGeneration || isClosed) return;
+      if (isClosed || generation != _runGeneration) return;
       // API returns 403 / code TFA_REQUIRED when 2FA verification is required
       // before proceeding.
       if (e.statusCode == 403 || e.code == 'TFA_REQUIRED') {
@@ -160,7 +158,7 @@ class KycCubit extends Cubit<KycState> {
         rethrow;
       }
     } catch (e) {
-      if (generation != _runGeneration || isClosed) return;
+      if (isClosed || generation != _runGeneration) return;
       emit(KycFailure(e.toString()));
     }
   }


### PR DESCRIPTION
## Summary

Fix #315: replace the shared `_timedOut` bool in `KycCubit` with a per-call generation counter so late HTTP responses from a timed-out call cannot overwrite fresh state emitted by a subsequent retry.

## Why

`Future.timeout` does not cancel the underlying work — the original future keeps running and resumes after the timeout fires. The previous `_timedOut` flag was reset at the start of every new `checkKyc()` call, so the guard worked within a single call but not across calls:

1. `t=0`  — Call 1 starts, `_timedOut = false`
2. `t=30s` — Call 1 times out, `_timedOut = true`, `KycFailure` emitted
3. `t=35s` — User retries → Call 2 starts, **`_timedOut = false` (reset)**
4. `t=36s` — Call 2 emits fresh state (e.g. `KycSuccess(ident)`)
5. `t=45s` — Call 1's late response arrives, guard passes (flag was reset), Call 1 emits its **stale** state as the last state change

The user lands permanently on the wrong step until the cubit is recreated. Concretely: stale `registration` over fresh `ident`, stale `completed` over fresh `2FA-required`, etc. See issue for full timeline + reproducer.

## What changed

- `_timedOut` (bool) → `_runGeneration` (int), incremented at the start of each `checkKyc()`
- `checkKyc()` captures its own `generation`; `TimeoutException` / `catch` arms only emit if the generation is still current
- `_runCheckKyc(generation)` and `_continueKyc(generation)` take the generation as a parameter and bail at every await-resumption point if it no longer matches
- Generation threaded through the recursive `_runCheckKyc(generation)` in the email-registration branch
- Comment block updated to describe cancellation-token semantics

Single-file change: `lib/screens/kyc/cubits/kyc/kyc_cubit.dart` (+24 / -14).

## Test plan

- [x] `flutter analyze lib/screens/kyc/` — clean
- [x] `dart format` — clean
- [ ] Manual: trigger KYC, force backend slowness so the 30s timeout fires, retry — verify the final state matches the retry, not the late first-call response
- [ ] Unit test for the retry-race scenario will be added in #314 Phase 0 (per issue AC), once the `kyc_cubit_test.dart` scaffold lands

Closes #315