### PR TITLE
ci: measure test coverage and upload as artifact

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -20,4 +20,29 @@ jobs:
       - run: dart run tool/generate_localization.dart
       - run: flutter pub run build_runner build
       - run: flutter analyze
-      - run: flutter test
+      - run: flutter test --coverage
+
+      # Strip generated and unreachable-from-tests files before reporting so
+      # the artifact reflects only the activated surface we actually intend
+      # to cover. Threshold enforcement is not yet wired (see README
+      # "Coverage infrastructure roadmap"); this step only produces a
+      # measurable baseline.
+      - name: Filter coverage report
+        run: |
+          if [ -f coverage/lcov.info ]; then
+            brew install lcov >/dev/null
+            lcov --remove coverage/lcov.info \
+              'lib/generated/**' \
+              'lib/main.dart' \
+              --output-file coverage/lcov.info \
+              --ignore-errors unused
+            lcov --summary coverage/lcov.info || true
+          fi
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
Adds `flutter test --coverage` to the existing PR workflow and uploads the (filtered) `lcov.info` as a CI artifact.

- `flutter test --coverage` replaces the plain `flutter test` invocation
- `coverage/lcov.info` is filtered with `lcov --remove` to drop generated files (`lib/generated/**`) and `lib/main.dart` so the artifact reflects only the activated surface
- The filtered report is uploaded as artifact `coverage-lcov` on every run (`if: always()`)
- `lcov --summary` prints to the CI log so contributors can eyeball the line/function/branch numbers without downloading the artifact

## Why
Step 1 of the coverage infrastructure roadmap documented in PR #322. Without measurement, the 100% rule is unverifiable; with measurement but no threshold, this PR is safe to merge today and lays the foundation for the threshold gate in a follow-up.

## What this PR is _not_
- Does **not** enforce any threshold. The build still passes regardless of coverage %. Hard-gating below 100% would block every open PR today (current coverage ratio ≈ 10%).
- Does **not** add any new tests.
- Does **not** change which files exist in `test/`.

## Test plan
- [ ] CI run completes green
- [ ] `coverage-lcov` artifact is present on the PR's checks page
- [ ] `lcov --summary` line of the CI log shows non-zero coverage on `lib/packages/**`
- [ ] Filtered report excludes `lib/generated/**`