### PR TITLE
test(payment): Buy + Sell DTOs + PaymentInfoError (+12 tests)

### DIFF
--- a/test/packages/service/dfx/models/payment/buy_sell_dtos_test.dart
+++ b/test/packages/service/dfx/models/payment/buy_sell_dtos_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/dto/real_unit_buy_confirm_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/dto/real_unit_buy_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/dto/real_unit_buy_payment_info_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/payment_info_error.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_payment_info_dto.dart';
+import 'package:realunit_wallet/styles/currency.dart';
+
+void main() {
+  group('$RealUnitBuyDto.toJson', () {
+    test('defaults currency to CHF and serialises amount + code', () {
+      const dto = RealUnitBuyDto(amount: 100);
+
+      expect(dto.toJson(), {'amount': 100, 'currency': 'CHF'});
+    });
+
+    test('honours an overridden currency by code', () {
+      const dto = RealUnitBuyDto(amount: 250, currency: Currency.eur);
+
+      expect(dto.toJson()['currency'], 'EUR');
+    });
+  });
+
+  group('$RealUnitBuyConfirmDto.fromJson', () {
+    test('reads the reference field', () {
+      final dto = RealUnitBuyConfirmDto.fromJson({'reference': 'XYZ-123'});
+
+      expect(dto.reference, 'XYZ-123');
+    });
+  });
+
+  group('$RealUnitBuyPaymentInfoDto.fromJson', () {
+    Map<String, dynamic> baseJson() => {
+          'id': 1,
+          'routeId': 2,
+          'timestamp': '2026-05-15T10:00:00Z',
+          'iban': 'CH...',
+          'bic': 'BIC',
+          'name': 'DFX AG',
+          'street': 'Bahnhofstrasse',
+          'number': '1',
+          'zip': '8000',
+          'city': 'Zurich',
+          'country': 'CH',
+          'amount': 100.5,
+          'currency': 'CHF',
+          'fees': {
+            'rate': 0.01,
+            'fixed': 0.5,
+            'network': 0.0,
+            'min': 1.0,
+            'dfx': 0.5,
+            'total': 2.0,
+          },
+          'minVolume': 5.0,
+          'maxVolume': 5000.0,
+          'minVolumeTarget': 5.1,
+          'maxVolumeTarget': 5100.0,
+          'exchangeRate': 1.1,
+          'rate': 1.05,
+          'priceSteps': <Map<String, dynamic>>[],
+          'estimatedAmount': 95.5,
+          'paymentRequest': 'pay-req',
+          'remittanceInfo': 'rem-info',
+          'isValid': true,
+        };
+
+    test('parses every field on the happy path', () {
+      final dto = RealUnitBuyPaymentInfoDto.fromJson(baseJson());
+
+      expect(dto.id, 1);
+      expect(dto.routeId, 2);
+      expect(dto.timestamp, DateTime.utc(2026, 5, 15, 10));
+      expect(dto.amount, 100.5);
+      expect(dto.currency, Currency.chf);
+      expect(dto.fees.total, 2.0);
+      expect(dto.minVolume, 5.0);
+      expect(dto.maxVolume, 5000.0);
+      expect(dto.paymentRequest, 'pay-req');
+      expect(dto.remittanceInfo, 'rem-info');
+      expect(dto.isValid, isTrue);
+      expect(dto.priceSteps, isEmpty);
+    });
+
+    test('keeps optional fields null when the wire sends null', () {
+      final json = baseJson()
+        ..['minVolume'] = null
+        ..['maxVolume'] = null
+        ..['paymentRequest'] = null
+        ..['remittanceInfo'] = null;
+
+      final dto = RealUnitBuyPaymentInfoDto.fromJson(json);
+
+      expect(dto.minVolume, isNull);
+      expect(dto.maxVolume, isNull);
+      expect(dto.paymentRequest, isNull);
+      expect(dto.remittanceInfo, isNull);
+    });
+  });
+
+  group('$RealUnitSellDto.toJson', () {
+    test('serialises amount-only and defaults currency to CHF', () {
+      final dto = RealUnitSellDto(amount: 100, iban: 'CH...');
+
+      expect(dto.toJson(), {'amount': 100, 'iban': 'CH...', 'currency': 'CHF'});
+    });
+
+    test('serialises targetAmount-only and omits the amount key', () {
+      final dto = RealUnitSellDto(targetAmount: 50, iban: 'CH...');
+
+      expect(dto.toJson().containsKey('amount'), isFalse);
+      expect(dto.toJson()['targetAmount'], 50);
+    });
+
+    test('honours an overridden currency by code', () {
+      final dto =
+          RealUnitSellDto(amount: 100, iban: 'CH...', currency: Currency.eur);
+
+      expect(dto.toJson()['currency'], 'EUR');
+    });
+
+    test('asserts that exactly one of amount / targetAmount is set', () {
+      expect(() => RealUnitSellDto(iban: 'CH...'), throwsA(isA<AssertionError>()));
+      expect(
+        () => RealUnitSellDto(amount: 1, targetAmount: 1, iban: 'CH...'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('$BeneficiaryDto.fromJson', () {
+    test('parses name + iban', () {
+      final dto = BeneficiaryDto.fromJson({'name': 'Alice', 'iban': 'CH...'});
+
+      expect(dto.name, 'Alice');
+      expect(dto.iban, 'CH...');
+    });
+
+    test('keeps name null when missing', () {
+      final dto = BeneficiaryDto.fromJson({'iban': 'CH...'});
+
+      expect(dto.name, isNull);
+      expect(dto.iban, 'CH...');
+    });
+  });
+
+  group('$PaymentInfoError', () {
+    test('has the four documented variants', () {
+      // Pin the wire contract — any new variant has to be added intentionally.
+      expect(PaymentInfoError.values, hasLength(4));
+      expect(
+        PaymentInfoError.values.toSet(),
+        {
+          PaymentInfoError.registrationRequired,
+          PaymentInfoError.kycRequired,
+          PaymentInfoError.minAmountNotMet,
+          PaymentInfoError.unknown,
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 36 of the coverage push. Pure DTO tests for the RealUnit buy + sell wire surface, plus the \`PaymentInfoError\` enum contract.

## Cases

| Target | Cases |
| --- | --- |
| \`RealUnitBuyDto.toJson\` | 2 — defaults currency to \`CHF\`; honours an override |
| \`RealUnitBuyConfirmDto.fromJson\` | 1 — reference field |
| \`RealUnitBuyPaymentInfoDto.fromJson\` | 2 — happy path; optional \`minVolume\` / \`maxVolume\` / \`paymentRequest\` / \`remittanceInfo\` as null |
| \`RealUnitSellDto.toJson\` | 4 — amount-only; targetAmount-only; currency override; assertion that exactly one of \`amount\` / \`targetAmount\` is set |
| \`BeneficiaryDto.fromJson\` | 2 — name + iban; name null |
| \`PaymentInfoError\` | 1 — four documented variants pinned |

## What's pinned

- \`RealUnitSellDto\` enforces XOR-style mutual exclusion on \`amount\` / \`targetAmount\` via assertion — both negative cases (neither / both) are covered.
- The optional-field handling on \`RealUnitBuyPaymentInfoDto\` is byte-exact: \`minVolume\` / \`maxVolume\` / \`paymentRequest\` / \`remittanceInfo\` survive an explicit \`null\` on the wire.
- \`Currency\` round-trips through \`.code\` on serialisation and \`Currency.fromCode\` on parse.
- \`PaymentInfoError\` is locked at four variants so a sneaky addition doesn't slip past without an intentional bump.

## Excluded (and why)

- \`RealUnitSellPaymentInfoDto.fromJson\` — entangles \`Eip7702Data\`, \`DfxFeesData\` and \`BeneficiaryDto\` parsing in one shot; better covered via the \`real_unit_sell_payment_info_service\` integration tests once PR #332 is in.

## Test plan

- [x] \`flutter test test/packages/service/dfx/models/payment/buy_sell_dtos_test.dart\` — 12 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green