### PR TITLE
fix: keep dashboard buy actions visible

### DIFF
--- a/lib/packages/service/dfx/dfx_auth_service.dart
+++ b/lib/packages/service/dfx/dfx_auth_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:http/http.dart' as http;
 import 'package:realunit_wallet/packages/config/api_config.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
@@ -107,5 +108,98 @@ abstract class DFXAuthService {
   Future<String?> refreshAuthToken() async {
     invalidateAuthToken();
     return getAuthToken();
+  }
+
+  Future<http.Response> authenticatedGet(
+    Uri uri, {
+    Map<String, String> headers = const {},
+  }) async {
+    var authToken = await getAuthToken();
+    var response = await appStore.httpClient.get(
+      uri,
+      headers: {
+        ...headers,
+        'Authorization': 'Bearer $authToken',
+      },
+    );
+
+    if (response.statusCode == 401) {
+      authToken = await refreshAuthToken();
+      response = await appStore.httpClient.get(
+        uri,
+        headers: {
+          ...headers,
+          'Authorization': 'Bearer $authToken',
+        },
+      );
+    }
+
+    return response;
+  }
+
+  Future<http.Response> authenticatedPut(
+    Uri uri, {
+    Map<String, String> headers = const {},
+    Object? body,
+    Encoding? encoding,
+  }) async {
+    var authToken = await getAuthToken();
+    var response = await appStore.httpClient.put(
+      uri,
+      headers: {
+        ...headers,
+        'Authorization': 'Bearer $authToken',
+      },
+      body: body,
+      encoding: encoding,
+    );
+
+    if (response.statusCode == 401) {
+      authToken = await refreshAuthToken();
+      response = await appStore.httpClient.put(
+        uri,
+        headers: {
+          ...headers,
+          'Authorization': 'Bearer $authToken',
+        },
+        body: body,
+        encoding: encoding,
+      );
+    }
+
+    return response;
+  }
+
+  Future<http.Response> authenticatedPost(
+    Uri uri, {
+    Map<String, String> headers = const {},
+    Object? body,
+    Encoding? encoding,
+  }) async {
+    var authToken = await getAuthToken();
+    var response = await appStore.httpClient.post(
+      uri,
+      headers: {
+        ...headers,
+        'Authorization': 'Bearer $authToken',
+      },
+      body: body,
+      encoding: encoding,
+    );
+
+    if (response.statusCode == 401) {
+      authToken = await refreshAuthToken();
+      response = await appStore.httpClient.post(
+        uri,
+        headers: {
+          ...headers,
+          'Authorization': 'Bearer $authToken',
+        },
+        body: body,
+        encoding: encoding,
+      );
+    }
+
+    return response;
   }
 }

--- a/lib/packages/service/dfx/dfx_bank_account_service.dart
+++ b/lib/packages/service/dfx/dfx_bank_account_service.dart
@@ -1,28 +1,28 @@
 import 'dart:convert';
 
 import 'package:realunit_wallet/packages/config/api_config.dart';
-import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/bank_account/dto/bank_account_dto.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 
-class DfxBankAccountService {
+class DfxBankAccountService extends DFXAuthService {
   static const _bankAccountPath = 'v1/bankAccount';
 
-  String get _host => _appStore.apiConfig.apiHost;
+  DfxBankAccountService(super.appStore);
 
-  final AppStore _appStore;
+  @override
+  AWalletAccount get wallet => appStore.wallet.currentAccount;
 
-  DfxBankAccountService(AppStore appStore) : _appStore = appStore;
+  @override
+  String get walletAddress => wallet.primaryAddress.address.hexEip55;
 
   Future<List<BankAccountDto>> getBankAccounts() async {
-    final authToken = _appStore.sessionCache.authToken;
-
-    final uri = buildUri(_host, _bankAccountPath);
-    final response = await _appStore.httpClient.get(
+    final uri = buildUri(host, _bankAccountPath);
+    final response = await authenticatedGet(
       uri,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer $authToken',
       },
     );
 
@@ -37,14 +37,11 @@ class DfxBankAccountService {
   }
 
   Future<BankAccountDto> createBankAccount(String iban, String? label) async {
-    final authToken = _appStore.sessionCache.authToken;
-
-    final uri = buildUri(_host, _bankAccountPath);
-    final response = await _appStore.httpClient.post(
+    final uri = buildUri(host, _bankAccountPath);
+    final response = await authenticatedPost(
       uri,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer $authToken',
       },
       body: jsonEncode({
         'iban': iban,
@@ -66,14 +63,11 @@ class DfxBankAccountService {
     bool? isDefault,
     bool? isActive,
   }) async {
-    final authToken = _appStore.sessionCache.authToken;
-
-    final uri = buildUri(_host, '$_bankAccountPath/$id');
-    final response = await _appStore.httpClient.put(
+    final uri = buildUri(host, '$_bankAccountPath/$id');
+    final response = await authenticatedPut(
       uri,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer $authToken',
       },
       body: jsonEncode({
         if (label != null) 'label': label,

--- a/lib/packages/service/dfx/dfx_brokerbot_service.dart
+++ b/lib/packages/service/dfx/dfx_brokerbot_service.dart
@@ -1,25 +1,28 @@
 import 'dart:convert';
 
 import 'package:realunit_wallet/packages/config/api_config.dart';
-import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/brokerbot/dfx_buy_price_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/brokerbot/dfx_buy_shares_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/brokerbot/dfx_sell_price_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/brokerbot/dfx_sell_shares_dto.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:realunit_wallet/styles/currency.dart';
 
-class DfxBrokerbotService {
+class DfxBrokerbotService extends DFXAuthService {
   static const _buyPricePath = '/v1/realunit/brokerbot/buyPrice';
   static const _buySharesPath = '/v1/realunit/brokerbot/buyShares';
   static const _sellPricePath = '/v1/realunit/brokerbot/sellPrice';
   static const _sellSharesPath = '/v1/realunit/brokerbot/sellShares';
 
-  String get _host => _appStore.apiConfig.apiHost;
+  DfxBrokerbotService(super.appStore);
 
-  final AppStore _appStore;
+  @override
+  AWalletAccount get wallet => appStore.wallet.currentAccount;
 
-  DfxBrokerbotService(this._appStore);
+  @override
+  String get walletAddress => wallet.primaryAddress.address.hexEip55;
 
   /// Convert REALU shares → CHF
   Future<BrokerbotBuyPriceDto> getBuyPrice(String sharesInput, Currency currency) async {
@@ -28,11 +31,11 @@ class DfxBrokerbotService {
       throw Exception('BuyPrice request failed: sharesInput is not valid');
     }
 
-    final uri = buildUri(_host, _buyPricePath, {
+    final uri = buildUri(host, _buyPricePath, {
       'shares': shares.toString(),
       'currency': currency.code,
     });
-    final res = await _appStore.httpClient.get(uri);
+    final res = await appStore.httpClient.get(uri);
 
     if (res.statusCode != 200) {
       throw Exception('BuyPrice request failed: ${res.body}');
@@ -48,11 +51,11 @@ class DfxBrokerbotService {
       throw Exception('Shares request failed: amountInput is not valid');
     }
 
-    final uri = buildUri(_host, _buySharesPath, {
+    final uri = buildUri(host, _buySharesPath, {
       'amount': amount.toString(),
       'currency': currency.code,
     });
-    final res = await _appStore.httpClient.get(uri);
+    final res = await appStore.httpClient.get(uri);
 
     if (res.statusCode != 200) {
       throw Exception('Shares request failed: ${res.body}');
@@ -68,15 +71,11 @@ class DfxBrokerbotService {
       throw Exception('SellPrice request failed: sharesInput is invalid');
     }
 
-    final authToken = _appStore.sessionCache.authToken;
-    final uri = buildUri(_host, _sellPricePath, {
+    final uri = buildUri(host, _sellPricePath, {
       'shares': shares.toString(),
       'currency': currency.code,
     });
-    final res = await _appStore.httpClient.get(
-      uri,
-      headers: {'Authorization': 'Bearer $authToken'},
-    );
+    final res = await authenticatedGet(uri);
 
     if (res.statusCode != 200) {
       final errorJson = jsonDecode(res.body) as Map<String, dynamic>;
@@ -93,15 +92,11 @@ class DfxBrokerbotService {
       throw Exception('SellShares request failed: amountInput is invalid');
     }
 
-    final authToken = _appStore.sessionCache.authToken;
-    final uri = buildUri(_host, _sellSharesPath, {
+    final uri = buildUri(host, _sellSharesPath, {
       'amount': amount.toString(),
       'currency': currency.code,
     });
-    final res = await _appStore.httpClient.get(
-      uri,
-      headers: {'Authorization': 'Bearer $authToken'},
-    );
+    final res = await authenticatedGet(uri);
 
     if (res.statusCode != 200) {
       final errorJson = jsonDecode(res.body) as Map<String, dynamic>;

--- a/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
@@ -1,34 +1,35 @@
 import 'dart:convert';
 
 import 'package:realunit_wallet/packages/config/api_config.dart';
-import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/buy_payment_info.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/dto/real_unit_buy_confirm_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/dto/real_unit_buy_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/dto/real_unit_buy_payment_info_dto.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:realunit_wallet/styles/currency.dart';
 
-class RealUnitBuyPaymentInfoService {
+class RealUnitBuyPaymentInfoService extends DFXAuthService {
   static const _buyPaymentInfoPath = '/v1/realunit/buy';
   static String _confirmPaymentPath(int id) => '/v1/realunit/buy/$id/confirm';
 
-  String get _host => _appStore.apiConfig.apiHost;
+  RealUnitBuyPaymentInfoService(super.appStore);
 
-  final AppStore _appStore;
+  @override
+  AWalletAccount get wallet => appStore.wallet.currentAccount;
 
-  RealUnitBuyPaymentInfoService(AppStore appStore) : _appStore = appStore;
+  @override
+  String get walletAddress => wallet.primaryAddress.address.hexEip55;
 
   Future<BuyPaymentInfo> getPaymentInfo(int amount, {Currency currency = Currency.chf}) async {
     final buyDto = RealUnitBuyDto(amount: amount, currency: currency);
 
-    final authToken = _appStore.sessionCache.authToken;
-    final uri = buildUri(_host, _buyPaymentInfoPath);
-    final response = await _appStore.httpClient.put(
+    final uri = buildUri(host, _buyPaymentInfoPath);
+    final response = await authenticatedPut(
       uri,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer $authToken',
       },
       body: jsonEncode(buyDto.toJson()),
     );
@@ -61,14 +62,10 @@ class RealUnitBuyPaymentInfoService {
   }
 
   Future<String> confirmPayment(int id) async {
-    final authToken = _appStore.sessionCache.authToken;
-    final uri = buildUri(_host, _confirmPaymentPath(id));
+    final uri = buildUri(host, _confirmPaymentPath(id));
 
-    final response = await _appStore.httpClient.put(
+    final response = await authenticatedPut(
       uri,
-      headers: {
-        'Authorization': 'Bearer $authToken',
-      },
     );
 
     if (response.statusCode != 200 && response.statusCode != 201) {

--- a/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:realunit_wallet/packages/config/api_config.dart';
-import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/broadcast_transaction_request_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/broadcast_transaction_response_dto.dart';
@@ -14,9 +14,10 @@ import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/rea
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/sell_payment_info.dart';
 import 'package:realunit_wallet/packages/wallet/eip712_signer.dart';
 import 'package:realunit_wallet/packages/wallet/eip7702_signer.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:realunit_wallet/styles/currency.dart';
 
-class RealUnitSellPaymentInfoService {
+class RealUnitSellPaymentInfoService extends DFXAuthService {
   static const _sellPaymentInfoPath = '/v1/realunit/sell';
   static String _confirmPaymentPath(int id) => '/v1/realunit/sell/$id/confirm';
   static String _unsignedTxsPath(int id) => '/v1/realunit/sell/$id/unsigned-transactions';
@@ -26,11 +27,13 @@ class RealUnitSellPaymentInfoService {
   static const _metaMaskDelegatorAddress = '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b';
   static const _delegationManagerAddress = '0xdb9b1e94b5b69df7e401ddbede43491141047db3';
 
-  String get _host => _appStore.apiConfig.apiHost;
+  RealUnitSellPaymentInfoService(super.appStore);
 
-  final AppStore _appStore;
+  @override
+  AWalletAccount get wallet => appStore.wallet.currentAccount;
 
-  RealUnitSellPaymentInfoService(AppStore appStore) : _appStore = appStore;
+  @override
+  String get walletAddress => wallet.primaryAddress.address.hexEip55;
 
   Future<SellPaymentInfo> getPaymentInfo(
     int amount,
@@ -43,13 +46,11 @@ class RealUnitSellPaymentInfoService {
       currency: currency,
     );
 
-    final authToken = _appStore.sessionCache.authToken;
-    final uri = buildUri(_host, _sellPaymentInfoPath);
-    final response = await _appStore.httpClient.put(
+    final uri = buildUri(host, _sellPaymentInfoPath);
+    final response = await authenticatedPut(
       uri,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer $authToken',
       },
       body: jsonEncode(sellDto.toJson()),
     );
@@ -84,7 +85,7 @@ class RealUnitSellPaymentInfoService {
 
   /// Confirms payment for Software Wallet
   Future<void> confirmPayment(SellPaymentInfo paymentInfo) async {
-    final credentials = _appStore.wallet.currentAccount.primaryAddress;
+    final credentials = appStore.wallet.currentAccount.primaryAddress;
     _validateEip7702Data(paymentInfo.eip7702, credentials.address.hexEip55, paymentInfo.amount);
 
     final delegationSignature = await Eip712Signer.signDelegation(
@@ -120,13 +121,11 @@ class RealUnitSellPaymentInfoService {
   }
 
   Future<RealUnitUnsignedTransactionsRequestDto> createUnsignedTransactions(int id) async {
-    final authToken = _appStore.sessionCache.authToken;
-    final uri = buildUri(_host, _unsignedTxsPath(id));
-    final response = await _appStore.httpClient.put(
+    final uri = buildUri(host, _unsignedTxsPath(id));
+    final response = await authenticatedPut(
       uri,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer $authToken',
       },
     );
     if (response.statusCode != 200 && response.statusCode != 201) {
@@ -141,13 +140,11 @@ class RealUnitSellPaymentInfoService {
     int id,
     BroadcastTransactionRequestDto dto,
   ) async {
-    final authToken = _appStore.sessionCache.authToken;
-    final uri = buildUri(_host, _broadcastPath(id));
-    final response = await _appStore.httpClient.put(
+    final uri = buildUri(host, _broadcastPath(id));
+    final response = await authenticatedPut(
       uri,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer $authToken',
       },
       body: jsonEncode(dto.toJson()),
     );
@@ -167,13 +164,11 @@ class RealUnitSellPaymentInfoService {
   }
 
   Future<void> _sendConfirm(int id, RealUnitSellConfirmDto dto) async {
-    final authToken = _appStore.sessionCache.authToken;
-    final uri = buildUri(_host, _confirmPaymentPath(id));
-    final response = await _appStore.httpClient.put(
+    final uri = buildUri(host, _confirmPaymentPath(id));
+    final response = await authenticatedPut(
       uri,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'Bearer $authToken',
       },
       body: jsonEncode(dto.toJson()),
     );
@@ -185,11 +180,13 @@ class RealUnitSellPaymentInfoService {
   }
 
   void _validateEip7702Data(Eip7702Data data, String walletAddress, int userAmount) {
-    final expectedChainId = _appStore.apiConfig.asset.chainId;
+    final expectedChainId = appStore.apiConfig.asset.chainId;
 
     // Pin signed contract addresses against known constants
     if (data.delegatorAddress.toLowerCase() != _metaMaskDelegatorAddress) {
-      throw Exception('EIP-7702 delegator address does not match expected MetaMask Delegator contract');
+      throw Exception(
+        'EIP-7702 delegator address does not match expected MetaMask Delegator contract',
+      );
     }
     if (data.delegationManagerAddress.toLowerCase() != _delegationManagerAddress) {
       throw Exception('EIP-7702 delegation manager address does not match expected contract');
@@ -203,7 +200,9 @@ class RealUnitSellPaymentInfoService {
       throw Exception('EIP-7702 message delegator does not match wallet address');
     }
     if (data.domain.chainId != expectedChainId) {
-      throw Exception('EIP-7702 chain ID mismatch: expected $expectedChainId, got ${data.domain.chainId}');
+      throw Exception(
+        'EIP-7702 chain ID mismatch: expected $expectedChainId, got ${data.domain.chainId}',
+      );
     }
 
     // Cross-check signed delegate against response metadata
@@ -212,10 +211,11 @@ class RealUnitSellPaymentInfoService {
     }
 
     // Validate unsigned metadata for consistency
-    if (data.tokenAddress.toLowerCase() != _appStore.apiConfig.asset.address.toLowerCase()) {
+    if (data.tokenAddress.toLowerCase() != appStore.apiConfig.asset.address.toLowerCase()) {
       throw Exception('EIP-7702 token address does not match RealUnit token');
     }
-    final expectedWei = BigInt.from(userAmount) * BigInt.from(10).pow(_appStore.apiConfig.asset.decimals);
+    final expectedWei =
+        BigInt.from(userAmount) * BigInt.from(10).pow(appStore.apiConfig.asset.decimals);
     final actualWei = BigInt.tryParse(data.amountWei);
     if (actualWei == null || actualWei != expectedWei) {
       throw Exception('EIP-7702 amount mismatch: expected $expectedWei, got ${data.amountWei}');

--- a/lib/screens/buy/widgets/payment_additional_action_needed_button.dart
+++ b/lib/screens/buy/widgets/payment_additional_action_needed_button.dart
@@ -58,6 +58,7 @@ class PaymentAdditionalActionNeededButton extends StatelessWidget {
                   if (context.mounted) {
                     context.read<BuyPaymentInfoCubit>().getPaymentInfo(
                       amount: amountController.text,
+                      currency: context.read<BuyConverterCubit>().state.currency,
                     );
                   }
                 },
@@ -77,10 +78,23 @@ class PaymentAdditionalActionNeededButton extends StatelessWidget {
                   if (context.mounted) {
                     context.read<BuyPaymentInfoCubit>().getPaymentInfo(
                       amount: amountController.text,
+                      currency: context.read<BuyConverterCubit>().state.currency,
                     );
                   }
                 },
                 label: S.of(context).next,
+              ),
+            );
+          }
+          if (paymentState.error == PaymentInfoError.unknown) {
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 20),
+              child: AppFilledButton(
+                onPressed: () => context.read<BuyPaymentInfoCubit>().getPaymentInfo(
+                  amount: amountController.text,
+                  currency: context.read<BuyConverterCubit>().state.currency,
+                ),
+                label: S.of(context).retry,
               ),
             );
           }

--- a/lib/screens/dashboard/dashboard_page.dart
+++ b/lib/screens/dashboard/dashboard_page.dart
@@ -17,7 +17,6 @@ import 'package:realunit_wallet/screens/dashboard/widgets/sections/dashboard_por
 import 'package:realunit_wallet/screens/dashboard/widgets/sections/dashboard_portfolio_chart_widget.dart';
 import 'package:realunit_wallet/screens/dashboard/widgets/sections/dashboard_price_widget.dart';
 import 'package:realunit_wallet/screens/dashboard/widgets/sections/dashboard_transaction_history.dart';
-import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
 import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
 import 'package:realunit_wallet/setup/di.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
@@ -67,7 +66,6 @@ class DashboardView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isFiatServiceAvailable = context.watch<HomeBloc>().state.isFiatServiceAvailable;
     final dashboardState = context.watch<DashboardBloc>().state;
     final balance = context.watch<BalanceCubit>().state.balance;
 
@@ -137,7 +135,7 @@ class DashboardView extends StatelessWidget {
                           child: Column(
                             spacing: 20.0,
                             children: [
-                              if (isFiatServiceAvailable) const DashboardActions(),
+                              const DashboardActions(),
                               DashboardPortfolio(
                                 price: dashboardState.price,
                               ),
@@ -164,14 +162,13 @@ class DashboardView extends StatelessWidget {
                               height: 165,
                             ),
                             const Spacer(),
-                            if (isFiatServiceAvailable)
-                              Padding(
-                                padding: const .symmetric(vertical: 20),
-                                child: AppFilledButton(
-                                  onPressed: () => context.pushNamed(AppRoutes.buy),
-                                  label: S.of(context).buyRealUnit,
-                                ),
+                            Padding(
+                              padding: const .symmetric(vertical: 20),
+                              child: AppFilledButton(
+                                onPressed: () => context.pushNamed(AppRoutes.buy),
+                                label: S.of(context).buyRealUnit,
                               ),
+                            ),
                           ],
                         ),
                       ),

--- a/lib/screens/home/bloc/home_bloc.dart
+++ b/lib/screens/home/bloc/home_bloc.dart
@@ -5,7 +5,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/balance_service.dart';
-import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
 import 'package:realunit_wallet/packages/service/settings_service.dart';
 import 'package:realunit_wallet/packages/service/transaction_history_service.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
@@ -19,7 +18,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     this._walletService,
     this._balanceService,
     this._transactionHistoryService,
-    this._dfxService,
     this._settingsService,
     this._appStore,
     this._bitboxService,
@@ -39,7 +37,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   final WalletService _walletService;
   final BalanceService _balanceService;
   final TransactionHistoryService _transactionHistoryService;
-  final DfxWidgetService _dfxService;
   final SettingsService _settingsService;
   final AppStore _appStore;
   final BitboxService _bitboxService;
@@ -69,8 +66,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
           isLoadingWallet: false,
         ),
       );
-
-      await _setupFiatService(emit);
     } catch (e) {
       developer.log('Something went wrong during wallet loading', error: e);
       emit(state.copyWith(isLoadingWallet: false));
@@ -100,7 +95,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
         hasWallet: false,
         openWallet: null,
         isLoadingWallet: false,
-        isFiatServiceAvailable: false,
         softwareTermsAccepted: state.softwareTermsAccepted,
       ),
     );
@@ -109,7 +103,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   Future<void> _onLoadWallet(LoadWalletEvent event, Emitter<HomeState> emit) async {
     _updateWallet(event.wallet);
     emit(state.copyWith(hasWallet: true, openWallet: _appStore.wallet, isLoadingWallet: false));
-    await _setupFiatService(emit);
   }
 
   void _onSyncWalletServices(
@@ -131,17 +124,6 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     final wallet = await _walletService.createDebugWallet(event.address);
     _appStore.wallet = wallet;
     emit(state.copyWith(hasWallet: true, openWallet: wallet));
-    await _setupFiatService(emit);
-  }
-
-  Future<void> _setupFiatService(Emitter<HomeState> emit) async {
-    try {
-      await _dfxService.getAuthToken();
-      emit(state.copyWith(isFiatServiceAvailable: _dfxService.isAvailable));
-    } catch (e) {
-      developer.log('Failed to authenticate with DFX service', error: e);
-      emit(state.copyWith(isFiatServiceAvailable: false));
-    }
   }
 
   void _updateWallet(AWallet wallet) {

--- a/lib/screens/home/bloc/home_state.dart
+++ b/lib/screens/home/bloc/home_state.dart
@@ -5,7 +5,6 @@ final class HomeState {
     this.hasWallet = false,
     this.openWallet,
     this.isLoadingWallet = false,
-    this.isFiatServiceAvailable = false,
     this.onboardingCompleted = false,
     this.softwareTermsAccepted = false,
   });
@@ -13,7 +12,6 @@ final class HomeState {
   final bool hasWallet;
   final AWallet? openWallet;
   final bool isLoadingWallet;
-  final bool isFiatServiceAvailable;
   final bool onboardingCompleted;
   final bool softwareTermsAccepted;
 
@@ -21,14 +19,12 @@ final class HomeState {
     bool? hasWallet,
     AWallet? openWallet,
     bool? isLoadingWallet,
-    bool? isFiatServiceAvailable,
     bool? onboardingCompleted,
     bool? softwareTermsAccepted,
   }) => HomeState(
     hasWallet: hasWallet ?? this.hasWallet,
     openWallet: openWallet ?? this.openWallet,
     isLoadingWallet: isLoadingWallet ?? this.isLoadingWallet,
-    isFiatServiceAvailable: isFiatServiceAvailable ?? this.isFiatServiceAvailable,
     onboardingCompleted: onboardingCompleted ?? this.onboardingCompleted,
     softwareTermsAccepted: softwareTermsAccepted ?? this.softwareTermsAccepted,
   );

--- a/lib/setup/di.dart
+++ b/lib/setup/di.dart
@@ -171,7 +171,6 @@ Future<void> setupBlocs() async {
       getIt<WalletService>(),
       getIt<BalanceService>(),
       getIt<TransactionHistoryService>(),
-      getIt<DfxWidgetService>(),
       getIt<SettingsService>(),
       getIt<AppStore>(),
       getIt<BitboxService>(),

--- a/test/packages/service/dfx/dfx_auth_service_test.dart
+++ b/test/packages/service/dfx/dfx_auth_service_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
+
+class MockApiConfig extends Mock implements ApiConfig {}
+
+class MockCacheRepository extends Mock implements CacheRepository {}
+
+class TestAppStore extends AppStore {
+  final http.Client client;
+
+  TestAppStore(this.client) : super(MockApiConfig.new, SessionCache(MockCacheRepository()));
+
+  @override
+  http.Client get httpClient => client;
+}
+
+class TestAuthService extends DFXAuthService {
+  TestAuthService(super.appStore);
+
+  int authTokenCalls = 0;
+  int refreshAuthTokenCalls = 0;
+
+  @override
+  AWalletAccount get wallet => throw UnimplementedError();
+
+  @override
+  String get walletAddress => throw UnimplementedError();
+
+  @override
+  Future<String?> getAuthToken() async {
+    authTokenCalls++;
+    return 'expired-token';
+  }
+
+  @override
+  Future<String?> refreshAuthToken() async {
+    refreshAuthTokenCalls++;
+    return 'fresh-token';
+  }
+}
+
+void main() {
+  group('$DFXAuthService', () {
+    test('retries authenticated requests once with a refreshed token on 401', () async {
+      final seenAuthHeaders = <String?>[];
+      final client = MockClient((request) async {
+        seenAuthHeaders.add(request.headers['Authorization']);
+
+        if (seenAuthHeaders.length == 1) {
+          return http.Response('{"message":"Unauthorized"}', 401);
+        }
+
+        return http.Response('{"ok":true}', 200);
+      });
+      final service = TestAuthService(TestAppStore(client));
+
+      final response = await service.authenticatedPut(
+        Uri.parse('https://api.example.test/v1/resource'),
+        headers: {'Content-Type': 'application/json'},
+        body: '{"value":1}',
+      );
+
+      expect(response.statusCode, 200);
+      expect(seenAuthHeaders, ['Bearer expired-token', 'Bearer fresh-token']);
+      expect(service.authTokenCalls, 1);
+      expect(service.refreshAuthTokenCalls, 1);
+    });
+  });
+}

--- a/test/packages/service/dfx/dfx_bank_account_service_test.dart
+++ b/test/packages/service/dfx/dfx_bank_account_service_test.dart
@@ -22,14 +22,13 @@ Map<String, dynamic> _bankAccount({
   String? label,
   bool isActive = true,
   bool isDefault = false,
-}) =>
-    {
-      'id': id,
-      'iban': iban,
-      'label': label,
-      'active': isActive,
-      'default': isDefault,
-    };
+}) => {
+  'id': id,
+  'iban': iban,
+  'label': label,
+  'active': isActive,
+  'default': isDefault,
+};
 
 void main() {
   late _MockAppStore appStore;
@@ -38,9 +37,12 @@ void main() {
   setUp(() {
     appStore = _MockAppStore();
     sessionCache = SessionCache(_MockCacheRepository());
+    // Pre-seed the JWT so `authenticatedGet/Put/Post` short-circuits the
+    // `getAuthToken` refresh path (which would otherwise need a fully
+    // stubbed wallet + signMessage endpoint).
+    sessionCache.setAuthToken('test-jwt');
     when(() => appStore.sessionCache).thenReturn(sessionCache);
-    when(() => appStore.apiConfig)
-        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+    when(() => appStore.apiConfig).thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
   });
 
   DfxBankAccountService build(http.Client client) {
@@ -74,10 +76,12 @@ void main() {
     });
 
     test('getBankAccounts throws ApiException on non-2xx', () async {
-      final client = MockClient((_) async => http.Response(
-            jsonEncode({'statusCode': 403, 'message': 'forbidden'}),
-            403,
-          ));
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'statusCode': 403, 'message': 'forbidden'}),
+          403,
+        ),
+      );
 
       expect(
         () => build(client).getBankAccounts(),
@@ -117,10 +121,12 @@ void main() {
     });
 
     test('createBankAccount throws ApiException on non-2xx', () async {
-      final client = MockClient((_) async => http.Response(
-            jsonEncode({'statusCode': 422, 'message': 'invalid iban'}),
-            422,
-          ));
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'statusCode': 422, 'message': 'invalid iban'}),
+          422,
+        ),
+      );
 
       expect(
         () => build(client).createBankAccount('NOT_AN_IBAN', null),
@@ -157,10 +163,12 @@ void main() {
     });
 
     test('updateBankAccount throws ApiException on non-2xx', () async {
-      final client = MockClient((_) async => http.Response(
-            jsonEncode({'statusCode': 404, 'message': 'not found'}),
-            404,
-          ));
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'statusCode': 404, 'message': 'not found'}),
+          404,
+        ),
+      );
 
       expect(
         () => build(client).updateBankAccount(id: 99, label: 'x'),

--- a/test/screens/buy/buy_page_test.dart
+++ b/test/screens/buy/buy_page_test.dart
@@ -56,7 +56,7 @@ void main() {
     when(
       () => buyPaymentInfoCubit.getPaymentInfo(
         amount: any(named: 'amount'),
-        currency: Currency.chf,
+        currency: any(named: 'currency'),
       ),
     ).thenAnswer((_) => Future.value());
   });
@@ -72,6 +72,7 @@ void main() {
   }
 
   setUpAll(() {
+    registerFallbackValue(Currency.chf);
     setupDependencyInjection();
   });
 
@@ -248,6 +249,30 @@ void main() {
         ),
         findsOne,
       );
+    });
+
+    testWidgets('retries payment info when unknown error is shown', (tester) async {
+      when(() => buyPaymentInfoCubit.state).thenReturn(
+        const BuyPaymentInfoFailure(PaymentInfoError.unknown),
+      );
+      when(() => converterCubit.state).thenReturn(
+        const BuyConverterState(currency: Currency.eur),
+      );
+
+      await tester.pumpApp(buildSubject(const BuyView()));
+
+      expect(find.text(S.current.paymentInformationFailed), findsOne);
+      expect(find.text(S.current.retry), findsOne);
+
+      await tester.tap(find.text(S.current.retry));
+      await tester.pump();
+
+      verify(
+        () => buyPaymentInfoCubit.getPaymentInfo(
+          amount: '',
+          currency: Currency.eur,
+        ),
+      ).called(1);
     });
 
     testWidgets('updates controllers when $BuyConverterState changes', (tester) async {


### PR DESCRIPTION
## Summary
- always show dashboard buy/sell actions and the empty-state Buy RealUnit button
- make Buy/Sell/BankAccount/Sell brokerbot requests auth-aware by using lazy DFX auth and a one-time 401 refresh retry
- remove the now-dead HomeState.isFiatServiceAvailable setup path

## Why
The dashboard must not hide fiat entry points behind a transient in-memory auth token. After making the entry points visible, the downstream services also need to avoid sending Authorization: Bearer null or stale tokens. Authenticated requests now call getAuthToken() at first use and retry once with refreshAuthToken() on 401.

## Tests
- flutter analyze
- flutter test test/packages/service/dfx/dfx_auth_service_test.dart test/packages/service/dfx/real_unit_buy_payment_info_service_test.dart test/screens/buy/buy_page_test.dart test/screens/sell/sell_page_test.dart