### PR TITLE
test: bank-account + price services, contact + tickets cubits (+23 tests)

### DIFF
--- a/test/packages/service/dfx/dfx_bank_account_service_test.dart
+++ b/test/packages/service/dfx/dfx_bank_account_service_test.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_bank_account_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+Map<String, dynamic> _bankAccount({
+  int id = 1,
+  String iban = 'CH5604835012345678009',
+  String? label,
+  bool isActive = true,
+  bool isDefault = false,
+}) =>
+    {
+      'id': id,
+      'iban': iban,
+      'label': label,
+      'active': isActive,
+      'default': isDefault,
+    };
+
+void main() {
+  late _MockAppStore appStore;
+  late SessionCache sessionCache;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    sessionCache = SessionCache(_MockCacheRepository());
+    when(() => appStore.sessionCache).thenReturn(sessionCache);
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+  });
+
+  DfxBankAccountService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return DfxBankAccountService(appStore);
+  }
+
+  group('$DfxBankAccountService', () {
+    test('getBankAccounts GETs /v1/bankAccount with the JWT and maps the list', () async {
+      sessionCache.setAuthToken('jwt-1');
+      String? capturedAuth;
+      String? capturedPath;
+      String? capturedMethod;
+      final client = MockClient((request) async {
+        capturedAuth = request.headers['Authorization'];
+        capturedPath = request.url.path;
+        capturedMethod = request.method;
+        return http.Response(
+          jsonEncode([_bankAccount(id: 1), _bankAccount(id: 2, label: 'Main')]),
+          200,
+        );
+      });
+
+      final list = await build(client).getBankAccounts();
+
+      expect(list, hasLength(2));
+      expect(list[1].label, 'Main');
+      expect(capturedMethod, 'GET');
+      expect(capturedPath, '/v1/bankAccount');
+      expect(capturedAuth, 'Bearer jwt-1');
+    });
+
+    test('getBankAccounts throws ApiException on non-2xx', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'statusCode': 403, 'message': 'forbidden'}),
+            403,
+          ));
+
+      expect(
+        () => build(client).getBankAccounts(),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('createBankAccount POSTs the iban and optional label', () async {
+      Map<String, dynamic>? body;
+      String? method;
+      final client = MockClient((request) async {
+        body = jsonDecode(request.body) as Map<String, dynamic>;
+        method = request.method;
+        return http.Response(jsonEncode(_bankAccount(id: 9, label: 'NewLabel')), 201);
+      });
+
+      final created = await build(client).createBankAccount('CH123', 'NewLabel');
+
+      expect(created.id, 9);
+      expect(created.label, 'NewLabel');
+      expect(method, 'POST');
+      expect(body!['iban'], 'CH123');
+      expect(body!['label'], 'NewLabel');
+    });
+
+    test('createBankAccount omits the label key when null', () async {
+      Map<String, dynamic>? body;
+      final client = MockClient((request) async {
+        body = jsonDecode(request.body) as Map<String, dynamic>;
+        return http.Response(jsonEncode(_bankAccount(id: 9)), 201);
+      });
+
+      await build(client).createBankAccount('CH123', null);
+
+      expect(body!.containsKey('label'), isFalse);
+      expect(body!['iban'], 'CH123');
+    });
+
+    test('createBankAccount throws ApiException on non-2xx', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'statusCode': 422, 'message': 'invalid iban'}),
+            422,
+          ));
+
+      expect(
+        () => build(client).createBankAccount('NOT_AN_IBAN', null),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('updateBankAccount PUTs to /v1/bankAccount/{id} with only the provided fields', () async {
+      Map<String, dynamic>? body;
+      String? method;
+      String? path;
+      final client = MockClient((request) async {
+        body = jsonDecode(request.body) as Map<String, dynamic>;
+        method = request.method;
+        path = request.url.path;
+        return http.Response(jsonEncode(_bankAccount(id: 7, label: 'X', isDefault: true)), 200);
+      });
+
+      final updated = await build(client).updateBankAccount(
+        id: 7,
+        label: 'X',
+        isDefault: true,
+      );
+
+      expect(updated.id, 7);
+      expect(updated.isDefault, isTrue);
+      expect(method, 'PUT');
+      expect(path, '/v1/bankAccount/7');
+      expect(body!['label'], 'X');
+      // `isDefault` becomes `default` in the wire payload.
+      expect(body!['default'], isTrue);
+      // No `active` field because the caller did not pass `isActive`.
+      expect(body!.containsKey('active'), isFalse);
+    });
+
+    test('updateBankAccount throws ApiException on non-2xx', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'statusCode': 404, 'message': 'not found'}),
+            404,
+          ));
+
+      expect(
+        () => build(client).updateBankAccount(id: 99, label: 'x'),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+}

--- a/test/packages/service/dfx/dfx_price_service_test.dart
+++ b/test/packages/service/dfx/dfx_price_service_test.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
+import 'package:realunit_wallet/packages/utils/default_assets.dart';
+import 'package:realunit_wallet/styles/currency.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+void main() {
+  late _MockAppStore appStore;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+  });
+
+  DFXPriceService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return DFXPriceService(appStore);
+  }
+
+  group('$DFXPriceService', () {
+    group('getPriceOfAsset', () {
+      test('parses CHF price scaled by 100 (rappen)', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'chf': 12.34, 'eur': 11.5}),
+              200,
+            ));
+
+        final price = await build(client).getPriceOfAsset(realUnitAsset, Currency.chf);
+
+        // 12.34 CHF → 1234 rappen.
+        expect(price, BigInt.from(1234));
+      });
+
+      test('parses EUR price scaled by 100 (cent)', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'chf': 12.34, 'eur': 11.5}),
+              200,
+            ));
+
+        final price = await build(client).getPriceOfAsset(realUnitAsset, Currency.eur);
+
+        expect(price, BigInt.from(1150));
+      });
+
+      test('throws on non-200', () async {
+        final client = MockClient((_) async => http.Response('boom', 500));
+
+        expect(
+          () => build(client).getPriceOfAsset(realUnitAsset, Currency.chf),
+          throwsException,
+        );
+      });
+    });
+
+    group('getPriceChart', () {
+      test('maps history entries to PricePoints with the asset, scaled price, and time', () async {
+        final client = MockClient((request) async {
+          // Service requests `timeFrame=ALL` for the chart endpoint.
+          expect(request.url.queryParameters['timeFrame'], 'ALL');
+          expect(request.url.path, '/v1/realunit/price/history');
+          return http.Response(
+            jsonEncode([
+              {'chf': 1.0, 'eur': 0.95, 'timestamp': '2026-01-01T00:00:00Z'},
+              {'chf': 2.5, 'eur': 2.30, 'timestamp': '2026-02-01T00:00:00Z'},
+            ]),
+            200,
+          );
+        });
+
+        final points = await build(client).getPriceChart(realUnitAsset, Currency.chf);
+
+        expect(points, hasLength(2));
+        expect(points[0].asset, realUnitAsset);
+        expect(points[0].price, BigInt.from(100));
+        expect(points[0].time, DateTime.utc(2026, 1, 1));
+        expect(points[1].price, BigInt.from(250));
+      });
+
+      test('parses EUR chart correctly', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode([
+                {'chf': 1.0, 'eur': 0.50, 'timestamp': '2026-01-01T00:00:00Z'},
+              ]),
+              200,
+            ));
+
+        final points = await build(client).getPriceChart(realUnitAsset, Currency.eur);
+
+        expect(points.single.price, BigInt.from(50));
+      });
+
+      test('throws on non-200', () async {
+        final client = MockClient((_) async => http.Response('nope', 404));
+
+        expect(
+          () => build(client).getPriceChart(realUnitAsset, Currency.eur),
+          throwsException,
+        );
+      });
+    });
+
+    group('getChfToEurRate', () {
+      test('returns eur/chf for a positive CHF value', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'chf': 2.0, 'eur': 1.0}),
+              200,
+            ));
+
+        final rate = await build(client).getChfToEurRate();
+
+        expect(rate, 0.5);
+      });
+
+      test('returns 0.0 when CHF is zero (avoids division by zero)', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'chf': 0.0, 'eur': 1.0}),
+              200,
+            ));
+
+        final rate = await build(client).getChfToEurRate();
+
+        expect(rate, 0.0);
+      });
+    });
+  });
+}

--- a/test/screens/settings_contact/settings_contact_cubit_test.dart
+++ b/test/screens/settings_contact/settings_contact_cubit_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/user/dto/user_dto.dart';
+import 'package:realunit_wallet/screens/settings_contact/cubit/settings_contact_cubit.dart';
+
+class _MockKycService extends Mock implements DfxKycService {}
+
+UserDto _user({String? mail}) => UserDto(
+      mail: mail,
+      kyc: const UserKycDto(hash: 'h', level: KycLevel.level0, dataComplete: false),
+    );
+
+void main() {
+  late _MockKycService kyc;
+
+  setUp(() {
+    kyc = _MockKycService();
+  });
+
+  // The cubit fires init() in its constructor; by the time a stream
+  // listener attaches, Loading has already been emitted. We assert the
+  // final state and the service call instead of the sequence.
+  group('$SettingsContactCubit', () {
+    test('reaches Success(emailSet: true) when getUser returns a mail', () async {
+      when(() => kyc.getUser()).thenAnswer((_) async => _user(mail: 'a@b.com'));
+
+      final cubit = SettingsContactCubit(kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsContactSuccess);
+
+      expect((cubit.state as SettingsContactSuccess).emailSet, isTrue);
+      verify(() => kyc.getUser()).called(1);
+    });
+
+    test('reaches Success(emailSet: false) when getUser returns no mail', () async {
+      when(() => kyc.getUser()).thenAnswer((_) async => _user(mail: null));
+
+      final cubit = SettingsContactCubit(kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsContactSuccess);
+
+      expect((cubit.state as SettingsContactSuccess).emailSet, isFalse);
+    });
+
+    test('reaches Failure when getUser throws', () async {
+      when(() => kyc.getUser()).thenAnswer((_) async => throw Exception('boom'));
+
+      final cubit = SettingsContactCubit(kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsContactFailure);
+
+      expect((cubit.state as SettingsContactFailure).message, contains('boom'));
+    });
+
+    test('manual init() call after a failure recovers to Success', () async {
+      // First call fails (async throw), second call returns a user.
+      var calls = 0;
+      when(() => kyc.getUser()).thenAnswer((_) async {
+        calls++;
+        if (calls == 1) throw Exception('transient');
+        return _user(mail: 'recovered@b.com');
+      });
+
+      final cubit = SettingsContactCubit(kyc);
+      // Wait for the constructor-driven init() to settle on Failure.
+      await cubit.stream.firstWhere((s) => s is SettingsContactFailure);
+      await cubit.init();
+
+      expect(cubit.state, isA<SettingsContactSuccess>());
+      expect((cubit.state as SettingsContactSuccess).emailSet, isTrue);
+    });
+  });
+}

--- a/test/screens/support/cubits/support_tickets_cubit_test.dart
+++ b/test/screens/support/cubits/support_tickets_cubit_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_support_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/dto/support_issue_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_reason.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_state.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_type.dart';
+import 'package:realunit_wallet/screens/support/cubits/support_tickets/support_tickets_cubit.dart';
+import 'package:realunit_wallet/screens/support/cubits/support_tickets/support_tickets_state.dart';
+
+class _MockSupportService extends Mock implements DfxSupportService {}
+
+SupportIssueDto _ticket({String uid = 'uid-1'}) => SupportIssueDto(
+      uid: uid,
+      state: SupportIssueState.created,
+      type: SupportIssueType.genericIssue,
+      reason: SupportIssueReason.other,
+      name: 'Test ticket',
+      created: DateTime.utc(2026, 1, 1),
+      messages: const [],
+    );
+
+void main() {
+  late _MockSupportService service;
+
+  setUp(() {
+    service = _MockSupportService();
+  });
+
+  // The cubit fires loadTickets() in its constructor; we assert the
+  // final state via stream.firstWhere instead of the sequence (a
+  // subscriber attached after construction misses the synchronous
+  // Loading emit on a broadcast stream).
+  group('$SupportTicketsCubit', () {
+    test('reaches Loaded with mapped DTOs', () async {
+      when(() => service.getTickets()).thenAnswer(
+        (_) async => [_ticket(uid: 'a'), _ticket(uid: 'b')],
+      );
+
+      final cubit = SupportTicketsCubit(service);
+      await cubit.stream.firstWhere((s) => s is SupportTicketsLoaded);
+
+      expect((cubit.state as SupportTicketsLoaded).tickets, hasLength(2));
+      expect((cubit.state as SupportTicketsLoaded).tickets.first.uid, 'a');
+    });
+
+    test('reaches Loaded(empty) for an empty list', () async {
+      when(() => service.getTickets()).thenAnswer((_) async => []);
+
+      final cubit = SupportTicketsCubit(service);
+      await cubit.stream.firstWhere((s) => s is SupportTicketsLoaded);
+
+      expect((cubit.state as SupportTicketsLoaded).tickets, isEmpty);
+    });
+
+    test('reaches Error when the service throws', () async {
+      when(() => service.getTickets()).thenAnswer((_) async => throw Exception('network down'));
+
+      final cubit = SupportTicketsCubit(service);
+      await cubit.stream.firstWhere((s) => s is SupportTicketsError);
+
+      expect((cubit.state as SupportTicketsError).message, contains('network down'));
+    });
+
+    test('manual loadTickets() refreshes after an initial error', () async {
+      // Async throw on the first call so Loading actually transitions.
+      var calls = 0;
+      when(() => service.getTickets()).thenAnswer((_) async {
+        calls++;
+        if (calls == 1) throw Exception('boom');
+        return [_ticket(uid: 'recovered')];
+      });
+
+      final cubit = SupportTicketsCubit(service);
+      await cubit.stream.firstWhere((s) => s is SupportTicketsError);
+      await cubit.loadTickets();
+
+      expect(cubit.state, isA<SupportTicketsLoaded>());
+      expect((cubit.state as SupportTicketsLoaded).tickets.single.uid, 'recovered');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 6 of the coverage push. Adds 23 unit tests for two more DFX services and two screen-level cubits whose only previous coverage was at the widget layer.

| File under test | Test file | Cases |
| --- | --- | --- |
| \`lib/packages/service/dfx/dfx_bank_account_service.dart\` | \`test/packages/service/dfx/dfx_bank_account_service_test.dart\` | 7 |
| \`lib/packages/service/dfx/dfx_price_service.dart\` | \`test/packages/service/dfx/dfx_price_service_test.dart\` | 8 |
| \`lib/screens/settings_contact/cubit/settings_contact_cubit.dart\` | \`test/screens/settings_contact/settings_contact_cubit_test.dart\` | 4 |
| \`lib/screens/support/cubits/support_tickets/support_tickets_cubit.dart\` | \`test/screens/support/cubits/support_tickets_cubit_test.dart\` | 4 |

## What each file covers
- **dfx_bank_account_service:** \`getBankAccounts\` GET shape (path, JWT header, list mapping) + \`ApiException\` on non-2xx; \`createBankAccount\` POST body, optional-label omission, error path; \`updateBankAccount\` PUT to \`/v1/bankAccount/{id}\` with only the provided fields (also pins the \`isDefault → "default"\` wire mapping).
- **dfx_price_service:** \`getPriceOfAsset\` CHF / EUR scaled by 100 (rappen / cents); \`getPriceChart\` maps each entry with asset, scaled price, and UTC time; \`getChfToEurRate\` returns \`eur / chf\` or \`0.0\` when chf == 0 (no division by zero); all three paths throw on non-200.
- **settings_contact_cubit:** Success with \`emailSet: true\` / \`false\`, Failure on async-throw, and a manual \`init()\` call recovering from a transient failure.
- **support_tickets_cubit:** Loaded with DTO → \`SupportIssue\` mapping, Loaded(empty), Error on async-throw, and a manual \`loadTickets()\` call recovering from a transient failure.

## Notes
- Both cubits fire their work (\`init()\` / \`loadTickets()\`) in the constructor, so by the time a stream subscriber attaches the synchronous Loading emit has already passed on the broadcast stream. The tests therefore assert the **final state** via \`stream.firstWhere\` rather than the full sequence — a deliberate documented choice in the test file headers.
- Mocked \`getUser\`/\`getTickets\` use \`thenAnswer((_) async => throw …)\` instead of \`thenThrow\` so the throw goes through a microtask boundary (otherwise the cubit's \`catch\` block emits Failure before any listener can hear it).
- Service tests use \`http.testing.MockClient\` against \`AppStore.httpClient\`, same pattern as #328.

## Excluded (and why)
- \`dfx_kyc_service\` — large surface (≈ 260 lines), heavy overlap with the KYC cubit logic already covered by #319; would invite review-time conflicts.
- \`dfx_brokerbot_service\`, \`real_unit_sell_payment_info_service\` — likely touched by #321 (dashboard buy/sell auth).
- \`transaction_history_service\`, \`real_unit_account_service\` — depend on \`AppStore.wallet.currentAccount\` plumbing; will be covered alongside the wallet-coupled hook tests in a follow-up.
- \`support_chat_cubit\`, \`support_create_ticket_cubit\` — share \`DfxSupportService\` with this PR; held back to keep the diff focused.

## Test plan
- [x] \`flutter analyze\` on the four new files — clean
- [x] \`flutter test\` — 23 / 23 passing locally
- [ ] CI green