### PR TITLE
test(dashboard+settings): chart cubits + dashboard_bloc + settings_bloc (+22 tests)

### DIFF
--- a/test/screens/dashboard/dashboard_bloc_test.dart
+++ b/test/screens/dashboard/dashboard_bloc_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/models/portfolio_value_point.dart';
+import 'package:realunit_wallet/models/price_point.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_account_service.dart';
+import 'package:realunit_wallet/packages/service/price_service.dart';
+import 'package:realunit_wallet/packages/utils/default_assets.dart';
+import 'package:realunit_wallet/screens/dashboard/bloc/dashboard_bloc.dart';
+import 'package:realunit_wallet/styles/currency.dart';
+
+class _MockPriceService extends Mock implements APriceService {}
+
+class _MockAccountService extends Mock implements RealUnitAccountService {}
+
+PricePoint _pp(int rappen, DateTime t) =>
+    PricePoint(asset: realUnitAsset, price: BigInt.from(rappen), time: t);
+
+PortfolioValuePoint _pt(int rappen, DateTime t) =>
+    PortfolioValuePoint(value: BigInt.from(rappen), balance: BigInt.one, time: t);
+
+void main() {
+  late _MockPriceService priceService;
+  late _MockAccountService accountService;
+
+  setUpAll(() {
+    registerFallbackValue(Currency.chf);
+    registerFallbackValue(realUnitAsset);
+  });
+
+  setUp(() {
+    priceService = _MockPriceService();
+    accountService = _MockAccountService();
+  });
+
+  DashboardBloc build({Currency currency = Currency.chf}) {
+    when(() => priceService.getPriceOfAsset(any(), any()))
+        .thenAnswer((_) async => BigInt.from(12345));
+    when(() => priceService.getPriceChart(any(), any())).thenAnswer((_) async => [
+          _pp(10000, DateTime.utc(2026, 1, 1)),
+          _pp(11000, DateTime.utc(2026, 2, 1)),
+        ]);
+    when(() => accountService.getPortfolioHistory(any())).thenAnswer((_) async => [
+          _pt(50000, DateTime.utc(2026, 1, 1)),
+          _pt(52000, DateTime.utc(2026, 2, 1)),
+        ]);
+    return DashboardBloc(
+      priceService,
+      accountService,
+      asset: realUnitAsset,
+      initialCurrency: currency,
+    );
+  }
+
+  group('$DashboardBloc', () {
+    test('initial state uses the supplied currency and zero-defaults', () {
+      final bloc = build();
+
+      // The constructor immediately calls refresh(); read the snapshot
+      // *before* any event has been processed.
+      expect(bloc.state.currency, Currency.chf);
+    });
+
+    test('refresh populates price + priceChart + portfolioHistory from the services', () async {
+      final bloc = build();
+
+      // Wait until all three refresh events have been processed.
+      await bloc.stream.firstWhere(
+        (s) =>
+            s.price == BigInt.from(12345) &&
+            s.priceChart.length == 2 &&
+            s.portfolioHistory.length == 2,
+      );
+
+      expect(bloc.state.price, BigInt.from(12345));
+      expect(bloc.state.priceChart, hasLength(2));
+      expect(bloc.state.portfolioHistory, hasLength(2));
+      verify(() => priceService.getPriceOfAsset(realUnitAsset, Currency.chf)).called(1);
+      verify(() => priceService.getPriceChart(realUnitAsset, Currency.chf)).called(1);
+      verify(() => accountService.getPortfolioHistory(Currency.chf)).called(1);
+    });
+
+    test('CurrencyChangedEvent updates state and re-fetches all three datasets', () async {
+      final bloc = build();
+      // Drain the initial refresh.
+      await bloc.stream.firstWhere((s) => s.portfolioHistory.isNotEmpty);
+      clearInteractions(priceService);
+      clearInteractions(accountService);
+      when(() => priceService.getPriceOfAsset(any(), any()))
+          .thenAnswer((_) async => BigInt.from(99));
+      when(() => priceService.getPriceChart(any(), any())).thenAnswer((_) async => []);
+      when(() => accountService.getPortfolioHistory(any())).thenAnswer((_) async => []);
+
+      // Subscribe BEFORE adding the event so we don't race the broadcast.
+      final emitted = <DashboardState>[];
+      final sub = bloc.stream.listen(emitted.add);
+      bloc.add(const CurrencyChangedEvent(Currency.eur));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      await sub.cancel();
+
+      expect(bloc.state.currency, Currency.eur);
+      expect(emitted.any((s) => s.currency == Currency.eur), isTrue);
+      verify(() => priceService.getPriceOfAsset(realUnitAsset, Currency.eur)).called(1);
+      verify(() => priceService.getPriceChart(realUnitAsset, Currency.eur)).called(1);
+      verify(() => accountService.getPortfolioHistory(Currency.eur)).called(1);
+    });
+  });
+}

--- a/test/screens/dashboard/dashboard_transaction_history_cubit_test.dart
+++ b/test/screens/dashboard/dashboard_transaction_history_cubit_test.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/models/transaction.dart';
+import 'package:realunit_wallet/packages/repository/transaction_repository.dart';
+import 'package:realunit_wallet/packages/utils/default_assets.dart';
+import 'package:realunit_wallet/screens/dashboard/bloc/dashboard_transaction_history_cubit.dart';
+
+class _MockTransactionRepository extends Mock implements TransactionRepository {}
+
+const _address = '0x0000000000000000000000000000000000000001';
+
+Transaction _tx(String txId) => Transaction(
+      height: 1,
+      txId: txId,
+      chainId: realUnitAsset.chainId,
+      senderAddress: _address,
+      receiverAddress: _address,
+      amount: BigInt.one,
+      asset: realUnitAsset,
+      type: TransactionTypes.tokenTransfer,
+      note: '',
+      data: null,
+      timestamp: DateTime.utc(2026, 1, 1),
+    );
+
+void main() {
+  late _MockTransactionRepository repo;
+  late StreamController<List<Transaction>> stream;
+
+  setUp(() {
+    repo = _MockTransactionRepository();
+    stream = StreamController<List<Transaction>>();
+    when(() => repo.watchTransactionsOfAssets(any(), any(), any()))
+        .thenAnswer((_) => stream.stream);
+  });
+
+  tearDown(() async {
+    await stream.close();
+  });
+
+  DashboardTransactionHistoryCubit build() => DashboardTransactionHistoryCubit(
+        repo,
+        asset: realUnitAsset,
+        walletAddress: _address,
+      );
+
+  group('$DashboardTransactionHistoryCubit', () {
+    test('initial state is an empty list', () {
+      final cubit = build();
+
+      expect(cubit.state, isEmpty);
+    });
+
+    test('subscribes with the asset, wallet address, and a limit of 3', () {
+      build();
+
+      verify(() => repo.watchTransactionsOfAssets([realUnitAsset], _address, 3))
+          .called(1);
+    });
+
+    test('forwards each stream emission into state', () async {
+      final cubit = build();
+      final ready = cubit.stream.firstWhere((s) => s.length == 2);
+      stream.add([_tx('a'), _tx('b')]);
+      await ready.timeout(const Duration(seconds: 1));
+
+      expect(cubit.state.map((t) => t.txId), ['a', 'b']);
+    });
+
+    test('close() cancels the subscription cleanly', () async {
+      final cubit = build();
+
+      await cubit.close();
+
+      expect(cubit.isClosed, isTrue);
+    });
+  });
+}

--- a/test/screens/dashboard/portfolio_chart_cubit_test.dart
+++ b/test/screens/dashboard/portfolio_chart_cubit_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/models/portfolio_value_point.dart';
+import 'package:realunit_wallet/screens/dashboard/bloc/portfolio_chart/portfolio_chart_cubit.dart';
+import 'package:realunit_wallet/screens/dashboard/models/time_period.dart';
+
+PortfolioValuePoint _pt(DateTime time, int rappen) => PortfolioValuePoint(
+      value: BigInt.from(rappen),
+      balance: BigInt.one,
+      time: time,
+    );
+
+void main() {
+  group('$PortfolioChartCubit', () {
+    test('empty input yields the zero-window initial-shape state', () {
+      final cubit = PortfolioChartCubit(const []);
+
+      expect(cubit.state.visibleSpots, isEmpty);
+      expect(cubit.state.minX, 0);
+      expect(cubit.state.maxX, 0);
+      expect(cubit.state.minY, 0);
+      expect(cubit.state.maxY, 1);
+      expect(cubit.state.horizontalLineValues, isEmpty);
+    });
+
+    test('all-period populates visibleSpots scaled by 100', () {
+      final points = [
+        _pt(DateTime.utc(2026, 1, 1), 50000), // 500.00
+        _pt(DateTime.utc(2026, 2, 1), 60000), // 600.00
+      ];
+
+      final cubit = PortfolioChartCubit(points);
+
+      expect(cubit.state.visibleSpots, hasLength(2));
+      expect(cubit.state.visibleSpots.first.y, 500.0);
+      expect(cubit.state.visibleSpots.last.y, 600.0);
+      // 6 horizontal lines are always produced when there is data.
+      expect(cubit.state.horizontalLineValues, hasLength(6));
+      // minY / maxY come from the first/last horizontal line.
+      expect(cubit.state.minY, cubit.state.horizontalLineValues.first);
+      expect(cubit.state.maxY, cubit.state.horizontalLineValues.last);
+    });
+
+    test('flat-value series still spreads lines via the 5% floor (no Y-collapse)', () {
+      // When all values are equal, the cubit floors the padded deviation at
+      // `average * 0.05` so the chart still has a visible Y-range instead of
+      // collapsing to a single horizontal line.
+      final points = [
+        _pt(DateTime.utc(2026, 1, 1), 10000),
+        _pt(DateTime.utc(2026, 2, 1), 10000),
+        _pt(DateTime.utc(2026, 3, 1), 10000),
+      ];
+
+      final cubit = PortfolioChartCubit(points);
+
+      expect(cubit.state.horizontalLineValues, hasLength(6));
+      // average 100 → floor 5 → rawInterval 2 → niceNumber 2 → bottom 94.
+      expect(
+        cubit.state.horizontalLineValues,
+        [94.0, 96.0, 98.0, 100.0, 102.0, 104.0],
+      );
+      expect(cubit.state.minY, 94.0);
+      expect(cubit.state.maxY, 104.0);
+    });
+
+    test('selectPeriod to the same period is a no-op (no emit)', () async {
+      final cubit = PortfolioChartCubit([_pt(DateTime.utc(2026, 1, 1), 5000)]);
+      final emitted = [];
+      final sub = cubit.stream.listen(emitted.add);
+
+      cubit.selectPeriod(TimePeriod.all);
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(emitted, isEmpty);
+    });
+
+    test('selectPeriod to oneWeek narrows visibleSpots to the 7-day window', () {
+      final now = DateTime.now();
+      final old = _pt(now.subtract(const Duration(days: 60)), 5000);
+      final recent = _pt(now.subtract(const Duration(days: 2)), 6000);
+
+      final cubit = PortfolioChartCubit([old, recent]);
+      cubit.selectPeriod(TimePeriod.oneWeek);
+
+      expect(cubit.state.selectedPeriod, TimePeriod.oneWeek);
+      expect(cubit.state.visibleSpots, hasLength(1));
+      expect(cubit.state.visibleSpots.single.y, 60.0);
+    });
+  });
+}

--- a/test/screens/dashboard/price_chart_cubit_test.dart
+++ b/test/screens/dashboard/price_chart_cubit_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/models/price_point.dart';
+import 'package:realunit_wallet/packages/utils/default_assets.dart';
+import 'package:realunit_wallet/screens/dashboard/bloc/price_chart/price_chart_cubit.dart';
+import 'package:realunit_wallet/screens/dashboard/bloc/price_chart/price_chart_state.dart';
+import 'package:realunit_wallet/screens/dashboard/models/time_period.dart';
+
+PricePoint _pp(DateTime time, int rappen) =>
+    PricePoint(asset: realUnitAsset, price: BigInt.from(rappen), time: time);
+
+void main() {
+  group('$PriceChartCubit', () {
+    test('empty price list yields the zero-window initial-shape state', () {
+      final cubit = PriceChartCubit(const []);
+
+      expect(cubit.state.visibleSpots, isEmpty);
+      expect(cubit.state.minX, 0);
+      expect(cubit.state.maxX, 0);
+      expect(cubit.state.minY, 0);
+      expect(cubit.state.maxY, 1);
+    });
+
+    test('all-period populates visibleSpots scaled by 100 and adds 10% Y-padding', () {
+      final prices = [
+        _pp(DateTime.utc(2026, 1, 1), 10000), // 100.00
+        _pp(DateTime.utc(2026, 2, 1), 12000), // 120.00
+        _pp(DateTime.utc(2026, 3, 1), 11000), // 110.00
+      ];
+
+      final cubit = PriceChartCubit(prices);
+
+      expect(cubit.state.visibleSpots, hasLength(3));
+      expect(cubit.state.visibleSpots.first.y, 100.0);
+      expect(cubit.state.visibleSpots.last.y, 110.0);
+      // Y range: min 100, max 120 → padding (120-100)*0.1 = 2.
+      expect(cubit.state.minY, closeTo(98.0, 1e-9));
+      expect(cubit.state.maxY, closeTo(122.0, 1e-9));
+    });
+
+    test('selectPeriod to the same period is a no-op (no emit)', () async {
+      final cubit = PriceChartCubit([_pp(DateTime.utc(2026, 1, 1), 1000)]);
+      final emitted = <PriceChartState>[];
+      final sub = cubit.stream.listen(emitted.add);
+
+      cubit.selectPeriod(TimePeriod.all);
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(emitted, isEmpty);
+    });
+
+    test('selectPeriod to oneWeek filters to spots within the 7-day window', () {
+      final now = DateTime.now();
+      final oldPoint = _pp(now.subtract(const Duration(days: 60)), 5000);
+      final recentPoint = _pp(now.subtract(const Duration(days: 2)), 6000);
+
+      final cubit = PriceChartCubit([oldPoint, recentPoint]);
+      cubit.selectPeriod(TimePeriod.oneWeek);
+
+      expect(cubit.state.selectedPeriod, TimePeriod.oneWeek);
+      // Only the recent point falls within the last 7 days.
+      expect(cubit.state.visibleSpots, hasLength(1));
+      expect(cubit.state.visibleSpots.first.y, 60.0);
+    });
+  });
+}

--- a/test/screens/settings/settings_bloc_test.dart
+++ b/test/screens/settings/settings_bloc_test.dart
@@ -1,0 +1,98 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/settings_repository.dart';
+import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
+import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
+
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
+
+void main() {
+  late _MockSettingsRepository repo;
+  late int authRefreshCount;
+
+  setUp(() {
+    repo = _MockSettingsRepository();
+    authRefreshCount = 0;
+    // Defaults — sane values for the initial state.
+    when(() => repo.language).thenReturn('en');
+    when(() => repo.currency).thenReturn('CHF');
+    when(() => repo.networkMode).thenReturn(NetworkMode.mainnet);
+  });
+
+  SettingsBloc build() => SettingsBloc(
+        repo,
+        () async {
+          authRefreshCount++;
+        },
+      );
+
+  group('$SettingsBloc', () {
+    test('initial state reads from the repository', () {
+      when(() => repo.language).thenReturn('de');
+      when(() => repo.currency).thenReturn('EUR');
+      when(() => repo.networkMode).thenReturn(NetworkMode.testnet);
+
+      final bloc = build();
+
+      expect(bloc.state.language, Language.de);
+      expect(bloc.state.currency, Currency.eur);
+      expect(bloc.state.networkMode, NetworkMode.testnet);
+      expect(bloc.state.hideAmounts, isFalse);
+    });
+
+    blocTest<SettingsBloc, SettingsState>(
+      'SetLanguageEvent writes to the repo and emits the new language',
+      build: build,
+      act: (bloc) => bloc.add(const SetLanguageEvent(Language.de)),
+      verify: (bloc) {
+        expect(bloc.state.language, Language.de);
+        verify(() => repo.language = 'de').called(1);
+      },
+    );
+
+    blocTest<SettingsBloc, SettingsState>(
+      'SetCurrencyEvent writes to the repo and emits the new currency',
+      build: build,
+      act: (bloc) => bloc.add(const SetCurrencyEvent(Currency.eur)),
+      verify: (bloc) {
+        expect(bloc.state.currency, Currency.eur);
+        verify(() => repo.currency = 'EUR').called(1);
+      },
+    );
+
+    test('SetNetworkModeEvent writes the new mode, refreshes auth, and emits', () async {
+      final bloc = build();
+
+      bloc.add(const SetNetworkModeEvent(NetworkMode.testnet));
+      await bloc.stream.firstWhere((s) => s.networkMode == NetworkMode.testnet);
+
+      expect(bloc.state.networkMode, NetworkMode.testnet);
+      expect(authRefreshCount, 1);
+      verify(() => repo.networkMode = NetworkMode.testnet).called(1);
+    });
+
+    blocTest<SettingsBloc, SettingsState>(
+      'ToggleHideAmountEvent flips hideAmounts each time',
+      build: build,
+      act: (bloc) {
+        bloc.add(const ToggleHideAmountEvent());
+        bloc.add(const ToggleHideAmountEvent());
+      },
+      verify: (bloc) {
+        expect(bloc.state.hideAmounts, isFalse);
+      },
+    );
+
+    blocTest<SettingsBloc, SettingsState>(
+      'a single ToggleHideAmountEvent sets hideAmounts=true',
+      build: build,
+      act: (bloc) => bloc.add(const ToggleHideAmountEvent()),
+      verify: (bloc) {
+        expect(bloc.state.hideAmounts, isTrue);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Stage 9 of the coverage push. Adds 22 unit tests for the remaining dashboard cubits/bloc plus the global settings bloc.

| Cubit / Bloc under test | Test file | Cases |
| --- | --- | --- |
| \`dashboard/bloc/price_chart/price_chart_cubit.dart\` | \`test/screens/dashboard/price_chart_cubit_test.dart\` | 4 |
| \`dashboard/bloc/portfolio_chart/portfolio_chart_cubit.dart\` | \`test/screens/dashboard/portfolio_chart_cubit_test.dart\` | 5 |
| \`dashboard/bloc/dashboard_transaction_history_cubit.dart\` | \`test/screens/dashboard/dashboard_transaction_history_cubit_test.dart\` | 4 |
| \`dashboard/bloc/dashboard_bloc.dart\` | \`test/screens/dashboard/dashboard_bloc_test.dart\` | 3 |
| \`settings/bloc/settings_bloc.dart\` | \`test/screens/settings/settings_bloc_test.dart\` | 6 |

## What each file covers
- **price_chart_cubit:** empty-input zero-window state, all-period spots scaled by 100 + 10% Y-padding, \`selectPeriod\`-same is a no-op (no emit), \`oneWeek\` filter narrows to recent points.
- **portfolio_chart_cubit:** empty-input zero-window state, all-period scaling + 6 horizontal-line values, flat-value series spreads via the 5% floor (no Y-collapse — pins the \`average * 0.05\` lower bound and the rounding to nice numbers \`{1,2,5,10}\`), \`selectPeriod\`-same no-op, \`oneWeek\` narrows visibleSpots.
- **dashboard_transaction_history_cubit:** initial empty list, subscribes to \`watchTransactionsOfAssets\` with limit \`3\`, forwards every stream emission into state, \`close()\` cancels the subscription.
- **dashboard_bloc:** initial state carries the supplied currency, the constructor \`refresh()\` populates price + priceChart + portfolioHistory via the services, \`CurrencyChangedEvent\` updates state and re-fetches all three datasets in the new currency.
- **settings_bloc:** initial state reads through the repo, \`SetLanguageEvent\` writes \`'de'\` + emits, \`SetCurrencyEvent\` writes \`'EUR'\` + emits, \`SetNetworkModeEvent\` writes + calls \`getNewAuthToken\` + emits, \`ToggleHideAmountEvent\` flips both ways, a single toggle sets \`hideAmounts=true\`.

## Notes
- The \`dashboard_bloc\` CurrencyChangedEvent test attaches a listener BEFORE adding the event because \`Bloc.stream\` is broadcast (no replay) and the event-driven re-fetch can complete before a follow-on \`firstWhere\` subscribes — same constraint we've now hit a few times in this push.

## Excluded (and why)
- \`dashboard_bloc\` refresh after a service throw — non-trivial to test cleanly because the bloc lets the exception propagate out of the handler (which then surfaces as an unhandled bloc error in tests). Leaving as a follow-up.
- \`transaction_history_receipt_cubit\`, \`transaction_history_multi_receipt_cubit\`, \`settings_tax_report_cubit\` — all use \`getTemporaryDirectory()\` + real \`File\` IO.
- Buy / sell / sell_bitbox / hardware_connect_bitbox cubits — touched by the still-open PRs (#321 dashboard buy actions, #332 bitbox sign hardening); held back to avoid review conflicts.
- \`settings_user_data_cubit\` — coordinates 3 services + country-lookup branches; deserves its own focused PR.

## Test plan
- [x] \`flutter analyze\` on all five new files — clean
- [x] \`flutter test\` — 22 / 22 passing locally
- [ ] CI green