### PR TITLE
test(pin): PinAuthCubit (+10 tests)

### DIFF
--- a/test/screens/pin/pin_auth_cubit_test.dart
+++ b/test/screens/pin/pin_auth_cubit_test.dart
@@ -1,0 +1,128 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/storage/secure_storage.dart';
+import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
+import 'package:realunit_wallet/screens/pin/constants/pin_constants.dart';
+
+class _MockSecureStorage extends Mock implements SecureStorage {}
+
+void main() {
+  late _MockSecureStorage storage;
+
+  setUp(() {
+    storage = _MockSecureStorage();
+  });
+
+  PinAuthCubit build() => PinAuthCubit(storage);
+
+  group('$PinAuthCubit initial state', () {
+    test('isPinSetup=false and isPinVerified=false', () {
+      expect(build().state, const PinAuthState());
+    });
+  });
+
+  group('initialize', () {
+    blocTest<PinAuthCubit, PinAuthState>(
+      'PIN is set: emits isPinSetup=true and keeps isPinVerified=false',
+      setUp: () => when(() => storage.hasPinHash()).thenAnswer((_) async => true),
+      build: build,
+      act: (c) => c.initialize(),
+      expect: () => const [
+        PinAuthState(isPinSetup: true),
+      ],
+    );
+
+    blocTest<PinAuthCubit, PinAuthState>(
+      'no PIN set: emits isPinSetup=false and isPinVerified=true (auto-pass)',
+      setUp: () => when(() => storage.hasPinHash()).thenAnswer((_) async => false),
+      build: build,
+      act: (c) => c.initialize(),
+      expect: () => const [
+        PinAuthState(isPinVerified: true),
+      ],
+    );
+  });
+
+  group('verification helpers', () {
+    blocTest<PinAuthCubit, PinAuthState>(
+      'onPinSetupComplete sets both flags true',
+      build: build,
+      act: (c) => c.onPinSetupComplete(),
+      expect: () => const [
+        PinAuthState(isPinSetup: true, isPinVerified: true),
+      ],
+    );
+
+    blocTest<PinAuthCubit, PinAuthState>(
+      'onPinVerified flips isPinVerified true and preserves isPinSetup',
+      seed: () => const PinAuthState(isPinSetup: true),
+      build: build,
+      act: (c) => c.onPinVerified(),
+      expect: () => const [
+        PinAuthState(isPinSetup: true, isPinVerified: true),
+      ],
+    );
+  });
+
+  group('background / resume lockout', () {
+    test('onAppResumed without onAppHidden is a no-op (no emit)', () {
+      final cubit = build();
+      final before = cubit.state;
+      cubit.onAppResumed();
+      expect(cubit.state, before);
+    });
+
+    test('onAppResumed when PIN not setup is a no-op (no emit)', () async {
+      final cubit = build()..onAppHidden();
+      final before = cubit.state;
+      cubit.onAppResumed();
+      expect(cubit.state, before);
+    });
+
+    test(
+      'short hide → resume keeps isPinVerified true (elapsed < lockoutDuration)',
+      () async {
+        final cubit = build()..onPinSetupComplete();
+        expect(cubit.state.isPinVerified, isTrue);
+
+        // The lockout check uses wall-clock time, so we exercise the
+        // elapsed-too-small branch by hiding and resuming back-to-back.
+        // The elapsed-too-large branch is implicitly covered by the
+        // lockoutDuration constant pin below — flipping that constant or the
+        // comparator surfaces in the auth flow's own tests.
+        cubit
+          ..onAppHidden()
+          ..onAppResumed();
+
+        expect(cubit.state.isPinVerified, isTrue);
+      },
+    );
+
+    test('lockoutDuration constant is 5 minutes (boundary pin)', () {
+      // The behaviour depends on this exact constant — pin it so changes
+      // surface in this file rather than only in the auth flow.
+      expect(lockoutDuration, const Duration(minutes: 5));
+    });
+  });
+
+  group('reset', () {
+    blocTest<PinAuthCubit, PinAuthState>(
+      'wipes pin hash + biometric + lockout and emits the initial state',
+      setUp: () {
+        when(() => storage.deletePinHash()).thenAnswer((_) async {});
+        when(() => storage.deleteBiometricEnabled()).thenAnswer((_) async {});
+        when(() => storage.resetPinLockout()).thenAnswer((_) async {});
+      },
+      seed: () => const PinAuthState(isPinSetup: true, isPinVerified: true),
+      build: build,
+      act: (c) => c.reset(),
+      verify: (_) {
+        verify(() => storage.deletePinHash()).called(1);
+        verify(() => storage.deleteBiometricEnabled()).called(1);
+        verify(() => storage.resetPinLockout()).called(1);
+      },
+      expect: () => const [PinAuthState()],
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Stage 40 of the coverage push. First cubit-level coverage of the PIN authentication lifecycle: setup, verification, background lockout, and reset.

## Cases

| Target | Cases |
| --- | --- |
| initial state | 1 — both flags false |
| \`initialize\` | 2 — PIN set: \`isPinSetup=true\`, \`isPinVerified\` stays false; no PIN: \`isPinVerified\` auto-passes |
| \`onPinSetupComplete\` | 1 — both flags true |
| \`onPinVerified\` | 1 — preserves \`isPinSetup\`, flips \`isPinVerified\` |
| background / resume lockout | 4 — resume without prior hide is a no-op; resume when PIN not setup is a no-op; elapsed < \`lockoutDuration\` keeps verification; \`lockoutDuration\` constant pin (5 min) |
| \`reset\` | 1 — wipes pin hash + biometric + lockout, emits initial state |

## What's pinned

- The "no PIN set" branch in \`initialize\` deliberately auto-passes verification — pinning it so a refactor doesn't silently force an unnecessary PIN prompt.
- The lockout-window comparator and the \`lockoutDuration\` constant are tested in tandem: the elapsed-too-small branch via behavior, the boundary via the constant pin. The elapsed-too-large branch would require wall-clock manipulation; the constant pin is what catches drift today.
- \`reset\` issues three independent storage deletes (\`deletePinHash\` + \`deleteBiometricEnabled\` + \`resetPinLockout\`) — all three are verified to fire once.

## Excluded (and why)

- The elapsed-≥-\`lockoutDuration\` invalidation branch — requires fake-clock or 5 minutes of real wait; covered indirectly by the constant pin and by integration tests on the wider auth flow.

## Test plan

- [x] \`flutter test test/screens/pin/pin_auth_cubit_test.dart\` — 10 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green