### PR TITLE
test: DfxCountryDto + SupportMessage + KycLevel (+16 tests)

### DIFF
--- a/test/packages/service/dfx/models/country/dfx_country_dto_test.dart
+++ b/test/packages/service/dfx/models/country/dfx_country_dto_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/country/country.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/country/dto/dfx_country_dto.dart';
+
+Map<String, dynamic> _wire({String? foreignName, bool ibanAllowed = true}) => {
+      'id': 41,
+      'symbol': 'CH',
+      'name': 'Switzerland',
+      'foreignName': foreignName,
+      'locationAllowed': true,
+      'ibanAllowed': ibanAllowed,
+      'kycAllowed': true,
+      'kycOrganizationAllowed': true,
+      'nationalityAllowed': true,
+      'bankAllowed': true,
+      'cardAllowed': true,
+      'cryptoAllowed': true,
+    };
+
+void main() {
+  group('$DfxCountryDto.fromJson', () {
+    test('maps every field from the wire', () {
+      final dto = DfxCountryDto.fromJson(_wire(foreignName: 'Schweiz'));
+
+      expect(dto.id, 41);
+      expect(dto.symbol, 'CH');
+      expect(dto.name, 'Switzerland');
+      expect(dto.foreignName, 'Schweiz');
+      expect(dto.locationAllowed, isTrue);
+      expect(dto.ibanAllowed, isTrue);
+      expect(dto.kycAllowed, isTrue);
+      expect(dto.kycOrganizationAllowed, isTrue);
+      expect(dto.nationalityAllowed, isTrue);
+      expect(dto.bankAllowed, isTrue);
+      expect(dto.cardAllowed, isTrue);
+      expect(dto.cryptoAllowed, isTrue);
+    });
+
+    test('foreignName is optional (null on the wire stays null)', () {
+      final dto = DfxCountryDto.fromJson(_wire(foreignName: null));
+
+      expect(dto.foreignName, isNull);
+    });
+
+    test('boolean false flags are preserved (not coerced)', () {
+      final dto = DfxCountryDto.fromJson(_wire(ibanAllowed: false));
+
+      expect(dto.ibanAllowed, isFalse);
+    });
+  });
+
+  group('DfxCountryDtoMapper.toCountry', () {
+    test('keeps id / symbol / name / foreignName, drops the *_allowed flags', () {
+      final country = DfxCountryDto.fromJson(_wire(foreignName: 'Schweiz')).toCountry();
+
+      expect(country, isA<Country>());
+      expect(country.id, 41);
+      expect(country.symbol, 'CH');
+      expect(country.name, 'Switzerland');
+      expect(country.foreignName, 'Schweiz');
+    });
+  });
+
+  group('$Country equality', () {
+    test('two Country instances with the same id are ==', () {
+      const a = Country(id: 41, symbol: 'CH', name: 'Switzerland');
+      const b = Country(id: 41, symbol: 'XX', name: 'Different name', foreignName: 'F');
+
+      // Equality only on id (props returns [id]).
+      expect(a, equals(b));
+    });
+
+    test('different ids → different equality', () {
+      const a = Country(id: 41, symbol: 'CH', name: 'Switzerland');
+      const b = Country(id: 49, symbol: 'DE', name: 'Germany');
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/test/packages/service/dfx/models/kyc/kyc_level_test.dart
+++ b/test/packages/service/dfx/models/kyc/kyc_level_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
+
+void main() {
+  group('$KycLevel', () {
+    test('values has exactly 8 entries', () {
+      // 6 numeric levels + terminated + rejected. Catches accidental
+      // additions to the enum that would silently bypass every
+      // switch-on-level call site.
+      expect(KycLevel.values, hasLength(8));
+    });
+
+    group('value (extension getter)', () {
+      test('level0..level50 map to 0/10/20/30/40/50', () {
+        expect(KycLevel.level0.value, 0);
+        expect(KycLevel.level10.value, 10);
+        expect(KycLevel.level20.value, 20);
+        expect(KycLevel.level30.value, 30);
+        expect(KycLevel.level40.value, 40);
+        expect(KycLevel.level50.value, 50);
+      });
+
+      test('terminated → -10, rejected → -20', () {
+        // Negative sentinels for terminal states. Pinned because the
+        // server distinguishes between user-aborted and rejected KYC.
+        expect(KycLevel.terminated.value, -10);
+        expect(KycLevel.rejected.value, -20);
+      });
+    });
+
+    group('fromValue (static)', () {
+      test('round-trips every enum value', () {
+        for (final level in KycLevel.values) {
+          expect(KycLevelExtension.fromValue(level.value), level);
+        }
+      });
+
+      test('throws ArgumentError on unknown numeric input', () {
+        expect(() => KycLevelExtension.fromValue(99), throwsArgumentError);
+        expect(() => KycLevelExtension.fromValue(-1), throwsArgumentError);
+      });
+    });
+  });
+}

--- a/test/packages/service/dfx/models/support/support_message_test.dart
+++ b/test/packages/service/dfx/models/support/support_message_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/dto/support_message_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_message.dart';
+
+void main() {
+  group('$SupportMessageDto.fromJson', () {
+    test('parses the full wire shape', () {
+      final dto = SupportMessageDto.fromJson({
+        'id': 7,
+        'author': 'alice',
+        'created': '2026-05-15T10:00:00Z',
+        'message': 'hi',
+        'fileName': 'attachment.pdf',
+      });
+
+      expect(dto.id, 7);
+      expect(dto.author, 'alice');
+      expect(dto.created, DateTime.utc(2026, 5, 15, 10));
+      expect(dto.message, 'hi');
+      expect(dto.fileName, 'attachment.pdf');
+    });
+
+    test('author / message / fileName are all optional (null preserved)', () {
+      final dto = SupportMessageDto.fromJson({
+        'id': 1,
+        'author': null,
+        'created': '2026-01-01T00:00:00Z',
+        'message': null,
+        'fileName': null,
+      });
+
+      expect(dto.author, isNull);
+      expect(dto.message, isNull);
+      expect(dto.fileName, isNull);
+    });
+  });
+
+  group('$SupportMessage.fromDto', () {
+    test('copies every field from the DTO', () {
+      final dto = SupportMessageDto.fromJson({
+        'id': 7,
+        'author': 'alice',
+        'created': '2026-05-15T10:00:00Z',
+        'message': 'hi',
+        'fileName': 'attachment.pdf',
+      });
+
+      final msg = SupportMessage.fromDto(dto);
+
+      expect(msg.id, dto.id);
+      expect(msg.author, dto.author);
+      expect(msg.created, dto.created);
+      expect(msg.message, dto.message);
+      expect(msg.fileName, dto.fileName);
+    });
+
+    test('isFromSupport is true when author is null', () {
+      final msg = SupportMessage.fromDto(
+        SupportMessageDto(
+          id: 1,
+          created: DateTime.utc(2026, 1, 1),
+          // author absent → from support (server side)
+        ),
+      );
+
+      expect(msg.isFromSupport, isTrue);
+    });
+
+    test('isFromSupport is false when author is set', () {
+      final msg = SupportMessage.fromDto(
+        SupportMessageDto(
+          id: 1,
+          author: 'alice',
+          created: DateTime.utc(2026, 1, 1),
+        ),
+      );
+
+      expect(msg.isFromSupport, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Stage 30 of the coverage push. Three more wire-format DTOs and the \`KycLevel\` int↔enum mapping.

| File | Cases |
| --- | --- |
| \`dfx_country_dto.dart\` (+ \`Country\` equality) | 5 |
| \`support_message_dto.dart\` + \`SupportMessage.fromDto\` | 5 |
| \`kyc_level.dart\` (value getter + fromValue) | 4 (+ 2 round-trip / error cases) |

## What's pinned
- **DfxCountryDto.fromJson:** full wire mapping; \`foreignName\` optional; false boolean flags preserved (not coerced); \`toCountry\` extension drops the \`*_allowed\` flags; \`Country\` equality is **id-only** — two Country instances with the same id are \`==\` even if name / symbol differ (\`props = [id]\`).
- **SupportMessageDto / SupportMessage:** full wire shape; \`author\` / \`message\` / \`fileName\` all optional with nulls preserved; \`fromDto\` copies every field; \`isFromSupport\` true when \`author == null\`, false otherwise — pins the **support-vs-user** distinction used in the chat UI.
- **KycLevel:** \`values\` has exactly 8 entries; numeric levels map to 0/10/20/30/40/50; terminated → −10, rejected → −20 (negative sentinels for terminal states); \`KycLevelExtension.fromValue\` round-trips every enum entry; throws \`ArgumentError\` on unknown int.

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` — 16 / 16 passing locally
- [ ] CI green