### PR TITLE
test: Currency + Language enums + DfxTransaction model (+13 tests)

### DIFF
--- a/test/models/dfx_transaction_test.dart
+++ b/test/models/dfx_transaction_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/models/dfx_transaction.dart';
+import 'package:realunit_wallet/models/transaction.dart';
+import 'package:realunit_wallet/packages/utils/default_assets.dart';
+
+void main() {
+  DfxTransaction build({
+    int dfxId = 7,
+    String? inputTxId,
+    String? outputTxId,
+    double? rate,
+  }) =>
+      DfxTransaction(
+        dfxId: dfxId,
+        rate: rate,
+        inputTxId: inputTxId,
+        outputTxId: outputTxId,
+        height: 1,
+        txId: '0xabc',
+        chainId: realUnitAsset.chainId,
+        senderAddress: '0x0',
+        receiverAddress: '0x0',
+        amount: BigInt.from(123),
+        asset: realUnitAsset,
+        type: TransactionTypes.tokenTransfer,
+        note: null,
+        data: null,
+        timestamp: DateTime.utc(2026, 1, 1),
+      );
+
+  group('$DfxTransaction', () {
+    test('is a Transaction subclass and inherits the base fields', () {
+      final tx = build();
+
+      expect(tx, isA<Transaction>());
+      expect(tx.txId, '0xabc');
+      expect(tx.amount, BigInt.from(123));
+      expect(tx.asset, realUnitAsset);
+    });
+
+    test('carries the four DFX-only fields', () {
+      final tx = build(
+        dfxId: 42,
+        rate: 1.05,
+        inputTxId: '0xin',
+        outputTxId: '0xout',
+      );
+
+      expect(tx.dfxId, 42);
+      expect(tx.rate, 1.05);
+      expect(tx.inputTxId, '0xin');
+      expect(tx.outputTxId, '0xout');
+    });
+
+    test('rate / inputTxId / outputTxId are optional', () {
+      final tx = build();
+
+      expect(tx.rate, isNull);
+      expect(tx.inputTxId, isNull);
+      expect(tx.outputTxId, isNull);
+    });
+  });
+}

--- a/test/styles/currency_test.dart
+++ b/test/styles/currency_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/styles/currency.dart';
+
+void main() {
+  group('$Currency', () {
+    test('eur and chf have the wire codes "EUR" and "CHF"', () {
+      expect(Currency.eur.code, 'EUR');
+      expect(Currency.chf.code, 'CHF');
+    });
+
+    test('values has exactly the two entries', () {
+      expect(Currency.values, hasLength(2));
+      expect(Currency.values, contains(Currency.eur));
+      expect(Currency.values, contains(Currency.chf));
+    });
+
+    group('fromCode', () {
+      test('resolves "EUR" and "CHF"', () {
+        expect(Currency.fromCode('EUR'), Currency.eur);
+        expect(Currency.fromCode('CHF'), Currency.chf);
+      });
+
+      test('is case-insensitive on the input', () {
+        expect(Currency.fromCode('eur'), Currency.eur);
+        expect(Currency.fromCode('chf'), Currency.chf);
+        expect(Currency.fromCode('Eur'), Currency.eur);
+      });
+
+      test('throws StateError on an unknown code', () {
+        expect(() => Currency.fromCode('USD'), throwsA(isA<StateError>()));
+        expect(() => Currency.fromCode(''), throwsA(isA<StateError>()));
+      });
+    });
+  });
+}

--- a/test/styles/language_test.dart
+++ b/test/styles/language_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/styles/language.dart';
+
+void main() {
+  group('$Language', () {
+    test('en and de carry their wire codes and flag asset paths', () {
+      expect(Language.en.code, 'en');
+      expect(Language.en.imagePath, 'assets/images/flags/gbr.png');
+      expect(Language.de.code, 'de');
+      expect(Language.de.imagePath, 'assets/images/flags/deu.png');
+    });
+
+    test('values has exactly the two entries', () {
+      expect(Language.values, hasLength(2));
+      expect(Language.values, contains(Language.en));
+      expect(Language.values, contains(Language.de));
+    });
+
+    group('fromCode', () {
+      test('resolves "en" and "de"', () {
+        expect(Language.fromCode('en'), Language.en);
+        expect(Language.fromCode('de'), Language.de);
+      });
+
+      test('is case-SENSITIVE on the input (matches the production lookup)', () {
+        // Documents the current behaviour: codes are lowercase on the wire,
+        // and the lookup does NOT lowercase the input. Different from
+        // Currency.fromCode which normalises with toUpperCase.
+        expect(() => Language.fromCode('EN'), throwsA(isA<StateError>()));
+        expect(() => Language.fromCode('De'), throwsA(isA<StateError>()));
+      });
+
+      test('throws StateError on an unknown code', () {
+        expect(() => Language.fromCode('fr'), throwsA(isA<StateError>()));
+        expect(() => Language.fromCode(''), throwsA(isA<StateError>()));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 28 of the coverage push.

| File | Cases |
| --- | --- |
| \`lib/styles/currency.dart\` | 5 |
| \`lib/styles/language.dart\` | 5 |
| \`lib/models/dfx_transaction.dart\` | 3 |

## What's pinned
- **Currency:** wire codes (\`EUR\` / \`CHF\`); enum has exactly 2 values; \`fromCode\` resolves canonical inputs; **case-insensitive** on input (production calls \`toUpperCase\` first); throws \`StateError\` on unknown.
- **Language:** wire codes (\`en\` / \`de\`) and flag asset paths; enum has exactly 2 values; \`fromCode\` resolves canonical; **case-SENSITIVE** on input (the lookup does NOT lowercase — pinned because it's different from Currency); throws \`StateError\` on unknown.
- **DfxTransaction:** is-a \`Transaction\` with inherited fields; carries \`dfxId\` + \`rate\` + \`inputTxId\` + \`outputTxId\`; rate / inputTxId / outputTxId are all optional (\`isNull\` check pins the constructor's default-null contract).

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 13 / 13 passing locally
- [ ] CI green