### PR TITLE
test(widgets): IbanTextFormatter + IbanInputFormatter (+9 tests)

### DIFF
--- a/test/widgets/iban_formatters_test.dart
+++ b/test/widgets/iban_formatters_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/widgets/iban_input_formatter.dart';
+import 'package:realunit_wallet/widgets/iban_text_formatter.dart';
+
+void main() {
+  group('$IbanTextFormatter.formatIban', () {
+    test('empty input returns empty string', () {
+      expect(IbanTextFormatter.formatIban(''), '');
+    });
+
+    test('uppercases lowercase characters', () {
+      expect(IbanTextFormatter.formatIban('ch93'), 'CH93');
+    });
+
+    test('strips existing spaces before regrouping', () {
+      expect(IbanTextFormatter.formatIban('CH 93 008'), 'CH93 008');
+    });
+
+    test('groups long input every four characters', () {
+      expect(
+        IbanTextFormatter.formatIban('CH9300762011623852957'),
+        'CH93 0076 2011 6238 5295 7',
+      );
+    });
+
+    test('exactly four characters: no trailing space', () {
+      expect(IbanTextFormatter.formatIban('CHFR'), 'CHFR');
+    });
+  });
+
+  group('$IbanInputFormatter.formatEditUpdate', () {
+    final formatter = IbanInputFormatter();
+
+    TextEditingValue update(String input) => formatter.formatEditUpdate(
+          TextEditingValue.empty,
+          TextEditingValue(text: input),
+        );
+
+    test('groups output in fours and uppercases', () {
+      final out = update('ch93007620116238');
+      expect(out.text, 'CH93 0076 2011 6238');
+    });
+
+    test('drops invalid characters silently', () {
+      final out = update('CH 93-0076.2011');
+      expect(out.text, 'CH93 0076 2011');
+    });
+
+    test('keeps the caret collapsed at the end of the formatted text', () {
+      final out = update('CH9300762011');
+      expect(out.text, 'CH93 0076 2011');
+      expect(out.selection, TextSelection.collapsed(offset: out.text.length));
+      expect(out.composing, TextRange.empty);
+    });
+
+    test('empty input remains empty', () {
+      final out = update('');
+      expect(out.text, '');
+      expect(out.selection.baseOffset, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 42 of the coverage push. Pure-function tests for the two IBAN formatters that drive the bank-account input field.

## Cases

| Target | Cases |
| --- | --- |
| \`IbanTextFormatter.formatIban\` | 5 — empty; lowercase → upper; strips existing spaces before regrouping; long input groups every four chars; exactly four chars: no trailing space |
| \`IbanInputFormatter.formatEditUpdate\` | 4 — groups output in fours and uppercases; drops invalid characters silently; caret stays collapsed at the end; empty input remains empty |

## What's pinned

- \`IbanTextFormatter\` is the read-side display helper — it does not validate characters, it just regroups and uppercases.
- \`IbanInputFormatter\` is the write-side \`TextInputFormatter\`; the regex \`[A-Z0-9]\` is applied **after** uppercasing, so lowercase letters survive but punctuation does not. The "drops invalid characters silently" case pins this contract.
- The caret behaviour (\`selection: TextSelection.collapsed(offset: text.length)\`) is essential UX — explicit case covers it so a future refactor can't silently strand the caret mid-string.

## Test plan

- [x] \`flutter test test/widgets/iban_formatters_test.dart\` — 9 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green