### PR TITLE
test(dto): RealUnitSellPaymentInfoDto.fromJson (+3 tests)

### DIFF
--- a/test/packages/service/dfx/models/payment/sell_payment_info_dto_test.dart
+++ b/test/packages/service/dfx/models/payment/sell_payment_info_dto_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_payment_info_dto.dart';
+import 'package:realunit_wallet/styles/currency.dart';
+
+void main() {
+  Map<String, dynamic> eip7702Json() => {
+        'relayerAddress': '0xrelay',
+        'delegationManagerAddress': '0xmgr',
+        'delegatorAddress': '0xdr',
+        'userNonce': 7,
+        'domain': {
+          'name': 'RealUnit',
+          'version': '1',
+          'chainId': 1,
+          'verifyingContract': '0xverify',
+        },
+        'types': {
+          'Delegation': <Map<String, dynamic>>[],
+          'Caveat': <Map<String, dynamic>>[],
+        },
+        'message': {
+          'delegate': '0xd',
+          'delegator': '0xdr',
+          'authority': '0xauth',
+          'caveats': <Map<String, dynamic>>[],
+          'salt': 0,
+        },
+        'tokenAddress': '0xtoken',
+        'amountWei': '12345',
+        'depositAddress': '0xdeposit',
+      };
+
+  Map<String, dynamic> base() => {
+        'id': 1,
+        'routeId': 2,
+        'timestamp': '2026-05-15T10:00:00Z',
+        'eip7702': eip7702Json(),
+        'depositAddress': '0xdeposit',
+        'amount': 100.5,
+        'tokenAddress': '0xtoken',
+        'chainId': 1,
+        'fees': {
+          'rate': 0.01,
+          'fixed': 0.5,
+          'network': 0.0,
+          'min': 1.0,
+          'dfx': 0.25,
+          'total': 1.76,
+        },
+        'minVolume': 5.0,
+        'maxVolume': 5000.0,
+        'minVolumeTarget': 5.1,
+        'maxVolumeTarget': 5100.0,
+        'exchangeRate': 1.1,
+        'rate': 1.05,
+        'priceSteps': <Map<String, dynamic>>[],
+        'estimatedAmount': 95.5,
+        'currency': 'CHF',
+        'beneficiary': {'name': 'Alice', 'iban': 'CH...'},
+        'ethBalance': 0.1,
+        'requiredGasEth': 0.001,
+        'isValid': true,
+      };
+
+  group('$RealUnitSellPaymentInfoDto.fromJson', () {
+    test('parses the full happy-path wire shape', () {
+      final dto = RealUnitSellPaymentInfoDto.fromJson(base());
+
+      expect(dto.id, 1);
+      expect(dto.routeId, 2);
+      expect(dto.timestamp, DateTime.utc(2026, 5, 15, 10));
+      expect(dto.depositAddress, '0xdeposit');
+      expect(dto.amount, 100.5);
+      expect(dto.tokenAddress, '0xtoken');
+      expect(dto.chainId, 1);
+      expect(dto.fees.total, 1.76);
+      expect(dto.minVolume, 5.0);
+      expect(dto.maxVolume, 5000.0);
+      expect(dto.currency, Currency.chf);
+      expect(dto.beneficiary.name, 'Alice');
+      expect(dto.beneficiary.iban, 'CH...');
+      expect(dto.ethBalance, 0.1);
+      expect(dto.requiredGasEth, 0.001);
+      expect(dto.isValid, isTrue);
+    });
+
+    test('walks into the nested Eip7702Data DTO', () {
+      final dto = RealUnitSellPaymentInfoDto.fromJson(base());
+
+      // The recursive parse must walk all the way down — pin one leaf field
+      // from each level.
+      expect(dto.eip7702.relayerAddress, '0xrelay');
+      expect(dto.eip7702.domain.chainId, 1);
+      expect(dto.eip7702.message.delegate, '0xd');
+      expect(dto.eip7702.amountWei, '12345');
+    });
+
+    test('integer wire values for floating-point fields widen to double', () {
+      final json = base()
+        ..['amount'] = 100
+        ..['exchangeRate'] = 1
+        ..['rate'] = 1;
+
+      final dto = RealUnitSellPaymentInfoDto.fromJson(json);
+
+      expect(dto.amount, 100.0);
+      expect(dto.exchangeRate, 1.0);
+      expect(dto.rate, 1.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 49 of the coverage push. Final big sell-flow DTO that wasn't reachable from the payment_dtos aggregate file — it recursively pulls in \`Eip7702Data\` + \`DfxFeesData\` + \`BeneficiaryDto\` + \`PriceStep\`.

## Cases

| Target | Cases |
| --- | --- |
| \`RealUnitSellPaymentInfoDto.fromJson\` | 3 — full happy-path wire shape; nested \`Eip7702Data\` DTO walked all the way down (one leaf per level pinned); integer wire values for \`amount\` / \`exchangeRate\` / \`rate\` widen to double |

## What's pinned

- The recursive \`fromJson\` chain actually parses every nested DTO. One leaf field per level (\`relayerAddress\` → \`domain.chainId\` → \`message.delegate\` → \`amountWei\`) is pinned so a regression to "stops at top level" surfaces here.
- \`Currency.fromCode\` is the wire→Dart conversion; \`CHF\` round-trips correctly.
- Integer-typed JSON values widen to double for the floating-point fields — pins the contract used by partner APIs that sometimes serialize whole-number rates as \`int\`.

## Test plan

- [x] \`flutter test test/packages/service/dfx/models/payment/sell_payment_info_dto_test.dart\` — 3 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green