### PR TITLE
test: cover verify_pin_cubit + three DFX services (+32 tests)

### DIFF
--- a/test/packages/service/dfx/dfx_blockchain_api_service_test.dart
+++ b/test/packages/service/dfx/dfx_blockchain_api_service_test.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_blockchain_api_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+const _testAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+void main() {
+  late _MockAppStore appStore;
+  late SessionCache sessionCache;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    sessionCache = SessionCache(_MockCacheRepository());
+    when(() => appStore.sessionCache).thenReturn(sessionCache);
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+  });
+
+  DfxBlockchainApiService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return DfxBlockchainApiService(appStore);
+  }
+
+  group('$DfxBlockchainApiService', () {
+    test('getEthBalance posts the address + chain + asset id with the JWT', () async {
+      sessionCache.setAuthToken('jwt-abc');
+      Map<String, dynamic>? capturedBody;
+      Map<String, String>? capturedHeaders;
+      final client = MockClient((request) async {
+        capturedBody = jsonDecode(request.body) as Map<String, dynamic>;
+        capturedHeaders = request.headers;
+        return http.Response(
+          jsonEncode({
+            'balances': [
+              {'balance': 1.25},
+            ],
+          }),
+          200,
+        );
+      });
+
+      final balance = await build(client).getEthBalance(_testAddress);
+
+      expect(balance, 1.25);
+      expect(capturedBody!['address'], _testAddress);
+      // chainId 1 → 'Ethereum'.
+      expect(capturedBody!['blockchain'], 'Ethereum');
+      expect(capturedBody!['assetIds'], isA<List>());
+      expect(capturedHeaders!['Authorization'], 'Bearer jwt-abc');
+      expect(capturedHeaders!['Content-Type'], 'application/json');
+    });
+
+    test('uses "Sepolia" as the blockchain name on the testnet chain', () async {
+      when(() => appStore.apiConfig)
+          .thenReturn(const ApiConfig(networkMode: NetworkMode.testnet));
+      sessionCache.setAuthToken('jwt-abc');
+      Map<String, dynamic>? capturedBody;
+      final client = MockClient((request) async {
+        capturedBody = jsonDecode(request.body) as Map<String, dynamic>;
+        return http.Response(jsonEncode({'balances': []}), 200);
+      });
+
+      await build(client).getEthBalance(_testAddress);
+
+      expect(capturedBody!['blockchain'], 'Sepolia');
+    });
+
+    test('returns 0.0 when the balances list is empty', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'balances': []}),
+            200,
+          ));
+
+      expect(await build(client).getEthBalance(_testAddress), 0.0);
+    });
+
+    test('accepts a 201 response in addition to 200', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({
+              'balances': [
+                {'balance': 3.5},
+              ],
+            }),
+            201,
+          ));
+
+      expect(await build(client).getEthBalance(_testAddress), 3.5);
+    });
+
+    test('throws ApiException on a non-2xx response', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'statusCode': 401, 'message': 'Unauthorized'}),
+            401,
+          ));
+
+      expect(
+        () => build(client).getEthBalance(_testAddress),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+}

--- a/test/packages/service/dfx/dfx_country_service_test.dart
+++ b/test/packages/service/dfx/dfx_country_service_test.dart
@@ -1,0 +1,114 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_country_service.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+const _ch = {
+  'id': 41,
+  'symbol': 'CH',
+  'name': 'Switzerland',
+  'foreignName': null,
+  'locationAllowed': true,
+  'ibanAllowed': true,
+  'kycAllowed': true,
+  'kycOrganizationAllowed': true,
+  'nationalityAllowed': true,
+  'bankAllowed': true,
+  'cardAllowed': true,
+  'cryptoAllowed': true,
+};
+
+const _de = {
+  'id': 49,
+  'symbol': 'DE',
+  'name': 'Germany',
+  'foreignName': 'Deutschland',
+  'locationAllowed': true,
+  'ibanAllowed': true,
+  'kycAllowed': true,
+  'kycOrganizationAllowed': true,
+  'nationalityAllowed': true,
+  'bankAllowed': true,
+  'cardAllowed': true,
+  'cryptoAllowed': true,
+};
+
+void main() {
+  late _MockAppStore appStore;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+  });
+
+  DfxCountryService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return DfxCountryService(appStore);
+  }
+
+  group('$DfxCountryService', () {
+    test('getAllCountries maps the DTO list and caches the result', () async {
+      var callCount = 0;
+      final client = MockClient((request) async {
+        callCount++;
+        expect(request.url.path, '/v1/country');
+        return http.Response(jsonEncode([_ch, _de]), 200);
+      });
+      final service = build(client);
+
+      final first = await service.getAllCountries();
+      final second = await service.getAllCountries();
+
+      expect(first, hasLength(2));
+      expect(first.map((c) => c.symbol), ['CH', 'DE']);
+      expect(first.firstWhere((c) => c.symbol == 'DE').foreignName, 'Deutschland');
+      // Second call must hit the cache, not the network.
+      expect(callCount, 1);
+      expect(identical(first, second), isTrue);
+    });
+
+    test('getAllCountries throws on a non-200 response', () async {
+      final client = MockClient((_) async => http.Response('boom', 500));
+      final service = build(client);
+
+      expect(() => service.getAllCountries(), throwsException);
+    });
+
+    test('getCountryBySymbol matches case-insensitively', () async {
+      final client = MockClient((_) async => http.Response(jsonEncode([_ch]), 200));
+      final service = build(client);
+
+      final byUpper = await service.getCountryBySymbol('CH');
+      final byLower = await service.getCountryBySymbol('ch');
+
+      expect(byUpper.id, 41);
+      expect(byLower.id, 41);
+    });
+
+    test('getCountryBySymbol throws when the symbol is unknown', () async {
+      final client = MockClient((_) async => http.Response(jsonEncode([_ch]), 200));
+      final service = build(client);
+
+      expect(() => service.getCountryBySymbol('XX'), throwsException);
+    });
+
+    test('cachedCountries field is populated after a successful fetch', () async {
+      final client = MockClient((_) async => http.Response(jsonEncode([_ch]), 200));
+      final service = build(client);
+
+      expect(service.cachedCountries, isNull);
+      await service.getAllCountries();
+      expect(service.cachedCountries, isNotNull);
+      expect(service.cachedCountries, hasLength(1));
+    });
+  });
+}

--- a/test/packages/service/dfx/dfx_faucet_service_test.dart
+++ b/test/packages/service/dfx/dfx_faucet_service_test.dart
@@ -1,0 +1,97 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_faucet_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+void main() {
+  late _MockAppStore appStore;
+  late SessionCache sessionCache;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    sessionCache = SessionCache(_MockCacheRepository());
+    when(() => appStore.sessionCache).thenReturn(sessionCache);
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.testnet));
+  });
+
+  DfxFaucetService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return DfxFaucetService(appStore);
+  }
+
+  group('$DfxFaucetService', () {
+    test('requestFaucet posts to /v1/faucet with the JWT and parses the response', () async {
+      sessionCache.setAuthToken('jwt-zzz');
+      Map<String, String>? capturedHeaders;
+      String? capturedPath;
+      final client = MockClient((request) async {
+        capturedHeaders = request.headers;
+        capturedPath = request.url.path;
+        expect(request.method, 'POST');
+        return http.Response(
+          jsonEncode({'txId': '0xdeadbeef', 'amount': 0.05}),
+          200,
+        );
+      });
+
+      final response = await build(client).requestFaucet();
+
+      expect(response.txId, '0xdeadbeef');
+      expect(response.amount, 0.05);
+      expect(capturedPath, '/v1/faucet');
+      expect(capturedHeaders!['Authorization'], 'Bearer jwt-zzz');
+      expect(capturedHeaders!['Content-Type'], 'application/json');
+    });
+
+    test('accepts a 201 response in addition to 200', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'txId': 'tx-1', 'amount': 1.0}),
+            201,
+          ));
+
+      final response = await build(client).requestFaucet();
+
+      expect(response.txId, 'tx-1');
+    });
+
+    test('throws ApiException on a non-2xx response', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'statusCode': 429, 'message': 'Too Many Requests'}),
+            429,
+          ));
+
+      expect(
+        () => build(client).requestFaucet(),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('omits the authToken value (sends literal "null") when none is set', () async {
+      Map<String, String>? capturedHeaders;
+      final client = MockClient((request) async {
+        capturedHeaders = request.headers;
+        return http.Response(jsonEncode({'txId': '0x', 'amount': 0.0}), 200);
+      });
+
+      await build(client).requestFaucet();
+
+      // Documents the current behaviour: callers must guard against an empty
+      // auth token themselves; the service does not refuse the request.
+      expect(capturedHeaders!['Authorization'], 'Bearer null');
+    });
+  });
+}

--- a/test/screens/pin/verify_pin_cubit_test.dart
+++ b/test/screens/pin/verify_pin_cubit_test.dart
@@ -1,0 +1,266 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/biometric_service.dart';
+import 'package:realunit_wallet/packages/storage/secure_storage.dart';
+import 'package:realunit_wallet/screens/pin/bloc/verify_pin/verify_pin_cubit.dart';
+import 'package:realunit_wallet/screens/pin/constants/pin_constants.dart';
+
+class _MockSecureStorage extends Mock implements SecureStorage {}
+
+class _MockBiometricService extends Mock implements BiometricService {}
+
+void main() {
+  late _MockSecureStorage secureStorage;
+  late _MockBiometricService biometricService;
+
+  setUpAll(() {
+    registerFallbackValue(DateTime(2026));
+  });
+
+  setUp(() {
+    secureStorage = _MockSecureStorage();
+    biometricService = _MockBiometricService();
+    when(() => secureStorage.resetPinLockout()).thenAnswer((_) async {});
+    when(() => secureStorage.setPinFailedAttempts(any())).thenAnswer((_) async {});
+    when(() => secureStorage.setPinLockedUntil(any())).thenAnswer((_) async {});
+    when(() => secureStorage.getPinFailedAttempts()).thenAnswer((_) async => 0);
+    when(() => secureStorage.getPinLockedUntil()).thenAnswer((_) async => null);
+  });
+
+  VerifyPinCubit build({bool enableLockout = true}) => VerifyPinCubit(
+        secureStorage,
+        biometricService,
+        enableLockout: enableLockout,
+      );
+
+  void addPin(VerifyPinCubit cubit, String pin) {
+    for (final c in pin.split('')) {
+      cubit.addDigit(int.parse(c));
+    }
+  }
+
+  group('$VerifyPinCubit', () {
+    test('initial state is empty pin, zero failed attempts', () {
+      final cubit = build();
+
+      expect(cubit.state.pin, '');
+      expect(cubit.state.failedAttempts, 0);
+    });
+
+    group('digit input', () {
+      blocTest<VerifyPinCubit, VerifyPinState>(
+        'addDigit appends to the pin',
+        build: build,
+        act: (cubit) {
+          cubit.addDigit(1);
+          cubit.addDigit(2);
+        },
+        expect: () => [
+          const VerifyPinState(pin: '1'),
+          const VerifyPinState(pin: '12'),
+        ],
+      );
+
+      blocTest<VerifyPinCubit, VerifyPinState>(
+        'deleteDigit removes the last character',
+        build: build,
+        seed: () => const VerifyPinState(pin: '123'),
+        act: (cubit) => cubit.deleteDigit(),
+        expect: () => [const VerifyPinState(pin: '12')],
+      );
+
+      blocTest<VerifyPinCubit, VerifyPinState>(
+        'deleteDigit on empty pin is a no-op',
+        build: build,
+        act: (cubit) => cubit.deleteDigit(),
+        expect: () => [],
+      );
+
+      blocTest<VerifyPinCubit, VerifyPinState>(
+        'addDigit ignored while temporarily locked',
+        build: build,
+        seed: () => VerifyPinTemporarilyLocked(
+          failedAttempts: 5,
+          lockedUntil: DateTime(2030),
+        ),
+        act: (cubit) => cubit.addDigit(1),
+        expect: () => [],
+      );
+
+      blocTest<VerifyPinCubit, VerifyPinState>(
+        'addDigit ignored while permanently locked',
+        build: build,
+        seed: () => const VerifyPinLocked(failedAttempts: 9),
+        act: (cubit) => cubit.addDigit(1),
+        expect: () => [],
+      );
+    });
+
+    group('checkPin (auto-triggered after 6 digits)', () {
+      test('correct pin resets lockout counter and emits VerifyPinSuccess', () async {
+        when(() => secureStorage.verifyPin(any())).thenAnswer((_) async => true);
+        final cubit = build();
+        final success = cubit.stream.firstWhere((s) => s is VerifyPinSuccess);
+
+        addPin(cubit, '123456');
+        await success.timeout(const Duration(seconds: 30));
+
+        expect(cubit.state, isA<VerifyPinSuccess>());
+        verify(() => secureStorage.resetPinLockout()).called(1);
+      });
+
+      test('wrong pin (1st attempt) with lockout on emits VerifyPinFailure', () async {
+        when(() => secureStorage.verifyPin(any())).thenAnswer((_) async => false);
+        when(() => secureStorage.getPinFailedAttempts()).thenAnswer((_) async => 0);
+        final cubit = build();
+        final failure = cubit.stream.firstWhere((s) => s is VerifyPinFailure);
+
+        addPin(cubit, '999999');
+        await failure.timeout(const Duration(seconds: 30));
+
+        expect(cubit.state, isA<VerifyPinFailure>());
+        expect((cubit.state as VerifyPinFailure).failedAttempts, 1);
+        verify(() => secureStorage.setPinFailedAttempts(1)).called(1);
+        // First attempt → no temporary lockout written.
+        verifyNever(() => secureStorage.setPinLockedUntil(any()));
+      });
+
+      test('wrong pin with lockout disabled never persists attempts', () async {
+        when(() => secureStorage.verifyPin(any())).thenAnswer((_) async => false);
+        final cubit = build(enableLockout: false);
+        final failure = cubit.stream.firstWhere((s) => s is VerifyPinFailure);
+
+        addPin(cubit, '999999');
+        await failure.timeout(const Duration(seconds: 30));
+
+        expect(cubit.state, isA<VerifyPinFailure>());
+        expect((cubit.state as VerifyPinFailure).failedAttempts, 0);
+        verifyNever(() => secureStorage.getPinFailedAttempts());
+        verifyNever(() => secureStorage.setPinFailedAttempts(any()));
+      });
+
+      test('5th wrong attempt triggers a 1-minute temporary lockout', () async {
+        when(() => secureStorage.verifyPin(any())).thenAnswer((_) async => false);
+        when(() => secureStorage.getPinFailedAttempts()).thenAnswer((_) async => 4);
+        final cubit = build();
+        final locked = cubit.stream.firstWhere((s) => s is VerifyPinTemporarilyLocked);
+
+        addPin(cubit, '999999');
+        await locked.timeout(const Duration(seconds: 30));
+
+        expect(cubit.state, isA<VerifyPinTemporarilyLocked>());
+        expect(cubit.state.failedAttempts, 5);
+        verify(() => secureStorage.setPinFailedAttempts(5)).called(1);
+        verify(() => secureStorage.setPinLockedUntil(any())).called(1);
+      });
+
+      test('reaching permanentLockoutThreshold emits VerifyPinLocked', () async {
+        when(() => secureStorage.verifyPin(any())).thenAnswer((_) async => false);
+        when(() => secureStorage.getPinFailedAttempts())
+            .thenAnswer((_) async => permanentLockoutThreshold - 1);
+        final cubit = build();
+        final locked = cubit.stream.firstWhere((s) => s is VerifyPinLocked);
+
+        addPin(cubit, '999999');
+        await locked.timeout(const Duration(seconds: 30));
+
+        expect(cubit.state, isA<VerifyPinLocked>());
+        expect(cubit.state.failedAttempts, permanentLockoutThreshold);
+        verify(() => secureStorage.setPinFailedAttempts(permanentLockoutThreshold)).called(1);
+        // Permanent lockout does NOT write a temporary lockedUntil.
+        verifyNever(() => secureStorage.setPinLockedUntil(any()));
+      });
+    });
+
+    group('onLockExpired', () {
+      blocTest<VerifyPinCubit, VerifyPinState>(
+        'returns to a plain state preserving the failedAttempts count',
+        build: build,
+        seed: () => VerifyPinTemporarilyLocked(
+          failedAttempts: 5,
+          lockedUntil: DateTime(2030),
+        ),
+        act: (cubit) => cubit.onLockExpired(),
+        expect: () => [const VerifyPinState(failedAttempts: 5)],
+      );
+    });
+
+    group('checkBiometricAvailability', () {
+      test('returns early as TemporarilyLocked when within lockedUntil window', () async {
+        final until = DateTime.now().add(const Duration(minutes: 5));
+        when(() => secureStorage.getPinLockedUntil()).thenAnswer((_) async => until);
+        when(() => secureStorage.getPinFailedAttempts()).thenAnswer((_) async => 5);
+        final cubit = build();
+        final locked = cubit.stream.firstWhere((s) => s is VerifyPinTemporarilyLocked);
+
+        await cubit.checkBiometricAvailability();
+        await locked.timeout(const Duration(seconds: 1));
+
+        expect(cubit.state, isA<VerifyPinTemporarilyLocked>());
+        verifyNever(() => biometricService.canUse());
+      });
+
+      test('clears expired lockout and proceeds to biometric path', () async {
+        final past = DateTime.now().subtract(const Duration(minutes: 5));
+        when(() => secureStorage.getPinLockedUntil()).thenAnswer((_) async => past);
+        when(() => secureStorage.getPinFailedAttempts()).thenAnswer((_) async => 5);
+        when(() => biometricService.canUse()).thenAnswer((_) async => false);
+        final cubit = build();
+
+        await cubit.checkBiometricAvailability();
+
+        verify(() => secureStorage.setPinLockedUntil(null)).called(1);
+        verify(() => biometricService.canUse()).called(1);
+      });
+
+      test('emits VerifyPinLocked when persisted attempts reach the threshold', () async {
+        when(() => secureStorage.getPinFailedAttempts())
+            .thenAnswer((_) async => permanentLockoutThreshold);
+        final cubit = build();
+        final locked = cubit.stream.firstWhere((s) => s is VerifyPinLocked);
+
+        await cubit.checkBiometricAvailability();
+        await locked.timeout(const Duration(seconds: 1));
+
+        expect(cubit.state, isA<VerifyPinLocked>());
+        verifyNever(() => biometricService.canUse());
+      });
+
+      test('successful biometric unlock resets lockout and emits VerifyPinSuccess', () async {
+        when(() => biometricService.canUse()).thenAnswer((_) async => true);
+        when(() => biometricService.authenticate()).thenAnswer((_) async => true);
+        final cubit = build();
+        final success = cubit.stream.firstWhere((s) => s is VerifyPinSuccess);
+
+        await cubit.checkBiometricAvailability();
+        await success.timeout(const Duration(seconds: 1));
+
+        expect(cubit.state, isA<VerifyPinSuccess>());
+        verify(() => secureStorage.resetPinLockout()).called(1);
+      });
+
+      test('failed biometric authenticate does NOT emit success', () async {
+        when(() => biometricService.canUse()).thenAnswer((_) async => true);
+        when(() => biometricService.authenticate()).thenAnswer((_) async => false);
+        final cubit = build();
+
+        await cubit.checkBiometricAvailability();
+
+        expect(cubit.state, isNot(isA<VerifyPinSuccess>()));
+        verifyNever(() => secureStorage.resetPinLockout());
+      });
+
+      test('biometrics unavailable is a quiet no-op', () async {
+        when(() => biometricService.canUse()).thenAnswer((_) async => false);
+        final cubit = build();
+
+        await cubit.checkBiometricAvailability();
+
+        expect(cubit.state, isA<VerifyPinState>());
+        expect(cubit.state, isNot(isA<VerifyPinSuccess>()));
+        verifyNever(() => biometricService.authenticate());
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 5 of the coverage push. Adds 32 unit tests for the PIN unlock cubit and three previously-untested DFX backend services. mocktail mocks for AppStore + repository boundaries; \`http.testing.MockClient\` for the HTTP surface.

| File under test | Test file | Cases |
| --- | --- | --- |
| \`lib/screens/pin/bloc/verify_pin/verify_pin_cubit.dart\` | \`test/screens/pin/verify_pin_cubit_test.dart\` | 18 |
| \`lib/packages/service/dfx/dfx_country_service.dart\` | \`test/packages/service/dfx/dfx_country_service_test.dart\` | 5 |
| \`lib/packages/service/dfx/dfx_blockchain_api_service.dart\` | \`test/packages/service/dfx/dfx_blockchain_api_service_test.dart\` | 5 |
| \`lib/packages/service/dfx/dfx_faucet_service.dart\` | \`test/packages/service/dfx/dfx_faucet_service_test.dart\` | 4 |

## What each file covers
- **verify_pin_cubit:** initial state; \`addDigit\` / \`deleteDigit\` including no-ops at boundaries + while \`VerifyPinTemporarilyLocked\` / \`VerifyPinLocked\`; correct pin resets lockout and emits \`VerifyPinSuccess\` (real 600k-iter PBKDF2 via \`compute()\`); wrong-pin first-attempt path; \`enableLockout: false\` never persists attempts; 5th wrong attempt triggers a 1-minute temporary lockout; reaching \`permanentLockoutThreshold\` emits \`VerifyPinLocked\` and skips the temporary-lockout write; \`onLockExpired\` preserves \`failedAttempts\`; \`checkBiometricAvailability\` for the in-window / expired / threshold / success / fail / unavailable branches.
- **dfx_country_service:** list mapping from the DTO + cache (single fetch even on repeated reads), non-200 throws, case-insensitive symbol lookup, unknown-symbol error, public \`cachedCountries\` field is populated post-fetch.
- **dfx_blockchain_api_service:** POST shape (address + Bearer JWT + chain name + asset id), testnet flips \`blockchain\` to \`'Sepolia'\`, empty balances list returns \`0.0\`, 201 acceptance in addition to 200, \`ApiException\` on non-2xx with the JSON body.
- **dfx_faucet_service:** POST + Bearer JWT to \`/v1/faucet\`, 201 acceptance, \`ApiException\` on non-2xx, **documents** the current behaviour of sending the literal string \`'Bearer null'\` when no auth token is set — useful as a regression marker if/when the service grows a guard.

## Notes
- The verify-pin happy-path test exercises a real PBKDF2 (600k iterations) via \`compute()\`. On the Flutter-test isolate shim this takes a few seconds; the test uses a 30 s timeout, same approach as in PR #327's setup_pin test.
- \`MockClient\` lets us stub \`AppStore.httpClient\` without giving the service its own real \`http.Client\`; the production code is unchanged.

## Excluded (and why)
- \`dfx_kyc_service\`, \`real_unit_registration_service\` — overlap with the KYC cubits that #319 already covers; want to avoid a stack on top of that work mid-review.
- \`real_unit_account_service\`, \`transaction_history_service\` — hit \`appStore.wallet.currentAccount.primaryAddress.address.hexEip55\`, which needs a real \`SoftwareWallet\` plumbed through the mock. Doable but more setup than the surface justifies; will be covered in a follow-up alongside hook tests.
- \`dfx_brokerbot_service\`, \`real_unit_sell_payment_info_service\` — possibly touched by #321 (dashboard buy/sell auth). Hold to avoid review-time conflicts.
- \`biometric_service\`, \`price_service\` — same constraints documented in #326.

## Test plan
- [x] \`flutter analyze\` on the four new files — clean
- [x] \`flutter test\` — 32 / 32 passing locally
- [ ] CI green