### PR TITLE
test(service): dfx_kyc_service core methods (+10 tests)

### DIFF
--- a/test/packages/service/dfx/dfx_kyc_service_test.dart
+++ b/test/packages/service/dfx/dfx_kyc_service_test.dart
@@ -1,0 +1,228 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/wallet/wallet.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
+import 'package:web3dart/web3dart.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+class _StubWalletAccount extends AWalletAccount {
+  _StubWalletAccount() : super(0, _StubCreds());
+  @override
+  Future<String> signMessage(String message, {int addressIndex = 0}) async =>
+      '0xstub-signature';
+}
+
+class _StubCreds extends Fake implements CredentialsWithKnownAddress {
+  @override
+  EthereumAddress get address =>
+      EthereumAddress.fromHex('0x0000000000000000000000000000000000000001');
+}
+
+class _StubWallet extends AWallet {
+  _StubWallet() : super(1, 'Stub');
+  @override
+  WalletType get walletType => WalletType.software;
+  @override
+  AWalletAccount get primaryAccount => _StubWalletAccount();
+  @override
+  AWalletAccount get currentAccount => _StubWalletAccount();
+}
+
+const _userJson = {
+  'mail': 'a@b.com',
+  'kyc': {
+    'hash': 'kyc-hash-123',
+    // Wire format is the numeric level (20 → KycLevel.level20).
+    'level': 20,
+    'dataComplete': true,
+  },
+};
+
+void main() {
+  late _MockAppStore appStore;
+  late SessionCache sessionCache;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    sessionCache = SessionCache(_MockCacheRepository());
+    sessionCache.setAuthToken('jwt-1');
+    when(() => appStore.sessionCache).thenReturn(sessionCache);
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+    when(() => appStore.wallet).thenReturn(_StubWallet());
+  });
+
+  DfxKycService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return DfxKycService(appStore);
+  }
+
+  group('$DfxKycService', () {
+    group('getUser', () {
+      test('GETs /v2/user with the Bearer JWT and parses the response', () async {
+        String? path;
+        String? auth;
+        final client = MockClient((request) async {
+          path = request.url.path;
+          auth = request.headers['Authorization'];
+          return http.Response(jsonEncode(_userJson), 200);
+        });
+
+        final user = await build(client).getUser();
+
+        expect(user.mail, 'a@b.com');
+        expect(user.kyc.hash, 'kyc-hash-123');
+        expect(path, '/v2/user');
+        expect(auth, 'Bearer jwt-1');
+      });
+
+      test('accepts a 201 in addition to 200', () async {
+        final client = MockClient(
+          (_) async => http.Response(jsonEncode(_userJson), 201),
+        );
+
+        final user = await build(client).getUser();
+        expect(user.mail, 'a@b.com');
+      });
+
+      test('throws ApiException on a non-2xx non-401 response', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'statusCode': 500, 'message': 'oops'}),
+              500,
+            ));
+
+        expect(() => build(client).getUser(), throwsA(isA<ApiException>()));
+      });
+    });
+
+    group('updateUser', () {
+      test('PUTs /v2/user with the JSON body and Bearer JWT', () async {
+        Map<String, dynamic>? body;
+        String? method;
+        final client = MockClient((request) async {
+          body = jsonDecode(request.body) as Map<String, dynamic>;
+          method = request.method;
+          return http.Response('{}', 200);
+        });
+
+        await build(client).updateUser({'phone': '+41790000000'});
+
+        expect(method, 'PUT');
+        expect(body!['phone'], '+41790000000');
+      });
+
+      test('accepts a 201 response', () async {
+        final client = MockClient((_) async => http.Response('{}', 201));
+
+        await build(client).updateUser({'x': 'y'});
+      });
+
+      test('throws ApiException on non-2xx', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'statusCode': 422, 'message': 'bad'}),
+              422,
+            ));
+
+        expect(
+          () => build(client).updateUser({'phone': 'x'}),
+          throwsA(isA<ApiException>()),
+        );
+      });
+    });
+
+    group('request2FaCode', () {
+      test('POSTs /v2/kyc/2fa?level=Strict with kyc-hash header', () async {
+        Uri? uri;
+        Map<String, String>? headers;
+        String? method;
+        final client = MockClient((request) async {
+          uri = request.url;
+          headers = request.headers;
+          method = request.method;
+          if (request.url.path == '/v2/user') {
+            return http.Response(jsonEncode(_userJson), 200);
+          }
+          return http.Response('{}', 201);
+        });
+
+        await build(client).request2FaCode();
+
+        expect(method, 'POST');
+        expect(uri!.path, '/v2/kyc/2fa');
+        expect(uri!.queryParameters['level'], 'Strict');
+        expect(headers!['x-kyc-code'], 'kyc-hash-123');
+      });
+
+      test('throws ApiException on non-2xx', () async {
+        final client = MockClient((request) async {
+          if (request.url.path == '/v2/user') {
+            return http.Response(jsonEncode(_userJson), 200);
+          }
+          return http.Response(
+            jsonEncode({'statusCode': 429, 'message': 'too many'}),
+            429,
+          );
+        });
+
+        expect(
+          () => build(client).request2FaCode(),
+          throwsA(isA<ApiException>()),
+        );
+      });
+    });
+
+    group('verify2FaCode', () {
+      test('POSTs the token to /v2/kyc/2fa/verify with kyc-hash header', () async {
+        Map<String, dynamic>? body;
+        Uri? uri;
+        Map<String, String>? headers;
+        final client = MockClient((request) async {
+          if (request.url.path == '/v2/user') {
+            return http.Response(jsonEncode(_userJson), 200);
+          }
+          uri = request.url;
+          headers = request.headers;
+          body = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response('{}', 201);
+        });
+
+        await build(client).verify2FaCode('123456');
+
+        expect(uri!.path, '/v2/kyc/2fa/verify');
+        expect(body!['token'], '123456');
+        expect(headers!['x-kyc-code'], 'kyc-hash-123');
+      });
+
+      test('throws ApiException on non-2xx', () async {
+        final client = MockClient((request) async {
+          if (request.url.path == '/v2/user') {
+            return http.Response(jsonEncode(_userJson), 200);
+          }
+          return http.Response(
+            jsonEncode({'statusCode': 403, 'message': 'wrong code'}),
+            403,
+          );
+        });
+
+        expect(
+          () => build(client).verify2FaCode('000000'),
+          throwsA(isA<ApiException>()),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 20 of the coverage push. Covers four core methods of the previously-deferred \`dfx_kyc_service\`.

| Method | Cases |
| --- | --- |
| \`getUser\` | 3 |
| \`updateUser\` | 3 |
| \`request2FaCode\` | 2 |
| \`verify2FaCode\` | 2 |

## What each method's tests pin
- **getUser:** GET \`/v2/user\` with Bearer JWT + parses \`UserDto\`; 201 also accepted (in addition to 200); throws \`ApiException\` on a non-2xx non-401 (the 401-refresh-and-retry path is large enough to deserve its own test, deferred).
- **updateUser:** PUT \`/v2/user\` with the JSON body; 201 accepted; \`ApiException\` on non-2xx.
- **request2FaCode:** POST \`/v2/kyc/2fa?level=Strict\` with \`x-kyc-code\` header set from \`getUser().kyc.hash\` (pins the kyc-hash propagation); \`ApiException\` on non-2xx.
- **verify2FaCode:** POST \`/v2/kyc/2fa/verify\` with \`{ token: code }\` body and the same \`x-kyc-code\` header; \`ApiException\` on non-2xx.

## Conflict avoidance
PR #332 (bitbox sign + KYC routing) touches \`lib/screens/kyc/cubits/kyc/kyc_cubit.dart\` and \`real_unit_registration_service.dart\` — NOT this service. \`dfx_kyc_service.dart\` itself is unchanged on that branch, so this PR is conflict-free.

## Notes
- Tests use a tiny \`_StubWallet\` so \`DFXAuthService.wallet\` resolves without plumbing a real \`SoftwareWallet\` through.
- The wire format for \`kyc.level\` is the numeric value (e.g. \`20\` → \`KycLevel.level20\`), pinned in the test fixture so a future enum / DTO refactor surfaces immediately.

## Excluded (deferred)
- \`getUser\`'s 401 → \`refreshAuthToken\` → retry path needs a stateful MockClient + the auth-service signing flow; deserves its own focused test.
- \`continueKyc\`, \`startStep\`, \`setData\`, \`getFinancialData\`, \`setFinancialData\` — more elaborate bodies + headers; will follow up if/when needed.

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 10 / 10 passing locally
- [ ] CI green