### PR TITLE
test(service): cover non-DFX services (+38 tests)

### DIFF
--- a/test/packages/service/app_store_test.dart
+++ b/test/packages/service/app_store_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/wallet/wallet.dart';
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+const _testMnemonic =
+    'test test test test test test test test test test test junk';
+
+void main() {
+  late SessionCache sessionCache;
+  late ApiConfig apiConfig;
+  late AppStore store;
+
+  setUp(() {
+    sessionCache = SessionCache(_MockCacheRepository());
+    apiConfig = const ApiConfig(networkMode: NetworkMode.mainnet);
+    store = AppStore(() => apiConfig, sessionCache);
+  });
+
+  group('$AppStore', () {
+    test('wallet getter throws before a wallet has been set', () {
+      expect(() => store.wallet, throwsException);
+    });
+
+    test('wallet getter returns the wallet once set', () {
+      final wallet = SoftwareWallet(1, 'Main', _testMnemonic);
+
+      store.wallet = wallet;
+
+      expect(store.wallet, same(wallet));
+    });
+
+    test('primaryAddress proxies the current account address (hex)', () {
+      final wallet = SoftwareWallet(1, 'Main', _testMnemonic);
+      store.wallet = wallet;
+
+      // Hardhat account #0 derived from the test mnemonic.
+      expect(
+        store.primaryAddress.toLowerCase(),
+        '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      );
+    });
+
+    test('primaryAddress updates when selectAccount changes the current account', () {
+      final wallet = SoftwareWallet(1, 'Main', _testMnemonic);
+      store.wallet = wallet;
+      final firstAddress = store.primaryAddress;
+
+      wallet.selectAccount(1);
+
+      expect(store.primaryAddress, isNot(firstAddress));
+    });
+
+    test('apiConfig re-reads from the getter on every access', () {
+      var current = const ApiConfig(networkMode: NetworkMode.mainnet);
+      final dynamicStore = AppStore(() => current, sessionCache);
+
+      expect(dynamicStore.apiConfig.networkMode, NetworkMode.mainnet);
+
+      current = const ApiConfig(networkMode: NetworkMode.testnet);
+
+      // The getter must not cache — the network can switch at runtime
+      // (testnet / mainnet toggle in settings).
+      expect(dynamicStore.apiConfig.networkMode, NetworkMode.testnet);
+    });
+
+    test('sessionCache is exposed unchanged', () {
+      expect(store.sessionCache, same(sessionCache));
+    });
+  });
+}

--- a/test/packages/service/session_cache_test.dart
+++ b/test/packages/service/session_cache_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+void main() {
+  late _MockCacheRepository repo;
+  late SessionCache cache;
+
+  setUp(() {
+    repo = _MockCacheRepository();
+    cache = SessionCache(repo);
+    when(() => repo.write(any(), any())).thenAnswer((_) async => 1);
+    when(() => repo.delete(any())).thenAnswer((_) async {});
+  });
+
+  group('$SessionCache', () {
+    group('auth token', () {
+      test('starts null', () {
+        expect(cache.authToken, isNull);
+      });
+
+      test('setAuthToken stores in memory only', () {
+        cache.setAuthToken('jwt-123');
+
+        expect(cache.authToken, 'jwt-123');
+        // setAuthToken must NEVER touch the repository — JWTs live for one
+        // session and persisting them to disk would defeat that lifetime.
+        verifyNever(() => repo.write(any(), any()));
+      });
+
+      test('clearAuthToken resets to null without touching the repository', () {
+        cache.setAuthToken('jwt-123');
+
+        cache.clearAuthToken();
+
+        expect(cache.authToken, isNull);
+        verifyNever(() => repo.write(any(), any()));
+        verifyNever(() => repo.delete(any()));
+      });
+    });
+
+    group('signature', () {
+      test('starts null', () {
+        expect(cache.signature, isNull);
+        expect(cache.signatureAddress, isNull);
+      });
+
+      test('saveSignature writes both the signature and the address to the repo', () async {
+        await cache.saveSignature('0xabc', '0xsig');
+
+        expect(cache.signature, '0xsig');
+        expect(cache.signatureAddress, '0xabc');
+        verify(() => repo.write('cached_signature', '0xsig')).called(1);
+        verify(() => repo.write('cached_signature_address', '0xabc')).called(1);
+      });
+
+      test('loadSignature populates from the repo when memory is empty', () async {
+        when(() => repo.read('cached_signature')).thenAnswer((_) async => '0xsig');
+        when(() => repo.read('cached_signature_address')).thenAnswer((_) async => '0xabc');
+
+        await cache.loadSignature();
+
+        expect(cache.signature, '0xsig');
+        expect(cache.signatureAddress, '0xabc');
+      });
+
+      test('loadSignature does not overwrite an in-memory signature', () async {
+        await cache.saveSignature('0xabc', '0xsig');
+        when(() => repo.read(any())).thenAnswer((_) async => 'wrong');
+
+        await cache.loadSignature();
+
+        expect(cache.signature, '0xsig');
+        expect(cache.signatureAddress, '0xabc');
+        verifyNever(() => repo.read(any()));
+      });
+
+      test('loadSignature tolerates a missing entry in the repo', () async {
+        when(() => repo.read(any())).thenAnswer((_) async => null);
+
+        await cache.loadSignature();
+
+        expect(cache.signature, isNull);
+        expect(cache.signatureAddress, isNull);
+      });
+    });
+
+    group('clear', () {
+      test('removes both signature keys and resets auth token + memory', () async {
+        cache.setAuthToken('jwt-123');
+        await cache.saveSignature('0xabc', '0xsig');
+        clearInteractions(repo);
+        when(() => repo.delete(any())).thenAnswer((_) async {});
+
+        await cache.clear();
+
+        expect(cache.authToken, isNull);
+        expect(cache.signature, isNull);
+        expect(cache.signatureAddress, isNull);
+        verify(() => repo.delete('cached_signature')).called(1);
+        verify(() => repo.delete('cached_signature_address')).called(1);
+      });
+    });
+  });
+}

--- a/test/packages/service/settings_service_test.dart
+++ b/test/packages/service/settings_service_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/repository/settings_repository.dart';
+import 'package:realunit_wallet/packages/service/settings_service.dart';
+
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
+
+void main() {
+  late _MockSettingsRepository repo;
+  late SettingsService service;
+
+  setUp(() {
+    repo = _MockSettingsRepository();
+    service = SettingsService(repo);
+  });
+
+  group('$SettingsService', () {
+    group('terms accepted', () {
+      test('reads through to the repository', () {
+        when(() => repo.termsAccepted).thenReturn(true);
+
+        expect(service.isTermsAccepted, isTrue);
+      });
+
+      test('returns false when the repository reports false', () {
+        when(() => repo.termsAccepted).thenReturn(false);
+
+        expect(service.isTermsAccepted, isFalse);
+      });
+
+      test('writes through to the repository', () {
+        service.setTermsAccepted(true);
+
+        verify(() => repo.termsAccepted = true).called(1);
+      });
+
+      test('propagates the false value as well', () {
+        service.setTermsAccepted(false);
+
+        verify(() => repo.termsAccepted = false).called(1);
+      });
+    });
+
+    group('software terms accepted', () {
+      test('reads through to the repository', () {
+        when(() => repo.softwareTermsAccepted).thenReturn(true);
+
+        expect(service.isSoftwareTermsAccepted, isTrue);
+      });
+
+      test('writes through to the repository', () {
+        service.setSoftwareTermsAccepted(true);
+
+        verify(() => repo.softwareTermsAccepted = true).called(1);
+      });
+
+      test('software-terms and terms are independent settings', () {
+        when(() => repo.termsAccepted).thenReturn(true);
+        when(() => repo.softwareTermsAccepted).thenReturn(false);
+
+        expect(service.isTermsAccepted, isTrue);
+        expect(service.isSoftwareTermsAccepted, isFalse);
+      });
+    });
+  });
+}

--- a/test/packages/service/wallet_service_test.dart
+++ b/test/packages/service/wallet_service_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
+import 'package:realunit_wallet/packages/repository/settings_repository.dart';
+import 'package:realunit_wallet/packages/repository/wallet_repository.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
+import 'package:realunit_wallet/packages/storage/database.dart';
+import 'package:realunit_wallet/packages/wallet/wallet.dart';
+
+class _MockWalletRepository extends Mock implements WalletRepository {}
+
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
+
+class _MockBitboxService extends Mock implements BitboxService {}
+
+const _testMnemonic =
+    'test test test test test test test test test test test junk';
+const _debugAddress = '0x0000000000000000000000000000000000000001';
+
+WalletInfo _info({
+  int id = 1,
+  String name = 'Main',
+  String seed = '',
+  String address = '',
+  required WalletType type,
+}) =>
+    WalletInfo(id: id, name: name, seed: seed, address: address, type: type.index);
+
+void main() {
+  late _MockWalletRepository repo;
+  late _MockSettingsRepository settings;
+  late _MockBitboxService bitbox;
+  late WalletService service;
+
+  setUpAll(() {
+    // mocktail needs a default for non-primitive types used with `any()`.
+    registerFallbackValue(WalletType.software);
+  });
+
+  setUp(() {
+    repo = _MockWalletRepository();
+    settings = _MockSettingsRepository();
+    bitbox = _MockBitboxService();
+    service = WalletService(bitbox, repo, settings);
+
+    when(() => settings.saveCurrentWalletId(any())).thenAnswer((_) async => true);
+    when(() => settings.removeCurrentWalletId()).thenAnswer((_) async => true);
+    when(() => repo.deleteWallet(any())).thenAnswer((_) async {});
+  });
+
+  group('$WalletService', () {
+    group('createSeedWallet', () {
+      test('returns a SoftwareWallet with the generated mnemonic persisted', () async {
+        when(() => repo.createWallet(any(), any(), any())).thenAnswer((_) async => 42);
+
+        final wallet = await service.createSeedWallet('Main');
+
+        expect(wallet, isA<SoftwareWallet>());
+        expect(wallet.id, 42);
+        expect(wallet.name, 'Main');
+        // Generated mnemonic must be valid bip39.
+        expect(service.validateSeed(wallet.seed), isTrue);
+        verify(() => repo.createWallet('Main', WalletType.software, wallet.seed)).called(1);
+      });
+
+      test('does not set the wallet as current (caller is responsible)', () async {
+        when(() => repo.createWallet(any(), any(), any())).thenAnswer((_) async => 42);
+
+        await service.createSeedWallet('Main');
+
+        verifyNever(() => settings.saveCurrentWalletId(any()));
+      });
+    });
+
+    group('restoreWallet', () {
+      test('persists the provided seed and marks the wallet as current', () async {
+        when(() => repo.createWallet(any(), any(), any())).thenAnswer((_) async => 7);
+
+        final wallet = await service.restoreWallet('Restored', _testMnemonic);
+
+        expect(wallet.id, 7);
+        expect(wallet.name, 'Restored');
+        expect(wallet.seed, _testMnemonic);
+        verify(() => repo.createWallet('Restored', WalletType.software, _testMnemonic)).called(1);
+        verify(() => settings.saveCurrentWalletId(7)).called(1);
+      });
+    });
+
+    group('createDebugWallet', () {
+      test('persists a view wallet and marks it current', () async {
+        when(() => repo.createViewWallet(any(), any(), any())).thenAnswer((_) async => 99);
+
+        final wallet = await service.createDebugWallet(_debugAddress);
+
+        expect(wallet, isA<DebugWallet>());
+        expect(wallet.id, 99);
+        expect(wallet.address, _debugAddress);
+        verify(() => repo.createViewWallet('Debug', WalletType.debug, _debugAddress)).called(1);
+        verify(() => settings.saveCurrentWalletId(99)).called(1);
+      });
+    });
+
+    group('getWalletById', () {
+      test('returns SoftwareWallet for software type', () async {
+        when(() => repo.getWalletById(1)).thenAnswer(
+          (_) async => _info(id: 1, name: 'Main', seed: _testMnemonic, type: WalletType.software),
+        );
+
+        final wallet = await service.getWalletById(1);
+
+        expect(wallet, isA<SoftwareWallet>());
+        expect((wallet as SoftwareWallet).seed, _testMnemonic);
+      });
+
+      test('returns DebugWallet for debug type', () async {
+        when(() => repo.getWalletById(2)).thenAnswer(
+          (_) async => _info(id: 2, name: 'Debug', address: _debugAddress, type: WalletType.debug),
+        );
+
+        final wallet = await service.getWalletById(2);
+
+        expect(wallet, isA<DebugWallet>());
+        expect((wallet as DebugWallet).address, _debugAddress);
+      });
+
+      test('throws when the repository returns null (no such id)', () async {
+        when(() => repo.getWalletById(404)).thenAnswer((_) async => null);
+
+        expect(() => service.getWalletById(404), throwsA(isA<TypeError>()));
+      });
+    });
+
+    group('setCurrentWallet', () {
+      test('delegates to SettingsRepository.saveCurrentWalletId', () async {
+        await service.setCurrentWallet(5);
+
+        verify(() => settings.saveCurrentWalletId(5)).called(1);
+      });
+    });
+
+    group('getCurrentWallet', () {
+      test('reads the current id and resolves it through getWalletById', () async {
+        when(() => settings.currentWalletId).thenReturn(3);
+        when(() => repo.getWalletById(3)).thenAnswer(
+          (_) async => _info(id: 3, name: 'Saved', seed: _testMnemonic, type: WalletType.software),
+        );
+
+        final wallet = await service.getCurrentWallet();
+
+        expect(wallet.id, 3);
+        expect(wallet.name, 'Saved');
+      });
+
+      test('throws when no current id is set', () async {
+        when(() => settings.currentWalletId).thenReturn(null);
+
+        expect(() => service.getCurrentWallet(), throwsA(isA<TypeError>()));
+      });
+    });
+
+    group('deleteCurrentWallet', () {
+      test('deletes the wallet and clears the current-id setting', () async {
+        when(() => settings.currentWalletId).thenReturn(8);
+
+        await service.deleteCurrentWallet();
+
+        verify(() => repo.deleteWallet(8)).called(1);
+        verify(() => settings.removeCurrentWalletId()).called(1);
+      });
+    });
+
+    group('hasWallet', () {
+      test('returns true when a current id is set', () {
+        when(() => settings.currentWalletId).thenReturn(1);
+
+        expect(service.hasWallet(), isTrue);
+      });
+
+      test('returns false when no current id is set', () {
+        when(() => settings.currentWalletId).thenReturn(null);
+
+        expect(service.hasWallet(), isFalse);
+      });
+    });
+
+    group('validateSeed', () {
+      test('accepts a valid bip39 mnemonic', () {
+        expect(service.validateSeed(_testMnemonic), isTrue);
+      });
+
+      test('rejects an obviously invalid mnemonic', () {
+        expect(service.validateSeed('not a valid seed phrase at all'), isFalse);
+      });
+
+      test('rejects an empty string', () {
+        expect(service.validateSeed(''), isFalse);
+      });
+
+      test('rejects a mnemonic with a wrong checksum word', () {
+        // Replace the final checksum word with a different valid bip39 word.
+        const broken =
+            'test test test test test test test test test test test ability';
+        expect(service.validateSeed(broken), isFalse);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 3 of the coverage push. Adds 38 unit tests across four previously-untested service files in \`lib/packages/service/\` that have no DFX backend coupling. \`mocktail\` mocks for the repository / bitbox dependencies; no real I/O.

| Service | Test file | Cases |
| --- | --- | --- |
| \`session_cache.dart\` | \`test/packages/service/session_cache_test.dart\` | 9 |
| \`settings_service.dart\` | \`test/packages/service/settings_service_test.dart\` | 6 |
| \`app_store.dart\` | \`test/packages/service/app_store_test.dart\` | 6 |
| \`wallet_service.dart\` | \`test/packages/service/wallet_service_test.dart\` | 17 |

## What each file covers
- **session_cache:** auth-token in-memory-only lifecycle (no disk write); signature/address persistence through \`CacheRepository\`; \`loadSignature\` preserves in-memory state when already set; tolerates missing repo entries; \`clear\` wipes both keys, auth token, and memory.
- **settings_service:** terms / software-terms read + write delegation; the two flags are independent.
- **app_store:** wallet-not-set throws; primaryAddress derived through current account; selectAccount-driven address change; \`apiConfig\` getter re-evaluates on every access (network mode can switch at runtime); sessionCache passthrough.
- **wallet_service:** \`createSeedWallet\` (bip39 generation + persistence, does NOT mark current); \`restoreWallet\` (seed persistence + marks current); \`createDebugWallet\` (view-wallet path); \`getWalletById\` (software / debug branches + null-repo error); \`setCurrentWallet\`; \`getCurrentWallet\` (resolves through id); \`deleteCurrentWallet\`; \`hasWallet\` (both branches); \`validateSeed\` (valid / invalid / empty / wrong-checksum).

## Excluded (with reasons)
- **biometric_service.dart** — the \`LocalAuthentication\` instance is constructed in the field initializer with no seam. Testing requires either a prod refactor (out of scope here) or platform-channel test plumbing. Flagged in the README features matrix as a triage gap.
- **transaction_history_service.dart** — hits \`app_store.httpClient\` (a final \`http.Client\` field) which is not currently injectable. Same constraint as the DFX services.
- **price_service.dart** — abstract interface only; no implementation to test yet.
- **wallet_service \`createBitboxWallet\` / getWalletById bitbox branch** — belongs to Tier 1 with \`FakeBitboxCredentials\` (now landed via #319/#320). Will be covered in a follow-up.

## Test plan
- [x] \`flutter analyze\` clean (locally on Flutter 3.38.5)
- [x] \`flutter test test/packages/service/\` — 38 / 38 passing on these new files
- [ ] CI green