### PR TITLE
test(service): support + brokerbot DFX services (+21 tests)

### DIFF
--- a/test/packages/service/dfx/dfx_brokerbot_service_test.dart
+++ b/test/packages/service/dfx/dfx_brokerbot_service_test.dart
@@ -1,0 +1,226 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_brokerbot_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/styles/currency.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+void main() {
+  late _MockAppStore appStore;
+  late SessionCache sessionCache;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    sessionCache = SessionCache(_MockCacheRepository());
+    when(() => appStore.sessionCache).thenReturn(sessionCache);
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+  });
+
+  DfxBrokerbotService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return DfxBrokerbotService(appStore);
+  }
+
+  group('$DfxBrokerbotService', () {
+    group('getBuyPrice', () {
+      test('GETs /buyPrice with shares + currency and maps the response', () async {
+        Uri? capturedUri;
+        final client = MockClient((request) async {
+          capturedUri = request.url;
+          return http.Response(
+            jsonEncode({'totalPrice': 100.5, 'pricePerShare': 10.05, 'availableShares': 50}),
+            200,
+          );
+        });
+
+        final price = await build(client).getBuyPrice('10', Currency.chf);
+
+        expect(price.totalCost, 100.5);
+        expect(price.pricePerShare, 10.05);
+        expect(price.availableShares, 50);
+        expect(capturedUri!.path, '/v1/realunit/brokerbot/buyPrice');
+        expect(capturedUri!.queryParameters['shares'], '10');
+        expect(capturedUri!.queryParameters['currency'], 'CHF');
+      });
+
+      test('throws for non-numeric shares input', () {
+        final client = MockClient((_) async => http.Response('{}', 200));
+
+        expect(
+          () => build(client).getBuyPrice('abc', Currency.chf),
+          throwsException,
+        );
+      });
+
+      test('throws for zero / negative shares input', () {
+        final client = MockClient((_) async => http.Response('{}', 200));
+
+        expect(
+          () => build(client).getBuyPrice('0', Currency.chf),
+          throwsException,
+        );
+        expect(
+          () => build(client).getBuyPrice('-3', Currency.chf),
+          throwsException,
+        );
+      });
+
+      test('throws when the server returns a non-200', () async {
+        final client = MockClient((_) async => http.Response('boom', 500));
+
+        expect(
+          () => build(client).getBuyPrice('5', Currency.chf),
+          throwsException,
+        );
+      });
+    });
+
+    group('getBuyShares', () {
+      test('GETs /buyShares with amount + currency and maps the response', () async {
+        Uri? uri;
+        final client = MockClient((request) async {
+          uri = request.url;
+          return http.Response(
+            jsonEncode({'shares': 7, 'pricePerShare': 12.5, 'availableShares': 100}),
+            200,
+          );
+        });
+
+        final shares = await build(client).getBuyShares('100.0', Currency.eur);
+
+        expect(shares.shares, 7);
+        expect(shares.pricePerShare, 12.5);
+        expect(uri!.queryParameters['amount'], '100.0');
+        expect(uri!.queryParameters['currency'], 'EUR');
+      });
+
+      test('throws for non-numeric / zero / negative amount input', () {
+        final client = MockClient((_) async => http.Response('{}', 200));
+
+        expect(() => build(client).getBuyShares('hi', Currency.chf), throwsException);
+        expect(() => build(client).getBuyShares('0', Currency.chf), throwsException);
+        expect(() => build(client).getBuyShares('-1.5', Currency.chf), throwsException);
+      });
+    });
+
+    group('getSellPrice', () {
+      test('GETs /sellPrice with the Bearer JWT', () async {
+        sessionCache.setAuthToken('jwt-1');
+        String? auth;
+        Uri? uri;
+        final client = MockClient((request) async {
+          auth = request.headers['Authorization'];
+          uri = request.url;
+          return http.Response(
+            jsonEncode({
+              'shares': 5,
+              'pricePerShare': 9.0,
+              'estimatedAmount': 45.0,
+              'currency': 'CHF',
+            }),
+            200,
+          );
+        });
+
+        final price = await build(client).getSellPrice('5', Currency.chf);
+
+        expect(price.shares, 5);
+        expect(price.estimatedAmount, 45.0);
+        expect(auth, 'Bearer jwt-1');
+        expect(uri!.path, '/v1/realunit/brokerbot/sellPrice');
+      });
+
+      test('throws ApiException with the JSON body on non-200', () async {
+        sessionCache.setAuthToken('jwt-1');
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'statusCode': 422, 'message': 'no'}),
+              422,
+            ));
+
+        expect(
+          () => build(client).getSellPrice('5', Currency.chf),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('throws when shares input is invalid (before any HTTP call)', () async {
+        var called = false;
+        final client = MockClient((_) async {
+          called = true;
+          return http.Response('{}', 200);
+        });
+
+        expect(
+          () => build(client).getSellPrice('bad', Currency.chf),
+          throwsException,
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect(called, isFalse);
+      });
+    });
+
+    group('getSellShares', () {
+      test('GETs /sellShares with the Bearer JWT and maps the response', () async {
+        sessionCache.setAuthToken('jwt-2');
+        final client = MockClient((request) async {
+          expect(request.headers['Authorization'], 'Bearer jwt-2');
+          return http.Response(
+            jsonEncode({
+              'targetAmount': 100.0,
+              'shares': 11,
+              'pricePerShare': 9.09,
+              'currency': 'EUR',
+            }),
+            200,
+          );
+        });
+
+        final shares = await build(client).getSellShares('100.0', Currency.eur);
+
+        expect(shares.shares, 11);
+        expect(shares.targetAmount, 100.0);
+      });
+
+      test('throws ApiException on non-200', () async {
+        sessionCache.setAuthToken('jwt-2');
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'statusCode': 503, 'message': 'broker offline'}),
+              503,
+            ));
+
+        expect(
+          () => build(client).getSellShares('100', Currency.eur),
+          throwsA(isA<ApiException>()),
+        );
+      });
+
+      test('throws when amount is invalid (before any HTTP call)', () async {
+        var called = false;
+        final client = MockClient((_) async {
+          called = true;
+          return http.Response('{}', 200);
+        });
+
+        expect(
+          () => build(client).getSellShares('not-a-num', Currency.eur),
+          throwsException,
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect(called, isFalse);
+      });
+    });
+  });
+}

--- a/test/packages/service/dfx/dfx_support_service_test.dart
+++ b/test/packages/service/dfx/dfx_support_service_test.dart
@@ -1,0 +1,188 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_support_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_reason.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_type.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+Map<String, dynamic> _ticketJson({String uid = 'uid-1'}) => {
+      'uid': uid,
+      'state': 'Created',
+      'type': 'GenericIssue',
+      'reason': 'Other',
+      'name': 'Test ticket',
+      'created': '2026-01-01T00:00:00Z',
+      'messages': <Map<String, dynamic>>[],
+    };
+
+void main() {
+  late _MockAppStore appStore;
+  late SessionCache sessionCache;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    sessionCache = SessionCache(_MockCacheRepository());
+    // Pre-populate the auth token so the base-class getAuthToken short-
+    // circuits without exercising the signing flow.
+    sessionCache.setAuthToken('jwt-xyz');
+    when(() => appStore.sessionCache).thenReturn(sessionCache);
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+  });
+
+  DfxSupportService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return DfxSupportService(appStore);
+  }
+
+  group('$DfxSupportService', () {
+    test('getTickets GETs /v1/support/issue with the Bearer JWT', () async {
+      String? path;
+      String? method;
+      String? auth;
+      final client = MockClient((request) async {
+        path = request.url.path;
+        method = request.method;
+        auth = request.headers['Authorization'];
+        return http.Response(jsonEncode([_ticketJson(uid: 'a'), _ticketJson(uid: 'b')]), 200);
+      });
+
+      final list = await build(client).getTickets();
+
+      expect(list.map((t) => t.uid), ['a', 'b']);
+      expect(method, 'GET');
+      expect(path, '/v1/support/issue');
+      expect(auth, 'Bearer jwt-xyz');
+    });
+
+    test('getTickets throws ApiException on non-200', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'statusCode': 500, 'message': 'oops'}),
+            500,
+          ));
+
+      expect(() => build(client).getTickets(), throwsA(isA<ApiException>()));
+    });
+
+    test('getTicket GETs /v1/support/issue/<uid> and returns the mapped DTO', () async {
+      String? path;
+      final client = MockClient((request) async {
+        path = request.url.path;
+        return http.Response(jsonEncode(_ticketJson(uid: 'abc')), 200);
+      });
+
+      final ticket = await build(client).getTicket('abc');
+
+      expect(ticket.uid, 'abc');
+      expect(path, '/v1/support/issue/abc');
+    });
+
+    test('getTicket throws ApiException on non-200', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'statusCode': 404, 'message': 'not found'}),
+            404,
+          ));
+
+      expect(
+        () => build(client).getTicket('missing'),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('createTicket POSTs the type+reason+name and includes message when present', () async {
+      Map<String, dynamic>? body;
+      String? method;
+      final client = MockClient((request) async {
+        body = jsonDecode(request.body) as Map<String, dynamic>;
+        method = request.method;
+        return http.Response(jsonEncode(_ticketJson(uid: 'created')), 201);
+      });
+
+      final ticket = await build(client).createTicket(
+        type: SupportIssueType.bugReport,
+        reason: SupportIssueReason.other,
+        name: 'Bug Report',
+        message: 'crash on launch',
+      );
+
+      expect(ticket.uid, 'created');
+      expect(method, 'POST');
+      expect(body!['type'], 'BugReport');
+      expect(body!['reason'], 'Other');
+      expect(body!['name'], 'Bug Report');
+      expect(body!['message'], 'crash on launch');
+    });
+
+    test('createTicket omits the message field when null', () async {
+      Map<String, dynamic>? body;
+      final client = MockClient((request) async {
+        body = jsonDecode(request.body) as Map<String, dynamic>;
+        return http.Response(jsonEncode(_ticketJson(uid: 'c')), 201);
+      });
+
+      await build(client).createTicket(
+        type: SupportIssueType.genericIssue,
+        reason: SupportIssueReason.other,
+        name: 'General Issue',
+      );
+
+      expect(body!.containsKey('message'), isFalse);
+    });
+
+    test('createTicket throws ApiException on non-201 (even on 200)', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'statusCode': 200, 'message': 'wrong code'}),
+            200,
+          ));
+
+      expect(
+        () => build(client).createTicket(
+          type: SupportIssueType.genericIssue,
+          reason: SupportIssueReason.other,
+          name: 'x',
+        ),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('sendMessage POSTs to /v1/support/issue/<uid>/message with the body', () async {
+      Map<String, dynamic>? body;
+      String? path;
+      final client = MockClient((request) async {
+        body = jsonDecode(request.body) as Map<String, dynamic>;
+        path = request.url.path;
+        return http.Response('{}', 201);
+      });
+
+      await build(client).sendMessage('uid-1', 'hello there');
+
+      expect(path, '/v1/support/issue/uid-1/message');
+      expect(body!['message'], 'hello there');
+    });
+
+    test('sendMessage throws ApiException on non-201', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'statusCode': 422, 'message': 'too long'}),
+            422,
+          ));
+
+      expect(
+        () => build(client).sendMessage('uid', 'm'),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 10 of the coverage push. Adds 21 unit tests for the two remaining easy-to-mock DFX backend services.

| Service under test | Test file | Cases |
| --- | --- | --- |
| \`lib/packages/service/dfx/dfx_support_service.dart\` | \`test/packages/service/dfx/dfx_support_service_test.dart\` | 9 |
| \`lib/packages/service/dfx/dfx_brokerbot_service.dart\` | \`test/packages/service/dfx/dfx_brokerbot_service_test.dart\` | 12 |

## What each file covers
- **dfx_support_service:** \`getTickets\` GET shape (path, Bearer JWT) + ApiException on non-200; \`getTicket\` by uid + ApiException; \`createTicket\` POST body (type/reason/name + optional message) + omits message when null + requires status \`201\` (200 is rejected as ApiException); \`sendMessage\` POST shape + ApiException on non-201. \`getAuthToken\` is short-circuited by pre-populating \`sessionCache.authToken\` so the signing flow stays out of these unit tests.
- **dfx_brokerbot_service:** \`getBuyPrice\` GET + currency-code query + invalid-input guards (non-numeric, zero, negative, non-200); \`getBuyShares\` GET + currency + invalid-input guards; \`getSellPrice\` with Bearer JWT + ApiException on non-200 + the invalid-input case skips the HTTP call entirely; same matrix for \`getSellShares\`.

## Notes
- Same mocktail + \`http.testing.MockClient\` pattern as the previous DFX-service PRs (#326 / #328 / #329).
- The "invalid input never reaches HTTP" assertions are a small but meaningful contract: callers can rely on these methods to fail fast before any network round-trip.

## Excluded (deferred)
- \`settings_user_data_cubit\` was on the original Stage-10 plan but coordinates 3 services + Country lookups + multi-branch KYC-step-status handling. It deserves its own focused PR rather than tagging it onto these two service tests.
- \`dfx_kyc_service\` — held back to avoid review conflicts with open PR #332 (KYC routing / bitbox sign hardening).
- Buy / sell / Bitbox cubits — held back while #321 and #332 are open.

## Test plan
- [x] \`flutter analyze\` on the two new files — clean
- [x] \`flutter test\` — 21 / 21 passing locally
- [ ] CI green