### PR TITLE
test(repository): settings_repository (+16 tests)

### DIFF
--- a/test/packages/repository/settings_repository_test.dart
+++ b/test/packages/repository/settings_repository_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/settings_repository.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  // Initialise the binding so SharedPreferences plugin channels work.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('$SettingsRepository', () {
+    group('currentWalletId', () {
+      test('returns null when no value is stored', () async {
+        SharedPreferences.setMockInitialValues({});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        expect(repo.currentWalletId, isNull);
+      });
+
+      test('saveCurrentWalletId persists the id', () async {
+        SharedPreferences.setMockInitialValues({});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        await repo.saveCurrentWalletId(42);
+
+        expect(repo.currentWalletId, 42);
+      });
+
+      test('removeCurrentWalletId clears the stored id', () async {
+        SharedPreferences.setMockInitialValues({'currentWalletId': 7});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+        expect(repo.currentWalletId, 7);
+
+        await repo.removeCurrentWalletId();
+
+        expect(repo.currentWalletId, isNull);
+      });
+    });
+
+    group('language', () {
+      test('falls back to "en" for non-German system locales', () async {
+        SharedPreferences.setMockInitialValues({});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        // PlatformDispatcher.instance.locale in the test binding defaults to
+        // en_US; the fallback rule says "anything non-de → en".
+        expect(repo.language, 'en');
+      });
+
+      test('returns the stored language when set', () async {
+        SharedPreferences.setMockInitialValues({'language': 'de'});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        expect(repo.language, 'de');
+      });
+
+      test('language setter persists', () async {
+        SharedPreferences.setMockInitialValues({});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        repo.language = 'de';
+
+        // The setter is fire-and-forget; give the platform channel a tick.
+        await Future<void>.delayed(Duration.zero);
+        expect(repo.language, 'de');
+      });
+    });
+
+    group('currency', () {
+      test('defaults to CHF when no value is stored', () async {
+        SharedPreferences.setMockInitialValues({});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        expect(repo.currency, 'CHF');
+      });
+
+      test('returns the stored currency when set', () async {
+        SharedPreferences.setMockInitialValues({'currency': 'EUR'});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        expect(repo.currency, 'EUR');
+      });
+
+      test('currency setter persists', () async {
+        SharedPreferences.setMockInitialValues({});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        repo.currency = 'EUR';
+        await Future<void>.delayed(Duration.zero);
+
+        expect(repo.currency, 'EUR');
+      });
+    });
+
+    group('terms', () {
+      test('defaults to false when not stored', () async {
+        SharedPreferences.setMockInitialValues({});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        expect(repo.termsAccepted, isFalse);
+        expect(repo.softwareTermsAccepted, isFalse);
+      });
+
+      test('termsAccepted setter persists', () async {
+        SharedPreferences.setMockInitialValues({});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        repo.termsAccepted = true;
+        await Future<void>.delayed(Duration.zero);
+
+        expect(repo.termsAccepted, isTrue);
+      });
+
+      test('softwareTermsAccepted setter persists independently', () async {
+        SharedPreferences.setMockInitialValues({});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        repo.softwareTermsAccepted = true;
+        await Future<void>.delayed(Duration.zero);
+
+        expect(repo.softwareTermsAccepted, isTrue);
+        expect(repo.termsAccepted, isFalse);
+      });
+    });
+
+    group('networkMode', () {
+      test('defaults to mainnet when no value is stored', () async {
+        SharedPreferences.setMockInitialValues({});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        expect(repo.networkMode, NetworkMode.mainnet);
+      });
+
+      test('defaults to mainnet when stored value is unknown', () async {
+        SharedPreferences.setMockInitialValues({'networkMode': 'localnet'});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        // firstWhere falls back to mainnet via orElse.
+        expect(repo.networkMode, NetworkMode.mainnet);
+      });
+
+      test('returns testnet when stored under the enum constructor name', () async {
+        // The setter writes `mode.name`, which is the constructor arg
+        // ('Mainnet' / 'Testnet') — NOT the Dart enum identifier.
+        SharedPreferences.setMockInitialValues({'networkMode': 'Testnet'});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        expect(repo.networkMode, NetworkMode.testnet);
+      });
+
+      test('networkMode setter persists by enum name', () async {
+        SharedPreferences.setMockInitialValues({});
+        final repo = SettingsRepository(await SharedPreferences.getInstance());
+
+        repo.networkMode = NetworkMode.testnet;
+        await Future<void>.delayed(Duration.zero);
+
+        expect(repo.networkMode, NetworkMode.testnet);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 24 of the coverage push. The \`SettingsRepository\` wraps SharedPreferences and is one of the few storage-adjacent files that can be tested directly via \`SharedPreferences.setMockInitialValues\`.

| Group | Cases |
| --- | --- |
| currentWalletId | 3 |
| language | 3 |
| currency | 3 |
| terms (terms + softwareTerms) | 3 |
| networkMode | 4 |

## What each group covers
- **currentWalletId:** null when not stored; \`saveCurrentWalletId\` persists; \`removeCurrentWalletId\` clears.
- **language:** falls back to \`'en'\` for non-German system locales (PlatformDispatcher locale in tests is en_US); returns stored value when set; setter persists.
- **currency:** defaults to \`'CHF'\` when not stored; returns stored value; setter persists.
- **terms:** both \`termsAccepted\` and \`softwareTermsAccepted\` default to false; setters persist; setting one does not flip the other (independent flags).
- **networkMode:** defaults to mainnet when no value AND when stored value is unknown (\`firstWhere\`'s \`orElse\`); reads via the **enum constructor argument name** (\`'Mainnet'\` / \`'Testnet'\`) — not the Dart enum identifier (this trap surfaced during the tests because the production code uses \`.name\` and the constructor arg shadows it); setter persists.

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 16 / 16 passing locally
- [ ] CI green