### PR TITLE
test: wallet/pdf services + home_bloc onboarding flow (+17 tests)

### DIFF
--- a/test/packages/service/dfx/real_unit_pdf_service_test.dart
+++ b/test/packages/service/dfx/real_unit_pdf_service_test.dart
@@ -1,0 +1,194 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_pdf_service.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+const _address = '0x000000000000000000000000000000000000beef';
+
+void main() {
+  late _MockAppStore appStore;
+  late SessionCache sessionCache;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    sessionCache = SessionCache(_MockCacheRepository());
+    when(() => appStore.sessionCache).thenReturn(sessionCache);
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+    when(() => appStore.primaryAddress).thenReturn(_address);
+    sessionCache.setAuthToken('jwt-pdf');
+  });
+
+  RealUnitPdfService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return RealUnitPdfService(appStore);
+  }
+
+  group('$RealUnitPdfService', () {
+    group('getBalanceReport', () {
+      test('POSTs the BalancePdfDto payload and parses the pdfData response', () async {
+        Map<String, dynamic>? body;
+        String? auth;
+        String? path;
+        final client = MockClient((request) async {
+          body = jsonDecode(request.body) as Map<String, dynamic>;
+          auth = request.headers['Authorization'];
+          path = request.url.path;
+          return http.Response(jsonEncode({'pdfData': 'YmFsYW5jZQ=='}), 200);
+        });
+
+        final pdf = await build(client).getBalanceReport(
+          date: DateTime.utc(2026, 5, 15, 23, 59, 59),
+          currency: Currency.chf,
+          language: Language.de,
+        );
+
+        expect(pdf.pdfData, 'YmFsYW5jZQ==');
+        expect(path, '/v1/realunit/balance/pdf');
+        expect(auth, 'Bearer jwt-pdf');
+        expect(body!['address'], _address);
+        expect(body!['currency'], 'CHF');
+        // Language is uppercased on the wire.
+        expect(body!['language'], 'DE');
+      });
+
+      test('accepts a 201 response in addition to 200', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'pdfData': 'AAAA'}),
+              201,
+            ));
+
+        final pdf = await build(client).getBalanceReport(
+          date: DateTime.utc(2026, 1, 1),
+          currency: Currency.eur,
+          language: Language.en,
+        );
+
+        expect(pdf.pdfData, 'AAAA');
+      });
+
+      test('throws ApiException on non-2xx', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'statusCode': 500, 'message': 'oops'}),
+              500,
+            ));
+
+        expect(
+          () => build(client).getBalanceReport(
+            date: DateTime.utc(2026, 1, 1),
+            currency: Currency.chf,
+            language: Language.en,
+          ),
+          throwsA(isA<ApiException>()),
+        );
+      });
+    });
+
+    group('getTransactionsReceipt (multi)', () {
+      test('POSTs the txHashes list + currency to the multi-receipt endpoint', () async {
+        Map<String, dynamic>? body;
+        String? path;
+        final client = MockClient((request) async {
+          body = jsonDecode(request.body) as Map<String, dynamic>;
+          path = request.url.path;
+          return http.Response(jsonEncode({'pdfData': 'MULTI'}), 200);
+        });
+
+        final pdf = await build(client).getTransactionsReceipt(
+          ['0xa', '0xb', '0xc'],
+          currency: Currency.eur,
+        );
+
+        expect(pdf.pdfData, 'MULTI');
+        expect(path, '/v1/realunit/transactions/receipt/multi');
+        expect(body!['txHashes'], ['0xa', '0xb', '0xc']);
+        expect(body!['currency'], 'EUR');
+      });
+
+      test('defaults currency to CHF when not specified', () async {
+        Map<String, dynamic>? body;
+        final client = MockClient((request) async {
+          body = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(jsonEncode({'pdfData': 'X'}), 200);
+        });
+
+        await build(client).getTransactionsReceipt(['0x1']);
+
+        expect(body!['currency'], 'CHF');
+      });
+
+      test('throws ApiException on non-2xx', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'statusCode': 422, 'message': 'bad ids'}),
+              422,
+            ));
+
+        expect(
+          () => build(client).getTransactionsReceipt(['0x1']),
+          throwsA(isA<ApiException>()),
+        );
+      });
+    });
+
+    group('getTransactionReceipt (single)', () {
+      test('POSTs the txHash + currency to the single-receipt endpoint', () async {
+        Map<String, dynamic>? body;
+        String? path;
+        final client = MockClient((request) async {
+          body = jsonDecode(request.body) as Map<String, dynamic>;
+          path = request.url.path;
+          return http.Response(jsonEncode({'pdfData': 'SINGLE'}), 200);
+        });
+
+        final pdf = await build(client).getTransactionReceipt(
+          '0xabc',
+          currency: Currency.eur,
+        );
+
+        expect(pdf.pdfData, 'SINGLE');
+        expect(path, '/v1/realunit/transactions/receipt/single');
+        expect(body!['txHash'], '0xabc');
+        expect(body!['currency'], 'EUR');
+      });
+
+      test('defaults currency to CHF when not specified', () async {
+        Map<String, dynamic>? body;
+        final client = MockClient((request) async {
+          body = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(jsonEncode({'pdfData': 'X'}), 200);
+        });
+
+        await build(client).getTransactionReceipt('0xabc');
+
+        expect(body!['currency'], 'CHF');
+      });
+
+      test('throws ApiException on non-2xx', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'statusCode': 404, 'message': 'no tx'}),
+              404,
+            ));
+
+        expect(
+          () => build(client).getTransactionReceipt('0xmissing'),
+          throwsA(isA<ApiException>()),
+        );
+      });
+    });
+  });
+}

--- a/test/packages/service/dfx/real_unit_wallet_service_test.dart
+++ b/test/packages/service/dfx/real_unit_wallet_service_test.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+void main() {
+  late _MockAppStore appStore;
+  late SessionCache sessionCache;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    sessionCache = SessionCache(_MockCacheRepository());
+    when(() => appStore.sessionCache).thenReturn(sessionCache);
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+  });
+
+  RealUnitWalletService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return RealUnitWalletService(appStore);
+  }
+
+  group('$RealUnitWalletService', () {
+    test('getWalletStatus GETs /v1/realunit/wallet/status with the Bearer JWT', () async {
+      sessionCache.setAuthToken('jwt-1');
+      String? path;
+      String? auth;
+      String? method;
+      final client = MockClient((request) async {
+        path = request.url.path;
+        auth = request.headers['Authorization'];
+        method = request.method;
+        return http.Response(
+          jsonEncode({'isRegistered': false, 'userData': null}),
+          200,
+        );
+      });
+
+      final status = await build(client).getWalletStatus();
+
+      expect(status.isRegistered, isFalse);
+      expect(status.realUnitUserDataDto, isNull);
+      expect(method, 'GET');
+      expect(path, '/v1/realunit/wallet/status');
+      expect(auth, 'Bearer jwt-1');
+    });
+
+    test('getWalletStatus parses isRegistered=true with null userData', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'isRegistered': true, 'userData': null}),
+            200,
+          ));
+
+      final status = await build(client).getWalletStatus();
+
+      expect(status.isRegistered, isTrue);
+      expect(status.realUnitUserDataDto, isNull);
+    });
+
+    test('getWalletStatus throws ApiException on non-200', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'statusCode': 401, 'message': 'Unauthorized'}),
+            401,
+          ));
+
+      expect(
+        () => build(client).getWalletStatus(),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+}

--- a/test/screens/home/home_bloc_test.dart
+++ b/test/screens/home/home_bloc_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/balance_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
+import 'package:realunit_wallet/packages/service/settings_service.dart';
+import 'package:realunit_wallet/packages/service/transaction_history_service.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
+import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
+
+class _MockWalletService extends Mock implements WalletService {}
+
+class _MockBalanceService extends Mock implements BalanceService {}
+
+class _MockTransactionHistoryService extends Mock implements TransactionHistoryService {}
+
+class _MockDfxWidgetService extends Mock implements DfxWidgetService {}
+
+class _MockSettingsService extends Mock implements SettingsService {}
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockBitboxService extends Mock implements BitboxService {}
+
+void main() {
+  late _MockWalletService walletService;
+  late _MockBalanceService balanceService;
+  late _MockTransactionHistoryService transactionHistoryService;
+  late _MockDfxWidgetService dfxService;
+  late _MockSettingsService settingsService;
+  late _MockAppStore appStore;
+  late _MockBitboxService bitboxService;
+
+  setUp(() {
+    walletService = _MockWalletService();
+    balanceService = _MockBalanceService();
+    transactionHistoryService = _MockTransactionHistoryService();
+    dfxService = _MockDfxWidgetService();
+    settingsService = _MockSettingsService();
+    appStore = _MockAppStore();
+    bitboxService = _MockBitboxService();
+
+    // Sensible defaults so the auto-fired CheckWalletExistsEvent doesn't crash.
+    when(() => walletService.hasWallet()).thenReturn(false);
+    when(() => settingsService.isSoftwareTermsAccepted).thenReturn(false);
+    when(() => settingsService.isTermsAccepted).thenReturn(false);
+  });
+
+  HomeBloc build() => HomeBloc(
+        walletService,
+        balanceService,
+        transactionHistoryService,
+        dfxService,
+        settingsService,
+        appStore,
+        bitboxService,
+      );
+
+  group('$HomeBloc', () {
+    group('initial CheckWalletExistsEvent', () {
+      test('no wallet present → hasWallet=false, onboardingCompleted=false', () async {
+        when(() => walletService.hasWallet()).thenReturn(false);
+        when(() => settingsService.isSoftwareTermsAccepted).thenReturn(true);
+        when(() => settingsService.isTermsAccepted).thenReturn(true);
+
+        final bloc = build();
+        await bloc.stream.firstWhere(
+          (s) => s.softwareTermsAccepted == true && s.hasWallet == false,
+        );
+
+        expect(bloc.state.hasWallet, isFalse);
+        // Without a wallet, onboardingCompleted is forced false regardless of
+        // the persisted termsAccepted flag.
+        expect(bloc.state.onboardingCompleted, isFalse);
+        expect(bloc.state.softwareTermsAccepted, isTrue);
+      });
+
+      test('wallet present + terms accepted → onboardingCompleted=true', () async {
+        when(() => walletService.hasWallet()).thenReturn(true);
+        when(() => settingsService.isSoftwareTermsAccepted).thenReturn(true);
+        when(() => settingsService.isTermsAccepted).thenReturn(true);
+
+        final bloc = build();
+        await bloc.stream.firstWhere((s) => s.hasWallet);
+
+        expect(bloc.state.hasWallet, isTrue);
+        expect(bloc.state.onboardingCompleted, isTrue);
+        expect(bloc.state.softwareTermsAccepted, isTrue);
+      });
+
+      test('wallet present + terms NOT yet accepted → onboardingCompleted=false', () async {
+        when(() => walletService.hasWallet()).thenReturn(true);
+        when(() => settingsService.isSoftwareTermsAccepted).thenReturn(true);
+        when(() => settingsService.isTermsAccepted).thenReturn(false);
+
+        final bloc = build();
+        await bloc.stream.firstWhere((s) => s.hasWallet);
+
+        expect(bloc.state.hasWallet, isTrue);
+        expect(bloc.state.onboardingCompleted, isFalse);
+      });
+    });
+
+    group('CompleteOnboardingEvent', () {
+      test('writes termsAccepted=true and emits onboardingCompleted=true', () async {
+        final bloc = build();
+        await bloc.stream.firstWhere((s) => s.hasWallet == false);
+
+        bloc.add(const CompleteOnboardingEvent());
+        await bloc.stream.firstWhere((s) => s.onboardingCompleted);
+
+        expect(bloc.state.onboardingCompleted, isTrue);
+        verify(() => settingsService.setTermsAccepted(true)).called(1);
+      });
+    });
+
+    group('AcceptSoftwareTermsEvent', () {
+      test('writes softwareTermsAccepted=true and emits the new state', () async {
+        final bloc = build();
+        await bloc.stream.firstWhere((s) => s.hasWallet == false);
+
+        bloc.add(const AcceptSoftwareTermsEvent());
+        await bloc.stream.firstWhere((s) => s.softwareTermsAccepted);
+
+        expect(bloc.state.softwareTermsAccepted, isTrue);
+        verify(() => settingsService.setSoftwareTermsAccepted(true)).called(1);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 11 of the coverage push.

| File under test | Test file | Cases |
| --- | --- | --- |
| \`lib/packages/service/dfx/real_unit_wallet_service.dart\` | \`test/packages/service/dfx/real_unit_wallet_service_test.dart\` | 3 |
| \`lib/packages/service/dfx/real_unit_pdf_service.dart\` | \`test/packages/service/dfx/real_unit_pdf_service_test.dart\` | 9 |
| \`lib/screens/home/bloc/home_bloc.dart\` | \`test/screens/home/home_bloc_test.dart\` | 5 |

## What each file covers
- **real_unit_wallet_service:** \`getWalletStatus\` GET shape with the Bearer JWT, parses both \`isRegistered\` branches when \`userData\` is null, throws ApiException on non-200.
- **real_unit_pdf_service:** \`getBalanceReport\` POSTs the BalancePdfDto payload (\`address\`, currency code, **uppercased** language code); accepts 201; ApiException on non-2xx. \`getTransactionsReceipt\` (multi) posts \`txHashes\` + currency, defaults to CHF, ApiException on non-2xx. \`getTransactionReceipt\` (single) posts \`txHash\` + currency, defaults to CHF, ApiException on non-2xx.
- **home_bloc:** initial \`CheckWalletExistsEvent\` for three branches: no wallet → \`onboardingCompleted\` forced false; wallet+terms accepted → \`onboardingCompleted=true\`; wallet without terms → \`onboardingCompleted=false\`. \`CompleteOnboardingEvent\` writes \`termsAccepted=true\` and emits. \`AcceptSoftwareTermsEvent\` writes \`softwareTermsAccepted=true\` and emits.

## Notes
- The PDF DTOs serialize \`txId\` as \`txHash\` on the wire (single) and \`txIds\` as \`txHashes\` (multi). The tests pin these names explicitly to lock the wire contract.
- \`Language\` codes are uppercased in the balance-pdf payload (\`Language.de\` → \`'DE'\`). Also pinned.

## Excluded (and why)
- Other \`home_bloc\` handlers (\`LoadCurrentWallet\`, \`DeleteCurrentWallet\`, \`LoadWallet\`, \`SyncWalletServices\`, \`DebugAuthComplete\`) all touch \`BalanceService.startSync\` / \`TransactionHistoryService.apiBasedSync\` / \`DfxWidgetService.getAuthToken\` plus \`AppStore.wallet\` mutation. Each is meaningful but needs more dependency plumbing — deserves its own focused PR.
- \`settings_user_data_cubit\` — still deferred (coordinates 3 services + Country lookups + multi-branch KYC step status); will land separately.

## Test plan
- [x] \`flutter analyze\` on all three new files — clean
- [x] \`flutter test\` — 17 / 17 passing locally
- [ ] CI green