### PR TITLE
test(widgets): InfoRow (+3 tests)

### DIFF
--- a/test/widgets/info_row_test.dart
+++ b/test/widgets/info_row_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/widgets/info_row.dart';
+
+void main() {
+  group('$InfoRow', () {
+    testWidgets('renders the leading label with a trailing colon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: InfoRow(leading: 'IBAN', trailing: 'CH...'),
+          ),
+        ),
+      );
+
+      // The leading label gets a ":" appended.
+      expect(find.text('IBAN:'), findsOneWidget);
+      // The trailing value is rendered verbatim.
+      expect(find.text('CH...'), findsOneWidget);
+    });
+
+    testWidgets('default padding is 5 top + 5 bottom', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: InfoRow(leading: 'A', trailing: 'B'),
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding).first);
+      expect(
+        padding.padding,
+        const EdgeInsets.only(top: 5, bottom: 5),
+      );
+    });
+
+    testWidgets('custom padding overrides the default', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: InfoRow(
+              leading: 'A',
+              trailing: 'B',
+              padding: EdgeInsets.all(20),
+            ),
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding).first);
+      expect(padding.padding, const EdgeInsets.all(20));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 50 of the coverage push. Small widget test for the \`InfoRow\` label/value row used across receipts and detail screens.

## Cases

| Target | Cases |
| --- | --- |
| \`InfoRow\` | 3 — renders the leading label with a \`:\` appended and the trailing value verbatim; default padding is \`EdgeInsets.only(top: 5, bottom: 5)\`; custom padding overrides the default |

## What's pinned

- The trailing colon is a visual contract — pinned via \`find.text('IBAN:')\` rather than \`find.textContaining('IBAN')\`.
- Default vs override padding is the only configurable behaviour — both branches covered.

## Test plan

- [x] \`flutter test test/widgets/info_row_test.dart\` — 3 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green