### PR TITLE
test(models): Asset + Balance + Transaction (+14 tests)

### DIFF
--- a/test/models/asset_test.dart
+++ b/test/models/asset_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/models/asset.dart';
+import 'package:realunit_wallet/packages/utils/fast_hash.dart';
+
+void main() {
+  group('$Asset', () {
+    test('id is derived from chainId + address via fastHash', () {
+      const asset = Asset(
+        chainId: 1,
+        address: '0xdeadbeef',
+        name: 'X',
+        symbol: 'X',
+        decimals: 18,
+      );
+
+      expect(asset.id, fastHash('1:0xdeadbeef'));
+    });
+
+    test('Asset.getId matches the instance getter', () {
+      const asset = Asset(
+        chainId: 11155111,
+        address: '0xabc',
+        name: 'Y',
+        symbol: 'Y',
+        decimals: 18,
+      );
+
+      expect(Asset.getId(11155111, '0xabc'), asset.id);
+    });
+
+    test('different chainIds produce different ids for the same address', () {
+      const a = Asset(chainId: 1, address: '0xa', name: 'A', symbol: 'A', decimals: 18);
+      const b = Asset(chainId: 2, address: '0xa', name: 'A', symbol: 'A', decimals: 18);
+
+      expect(a.id, isNot(b.id));
+    });
+
+    test('different addresses produce different ids on the same chain', () {
+      const a = Asset(chainId: 1, address: '0xa', name: 'A', symbol: 'A', decimals: 18);
+      const b = Asset(chainId: 1, address: '0xb', name: 'A', symbol: 'A', decimals: 18);
+
+      expect(a.id, isNot(b.id));
+    });
+
+    test('id is deterministic across instances with the same chain+address', () {
+      const a = Asset(chainId: 1, address: '0xa', name: 'A', symbol: 'A', decimals: 6);
+      const b = Asset(chainId: 1, address: '0xa', name: 'Different', symbol: 'B', decimals: 18);
+
+      // id only depends on chainId + address, not metadata.
+      expect(a.id, b.id);
+    });
+  });
+}

--- a/test/models/balance_test.dart
+++ b/test/models/balance_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/models/balance.dart';
+import 'package:realunit_wallet/packages/utils/default_assets.dart';
+import 'package:realunit_wallet/packages/utils/fast_hash.dart';
+
+Balance _balance({
+  int chainId = 1,
+  String contract = '0xa',
+  String wallet = '0xw',
+  BigInt? amount,
+}) =>
+    Balance(
+      chainId: chainId,
+      contractAddress: contract,
+      walletAddress: wallet,
+      balance: amount ?? BigInt.zero,
+      asset: realUnitAsset,
+    );
+
+void main() {
+  group('$Balance', () {
+    test('id is fastHash(walletAddress:chainId:contractAddress)', () {
+      final b = _balance();
+
+      expect(b.id, fastHash('0xw:1:0xa'));
+    });
+
+    test('balance amount is mutable (BigInt is a non-final field)', () {
+      final b = _balance(amount: BigInt.from(10));
+
+      b.balance = BigInt.from(20);
+
+      expect(b.balance, BigInt.from(20));
+    });
+
+    test('two Balances with the same (chain, contract, wallet) are ==', () {
+      final a = _balance(amount: BigInt.from(1));
+      final b = _balance(amount: BigInt.from(999));
+
+      // Equality is by identity tuple, NOT by amount — pinned so a stream
+      // emit with a new amount can still match a prior key in a map / set.
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('a different chainId produces a different == identity', () {
+      final a = _balance();
+      final b = _balance(chainId: 2);
+
+      expect(a, isNot(equals(b)));
+    });
+
+    test('a different walletAddress produces a different == identity', () {
+      final a = _balance(wallet: '0xw1');
+      final b = _balance(wallet: '0xw2');
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/test/models/transaction_test.dart
+++ b/test/models/transaction_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/models/transaction.dart';
+import 'package:realunit_wallet/packages/utils/default_assets.dart';
+
+const _wallet = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+
+Transaction _tx({
+  String sender = '0x0000000000000000000000000000000000000001',
+  String receiver = '0x0000000000000000000000000000000000000002',
+}) =>
+    Transaction(
+      height: 1,
+      txId: '0xabc',
+      chainId: realUnitAsset.chainId,
+      senderAddress: sender,
+      receiverAddress: receiver,
+      amount: BigInt.one,
+      asset: realUnitAsset,
+      type: TransactionTypes.tokenTransfer,
+      note: '',
+      data: null,
+      timestamp: DateTime.utc(2026, 1, 1),
+    );
+
+void main() {
+  group('$Transaction', () {
+    test('isOutbound is true when sender matches the wallet (EIP-55 normalised)', () {
+      // Pass a lowercase wallet; the helper EIP-55-normalises both sides.
+      final tx = _tx(sender: _wallet.toLowerCase());
+
+      expect(tx.isOutbound(_wallet), isTrue);
+    });
+
+    test('isOutbound is false when sender differs from the wallet', () {
+      final tx = _tx(sender: '0x0000000000000000000000000000000000000005');
+
+      expect(tx.isOutbound(_wallet), isFalse);
+    });
+
+    test('isOutbound normalises hex-digit case via EIP-55 on both sides', () {
+      // EIP-55 keeps the literal `0x` prefix but mixes hex-digit case
+      // deterministically. The helper round-trips through fromHex/hexEip55
+      // so all-lowercase, all-mixed, and properly-EIP-55-cased variants
+      // of the SAME address compare equal.
+      final tx = _tx(sender: _wallet.toLowerCase());
+
+      expect(tx.isOutbound(_wallet), isTrue);
+      expect(tx.isOutbound(_wallet.toLowerCase()), isTrue);
+    });
+  });
+
+  group('$TransactionTypes', () {
+    test('exposes the five expected entries (catches accidental additions)', () {
+      // A new type added without updating the rendering switch would
+      // silently break the UI. Pin the count.
+      expect(TransactionTypes.values, hasLength(5));
+      expect(TransactionTypes.values, contains(TransactionTypes.transfer));
+      expect(TransactionTypes.values, contains(TransactionTypes.tokenTransfer));
+      expect(TransactionTypes.values, contains(TransactionTypes.savingsAdd));
+      expect(TransactionTypes.values, contains(TransactionTypes.savingsRemove));
+      expect(TransactionTypes.values, contains(TransactionTypes.genericContractCall));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 26 of the coverage push. Pure-Dart model classes.

| Model | Cases |
| --- | --- |
| \`Asset\` | 5 |
| \`Balance\` | 5 |
| \`Transaction\` | 3 |
| \`TransactionTypes\` enum | 1 |

## What each model pins
- **Asset:** \`id\` derived from \`fastHash(chainId:address)\`; \`Asset.getId\` static matches the instance getter; different chains / addresses produce different ids; \`id\` depends only on chain+address, not on metadata (\`name\` / \`symbol\` / \`decimals\` don't affect identity — important for repo de-duplication).
- **Balance:** \`id\` from \`fastHash(wallet:chain:contract)\`; \`balance\` amount is mutable; two Balances with the same identity tuple are \`==\` regardless of amount (pinned so a stream-emitted update with a new amount can still match an existing map key); different chain / wallet differs.
- **Transaction:** \`isOutbound\` true when sender matches wallet (EIP-55 normalised); false when sender differs; normalises hex-digit case via \`fromHex\` / \`hexEip55\` on both sides (NOT case-insensitive on the \`0x\` prefix — that breaks fromHex; the test pins the actual contract).
- **TransactionTypes:** values has exactly 5 entries (catches an accidental addition that would silently break the rendering switch).

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 14 / 14 passing locally
- [ ] CI green