### PR TITLE
test(widgets): TextSubstringHighlighting (+6 tests)

### DIFF
--- a/test/widgets/text_substring_highlighting_test.dart
+++ b/test/widgets/text_substring_highlighting_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/widgets/text_substring_highlighting.dart';
+
+void main() {
+  group('$TextSubstringHighlighting', () {
+    testWidgets('returns a plain Text when the substring is not found', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: TextSubstringHighlighting(
+              text: 'plain text',
+              highlightedText: 'missing',
+            ),
+          ),
+        ),
+      );
+
+      // Fallback path: a Text widget (which internally renders a RichText
+      // with a single non-children TextSpan), not a directly-built RichText.
+      expect(find.byType(Text), findsOneWidget);
+      expect(find.text('plain text'), findsOneWidget);
+
+      // The internal RichText has a TextSpan with no children list — that's
+      // the marker for the fallback vs the highlighted branch.
+      final rich = tester.widget<RichText>(find.byType(RichText));
+      expect((rich.text as TextSpan).children, isNull);
+    });
+
+    testWidgets('returns a RichText with three spans when the substring is found',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: TextSubstringHighlighting(
+              text: 'I accept the Terms here',
+              highlightedText: 'Terms',
+            ),
+          ),
+        ),
+      );
+
+      final rich = tester.widget<RichText>(find.byType(RichText));
+      final root = rich.text as TextSpan;
+      final children = root.children!;
+
+      expect(children, hasLength(3));
+      expect((children[0] as TextSpan).text, 'I accept the ');
+      expect((children[1] as TextSpan).text, 'Terms');
+      expect((children[2] as TextSpan).text, ' here');
+    });
+
+    testWidgets('highlighted span inherits bold when no highlightedStyle is given',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: TextSubstringHighlighting(
+              text: 'I accept the Terms here',
+              highlightedText: 'Terms',
+              style: TextStyle(fontSize: 14),
+            ),
+          ),
+        ),
+      );
+
+      final rich = tester.widget<RichText>(find.byType(RichText));
+      final highlightedSpan = (rich.text as TextSpan).children![1] as TextSpan;
+
+      // Default highlightedStyle is base.copyWith(fontWeight: .bold).
+      expect(highlightedSpan.style!.fontWeight, FontWeight.bold);
+      // The base font size is preserved via copyWith.
+      expect(highlightedSpan.style!.fontSize, 14);
+    });
+
+    testWidgets('a custom highlightedStyle replaces the default bold', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: TextSubstringHighlighting(
+              text: 'I accept the Terms here',
+              highlightedText: 'Terms',
+              highlightedStyle: TextStyle(color: Colors.red),
+            ),
+          ),
+        ),
+      );
+
+      final rich = tester.widget<RichText>(find.byType(RichText));
+      final highlightedSpan = (rich.text as TextSpan).children![1] as TextSpan;
+
+      expect(highlightedSpan.style!.color, Colors.red);
+      // The custom style does NOT inherit the default bold weight.
+      expect(highlightedSpan.style!.fontWeight, isNull);
+    });
+
+    testWidgets('attaches a tap recognizer when onHighlightedTap is given',
+        (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TextSubstringHighlighting(
+              text: 'I accept the Terms here',
+              highlightedText: 'Terms',
+              onHighlightedTap: () => taps++,
+            ),
+          ),
+        ),
+      );
+
+      final rich = tester.widget<RichText>(find.byType(RichText));
+      final highlightedSpan = (rich.text as TextSpan).children![1] as TextSpan;
+
+      expect(highlightedSpan.recognizer, isA<TapGestureRecognizer>());
+      // Fire the recognizer manually since hit-testing a TextSpan in a widget
+      // test is fiddly — the gestureRecognizer itself is what would receive
+      // the gesture in production.
+      (highlightedSpan.recognizer as TapGestureRecognizer).onTap!();
+      expect(taps, 1);
+    });
+
+    testWidgets('omits the tap recognizer when no callback is provided',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: TextSubstringHighlighting(
+              text: 'I accept the Terms here',
+              highlightedText: 'Terms',
+            ),
+          ),
+        ),
+      );
+
+      final rich = tester.widget<RichText>(find.byType(RichText));
+      final highlightedSpan = (rich.text as TextSpan).children![1] as TextSpan;
+
+      expect(highlightedSpan.recognizer, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 52 of the coverage push. Widget tests for the highlight-substring helper used by legal copy and toast snippets.

## Cases

| Target | Cases |
| --- | --- |
| \`TextSubstringHighlighting\` | 6 — substring-not-found fallback (plain \`Text\`, internal \`TextSpan.children\` is null); substring-found splits into three spans (before / match / after); default \`highlightedStyle\` is \`base.copyWith(fontWeight: bold)\`; custom \`highlightedStyle\` replaces the default bold entirely; \`onHighlightedTap\` attaches a \`TapGestureRecognizer\` and firing it triggers the callback; null callback → recognizer is null |

## What's pinned

- The fallback vs highlight branch is observable from the rendered tree: the fallback wraps a plain \`Text\` (internal \`RichText.text.children == null\`), the highlight branch builds a \`RichText\` directly with three children. Pin both.
- The default highlighting style preserves the base font size (\`copyWith\`) — refactoring the default to a fresh \`TextStyle()\` would break callers that rely on font-size inheritance.
- The tap recognizer is **optional**: when \`onHighlightedTap\` is null, no recognizer is attached so the span doesn't intercept touches.

## Test plan

- [x] \`flutter test test/widgets/text_substring_highlighting_test.dart\` — 6 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green