### PR TITLE
test(widgets): ActionButton (+4 tests)

### DIFF
--- a/test/widgets/action_button_test.dart
+++ b/test/widgets/action_button_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/widgets/action_button.dart';
+
+void main() {
+  group('$ActionButton', () {
+    testWidgets('renders icon + label when not loading', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ActionButton(
+              icon: Icon(Icons.arrow_upward),
+              label: 'Send',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.arrow_upward), findsOneWidget);
+      expect(find.text('Send'), findsOneWidget);
+      expect(find.byType(CupertinoActivityIndicator), findsNothing);
+    });
+
+    testWidgets('renders the activity indicator and hides icon + label when isLoading=true',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ActionButton(
+              icon: Icon(Icons.arrow_upward),
+              label: 'Send',
+              isLoading: true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_upward), findsNothing);
+      expect(find.text('Send'), findsNothing);
+    });
+
+    testWidgets('tap fires onPressed when enabled', (tester) async {
+      var tapped = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ActionButton(
+              icon: const Icon(Icons.arrow_upward),
+              label: 'Send',
+              onPressed: () => tapped++,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(ActionButton));
+      await tester.pump();
+
+      expect(tapped, 1);
+    });
+
+    testWidgets('tap is disabled while loading', (tester) async {
+      var tapped = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ActionButton(
+              icon: const Icon(Icons.arrow_upward),
+              label: 'Send',
+              isLoading: true,
+              onPressed: () => tapped++,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(ActionButton));
+      await tester.pump();
+
+      // The InkWell receives onTap: null while loading, so the callback never
+      // fires — pinned via the counter staying at 0.
+      expect(tapped, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 51 of the coverage push. Widget tests for the round action button used on the dashboard (Buy / Sell / Receive).

## Cases

| Target | Cases |
| --- | --- |
| \`ActionButton\` | 4 — renders icon + label when not loading (no activity indicator); renders the \`CupertinoActivityIndicator\` and hides icon + label when \`isLoading=true\`; tap fires \`onPressed\` when enabled; tap is disabled while loading (\`InkWell.onTap\` becomes \`null\`) |

## What's pinned

- The loading state is **mutually exclusive** with the content: when \`isLoading=true\`, the icon and label are not present in the tree — pinned via \`findsNothing\`.
- Tap-while-loading uses \`InkWell\`'s \`null\` onTap rather than just ignoring the callback, so the ink ripple never appears either. Counter-based assertion pins the callback contract.

## Test plan

- [x] \`flutter test test/widgets/action_button_test.dart\` — 4 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green