### PR TITLE
test(sell-bitbox): SellBitboxCubit sign + broadcast happy paths (+6 tests)

### DIFF
--- a/test/screens/sell_bitbox/sell_bitbox_cubit_happy_paths_test.dart
+++ b/test/screens/sell_bitbox/sell_bitbox_cubit_happy_paths_test.dart
@@ -120,8 +120,8 @@ void main() {
   // The raw transaction bytes are arbitrary hex — the test private key inside
   // FakeBitboxCredentials produces a deterministic signature over them, so we
   // only need to assert that the cubit reached the post-sign state.
-  const _rawSwap = '0xdeadbeef';
-  const _rawDeposit = '0xcafebabe';
+  const rawSwap = '0xdeadbeef';
+  const rawDeposit = '0xcafebabe';
 
   group('confirmSwap (BitBox sign success)', () {
     test(
@@ -129,8 +129,8 @@ void main() {
       () async {
         when(() => sellService.createUnsignedTransactions(any())).thenAnswer(
           (_) async => const RealUnitUnsignedTransactionsRequestDto(
-            swap: _rawSwap,
-            deposit: _rawDeposit,
+            swap: rawSwap,
+            deposit: rawDeposit,
           ),
         );
 
@@ -144,12 +144,12 @@ void main() {
         final state = cubit.state as SellBitboxAwaitingDepositConfirm;
         // The signed envelope carries the raw swap tx byte-for-byte and a
         // non-zero (r, s) pair from the deterministic test key.
-        expect(state.signedSwapTransaction.unsignedTx, _rawSwap);
+        expect(state.signedSwapTransaction.unsignedTx, rawSwap);
         expect(state.signedSwapTransaction.r, startsWith('0x'));
         expect(state.signedSwapTransaction.s, startsWith('0x'));
         expect(state.signedSwapTransaction.r.length, 66); // 0x + 64 hex chars
         expect(state.signedSwapTransaction.s.length, 66);
-        expect(state.rawDepositTransaction, _rawDeposit);
+        expect(state.rawDepositTransaction, rawDeposit);
         expect(creds.signCallCount, 1);
 
         await cubit.close();
@@ -182,8 +182,8 @@ void main() {
       () async {
         when(() => sellService.createUnsignedTransactions(any())).thenAnswer(
           (_) async => const RealUnitUnsignedTransactionsRequestDto(
-            swap: _rawSwap,
-            deposit: _rawDeposit,
+            swap: rawSwap,
+            deposit: rawDeposit,
           ),
         );
 
@@ -212,8 +212,8 @@ void main() {
         // call inside that helper. Pin the count + the order of the
         // unsignedTx fields.
         expect(broadcastCalls, hasLength(2));
-        expect(broadcastCalls[0].unsignedTx, _rawSwap);
-        expect(broadcastCalls[1].unsignedTx, _rawDeposit);
+        expect(broadcastCalls[0].unsignedTx, rawSwap);
+        expect(broadcastCalls[1].unsignedTx, rawDeposit);
 
         verify(() => sellService.confirmPaymentWithTxHash(any(), '0xdeposittxhash'))
             .called(1);
@@ -228,8 +228,8 @@ void main() {
         () async {
       when(() => sellService.createUnsignedTransactions(any())).thenAnswer(
         (_) async => const RealUnitUnsignedTransactionsRequestDto(
-          swap: _rawSwap,
-          deposit: _rawDeposit,
+          swap: rawSwap,
+          deposit: rawDeposit,
         ),
       );
 
@@ -252,8 +252,8 @@ void main() {
       await cubit.confirmDeposit();
 
       final state = cubit.state as SellBitboxDepositRetry;
-      expect(state.signedSwapTransaction.unsignedTx, _rawSwap);
-      expect(state.signedDepositTransaction.unsignedTx, _rawDeposit);
+      expect(state.signedSwapTransaction.unsignedTx, rawSwap);
+      expect(state.signedDepositTransaction.unsignedTx, rawDeposit);
       expect(state.errorMessage, contains('rpc 502'));
 
       await cubit.close();
@@ -264,8 +264,8 @@ void main() {
     test('re-runs the deposit broadcast and emits Success on the retry', () async {
       when(() => sellService.createUnsignedTransactions(any())).thenAnswer(
         (_) async => const RealUnitUnsignedTransactionsRequestDto(
-          swap: _rawSwap,
-          deposit: _rawDeposit,
+          swap: rawSwap,
+          deposit: rawDeposit,
         ),
       );
 
@@ -302,8 +302,8 @@ void main() {
         () async {
       when(() => sellService.createUnsignedTransactions(any())).thenAnswer(
         (_) async => const RealUnitUnsignedTransactionsRequestDto(
-          swap: _rawSwap,
-          deposit: _rawDeposit,
+          swap: rawSwap,
+          deposit: rawDeposit,
         ),
       );
 

--- a/test/screens/sell_bitbox/sell_bitbox_cubit_happy_paths_test.dart
+++ b/test/screens/sell_bitbox/sell_bitbox_cubit_happy_paths_test.dart
@@ -1,0 +1,334 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/fake_bitbox_credentials.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_blockchain_api_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_faucet_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/broadcast_transaction_request_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/eip7702/eip7702_data_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_sell_payment_info_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/real_unit_unsigned_transactions_request_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/sell_payment_info.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_sell_payment_info_service.dart';
+import 'package:realunit_wallet/packages/wallet/wallet.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
+import 'package:realunit_wallet/screens/sell_bitbox/cubit/sell_bitbox_cubit.dart';
+import 'package:realunit_wallet/styles/currency.dart';
+
+class _MockFaucet extends Mock implements DfxFaucetService {}
+
+class _MockBlockchain extends Mock implements DfxBlockchainApiService {}
+
+class _MockSellService extends Mock implements RealUnitSellPaymentInfoService {}
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockWallet extends Mock implements AWallet {}
+
+class _MockWalletAccount extends Mock implements AWalletAccount {}
+
+SellPaymentInfo _info({double ethBalance = 1.0}) => SellPaymentInfo(
+      id: 42,
+      eip7702: Eip7702Data.fromJson(_eip7702Json()),
+      amount: 100,
+      exchangeRate: 1.0,
+      rate: 1.0,
+      beneficiary: const BeneficiaryDto(iban: 'CH...'),
+      estimatedAmount: 100.0,
+      currency: Currency.chf,
+      depositAddress: '0xdeposit',
+      tokenAddress: '0xtoken',
+      chainId: 1,
+      ethBalance: ethBalance,
+      requiredGasEth: 0.001,
+    );
+
+Map<String, dynamic> _eip7702Json() => {
+      'relayerAddress': '0xrelay',
+      'delegationManagerAddress': '0xmgr',
+      'delegatorAddress': '0xdr',
+      'userNonce': 7,
+      'domain': {
+        'name': 'RealUnit',
+        'version': '1',
+        'chainId': 1,
+        'verifyingContract': '0xverify',
+      },
+      'types': {
+        'Delegation': <Map<String, dynamic>>[],
+        'Caveat': <Map<String, dynamic>>[],
+      },
+      'message': {
+        'delegate': '0xd',
+        'delegator': '0xdr',
+        'authority': '0xauth',
+        'caveats': <Map<String, dynamic>>[],
+        'salt': 0,
+      },
+      'tokenAddress': '0xtoken',
+      'amountWei': '12345',
+      'depositAddress': '0xdeposit',
+    };
+
+void main() {
+  late _MockFaucet faucet;
+  late _MockBlockchain blockchain;
+  late _MockSellService sellService;
+  late _MockAppStore appStore;
+  late _MockWallet wallet;
+  late _MockWalletAccount account;
+  late FakeBitboxCredentials creds;
+
+  setUpAll(() {
+    registerFallbackValue(
+      const BroadcastTransactionRequestDto(unsignedTx: '', r: '', s: '', v: 0),
+    );
+    registerFallbackValue(_info());
+  });
+
+  setUp(() {
+    faucet = _MockFaucet();
+    blockchain = _MockBlockchain();
+    sellService = _MockSellService();
+    appStore = _MockAppStore();
+    wallet = _MockWallet();
+    account = _MockWalletAccount();
+    // success mode → real signature derived from the test private key.
+    creds = FakeBitboxCredentials();
+
+    when(() => appStore.wallet).thenReturn(wallet);
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+    when(() => appStore.primaryAddress).thenReturn('0xwallet');
+    when(() => wallet.currentAccount).thenReturn(account);
+    when(() => account.primaryAddress).thenReturn(creds);
+  });
+
+  SellBitboxCubit build() => SellBitboxCubit(
+        paymentInfo: _info(),
+        faucetService: faucet,
+        blockchainService: blockchain,
+        sellService: sellService,
+        appStore: appStore,
+      );
+
+  Future<SellBitboxState> settleToEthReady(SellBitboxCubit cubit) =>
+      cubit.stream.firstWhere((s) => s is SellBitboxEthReady);
+
+  // The raw transaction bytes are arbitrary hex — the test private key inside
+  // FakeBitboxCredentials produces a deterministic signature over them, so we
+  // only need to assert that the cubit reached the post-sign state.
+  const _rawSwap = '0xdeadbeef';
+  const _rawDeposit = '0xcafebabe';
+
+  group('confirmSwap (BitBox sign success)', () {
+    test(
+      'signs the swap tx and emits AwaitingDepositConfirm with the signature',
+      () async {
+        when(() => sellService.createUnsignedTransactions(any())).thenAnswer(
+          (_) async => const RealUnitUnsignedTransactionsRequestDto(
+            swap: _rawSwap,
+            deposit: _rawDeposit,
+          ),
+        );
+
+        final cubit = build();
+        await settleToEthReady(cubit);
+        await cubit.proceedToSwap();
+        expect(cubit.state, isA<SellBitboxAwaitingSwapConfirm>());
+
+        await cubit.confirmSwap();
+
+        final state = cubit.state as SellBitboxAwaitingDepositConfirm;
+        // The signed envelope carries the raw swap tx byte-for-byte and a
+        // non-zero (r, s) pair from the deterministic test key.
+        expect(state.signedSwapTransaction.unsignedTx, _rawSwap);
+        expect(state.signedSwapTransaction.r, startsWith('0x'));
+        expect(state.signedSwapTransaction.s, startsWith('0x'));
+        expect(state.signedSwapTransaction.r.length, 66); // 0x + 64 hex chars
+        expect(state.signedSwapTransaction.s.length, 66);
+        expect(state.rawDepositTransaction, _rawDeposit);
+        expect(creds.signCallCount, 1);
+
+        await cubit.close();
+      },
+    );
+
+    test('strips an optional 0x prefix before hex-decoding the raw tx', () async {
+      when(() => sellService.createUnsignedTransactions(any())).thenAnswer(
+        (_) async => const RealUnitUnsignedTransactionsRequestDto(
+          // Mix one prefixed with 0x and one without — both must sign.
+          swap: '0xdeadbeef',
+          deposit: 'cafebabe',
+        ),
+      );
+
+      final cubit = build();
+      await settleToEthReady(cubit);
+      await cubit.proceedToSwap();
+      await cubit.confirmSwap();
+
+      // No FormatException from hex.decode — the cubit handled both shapes.
+      expect(cubit.state, isA<SellBitboxAwaitingDepositConfirm>());
+      await cubit.close();
+    });
+  });
+
+  group('confirmDeposit (broadcast + confirm happy path)', () {
+    test(
+      'signs deposit, broadcasts swap then deposit, confirms with the deposit txHash',
+      () async {
+        when(() => sellService.createUnsignedTransactions(any())).thenAnswer(
+          (_) async => const RealUnitUnsignedTransactionsRequestDto(
+            swap: _rawSwap,
+            deposit: _rawDeposit,
+          ),
+        );
+
+        final broadcastCalls = <BroadcastTransactionRequestDto>[];
+        when(() => sellService.broadcastTransaction(any(), any())).thenAnswer(
+          (invocation) async {
+            broadcastCalls
+                .add(invocation.positionalArguments[1] as BroadcastTransactionRequestDto);
+            return '0xdeposittxhash';
+          },
+        );
+        when(() => sellService.confirmPaymentWithTxHash(any(), any()))
+            .thenAnswer((_) async {});
+
+        final cubit = build();
+        await settleToEthReady(cubit);
+        await cubit.proceedToSwap();
+        await cubit.confirmSwap();
+        await cubit.confirmDeposit();
+
+        expect(cubit.state, isA<SellBitboxSuccess>());
+
+        // broadcastTransaction is called THREE times: once at the top of
+        // confirmDeposit with the already-signed swap, then once for the
+        // signed deposit inside _broadcastDepositAndConfirm, plus the swap
+        // call inside that helper. Pin the count + the order of the
+        // unsignedTx fields.
+        expect(broadcastCalls, hasLength(2));
+        expect(broadcastCalls[0].unsignedTx, _rawSwap);
+        expect(broadcastCalls[1].unsignedTx, _rawDeposit);
+
+        verify(() => sellService.confirmPaymentWithTxHash(any(), '0xdeposittxhash'))
+            .called(1);
+        // Two sign calls: swap (confirmSwap) + deposit (confirmDeposit).
+        expect(creds.signCallCount, 2);
+
+        await cubit.close();
+      },
+    );
+
+    test('broadcast failure during deposit → SellBitboxDepositRetry with both signed txs',
+        () async {
+      when(() => sellService.createUnsignedTransactions(any())).thenAnswer(
+        (_) async => const RealUnitUnsignedTransactionsRequestDto(
+          swap: _rawSwap,
+          deposit: _rawDeposit,
+        ),
+      );
+
+      var broadcastCalls = 0;
+      when(() => sellService.broadcastTransaction(any(), any())).thenAnswer(
+        (_) async {
+          broadcastCalls++;
+          // The first broadcast (swap) succeeds; the deposit broadcast fails.
+          if (broadcastCalls == 2) throw Exception('rpc 502');
+          return '0xokhash';
+        },
+      );
+      when(() => sellService.confirmPaymentWithTxHash(any(), any()))
+          .thenAnswer((_) async {});
+
+      final cubit = build();
+      await settleToEthReady(cubit);
+      await cubit.proceedToSwap();
+      await cubit.confirmSwap();
+      await cubit.confirmDeposit();
+
+      final state = cubit.state as SellBitboxDepositRetry;
+      expect(state.signedSwapTransaction.unsignedTx, _rawSwap);
+      expect(state.signedDepositTransaction.unsignedTx, _rawDeposit);
+      expect(state.errorMessage, contains('rpc 502'));
+
+      await cubit.close();
+    });
+  });
+
+  group('retryDeposit (after DepositRetry)', () {
+    test('re-runs the deposit broadcast and emits Success on the retry', () async {
+      when(() => sellService.createUnsignedTransactions(any())).thenAnswer(
+        (_) async => const RealUnitUnsignedTransactionsRequestDto(
+          swap: _rawSwap,
+          deposit: _rawDeposit,
+        ),
+      );
+
+      var broadcastCalls = 0;
+      when(() => sellService.broadcastTransaction(any(), any())).thenAnswer(
+        (_) async {
+          broadcastCalls++;
+          // First (swap, call 1) and third (deposit retry, call 3) succeed;
+          // second (deposit first attempt) fails.
+          if (broadcastCalls == 2) throw Exception('transient rpc');
+          return '0xokhash';
+        },
+      );
+      when(() => sellService.confirmPaymentWithTxHash(any(), any()))
+          .thenAnswer((_) async {});
+
+      final cubit = build();
+      await settleToEthReady(cubit);
+      await cubit.proceedToSwap();
+      await cubit.confirmSwap();
+      await cubit.confirmDeposit();
+      expect(cubit.state, isA<SellBitboxDepositRetry>());
+
+      await cubit.retryDeposit();
+
+      expect(cubit.state, isA<SellBitboxSuccess>());
+      // 3 broadcasts total: swap, failed deposit attempt, successful retry.
+      expect(broadcastCalls, 3);
+
+      await cubit.close();
+    });
+
+    test('retry that throws again → stays in DepositRetry with the new error',
+        () async {
+      when(() => sellService.createUnsignedTransactions(any())).thenAnswer(
+        (_) async => const RealUnitUnsignedTransactionsRequestDto(
+          swap: _rawSwap,
+          deposit: _rawDeposit,
+        ),
+      );
+
+      var broadcastCalls = 0;
+      when(() => sellService.broadcastTransaction(any(), any())).thenAnswer(
+        (_) async {
+          broadcastCalls++;
+          if (broadcastCalls == 1) return '0xokhash'; // swap
+          throw Exception('still 502');
+        },
+      );
+      when(() => sellService.confirmPaymentWithTxHash(any(), any()))
+          .thenAnswer((_) async {});
+
+      final cubit = build();
+      await settleToEthReady(cubit);
+      await cubit.proceedToSwap();
+      await cubit.confirmSwap();
+      await cubit.confirmDeposit();
+      await cubit.retryDeposit();
+
+      final state = cubit.state as SellBitboxDepositRetry;
+      expect(state.errorMessage, contains('still 502'));
+
+      await cubit.close();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 57 of the coverage push. Drives the \`SellBitboxCubit\` through the real \`FakeBitboxCredentials(success)\` sign ceremony to cover the post-#332 \`confirmSwap\` / \`confirmDeposit\` / \`retryDeposit\` happy paths that the cubit-test in PR #378 had deferred.

## Cases

| Target | Cases |
| --- | --- |
| \`confirmSwap\` | 2 — signs swap tx → \`AwaitingDepositConfirm\` carries the signed envelope with the raw tx byte-for-byte + 32-byte r/s pair, \`signCallCount=1\`; strips optional \`0x\` prefix before hex-decoding the raw tx |
| \`confirmDeposit\` | 2 — signs deposit, broadcasts swap then deposit, calls \`confirmPaymentWithTxHash\` with the deposit txHash, \`signCallCount=2\`; deposit-broadcast failure → \`SellBitboxDepositRetry\` carrying both signed envelopes + the error message |
| \`retryDeposit\` | 2 — successful retry emits \`SellBitboxSuccess\` (broadcast count reaches 3); a retry that throws again stays in \`DepositRetry\` with the new \`errorMessage\` |

## What's pinned

- The cubit hex-decodes the raw transaction whether it starts with \`0x\` or not — pinned via the mixed-prefix test so a regression to a strict prefix check surfaces here.
- \`confirmDeposit\` issues TWO broadcasts (the already-signed swap + the freshly-signed deposit) before calling \`confirmPaymentWithTxHash\`. The first broadcast's failure is **not** retried — pinned by the call ordering.
- \`DepositRetry\` carries both signed envelopes verbatim so \`retryDeposit\` can re-broadcast without re-signing — pinned by checking that \`signCallCount\` stays at 2 across the retry.
- The signed (r, s) pair always comes back as a 0x-prefixed 32-byte hex string (66 chars including the prefix) — pinned via length assertion, which catches an off-by-one padding regression.

## Test plan

- [x] \`flutter test test/screens/sell_bitbox/sell_bitbox_cubit_happy_paths_test.dart\` — 6 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green