### PR TITLE
test: support + edit-data cubits (+34 tests)

### DIFF
--- a/test/screens/settings_user_data/subpages/settings_edit_address_cubit_test.dart
+++ b/test/screens/settings_user_data/subpages/settings_edit_address_cubit_test.dart
@@ -1,0 +1,191 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_session_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
+import 'package:realunit_wallet/screens/settings_user_data/subpages/edit_address/cubit/settings_edit_address_cubit.dart';
+
+class _MockKycService extends Mock implements DfxKycService {}
+
+KycSessionDto _session({
+  required KycStepStatus stepStatus,
+  String? url = 'https://kyc.example/edit-address',
+}) {
+  final currentStep = url == null
+      ? null
+      : KycStepSessionDto(
+          name: KycStepName.addressChange,
+          status: stepStatus,
+          sequenceNumber: 0,
+          isCurrent: true,
+          session: KycSessionInfoDto(url: url, type: UrlType.browser),
+        );
+  return KycSessionDto(
+    kycLevel: KycLevel.level20,
+    kycSteps: const [],
+    currentStep: currentStep,
+  );
+}
+
+void main() {
+  late _MockKycService kyc;
+
+  setUpAll(() {
+    registerFallbackValue(KycStepName.addressChange);
+  });
+
+  setUp(() {
+    kyc = _MockKycService();
+  });
+
+  group('$SettingsEditAddressCubit', () {
+    test('reaches Ready with the session URL', () async {
+      when(() => kyc.startStep(KycStepName.addressChange))
+          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.notStarted));
+
+      final cubit = SettingsEditAddressCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditAddressReady);
+
+      expect((cubit.state as SettingsEditAddressReady).url, contains('edit-address'));
+    });
+
+    test('reaches Pending when the step is already inReview', () async {
+      when(() => kyc.startStep(KycStepName.addressChange))
+          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.inReview));
+
+      final cubit = SettingsEditAddressCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditAddressPending);
+
+      expect(cubit.state, isA<SettingsEditAddressPending>());
+    });
+
+    test('reaches Failure on API throw', () async {
+      when(() => kyc.startStep(any()))
+          .thenAnswer((_) async => throw Exception('throttle'));
+
+      final cubit = SettingsEditAddressCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditAddressFailure);
+
+      expect(
+        (cubit.state as SettingsEditAddressFailure).message,
+        contains('throttle'),
+      );
+    });
+
+    test('reaches Failure when session has no URL', () async {
+      when(() => kyc.startStep(KycStepName.addressChange))
+          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.notStarted, url: null));
+
+      final cubit = SettingsEditAddressCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditAddressFailure);
+
+      expect(
+        (cubit.state as SettingsEditAddressFailure).message,
+        contains('No session URL'),
+      );
+    });
+
+    test('submitAddress is a no-op when not in Ready state', () async {
+      when(() => kyc.startStep(any()))
+          .thenAnswer((_) async => throw Exception('boom'));
+      final cubit = SettingsEditAddressCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditAddressFailure);
+
+      await cubit.submitAddress(
+        street: 'Test',
+        houseNumber: '1',
+        zip: '8000',
+        city: 'Zurich',
+        countryId: 41,
+        fileBase64: 'AAAA',
+        fileName: 'address.pdf',
+      );
+
+      verifyNever(() => kyc.setData(any(), any()));
+    });
+
+    test('submitAddress sends the structured payload and emits Success', () async {
+      when(() => kyc.startStep(KycStepName.addressChange))
+          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.notStarted));
+      when(() => kyc.setData(any(), any())).thenAnswer((_) async {});
+
+      final cubit = SettingsEditAddressCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditAddressReady);
+
+      await cubit.submitAddress(
+        street: 'Bahnhofstrasse',
+        houseNumber: '12',
+        zip: '8001',
+        city: 'Zurich',
+        countryId: 41,
+        fileBase64: 'ZmFrZQ==',
+        fileName: 'utility.pdf',
+      );
+
+      expect(cubit.state, isA<SettingsEditAddressSuccess>());
+      verify(() => kyc.setData(any(), {
+            'file': 'ZmFrZQ==',
+            'fileName': 'utility.pdf',
+            'address': {
+              'street': 'Bahnhofstrasse',
+              'houseNumber': '12',
+              'zip': '8001',
+              'city': 'Zurich',
+              'country': {'id': 41},
+            },
+          })).called(1);
+    });
+
+    test('submitAddress omits houseNumber from address payload when empty', () async {
+      when(() => kyc.startStep(KycStepName.addressChange))
+          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.notStarted));
+      Map<String, dynamic>? captured;
+      when(() => kyc.setData(any(), any())).thenAnswer((invocation) async {
+        captured = invocation.positionalArguments[1] as Map<String, dynamic>;
+      });
+
+      final cubit = SettingsEditAddressCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditAddressReady);
+
+      await cubit.submitAddress(
+        street: 'Hauptstrasse',
+        houseNumber: '',
+        zip: '8000',
+        city: 'Zurich',
+        countryId: 41,
+        fileBase64: 'AAAA',
+        fileName: 'file.pdf',
+      );
+
+      final address = captured!['address'] as Map<String, dynamic>;
+      expect(address.containsKey('houseNumber'), isFalse);
+      expect(address['street'], 'Hauptstrasse');
+    });
+
+    test('submitAddress emits Failure if setData throws', () async {
+      when(() => kyc.startStep(KycStepName.addressChange))
+          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.notStarted));
+      when(() => kyc.setData(any(), any()))
+          .thenAnswer((_) async => throw Exception('400 bad request'));
+
+      final cubit = SettingsEditAddressCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditAddressReady);
+
+      await cubit.submitAddress(
+        street: 'S',
+        houseNumber: '1',
+        zip: '8000',
+        city: 'Z',
+        countryId: 41,
+        fileBase64: 'A',
+        fileName: 'f',
+      );
+
+      expect(cubit.state, isA<SettingsEditAddressFailure>());
+      expect(
+        (cubit.state as SettingsEditAddressFailure).message,
+        contains('400 bad request'),
+      );
+    });
+  });
+}

--- a/test/screens/settings_user_data/subpages/settings_edit_name_cubit_test.dart
+++ b/test/screens/settings_user_data/subpages/settings_edit_name_cubit_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_session_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
+import 'package:realunit_wallet/screens/settings_user_data/subpages/edit_name/cubit/settings_edit_name_cubit.dart';
+
+class _MockKycService extends Mock implements DfxKycService {}
+
+KycSessionDto _session({
+  required KycStepStatus stepStatus,
+  String? url = 'https://kyc.example/edit-name',
+}) {
+  final currentStep = url == null
+      ? null
+      : KycStepSessionDto(
+          name: KycStepName.nameChange,
+          status: stepStatus,
+          sequenceNumber: 0,
+          isCurrent: true,
+          session: KycSessionInfoDto(url: url, type: UrlType.browser),
+        );
+  return KycSessionDto(
+    kycLevel: KycLevel.level20,
+    kycSteps: const [],
+    currentStep: currentStep,
+  );
+}
+
+void main() {
+  late _MockKycService kyc;
+
+  setUpAll(() {
+    registerFallbackValue(KycStepName.nameChange);
+  });
+
+  setUp(() {
+    kyc = _MockKycService();
+  });
+
+  // The cubit fires _loadEdit() in its constructor. We assert the
+  // final state via stream.firstWhere.
+  group('$SettingsEditNameCubit', () {
+    test('reaches Ready with the session URL on a fresh step', () async {
+      when(() => kyc.startStep(KycStepName.nameChange))
+          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.notStarted));
+
+      final cubit = SettingsEditNameCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditNameReady);
+
+      expect((cubit.state as SettingsEditNameReady).url, contains('edit-name'));
+    });
+
+    test('reaches Pending when the step is already inReview', () async {
+      when(() => kyc.startStep(KycStepName.nameChange))
+          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.inReview));
+
+      final cubit = SettingsEditNameCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditNamePending);
+
+      expect(cubit.state, isA<SettingsEditNamePending>());
+    });
+
+    test('reaches Failure when the API throws', () async {
+      when(() => kyc.startStep(any()))
+          .thenAnswer((_) async => throw Exception('rate-limited'));
+
+      final cubit = SettingsEditNameCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditNameFailure);
+
+      expect((cubit.state as SettingsEditNameFailure).message, contains('rate-limited'));
+    });
+
+    test('reaches Failure when the session has no URL', () async {
+      when(() => kyc.startStep(KycStepName.nameChange))
+          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.notStarted, url: null));
+
+      final cubit = SettingsEditNameCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditNameFailure);
+
+      expect(
+        (cubit.state as SettingsEditNameFailure).message,
+        contains('No session URL'),
+      );
+    });
+
+    test('refresh() re-runs _loadEdit and can recover from a prior failure', () async {
+      var calls = 0;
+      when(() => kyc.startStep(any())).thenAnswer((_) async {
+        calls++;
+        if (calls == 1) throw Exception('transient');
+        return _session(stepStatus: KycStepStatus.notStarted);
+      });
+
+      final cubit = SettingsEditNameCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditNameFailure);
+      cubit.refresh();
+      await cubit.stream.firstWhere((s) => s is SettingsEditNameReady);
+
+      expect(cubit.state, isA<SettingsEditNameReady>());
+    });
+
+    test('submitName is a no-op when not in Ready state', () async {
+      when(() => kyc.startStep(any()))
+          .thenAnswer((_) async => throw Exception('boom'));
+      final cubit = SettingsEditNameCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditNameFailure);
+
+      await cubit.submitName(
+        firstName: 'A',
+        lastName: 'B',
+        fileBase64: 'AAAA',
+        fileName: 'id.pdf',
+      );
+
+      verifyNever(() => kyc.setData(any(), any()));
+      expect(cubit.state, isA<SettingsEditNameFailure>());
+    });
+
+    test('submitName POSTs the form payload and emits Success', () async {
+      when(() => kyc.startStep(KycStepName.nameChange))
+          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.notStarted));
+      when(() => kyc.setData(any(), any())).thenAnswer((_) async {});
+
+      final cubit = SettingsEditNameCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditNameReady);
+      final url = (cubit.state as SettingsEditNameReady).url;
+
+      await cubit.submitName(
+        firstName: 'Alice',
+        lastName: 'Doe',
+        fileBase64: 'ZmFrZQ==',
+        fileName: 'id.pdf',
+      );
+
+      expect(cubit.state, isA<SettingsEditNameSuccess>());
+      verify(() => kyc.setData(url, {
+            'firstName': 'Alice',
+            'lastName': 'Doe',
+            'file': 'ZmFrZQ==',
+            'fileName': 'id.pdf',
+          })).called(1);
+    });
+
+    test('submitName emits Failure if setData throws', () async {
+      when(() => kyc.startStep(KycStepName.nameChange))
+          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.notStarted));
+      when(() => kyc.setData(any(), any())).thenAnswer((_) async => throw Exception('500'));
+
+      final cubit = SettingsEditNameCubit(kycService: kyc);
+      await cubit.stream.firstWhere((s) => s is SettingsEditNameReady);
+
+      await cubit.submitName(
+        firstName: 'A',
+        lastName: 'B',
+        fileBase64: 'AAAA',
+        fileName: 'id.pdf',
+      );
+
+      expect(cubit.state, isA<SettingsEditNameFailure>());
+      expect((cubit.state as SettingsEditNameFailure).message, contains('500'));
+    });
+  });
+}

--- a/test/screens/settings_user_data/subpages/settings_edit_phone_number_cubit_test.dart
+++ b/test/screens/settings_user_data/subpages/settings_edit_phone_number_cubit_test.dart
@@ -1,0 +1,57 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
+import 'package:realunit_wallet/screens/settings_user_data/subpages/edit_phone_number/cubit/settings_edit_phone_number_cubit.dart';
+
+class _MockKycService extends Mock implements DfxKycService {}
+
+void main() {
+  late _MockKycService kyc;
+
+  setUp(() {
+    kyc = _MockKycService();
+  });
+
+  group('$SettingsEditPhoneNumberCubit', () {
+    test('initial state is Initial', () {
+      final cubit = SettingsEditPhoneNumberCubit(kycService: kyc);
+
+      expect(cubit.state, isA<SettingsEditPhoneNumberInitial>());
+    });
+
+    blocTest<SettingsEditPhoneNumberCubit, SettingsEditPhoneNumberState>(
+      'editPhoneNumber emits [Submitting, Success] and forwards the phone',
+      build: () {
+        when(() => kyc.updateUser(any())).thenAnswer((_) async {});
+        return SettingsEditPhoneNumberCubit(kycService: kyc);
+      },
+      act: (cubit) => cubit.editPhoneNumber('+41790000000'),
+      expect: () => [
+        const SettingsEditPhoneNumberSubmitting(),
+        const SettingsEditPhoneNumberSuccess(),
+      ],
+      verify: (_) {
+        verify(() => kyc.updateUser({'phone': '+41790000000'})).called(1);
+      },
+    );
+
+    blocTest<SettingsEditPhoneNumberCubit, SettingsEditPhoneNumberState>(
+      'editPhoneNumber emits [Submitting, Failure] on service throw',
+      build: () {
+        when(() => kyc.updateUser(any()))
+            .thenAnswer((_) async => throw Exception('boom'));
+        return SettingsEditPhoneNumberCubit(kycService: kyc);
+      },
+      act: (cubit) => cubit.editPhoneNumber('+41790000000'),
+      expect: () => [
+        const SettingsEditPhoneNumberSubmitting(),
+        isA<SettingsEditPhoneNumberFailure>().having(
+          (s) => s.message,
+          'message',
+          contains('boom'),
+        ),
+      ],
+    );
+  });
+}

--- a/test/screens/support/cubits/support_chat_cubit_test.dart
+++ b/test/screens/support/cubits/support_chat_cubit_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_support_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/dto/support_issue_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_reason.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_state.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_type.dart';
+import 'package:realunit_wallet/screens/support/cubits/support_chat/support_chat_cubit.dart';
+import 'package:realunit_wallet/screens/support/cubits/support_chat/support_chat_state.dart';
+
+class _MockSupportService extends Mock implements DfxSupportService {}
+
+const _ticketUid = 'uid-1';
+
+SupportIssueDto _ticket({String uid = _ticketUid}) => SupportIssueDto(
+      uid: uid,
+      state: SupportIssueState.created,
+      type: SupportIssueType.genericIssue,
+      reason: SupportIssueReason.other,
+      name: 'Test ticket',
+      created: DateTime.utc(2026, 1, 1),
+      messages: const [],
+    );
+
+void main() {
+  late _MockSupportService service;
+
+  setUp(() {
+    service = _MockSupportService();
+  });
+
+  // Constructor fires loadTicket(); we assert the final state via
+  // stream.firstWhere rather than the full sequence.
+  group('$SupportChatCubit', () {
+    test('reaches Loaded with the mapped ticket', () async {
+      when(() => service.getTicket(_ticketUid))
+          .thenAnswer((_) async => _ticket());
+
+      final cubit = SupportChatCubit(service, _ticketUid);
+      await cubit.stream.firstWhere((s) => s is SupportChatLoaded);
+
+      expect((cubit.state as SupportChatLoaded).ticket.uid, _ticketUid);
+      expect((cubit.state as SupportChatLoaded).isSending, isFalse);
+    });
+
+    test('reaches Error when getTicket fails', () async {
+      when(() => service.getTicket(any()))
+          .thenAnswer((_) async => throw Exception('boom'));
+
+      final cubit = SupportChatCubit(service, _ticketUid);
+      await cubit.stream.firstWhere((s) => s is SupportChatError);
+
+      expect((cubit.state as SupportChatError).message, contains('boom'));
+    });
+
+    test('sendMessage is a no-op when not in Loaded state', () async {
+      when(() => service.getTicket(any()))
+          .thenAnswer((_) async => throw Exception('still loading'));
+      final cubit = SupportChatCubit(service, _ticketUid);
+      await cubit.stream.firstWhere((s) => s is SupportChatError);
+
+      await cubit.sendMessage('hello');
+
+      // sendMessage must NOT call the service while in Error state.
+      verifyNever(() => service.sendMessage(any(), any()));
+    });
+
+    test('sendMessage is a no-op for whitespace-only input', () async {
+      when(() => service.getTicket(_ticketUid))
+          .thenAnswer((_) async => _ticket());
+      final cubit = SupportChatCubit(service, _ticketUid);
+      await cubit.stream.firstWhere((s) => s is SupportChatLoaded);
+      clearInteractions(service);
+
+      await cubit.sendMessage('   \t  ');
+
+      verifyNever(() => service.sendMessage(any(), any()));
+    });
+
+    test('sendMessage posts the message and re-fetches the ticket', () async {
+      when(() => service.getTicket(_ticketUid))
+          .thenAnswer((_) async => _ticket());
+      when(() => service.sendMessage(any(), any())).thenAnswer((_) async {});
+      final cubit = SupportChatCubit(service, _ticketUid);
+      await cubit.stream.firstWhere((s) => s is SupportChatLoaded);
+
+      await cubit.sendMessage('hello');
+
+      verify(() => service.sendMessage(_ticketUid, 'hello')).called(1);
+      // After loadTicket() + sendMessage(), getTicket has been called twice.
+      verify(() => service.getTicket(_ticketUid)).called(2);
+      expect(cubit.state, isA<SupportChatLoaded>());
+      expect((cubit.state as SupportChatLoaded).isSending, isFalse);
+    });
+
+    test('sendMessage clears isSending=true when the service fails', () async {
+      when(() => service.getTicket(_ticketUid))
+          .thenAnswer((_) async => _ticket());
+      when(() => service.sendMessage(any(), any()))
+          .thenAnswer((_) async => throw Exception('nope'));
+
+      final cubit = SupportChatCubit(service, _ticketUid);
+      await cubit.stream.firstWhere((s) => s is SupportChatLoaded);
+
+      await cubit.sendMessage('hello');
+
+      // Stays Loaded but isSending is reset to false.
+      expect(cubit.state, isA<SupportChatLoaded>());
+      expect((cubit.state as SupportChatLoaded).isSending, isFalse);
+    });
+  });
+}

--- a/test/screens/support/cubits/support_create_ticket_cubit_test.dart
+++ b/test/screens/support/cubits/support_create_ticket_cubit_test.dart
@@ -1,0 +1,203 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_support_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/dto/support_issue_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_reason.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_state.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_type.dart';
+import 'package:realunit_wallet/screens/support/cubits/support_create_ticket/support_create_ticket_cubit.dart';
+import 'package:realunit_wallet/screens/support/cubits/support_create_ticket/support_create_ticket_state.dart';
+
+class _MockSupportService extends Mock implements DfxSupportService {}
+
+SupportIssueDto _ticket() => SupportIssueDto(
+      uid: 'created',
+      state: SupportIssueState.created,
+      type: SupportIssueType.bugReport,
+      reason: SupportIssueReason.other,
+      name: 'Bug Report',
+      created: DateTime.utc(2026, 1, 1),
+      messages: const [],
+    );
+
+void main() {
+  late _MockSupportService service;
+
+  setUpAll(() {
+    registerFallbackValue(SupportIssueType.genericIssue);
+    registerFallbackValue(SupportIssueReason.other);
+  });
+
+  setUp(() {
+    service = _MockSupportService();
+  });
+
+  group('$SupportCreateTicketCubit', () {
+    test('initial state has no selection, empty message, canSubmit=false', () {
+      final cubit = SupportCreateTicketCubit(service);
+
+      expect(cubit.state.selectedType, isNull);
+      expect(cubit.state.selectedReason, isNull);
+      expect(cubit.state.message, '');
+      expect(cubit.state.canSubmit, isFalse);
+    });
+
+    blocTest<SupportCreateTicketCubit, SupportCreateTicketState>(
+      'selectType sets the type AND resets reason to SupportIssueReason.other',
+      build: () => SupportCreateTicketCubit(service),
+      seed: () => const SupportCreateTicketState(
+        selectedType: SupportIssueType.genericIssue,
+        selectedReason: SupportIssueReason.fundsNotReceived,
+      ),
+      act: (cubit) => cubit.selectType(SupportIssueType.bugReport),
+      expect: () => [
+        const SupportCreateTicketState(
+          selectedType: SupportIssueType.bugReport,
+          selectedReason: SupportIssueReason.other,
+        ),
+      ],
+    );
+
+    blocTest<SupportCreateTicketCubit, SupportCreateTicketState>(
+      'selectReason sets the reason without touching the type',
+      build: () => SupportCreateTicketCubit(service),
+      seed: () => const SupportCreateTicketState(
+        selectedType: SupportIssueType.bugReport,
+        selectedReason: SupportIssueReason.other,
+      ),
+      act: (cubit) => cubit.selectReason(SupportIssueReason.transactionMissing),
+      expect: () => [
+        const SupportCreateTicketState(
+          selectedType: SupportIssueType.bugReport,
+          selectedReason: SupportIssueReason.transactionMissing,
+        ),
+      ],
+    );
+
+    blocTest<SupportCreateTicketCubit, SupportCreateTicketState>(
+      'updateMessage updates the message field',
+      build: () => SupportCreateTicketCubit(service),
+      act: (cubit) => cubit.updateMessage('hi there'),
+      expect: () => [
+        const SupportCreateTicketState(message: 'hi there'),
+      ],
+    );
+
+    test('canSubmit requires type + reason + non-empty message + not submitting', () {
+      const ready = SupportCreateTicketState(
+        selectedType: SupportIssueType.bugReport,
+        selectedReason: SupportIssueReason.other,
+        message: 'a bug',
+      );
+      expect(ready.canSubmit, isTrue);
+      // copyWith uses `?? this.x`, so null-args don't clear fields — build
+      // each failing variant explicitly instead.
+      expect(
+        const SupportCreateTicketState(
+          selectedReason: SupportIssueReason.other,
+          message: 'a bug',
+        ).canSubmit,
+        isFalse,
+        reason: 'selectedType=null blocks submit',
+      );
+      expect(
+        const SupportCreateTicketState(
+          selectedType: SupportIssueType.bugReport,
+          message: 'a bug',
+        ).canSubmit,
+        isFalse,
+        reason: 'selectedReason=null blocks submit',
+      );
+      expect(ready.copyWith(message: '').canSubmit, isFalse);
+      expect(
+        ready.copyWith(message: '   ').canSubmit,
+        isFalse,
+        reason: 'whitespace-only message is not enough',
+      );
+      expect(ready.copyWith(isSubmitting: true).canSubmit, isFalse);
+    });
+
+    test('submit() is a no-op when canSubmit is false', () async {
+      final cubit = SupportCreateTicketCubit(service);
+
+      await cubit.submit();
+
+      verifyNever(() => service.createTicket(
+            type: any(named: 'type'),
+            reason: any(named: 'reason'),
+            name: any(named: 'name'),
+            message: any(named: 'message'),
+          ));
+      expect(cubit.state.isSubmitting, isFalse);
+      expect(cubit.state.isSuccess, isFalse);
+    });
+
+    test('submit() sets isSubmitting=true then isSuccess=true on success and forwards the right name', () async {
+      when(() => service.createTicket(
+            type: any(named: 'type'),
+            reason: any(named: 'reason'),
+            name: any(named: 'name'),
+            message: any(named: 'message'),
+          )).thenAnswer((_) async => _ticket());
+      final cubit = SupportCreateTicketCubit(service);
+      cubit.selectType(SupportIssueType.bugReport);
+      cubit.selectReason(SupportIssueReason.other);
+      cubit.updateMessage('a bug');
+
+      await cubit.submit();
+
+      expect(cubit.state.isSuccess, isTrue);
+      expect(cubit.state.isSubmitting, isFalse);
+      expect(cubit.state.error, isNull);
+      // bugReport → 'Bug Report' (one of the explicit mappings).
+      verify(() => service.createTicket(
+            type: SupportIssueType.bugReport,
+            reason: SupportIssueReason.other,
+            name: 'Bug Report',
+            message: 'a bug',
+          )).called(1);
+    });
+
+    test('submit() forwards "General Issue" for genericIssue type', () async {
+      when(() => service.createTicket(
+            type: any(named: 'type'),
+            reason: any(named: 'reason'),
+            name: any(named: 'name'),
+            message: any(named: 'message'),
+          )).thenAnswer((_) async => _ticket());
+      final cubit = SupportCreateTicketCubit(service);
+      cubit.selectType(SupportIssueType.genericIssue);
+      cubit.selectReason(SupportIssueReason.other);
+      cubit.updateMessage('hi');
+
+      await cubit.submit();
+
+      verify(() => service.createTicket(
+            type: SupportIssueType.genericIssue,
+            reason: SupportIssueReason.other,
+            name: 'General Issue',
+            message: 'hi',
+          )).called(1);
+    });
+
+    test('submit() captures the error message on failure', () async {
+      when(() => service.createTicket(
+            type: any(named: 'type'),
+            reason: any(named: 'reason'),
+            name: any(named: 'name'),
+            message: any(named: 'message'),
+          )).thenAnswer((_) async => throw Exception('rate limited'));
+      final cubit = SupportCreateTicketCubit(service);
+      cubit.selectType(SupportIssueType.bugReport);
+      cubit.selectReason(SupportIssueReason.other);
+      cubit.updateMessage('msg');
+
+      await cubit.submit();
+
+      expect(cubit.state.isSubmitting, isFalse);
+      expect(cubit.state.isSuccess, isFalse);
+      expect(cubit.state.error, contains('rate limited'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 7 of the coverage push. Adds 34 unit tests for the remaining support cubits and three settings-user-data edit cubits.

| Cubit under test | Test file | Cases |
| --- | --- | --- |
| \`support/cubits/support_chat/support_chat_cubit.dart\` | \`test/screens/support/cubits/support_chat_cubit_test.dart\` | 6 |
| \`support/cubits/support_create_ticket/support_create_ticket_cubit.dart\` | \`test/screens/support/cubits/support_create_ticket_cubit_test.dart\` | 9 |
| \`settings_user_data/subpages/edit_name/cubit/settings_edit_name_cubit.dart\` | \`test/screens/settings_user_data/subpages/settings_edit_name_cubit_test.dart\` | 8 |
| \`settings_user_data/subpages/edit_phone_number/cubit/settings_edit_phone_number_cubit.dart\` | \`test/screens/settings_user_data/subpages/settings_edit_phone_number_cubit_test.dart\` | 3 |
| \`settings_user_data/subpages/edit_address/cubit/settings_edit_address_cubit.dart\` | \`test/screens/settings_user_data/subpages/settings_edit_address_cubit_test.dart\` | 8 |

## What each file covers
- **support_chat_cubit:** Loaded with the mapped ticket; Error on \`getTicket\` throw; \`sendMessage\` no-op when not in Loaded state and for whitespace-only input; happy-path posts the message + re-fetches the ticket (2 \`getTicket\` calls verified); service failure resets \`isSending=false\` while keeping Loaded.
- **support_create_ticket_cubit:** initial state; \`selectType\` resets reason to \`.other\`; \`selectReason\` preserves type; \`updateMessage\` field-only; \`canSubmit\` gate matrix (type-null / reason-null / empty / whitespace / submitting → all false); \`submit\` no-op when not submittable; happy-path forwards type + reason + the mapped \`name\` for both \`bugReport\` and \`genericIssue\` (pins the \`_getTicketName\` switch); failure captures the error.
- **settings_edit_name_cubit:** Ready URL, Pending on \`inReview\`, Failure on API throw, Failure on missing URL, \`refresh\` recovers; \`submitName\` no-op when not Ready, posts the form payload + emits Success, Failure on \`setData\` throw.
- **settings_edit_phone_number_cubit:** initial state; happy-path emits \`[Submitting, Success]\` and forwards \`{'phone': N}\`; service throw yields \`[Submitting, Failure]\` with the error message.
- **settings_edit_address_cubit:** same shape as edit_name plus two address-specific pins — the nested payload (\`address.country.id\`) and \`houseNumber\` is omitted from the payload when empty.

## Notes
- Cubits that fire work in their constructor (\`support_chat\`, \`settings_edit_name\`, \`settings_edit_address\`) use \`stream.firstWhere\` to await the final state instead of \`blocTest\`'s sequence-based expect — same pattern as #329, with a one-line comment in each test file header.
- \`SupportCreateTicketState.copyWith\` uses \`?? this.x\`, so \`copyWith(selectedType: null)\` does **not** clear the field. The \`canSubmit\` matrix builds the failing variants as fresh state objects to avoid that footgun, and the rationale is on the test.

## Excluded (and why)
- \`settings_user_data_cubit.dart\` — touches three services + country lookups + multi-path KYC step status; will be covered in a follow-up alongside hook tests.
- \`settings_tax_report_cubit.dart\` — uses \`getTemporaryDirectory()\` + real \`File\` IO; needs path_provider platform-channel plumbing or a refactor.
- \`dashboard\` blocs, \`create_wallet\` cubit, \`restore_wallet_cubit\` — left for the next stage.
- \`dfx_kyc_service\` — covered indirectly via the edit cubits in this PR; a dedicated test of its surface would overlap heavily with #319's KYC cubit tests.

## Test plan
- [x] \`flutter analyze\` on all five new files — clean
- [x] \`flutter test\` — 34 / 34 passing locally
- [ ] CI green