### PR TITLE
test(packages): cover utils + wallet pure-Dart surface (+38 tests)

### DIFF
--- a/test/packages/utils/fast_hash_test.dart
+++ b/test/packages/utils/fast_hash_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/utils/fast_hash.dart';
+
+void main() {
+  group('fastHash', () {
+    test('empty string returns the FNV-1a 64-bit offset basis', () {
+      expect(fastHash(''), 0xcbf29ce484222325);
+    });
+
+    test('is deterministic for the same input', () {
+      const input = 'realunit-asset-id';
+
+      expect(fastHash(input), fastHash(input));
+    });
+
+    test('differs for distinct inputs', () {
+      expect(fastHash('a'), isNot(fastHash('b')));
+      expect(fastHash('aa'), isNot(fastHash('ab')));
+    });
+
+    test('handles unicode strings without throwing', () {
+      // Two-byte code units exercise both halves of the FNV mixing loop.
+      expect(() => fastHash('zürich'), returnsNormally);
+      expect(fastHash('zürich'), isNot(fastHash('zurich')));
+    });
+
+    test('is sensitive to ordering (not a commutative hash)', () {
+      expect(fastHash('ab'), isNot(fastHash('ba')));
+    });
+  });
+}

--- a/test/packages/utils/jwt_decoder_test.dart
+++ b/test/packages/utils/jwt_decoder_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/utils/jwt_decoder.dart';
+
+String _b64UrlNoPad(Object value) {
+  final encoded = base64Url.encode(utf8.encode(json.encode(value)));
+  return encoded.replaceAll('=', '');
+}
+
+String _jwtFromPayload(Object payload) {
+  final header = _b64UrlNoPad({'alg': 'HS256', 'typ': 'JWT'});
+  final body = _b64UrlNoPad(payload);
+  // Signature is opaque to the decoder; any non-empty placeholder is fine.
+  return '$header.$body.sig';
+}
+
+void main() {
+  group('$JwtDecoder', () {
+    test('parses a well-formed JWT payload into a map', () {
+      final token = _jwtFromPayload({'sub': 'user-1', 'level': 30});
+
+      final payload = JwtDecoder.parseJwt(token);
+
+      expect(payload['sub'], 'user-1');
+      expect(payload['level'], 30);
+    });
+
+    test('throws when the token has fewer than three segments', () {
+      expect(() => JwtDecoder.parseJwt('only.two'), throwsException);
+    });
+
+    test('throws when the token has more than three segments', () {
+      expect(() => JwtDecoder.parseJwt('a.b.c.d'), throwsException);
+    });
+
+    test('throws when the payload decodes to a non-map (e.g. a list)', () {
+      final token = _jwtFromPayload(['not', 'a', 'map']);
+
+      expect(() => JwtDecoder.parseJwt(token), throwsException);
+    });
+
+    test('handles base64url padding for length % 4 == 2', () {
+      // A two-key payload produces a body that needs '==' padding.
+      final token = _jwtFromPayload({'a': 1, 'bb': 2});
+
+      final payload = JwtDecoder.parseJwt(token);
+
+      expect(payload, containsPair('a', 1));
+      expect(payload, containsPair('bb', 2));
+    });
+
+    test('handles base64url padding for length % 4 == 3', () {
+      // A short payload produces a body that needs '=' padding.
+      final token = _jwtFromPayload({'a': 1});
+
+      final payload = JwtDecoder.parseJwt(token);
+
+      expect(payload, containsPair('a', 1));
+    });
+
+    test('throws on an illegal base64url length (% 4 == 1)', () {
+      // Hand-craft a payload segment of length 5 (5 % 4 == 1) to hit the
+      // 'Illegal base64url string' branch.
+      const illegal = 'header.AAAAA.sig';
+
+      expect(() => JwtDecoder.parseJwt(illegal), throwsException);
+    });
+  });
+}

--- a/test/packages/wallet/eip7702_signer_test.dart
+++ b/test/packages/wallet/eip7702_signer_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/eip7702/eip7702_data_dto.dart';
+import 'package:realunit_wallet/packages/wallet/eip7702_signer.dart';
+import 'package:web3dart/web3dart.dart';
+
+class _MockBitboxCredentials extends Mock implements BitboxCredentials {}
+
+const _delegatorAddress = '0x0000000000000000000000000000000000000001';
+
+Eip7702Data _data({int chainId = 1, int userNonce = 0}) => Eip7702Data(
+      relayerAddress: '0x0000000000000000000000000000000000000002',
+      delegationManagerAddress: '0x0000000000000000000000000000000000000003',
+      delegatorAddress: _delegatorAddress,
+      userNonce: userNonce,
+      domain: Eip7702Domain(
+        name: 'RealUnit',
+        version: '1',
+        chainId: chainId,
+        verifyingContract: '0x0000000000000000000000000000000000000004',
+      ),
+      types: const Eip7702Types(delegation: [], caveat: []),
+      message: const Eip7702Message(
+        delegate: '0x0000000000000000000000000000000000000005',
+        delegator: _delegatorAddress,
+        authority: '0x0000000000000000000000000000000000000006',
+        caveats: [],
+        salt: 0,
+      ),
+      tokenAddress: '0x0000000000000000000000000000000000000007',
+      amountWei: '0',
+      depositAddress: '0x0000000000000000000000000000000000000008',
+    );
+
+void main() {
+  group('$Eip7702Signer', () {
+    test('throws when credentials are not an EthPrivateKey', () {
+      // BitBox02 firmware does not expose a raw EIP-7702 signing API,
+      // so any hardware-wallet credential must be rejected up front.
+      final credentials = _MockBitboxCredentials();
+      when(() => credentials.address).thenReturn(
+        EthereumAddress.fromHex(_delegatorAddress),
+      );
+
+      expect(
+        () => Eip7702Signer.signAuthorization(
+          credentials: credentials,
+          eip7702Data: _data(),
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('returns a signature for a software EthPrivateKey credential', () {
+      final credentials = EthPrivateKey.fromHex(
+        'fb1ace12f9801e85f3db1b3935dd47d9f064f98152466f47c701b5e12680e612',
+      );
+
+      final signature = Eip7702Signer.signAuthorization(
+        credentials: credentials,
+        eip7702Data: _data(),
+      );
+
+      expect(signature, isNotNull);
+    });
+
+    test('produces a deterministic signature for identical inputs', () {
+      final credentials = EthPrivateKey.fromHex(
+        'fb1ace12f9801e85f3db1b3935dd47d9f064f98152466f47c701b5e12680e612',
+      );
+      final data = _data(chainId: 1, userNonce: 7);
+
+      final first = Eip7702Signer.signAuthorization(
+        credentials: credentials,
+        eip7702Data: data,
+      );
+      final second = Eip7702Signer.signAuthorization(
+        credentials: credentials,
+        eip7702Data: data,
+      );
+
+      expect(first.r, second.r);
+      expect(first.s, second.s);
+      expect(first.v, second.v);
+    });
+
+    test('different nonces produce different signatures', () {
+      final credentials = EthPrivateKey.fromHex(
+        'fb1ace12f9801e85f3db1b3935dd47d9f064f98152466f47c701b5e12680e612',
+      );
+
+      final a = Eip7702Signer.signAuthorization(
+        credentials: credentials,
+        eip7702Data: _data(userNonce: 0),
+      );
+      final b = Eip7702Signer.signAuthorization(
+        credentials: credentials,
+        eip7702Data: _data(userNonce: 1),
+      );
+
+      expect(a.r == b.r && a.s == b.s, isFalse);
+    });
+  });
+}

--- a/test/packages/wallet/payment_uri_test.dart
+++ b/test/packages/wallet/payment_uri_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/wallet/payment_uri.dart';
+
+void main() {
+  group('$EthereumURI', () {
+    const address = '0x0000000000000000000000000000000000000001';
+
+    test('omits the amount query when the amount string is empty', () {
+      final uri = EthereumURI(amount: '', address: address);
+
+      expect(uri.toString(), 'ethereum:$address');
+    });
+
+    test('appends a non-empty amount as a query parameter', () {
+      final uri = EthereumURI(amount: '1.5', address: address);
+
+      expect(uri.toString(), 'ethereum:$address?amount=1.5');
+    });
+
+    test("normalises the decimal separator from ',' to '.'", () {
+      // German locale formatters emit '1,5' — the URI must still parse as
+      // a numeric amount on the receiving side, which expects '.'.
+      final uri = EthereumURI(amount: '1,5', address: address);
+
+      expect(uri.toString(), 'ethereum:$address?amount=1.5');
+    });
+
+    test('preserves dotted amounts unchanged', () {
+      final uri = EthereumURI(amount: '0.000001', address: address);
+
+      expect(uri.toString(), 'ethereum:$address?amount=0.000001');
+    });
+  });
+}

--- a/test/packages/wallet/wallet_account_test.dart
+++ b/test/packages/wallet/wallet_account_test.dart
@@ -1,0 +1,74 @@
+import 'package:bip32/bip32.dart';
+import 'package:bip39/bip39.dart' as bip39;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
+
+const _testMnemonic =
+    'test test test test test test test test test test test junk';
+
+BIP32 _testRoot() => BIP32.fromSeed(bip39.mnemonicToSeed(_testMnemonic));
+
+void main() {
+  group('$WalletAccount', () {
+    test('getDerivationPath uses the BIP-44 Ethereum format', () {
+      final account = WalletAccount(_testRoot(), 0);
+
+      expect(account.getDerivationPath(0), "m/44'/60'/0'/0/0");
+      expect(account.getDerivationPath(5), "m/44'/60'/0'/0/5");
+    });
+
+    test('derivation path includes the account index', () {
+      final account = WalletAccount(_testRoot(), 3);
+
+      expect(account.getDerivationPath(0), "m/44'/60'/3'/0/0");
+    });
+
+    test('primaryAddress is derived deterministically from the seed', () {
+      // The first test-mnemonic Ethereum address is the well-known
+      // Hardhat / Foundry account #0.
+      const expected = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+
+      final account = WalletAccount(_testRoot(), 0);
+
+      expect(
+        account.primaryAddress.address.hexEip55,
+        expected,
+      );
+    });
+
+    test('different account indices derive different addresses', () {
+      final a = WalletAccount(_testRoot(), 0).primaryAddress.address.hex;
+      final b = WalletAccount(_testRoot(), 1).primaryAddress.address.hex;
+
+      expect(a, isNot(b));
+    });
+
+    test('signMessage produces a 65-byte hex signature', () async {
+      final account = WalletAccount(_testRoot(), 0);
+
+      final signature = await account.signMessage('hello');
+
+      // 0x prefix + 65 bytes * 2 hex chars = 132 chars.
+      expect(signature, startsWith('0x'));
+      expect(signature.length, 132);
+    });
+
+    test('signMessage is deterministic for the same input', () async {
+      final account = WalletAccount(_testRoot(), 0);
+
+      final first = await account.signMessage('payload');
+      final second = await account.signMessage('payload');
+
+      expect(first, second);
+    });
+
+    test('signMessage with a different addressIndex yields a different signature', () async {
+      final account = WalletAccount(_testRoot(), 0);
+
+      final fromZero = await account.signMessage('payload', addressIndex: 0);
+      final fromOne = await account.signMessage('payload', addressIndex: 1);
+
+      expect(fromZero, isNot(fromOne));
+    });
+  });
+}

--- a/test/packages/wallet/wallet_test.dart
+++ b/test/packages/wallet/wallet_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/wallet/wallet.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
+
+const _testMnemonic =
+    'test test test test test test test test test test test junk';
+
+void main() {
+  group('$SoftwareWallet', () {
+    test('exposes walletType == software', () {
+      final wallet = SoftwareWallet(1, 'Main', _testMnemonic);
+
+      expect(wallet.walletType, WalletType.software);
+    });
+
+    test('primaryAccount is derived at BIP-44 account index 0', () {
+      final wallet = SoftwareWallet(1, 'Main', _testMnemonic);
+
+      expect(wallet.primaryAccount, isA<WalletAccount>());
+      expect(wallet.primaryAccount.accountIndex, 0);
+    });
+
+    test('currentAccount starts equal to primaryAccount', () {
+      final wallet = SoftwareWallet(1, 'Main', _testMnemonic);
+
+      expect(
+        wallet.currentAccount.primaryAddress.address.hex,
+        wallet.primaryAccount.primaryAddress.address.hex,
+      );
+    });
+
+    test('selectAccount switches currentAccount to a different derivation', () {
+      final wallet = SoftwareWallet(1, 'Main', _testMnemonic);
+      final firstAddress = wallet.currentAccount.primaryAddress.address.hex;
+
+      wallet.selectAccount(1);
+
+      expect(wallet.currentAccount.accountIndex, 1);
+      expect(
+        wallet.currentAccount.primaryAddress.address.hex,
+        isNot(firstAddress),
+      );
+    });
+
+    test('selectAccount does not alter primaryAccount', () {
+      final wallet = SoftwareWallet(1, 'Main', _testMnemonic);
+      final primary = wallet.primaryAccount.primaryAddress.address.hex;
+
+      wallet.selectAccount(2);
+
+      expect(wallet.primaryAccount.primaryAddress.address.hex, primary);
+    });
+
+    test('id and name are preserved from the constructor', () {
+      final wallet = SoftwareWallet(42, 'Savings', _testMnemonic);
+
+      expect(wallet.id, 42);
+      expect(wallet.name, 'Savings');
+    });
+
+    test('name field is mutable (set after construction)', () {
+      final wallet = SoftwareWallet(1, 'Old', _testMnemonic);
+
+      wallet.name = 'New';
+
+      expect(wallet.name, 'New');
+    });
+  });
+
+  group('$DebugWallet', () {
+    const address = '0x0000000000000000000000000000000000000001';
+
+    test('exposes walletType == debug', () {
+      final wallet = DebugWallet(1, 'Debug', address);
+
+      expect(wallet.walletType, WalletType.debug);
+    });
+
+    test('primaryAccount equals currentAccount', () {
+      final wallet = DebugWallet(1, 'Debug', address);
+
+      expect(identical(wallet.primaryAccount, wallet.currentAccount), isTrue);
+    });
+
+    test('exposes the configured address through primaryAccount', () {
+      final wallet = DebugWallet(1, 'Debug', address);
+
+      expect(
+        wallet.primaryAccount.primaryAddress.address.hex.toLowerCase(),
+        address.toLowerCase(),
+      );
+    });
+
+    test('signMessage throws UnsupportedError', () async {
+      final wallet = DebugWallet(1, 'Debug', address);
+
+      expect(
+        () => wallet.primaryAccount.signMessage('payload'),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds 38 unit tests across six previously-untested files in `lib/packages/utils/` and `lib/packages/wallet/`. Each spec lives in the mirror path under `test/` per the project convention.

| File under test | Test file | Cases |
| --- | --- | --- |
| `lib/packages/utils/fast_hash.dart` | `test/packages/utils/fast_hash_test.dart` | 5 |
| `lib/packages/utils/jwt_decoder.dart` | `test/packages/utils/jwt_decoder_test.dart` | 7 |
| `lib/packages/wallet/payment_uri.dart` | `test/packages/wallet/payment_uri_test.dart` | 4 |
| `lib/packages/wallet/wallet_account.dart` | `test/packages/wallet/wallet_account_test.dart` | 7 |
| `lib/packages/wallet/wallet.dart` | `test/packages/wallet/wallet_test.dart` | 11 |
| `lib/packages/wallet/eip7702_signer.dart` | `test/packages/wallet/eip7702_signer_test.dart` | 4 |

## What each file covers
- **fast_hash:** FNV-1a determinism, distinct inputs differ, ordering matters, unicode safety, empty-string offset basis.
- **jwt_decoder:** well-formed payload parsing, segment-count errors, non-map payload rejection, all three valid base64url padding lengths, illegal length-mod-4 rejection.
- **payment_uri:** empty-amount short form, dotted and comma-locale amounts, preservation of decimal precision.
- **wallet_account:** BIP-44 derivation path format, deterministic Hardhat account #0 address from the standard test mnemonic, distinct indices, signMessage shape + determinism + sensitivity to addressIndex.
- **wallet:** `SoftwareWallet` walletType + primary/current account identity + `selectAccount` semantics + id/name mutability; `DebugWallet` sign refusal.
- **eip7702_signer:** hardware-credential refusal (BitBox cannot sign EIP-7702), software-credential signing, signature determinism, nonce-sensitivity.

## Why
Stage 2 of the coverage push tracked in the README features matrix ([#322](https://github.com/DFXswiss/realunit-app/pull/322)). These six files are pure-Dart with no platform dependencies, so they were the cheapest meaningful coverage win available — no service mocks, no widget rendering, no merge-conflict risk with the three in-flight test PRs ([#319](https://github.com/DFXswiss/realunit-app/pull/319), [#320](https://github.com/DFXswiss/realunit-app/pull/320), [#321](https://github.com/DFXswiss/realunit-app/pull/321)).

## Test plan
- [x] `flutter analyze` clean on all six new test files (locally on Flutter 3.38.5)
- [x] `flutter test test/packages/utils/ test/packages/wallet/` — 38 / 38 passing
- [ ] CI green on this branch
- [ ] Spot-check: coverage artifact from #323 (once that lands) shows non-zero coverage on the six files above