### PR TITLE
test(widgets): mnemonic extensions + controller styling (+9 tests)

### DIFF
--- a/test/widgets/mnemonic_extensions_test.dart
+++ b/test/widgets/mnemonic_extensions_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/widgets/mnemonic_field.dart';
+
+void main() {
+  group('SeedStringExtension.seedWords', () {
+    test('splits on single spaces', () {
+      expect(
+        'abandon ability about'.seedWords,
+        ['abandon', 'ability', 'about'],
+      );
+    });
+
+    test('collapses repeated whitespace and tabs', () {
+      expect(
+        'abandon   ability\tabout'.seedWords,
+        ['abandon', 'ability', 'about'],
+      );
+    });
+
+    test('strips leading + trailing whitespace', () {
+      expect(
+        '   abandon ability   '.seedWords,
+        ['abandon', 'ability'],
+      );
+    });
+
+    test('newlines count as whitespace', () {
+      expect(
+        'abandon\nability\nabout'.seedWords,
+        ['abandon', 'ability', 'about'],
+      );
+    });
+
+    test('empty input returns empty list', () {
+      expect(''.seedWords, isEmpty);
+      expect('   '.seedWords, isEmpty);
+    });
+  });
+
+  group('MnemonicListExtension.seed', () {
+    test('joins controller texts with single spaces and trims each entry', () {
+      // Build a list of MnemonicInputFieldController and seed them.
+      final controllers = List.generate(3, (_) => MnemonicInputFieldController());
+      controllers[0].text = '  abandon';
+      controllers[1].text = 'ability ';
+      controllers[2].text = 'about';
+
+      expect(controllers.seed, 'abandon ability about');
+
+      for (final c in controllers) {
+        c.dispose();
+      }
+    });
+
+    test('preserves the controller order', () {
+      final controllers = List.generate(3, (_) => MnemonicInputFieldController());
+      controllers[0].text = 'one';
+      controllers[1].text = 'two';
+      controllers[2].text = 'three';
+
+      expect(controllers.seed, 'one two three');
+
+      for (final c in controllers) {
+        c.dispose();
+      }
+    });
+  });
+
+  group('$MnemonicInputFieldController.buildTextSpan', () {
+    // The bip39 wordlist contains "abandon" but not "xyz".
+    final ctx = _StubContext();
+
+    test('returns the base style for a word that is in the BIP39 list', () {
+      final c = MnemonicInputFieldController()..text = 'abandon';
+      const baseStyle = TextStyle(fontSize: 16);
+
+      final span = c.buildTextSpan(context: ctx, style: baseStyle, withComposing: false);
+
+      expect(span.text, 'abandon');
+      expect(span.style, baseStyle);
+      c.dispose();
+    });
+
+    test('merges in the red non-match style for an unknown word', () {
+      final c = MnemonicInputFieldController()..text = 'xyzzyabcd';
+      const baseStyle = TextStyle(fontSize: 16);
+
+      final span = c.buildTextSpan(context: ctx, style: baseStyle, withComposing: false);
+
+      // The merged style retains the base font size but adopts the red color.
+      expect(span.style!.fontSize, 16);
+      expect(span.style!.color, isNot(isNull));
+      c.dispose();
+    });
+  });
+}
+
+class _StubContext extends BuildContext {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
## Summary

Stage 44 of the coverage push. Pure-function tests for the seed-word string utilities and the BIP39 highlighting on the mnemonic input controller.

## Cases

| Target | Cases |
| --- | --- |
| \`SeedStringExtension.seedWords\` | 5 — splits on single spaces; collapses repeated whitespace + tabs; strips leading/trailing whitespace; treats newlines as whitespace; empty input returns empty list |
| \`MnemonicListExtension.seed\` | 2 — joins controller texts and trims each entry; preserves the controller order |
| \`MnemonicInputFieldController.buildTextSpan\` | 2 — base style for a word in the BIP39 list; merges in the red non-match style for an unknown word |

## What's pinned

- The seed-word split uses \`RegExp(r'\s+')\`, so any whitespace boundary (tab / newline / multiple spaces) counts — all four whitespace classes are exercised.
- \`MnemonicListExtension.seed\` trims each controller entry individually before joining, so accidental leading/trailing spaces (e.g. from a paste) don't bleed into the recovered phrase.
- \`buildTextSpan\` differentiates valid vs invalid BIP39 words via a style merge — a word that **is** in the wordlist returns the unmodified base style, anything else picks up the red status color. Pinned by both branches.

## Test plan

- [x] \`flutter test test/widgets/mnemonic_extensions_test.dart\` — 9 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green