### PR TITLE
test: NetworkMode + ApiConfig + mnemonic_field extension (+11 tests)

### DIFF
--- a/test/packages/config/api_config_test.dart
+++ b/test/packages/config/api_config_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/packages/config/api_config.dart';
 import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/utils/default_assets.dart';
 
 void main() {
   late ApiConfig config;
@@ -12,6 +13,15 @@ void main() {
       test('returns correct apiHost', () {
         expect(config.apiHost, equals('dev.api.dfx.swiss'));
       });
+
+      test('asset is the Sepolia RealUnit testnet asset', () {
+        expect(config.asset, realUnitTestAsset);
+      });
+
+      test('ethAssetId and zchfAssetId are the Sepolia ids', () {
+        expect(config.ethAssetId, sepoliaEthAssetId);
+        expect(config.zchfAssetId, sepoliaZchfAssetId);
+      });
     });
 
     group('mainnet mode', () {
@@ -20,6 +30,38 @@ void main() {
       test('returns correct apiHost', () {
         expect(config.apiHost, equals('api.dfx.swiss'));
       });
+
+      test('asset is the Ethereum mainnet RealUnit asset', () {
+        expect(config.asset, realUnitAsset);
+      });
+
+      test('ethAssetId and zchfAssetId are the Ethereum ids', () {
+        expect(config.ethAssetId, ethereumEthAssetId);
+        expect(config.zchfAssetId, ethereumZchfAssetId);
+      });
+    });
+  });
+
+  group('buildUri', () {
+    test('builds an https URI (production is not local-testing)', () {
+      final uri = buildUri('api.dfx.swiss', '/v1/foo');
+
+      expect(uri.scheme, 'https');
+      expect(uri.host, 'api.dfx.swiss');
+      expect(uri.path, '/v1/foo');
+    });
+
+    test('appends queryParams when provided', () {
+      final uri = buildUri('api.dfx.swiss', '/v1/foo', {'a': '1', 'b': '2'});
+
+      expect(uri.queryParameters['a'], '1');
+      expect(uri.queryParameters['b'], '2');
+    });
+
+    test('omits the query string entirely when params are null', () {
+      final uri = buildUri('api.dfx.swiss', '/v1/foo');
+
+      expect(uri.hasQuery, isFalse);
     });
   });
 }

--- a/test/packages/config/network_mode_test.dart
+++ b/test/packages/config/network_mode_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+
+void main() {
+  group('$NetworkMode', () {
+    test('mainnet → isMainnet=true, isTestnet=false, name="Mainnet"', () {
+      const mode = NetworkMode.mainnet;
+
+      expect(mode.isMainnet, isTrue);
+      expect(mode.isTestnet, isFalse);
+      expect(mode.name, 'Mainnet');
+    });
+
+    test('testnet → isTestnet=true, isMainnet=false, name="Testnet"', () {
+      const mode = NetworkMode.testnet;
+
+      expect(mode.isTestnet, isTrue);
+      expect(mode.isMainnet, isFalse);
+      expect(mode.name, 'Testnet');
+    });
+
+    test('values has exactly the two enum entries (no accidental addition)', () {
+      // Catches the case where someone adds a third NetworkMode (e.g. local)
+      // without also updating all the switch-on-mode call sites.
+      expect(NetworkMode.values, hasLength(2));
+      expect(NetworkMode.values, contains(NetworkMode.mainnet));
+      expect(NetworkMode.values, contains(NetworkMode.testnet));
+    });
+  });
+}

--- a/test/screens/home/home_bloc_test.dart
+++ b/test/screens/home/home_bloc_test.dart
@@ -3,7 +3,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/balance_service.dart';
-import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
 import 'package:realunit_wallet/packages/service/settings_service.dart';
 import 'package:realunit_wallet/packages/service/transaction_history_service.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
@@ -15,8 +14,6 @@ class _MockBalanceService extends Mock implements BalanceService {}
 
 class _MockTransactionHistoryService extends Mock implements TransactionHistoryService {}
 
-class _MockDfxWidgetService extends Mock implements DfxWidgetService {}
-
 class _MockSettingsService extends Mock implements SettingsService {}
 
 class _MockAppStore extends Mock implements AppStore {}
@@ -27,7 +24,6 @@ void main() {
   late _MockWalletService walletService;
   late _MockBalanceService balanceService;
   late _MockTransactionHistoryService transactionHistoryService;
-  late _MockDfxWidgetService dfxService;
   late _MockSettingsService settingsService;
   late _MockAppStore appStore;
   late _MockBitboxService bitboxService;
@@ -36,7 +32,6 @@ void main() {
     walletService = _MockWalletService();
     balanceService = _MockBalanceService();
     transactionHistoryService = _MockTransactionHistoryService();
-    dfxService = _MockDfxWidgetService();
     settingsService = _MockSettingsService();
     appStore = _MockAppStore();
     bitboxService = _MockBitboxService();
@@ -51,7 +46,6 @@ void main() {
         walletService,
         balanceService,
         transactionHistoryService,
-        dfxService,
         settingsService,
         appStore,
         bitboxService,

--- a/test/widgets/mnemonic_field_extensions_test.dart
+++ b/test/widgets/mnemonic_field_extensions_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/widgets/mnemonic_field.dart';
+
+void main() {
+  group('SeedStringExtension.seedWords', () {
+    test('splits a normal mnemonic into 12 words', () {
+      const m = 'test test test test test test test test test test test junk';
+
+      expect(m.seedWords, hasLength(12));
+      expect(m.seedWords.last, 'junk');
+    });
+
+    test('collapses runs of whitespace (tabs, multiple spaces)', () {
+      const m = '  abandon   abandon\tabandon ';
+
+      expect(m.seedWords, ['abandon', 'abandon', 'abandon']);
+    });
+
+    test('returns an empty list for an empty / whitespace-only string', () {
+      expect(''.seedWords, isEmpty);
+      expect('   '.seedWords, isEmpty);
+      expect('\t\n  '.seedWords, isEmpty);
+    });
+
+    test('trims leading and trailing whitespace', () {
+      const m = '   one two three   ';
+
+      expect(m.seedWords, ['one', 'two', 'three']);
+    });
+
+    test('preserves the order of the words', () {
+      const m = 'alpha bravo charlie';
+
+      expect(m.seedWords, ['alpha', 'bravo', 'charlie']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 23 of the coverage push. Three small pure-Dart targets that round out the config + widget-extension surface.

| File | Cases (new) |
| --- | --- |
| \`lib/packages/config/network_mode.dart\` | 3 (new file) |
| \`lib/packages/config/api_config.dart\` | 6 (appended to existing) |
| \`lib/widgets/mnemonic_field.dart\` (\`SeedStringExtension\`) | 5 (new file) |

## What each file covers
- **network_mode:** mainnet / testnet getters + name; \`NetworkMode.values\` has exactly 2 entries (a third would silently bypass every \`switch (mode)\` call site).
- **api_config (extension):** testnet \`asset\` = \`realUnitTestAsset\`, testnet ids = Sepolia; mainnet \`asset\` = \`realUnitAsset\`, mainnet ids = Ethereum; \`buildUri\` produces https URIs; appends queryParams when provided; omits the query string when null.
- **mnemonic_field SeedStringExtension:** splits a 12-word mnemonic correctly; collapses tabs and multi-space runs; empty / whitespace-only input → \`[]\`; trims leading/trailing whitespace; preserves word order.

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 17 / 17 passing locally (incl. the 2 pre-existing api_config cases)
- [ ] CI green