### PR TITLE
test(utils): svg_parser + device_info + default_assets (+14 tests)

### DIFF
--- a/test/packages/utils/default_assets_test.dart
+++ b/test/packages/utils/default_assets_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/utils/default_assets.dart';
+
+void main() {
+  group('default RealUnit assets', () {
+    test('mainnet asset matches the production contract', () {
+      // These constants are referenced by ApiConfig and the entire fiat
+      // on/off-ramp pipeline. Pin them so an accidental edit (wrong
+      // contract address / decimals) is caught instantly.
+      expect(realUnitAsset.chainId, 1);
+      expect(realUnitAsset.address, '0x553C7f9C780316FC1D34b8e14ac2465Ab22a090B');
+      expect(realUnitAsset.symbol, 'REALU');
+      expect(realUnitAsset.decimals, 0);
+    });
+
+    test('Sepolia testnet asset matches the dev contract', () {
+      expect(realUnitTestAsset.chainId, 11155111);
+      expect(realUnitTestAsset.address, '0x0add9824820508dd7992cbebb9f13fbe8e45a30f');
+      expect(realUnitTestAsset.symbol, 'REALU');
+      expect(realUnitTestAsset.decimals, 0);
+    });
+
+    test('mainnet and Sepolia assets are distinct objects', () {
+      expect(realUnitAsset.address, isNot(realUnitTestAsset.address));
+      expect(realUnitAsset.chainId, isNot(realUnitTestAsset.chainId));
+    });
+
+    test('asset-id constants are stable', () {
+      expect(ethereumEthAssetId, 111);
+      expect(sepoliaEthAssetId, 392);
+      expect(ethereumZchfAssetId, 251);
+      expect(sepoliaZchfAssetId, 418);
+    });
+  });
+}

--- a/test/packages/utils/device_info_test.dart
+++ b/test/packages/utils/device_info_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/utils/device_info.dart';
+
+void main() {
+  // Save and restore the global platform override around each test so a
+  // failure doesn't leak the override into later tests in the suite.
+  final originalPlatform = debugDefaultTargetPlatformOverride;
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = originalPlatform;
+  });
+
+  group('$DeviceInfo', () {
+    test('iOS → isIOS=true, isMobile=true, isDesktop=false', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      final d = DeviceInfo.instance;
+      expect(d.isIOS, isTrue);
+      expect(d.isAndroid, isFalse);
+      expect(d.isMobile, isTrue);
+      expect(d.isDesktop, isFalse);
+    });
+
+    test('Android → isAndroid=true, isMobile=true', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      final d = DeviceInfo.instance;
+      expect(d.isAndroid, isTrue);
+      expect(d.isIOS, isFalse);
+      expect(d.isMobile, isTrue);
+      expect(d.isDesktop, isFalse);
+    });
+
+    test('macOS → isDesktop=true, isMobile=false', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+      final d = DeviceInfo.instance;
+      expect(d.isDesktop, isTrue);
+      expect(d.isMobile, isFalse);
+      expect(d.isIOS, isFalse);
+      expect(d.isAndroid, isFalse);
+    });
+
+    test('Windows + Linux are both desktop', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      expect(DeviceInfo.instance.isDesktop, isTrue);
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      expect(DeviceInfo.instance.isDesktop, isTrue);
+    });
+
+    test('Fuchsia falls into neither mobile nor desktop', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
+
+      final d = DeviceInfo.instance;
+      expect(d.isMobile, isFalse);
+      expect(d.isDesktop, isFalse);
+    });
+  });
+}

--- a/test/packages/utils/svg_parser_test.dart
+++ b/test/packages/utils/svg_parser_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/utils/svg_parser.dart';
+
+void main() {
+  group('$SvgParser', () {
+    test('converts integer mm values to px at 96 DPI (≈3.7795 px/mm)', () {
+      const svg = '<svg width="10mm" height="20mm"/>';
+
+      final out = SvgParser.normalize(svg);
+
+      // 10mm → 37.7952755... → rounded to 2 dp = 37.80; 20mm → 75.59.
+      expect(out, '<svg width="37.80px" height="75.59px"/>');
+    });
+
+    test('converts decimal mm values', () {
+      const svg = '<rect width="1.5mm"/>';
+
+      final out = SvgParser.normalize(svg);
+
+      // 1.5 × 3.7795275591 = 5.66929... → 5.67.
+      expect(out, '<rect width="5.67px"/>');
+    });
+
+    test('leaves non-mm units untouched', () {
+      const svg = '<svg width="10px" height="100%"/>';
+
+      final out = SvgParser.normalize(svg);
+
+      expect(out, svg);
+    });
+
+    test('replaces every mm occurrence in the string', () {
+      const svg = '<svg width="1mm"><path d="M2mm 3mm"/></svg>';
+
+      final out = SvgParser.normalize(svg);
+
+      // No 'mm' substring should remain.
+      expect(out.contains('mm'), isFalse);
+    });
+
+    test('preserves the rest of the SVG markup verbatim', () {
+      const svg = '<svg xmlns="http://www.w3.org/2000/svg" width="5mm"/>';
+
+      final out = SvgParser.normalize(svg);
+
+      expect(out.contains('xmlns="http://www.w3.org/2000/svg"'), isTrue);
+      expect(out.contains('width="18.90px"'), isTrue);
+    });
+  });
+}

--- a/test/screens/home/home_bloc_test.dart
+++ b/test/screens/home/home_bloc_test.dart
@@ -3,7 +3,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/balance_service.dart';
-import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
 import 'package:realunit_wallet/packages/service/settings_service.dart';
 import 'package:realunit_wallet/packages/service/transaction_history_service.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
@@ -15,8 +14,6 @@ class _MockBalanceService extends Mock implements BalanceService {}
 
 class _MockTransactionHistoryService extends Mock implements TransactionHistoryService {}
 
-class _MockDfxWidgetService extends Mock implements DfxWidgetService {}
-
 class _MockSettingsService extends Mock implements SettingsService {}
 
 class _MockAppStore extends Mock implements AppStore {}
@@ -27,7 +24,6 @@ void main() {
   late _MockWalletService walletService;
   late _MockBalanceService balanceService;
   late _MockTransactionHistoryService transactionHistoryService;
-  late _MockDfxWidgetService dfxService;
   late _MockSettingsService settingsService;
   late _MockAppStore appStore;
   late _MockBitboxService bitboxService;
@@ -36,7 +32,6 @@ void main() {
     walletService = _MockWalletService();
     balanceService = _MockBalanceService();
     transactionHistoryService = _MockTransactionHistoryService();
-    dfxService = _MockDfxWidgetService();
     settingsService = _MockSettingsService();
     appStore = _MockAppStore();
     bitboxService = _MockBitboxService();
@@ -51,7 +46,6 @@ void main() {
         walletService,
         balanceService,
         transactionHistoryService,
-        dfxService,
         settingsService,
         appStore,
         bitboxService,


### PR DESCRIPTION
## Summary
Stage 22 of the coverage push. Pure-Dart utility files.

| File | Cases |
| --- | --- |
| \`lib/packages/utils/svg_parser.dart\` | 5 |
| \`lib/packages/utils/device_info.dart\` | 5 |
| \`lib/packages/utils/default_assets.dart\` | 4 |

## What each file covers
- **svg_parser:** integer + decimal mm → px conversion at 96 DPI (≈ 3.7795 px/mm), non-mm units pass through unchanged, every \`mm\` occurrence is replaced (multiple per string), surrounding SVG markup is preserved.
- **device_info:** iOS / Android / macOS / Windows+Linux / Fuchsia matrix using \`debugDefaultTargetPlatformOverride\` (save + restore around each test so a failure doesn't leak the override).
- **default_assets:** mainnet \`realUnitAsset\` and Sepolia \`realUnitTestAsset\` pinned to their production / dev contract addresses + decimals + symbols (a typo here would silently route the entire fiat pipeline at the wrong contract). ETH and ZCHF asset-id constants also pinned.

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 14 / 14 passing locally
- [ ] CI green