### PR TITLE
test(settings-seed): SettingsSeedCubit + state (+5 tests)

### DIFF
--- a/test/screens/settings_seed/settings_seed_cubit_test.dart
+++ b/test/screens/settings_seed/settings_seed_cubit_test.dart
@@ -1,0 +1,66 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/wallet/wallet.dart';
+import 'package:realunit_wallet/screens/settings_seed/bloc/settings_seed_cubit.dart';
+
+// Canonical BIP39 test mnemonic — recommended fixture for any wallet code
+// path that needs a deterministic, well-known seed.
+const _testSeed =
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+void main() {
+  late SoftwareWallet wallet;
+
+  setUp(() {
+    wallet = SoftwareWallet(1, 'Test', _testSeed);
+  });
+
+  group('$SettingsSeedCubit', () {
+    test('initial state mirrors the wallet seed with showSeed=false', () {
+      final cubit = SettingsSeedCubit(wallet);
+
+      expect(cubit.state.seed, _testSeed);
+      expect(cubit.state.showSeed, isFalse);
+    });
+
+    blocTest<SettingsSeedCubit, SettingsSeedState>(
+      'toggleShowSeed flips showSeed and keeps seed unchanged',
+      build: () => SettingsSeedCubit(wallet),
+      act: (c) => c.toggleShowSeed(),
+      expect: () => [
+        SettingsSeedState(_testSeed, showSeed: true),
+      ],
+    );
+
+    blocTest<SettingsSeedCubit, SettingsSeedState>(
+      'toggleShowSeed twice returns to showSeed=false',
+      build: () => SettingsSeedCubit(wallet),
+      act: (c) => c
+        ..toggleShowSeed()
+        ..toggleShowSeed(),
+      expect: () => [
+        SettingsSeedState(_testSeed, showSeed: true),
+        SettingsSeedState(_testSeed),
+      ],
+    );
+  });
+
+  group('$SettingsSeedState', () {
+    test('copyWith only overrides the provided fields', () {
+      const seed = SettingsSeedState('seed-a');
+      final updated = seed.copyWith(showSeed: true);
+
+      expect(updated.seed, 'seed-a');
+      expect(updated.showSeed, isTrue);
+    });
+
+    test('Equatable props cover seed + showSeed', () {
+      const a = SettingsSeedState('s', showSeed: true);
+      const b = SettingsSeedState('s', showSeed: true);
+      const c = SettingsSeedState('s');
+
+      expect(a, b);
+      expect(a, isNot(c));
+    });
+  });
+}

--- a/test/screens/settings_seed/settings_seed_cubit_test.dart
+++ b/test/screens/settings_seed/settings_seed_cubit_test.dart
@@ -28,7 +28,7 @@ void main() {
       build: () => SettingsSeedCubit(wallet),
       act: (c) => c.toggleShowSeed(),
       expect: () => [
-        SettingsSeedState(_testSeed, showSeed: true),
+        const SettingsSeedState(_testSeed, showSeed: true),
       ],
     );
 
@@ -39,8 +39,8 @@ void main() {
         ..toggleShowSeed()
         ..toggleShowSeed(),
       expect: () => [
-        SettingsSeedState(_testSeed, showSeed: true),
-        SettingsSeedState(_testSeed),
+        const SettingsSeedState(_testSeed, showSeed: true),
+        const SettingsSeedState(_testSeed),
       ],
     );
   });


### PR DESCRIPTION
## Summary

Stage 41 of the coverage push. Cubit-level coverage of the 'show recovery seed' toggle screen.

## Cases

| Target | Cases |
| --- | --- |
| initial state | 1 — seed mirrors \`wallet.seed\`; \`showSeed=false\` |
| \`toggleShowSeed\` | 2 — single flip to true; double flip back to false |
| \`SettingsSeedState\` | 2 — \`copyWith\` preserves untouched fields; Equatable props cover \`seed\` + \`showSeed\` |

## What's pinned

- The toggle does not mutate the underlying seed — every emitted state still carries the canonical BIP39 test mnemonic.
- \`copyWith\` is non-destructive: passing only \`showSeed\` keeps \`seed\` intact.
- Equatable props enumerate both fields — pinned via the negative case (different \`showSeed\` breaks equality).

## Test plan

- [x] \`flutter test test/screens/settings_seed/settings_seed_cubit_test.dart\` — 5 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green