### PR TITLE
test(registration-service): completeRegistration + registerWallet happy paths (+2 tests)

### DIFF
--- a/test/packages/service/dfx/real_unit_registration_service_happy_test.dart
+++ b/test/packages/service/dfx/real_unit_registration_service_happy_test.dart
@@ -1,0 +1,178 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/country/country.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/registration/kyc/kyc_personal_data.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/registration/registration.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/registration/registration_status.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/registration/registration_user_type.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/user/dto/real_unit_user_data_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/wallet/wallet.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
+import 'package:web3dart/web3dart.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockWallet extends Mock implements AWallet {}
+
+class _MockAccount extends Mock implements AWalletAccount {}
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+const _testPrivateKeyHex =
+    'fb1ace12f9801e85f3db1b3935dd47d9f064f98152466f47c701b5e12680e612';
+
+final _privKey = EthPrivateKey.fromHex(_testPrivateKeyHex);
+
+void main() {
+  late _MockAppStore appStore;
+  late _MockWallet wallet;
+  late _MockAccount account;
+  late SessionCache session;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    wallet = _MockWallet();
+    account = _MockAccount();
+    session = SessionCache(_MockCacheRepository());
+    session.setAuthToken('jwt-1');
+
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+    when(() => appStore.sessionCache).thenReturn(session);
+    when(() => appStore.wallet).thenReturn(wallet);
+    when(() => wallet.primaryAccount).thenReturn(account);
+    when(() => account.primaryAddress).thenReturn(_privKey);
+  });
+
+  RealUnitRegistrationService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return RealUnitRegistrationService(appStore);
+  }
+
+  Registration buildRegistration() => const Registration(
+        type: RegistrationUserType.human,
+        email: 'AdA@ExAmPlE.COM',
+        // Diacritics → must be ASCII-transliterated (ä→ae, ü→ue) for the
+        // BitBox-safe wire envelope; the test asserts the transliteration
+        // round-trip below.
+        firstName: 'Adä',
+        lastName: 'Loveläce',
+        phoneNumber: '+41 79 000 00 00',
+        birthday: '1815-12-10',
+        nationality: Country(id: 41, symbol: 'CH', name: 'Switzerland'),
+        addressStreet: 'Bahnhofstraße',
+        addressStreetNumber: '1',
+        addressPostalCode: '8000',
+        addressCity: 'Zürich',
+        addressCountry: Country(id: 41, symbol: 'CH', name: 'Switzerland'),
+        swissTaxResidence: true,
+      );
+
+  RealUnitUserDataDto buildUserData() => const RealUnitUserDataDto(
+        email: 'a@b.com',
+        name: 'Ada Lovelace',
+        type: 'HUMAN',
+        phoneNumber: '+41 79 000 00 00',
+        birthday: '1815-12-10',
+        nationality: 'CH',
+        addressStreet: 'Bahnhofstrasse 1',
+        addressPostalCode: '8000',
+        addressCity: 'Zurich',
+        addressCountry: 'CH',
+        swissTaxResidence: true,
+        lang: 'de',
+        kycData: KycPersonalData(
+          accountType: KycAccountType.personal,
+          firstName: 'Ada',
+          lastName: 'Lovelace',
+          phone: '+41 79 000 00 00',
+          address: KycAddress(
+            street: 'Bahnhofstrasse',
+            zip: '8000',
+            city: 'Zurich',
+            country: 41,
+          ),
+        ),
+      );
+
+  group('completeRegistration happy path', () {
+    test(
+      'POSTs to /v1/realunit/register/complete with the ASCII-transliterated '
+      'envelope, the EIP-712 signature, and the original KYC personal data',
+      () async {
+        Uri? sentUri;
+        Map<String, dynamic>? body;
+        Map<String, String>? headers;
+        final client = MockClient((request) async {
+          sentUri = request.url;
+          body = jsonDecode(request.body) as Map<String, dynamic>;
+          headers = request.headers;
+          return http.Response(jsonEncode({'status': 'completed'}), 201);
+        });
+
+        final status = await build(client).completeRegistration(buildRegistration());
+
+        expect(status, RegistrationStatus.completed);
+        expect(sentUri!.path, '/v1/realunit/register/complete');
+        expect(headers!['authorization'], 'Bearer jwt-1');
+
+        // Signed envelope copy — must be ASCII-transliterated to match what
+        // BitBox firmware would have signed.
+        expect(body!['email'], 'ada@example.com'); // lowercased + ASCII
+        // ä → ae per German transliteration convention.
+        expect(body!['name'], 'Adae Lovelaece');
+        expect(body!['addressStreet'], 'Bahnhofstrasse 1');
+        // ü → ue, so Zürich → Zuerich.
+        expect(body!['addressCity'], 'Zuerich');
+
+        // KYC personal data keeps the original spelling so the ID
+        // verification provider sees the legal name.
+        final kyc = body!['kycData'] as Map<String, dynamic>;
+        expect(kyc['firstName'], 'Adä');
+        expect(kyc['lastName'], 'Loveläce');
+        final address = kyc['address'] as Map<String, dynamic>;
+        expect(address['street'], 'Bahnhofstraße');
+        expect(address['city'], 'Zürich');
+
+        // EIP-712 signature: 65 bytes → 0x + 130 hex chars.
+        expect((body!['signature'] as String).length, 132);
+        expect(body!['lang'], 'DE');
+        expect(body!['type'], 'HUMAN');
+      },
+    );
+  });
+
+  group('registerWallet happy path', () {
+    test(
+      'POSTs to /v1/realunit/register/wallet with walletAddress + signature + registrationDate',
+      () async {
+        Uri? sentUri;
+        Map<String, dynamic>? body;
+        final client = MockClient((request) async {
+          sentUri = request.url;
+          body = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(jsonEncode({'status': 'completed'}), 201);
+        });
+
+        final status = await build(client).registerWallet(buildUserData());
+
+        expect(status, RegistrationStatus.completed);
+        expect(sentUri!.path, '/v1/realunit/register/wallet');
+        expect(body!['walletAddress'], _privKey.address.hexEip55);
+        expect((body!['signature'] as String).length, 132);
+        // YYYY-MM-DD shape, length 10.
+        expect((body!['registrationDate'] as String).length, 10);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Stage 60 of the coverage push. Drives the two BitBox-aware registration endpoints with a real \`EthPrivateKey\` credential so the EIP-712 signing chain + ASCII transliteration are exercised end-to-end (Stage 55 only covered the BitBox-disconnected guard).

## Cases

| Endpoint | What's pinned |
| --- | --- |
| \`completeRegistration\` | POST to \`/v1/realunit/register/complete\`; envelope is ASCII-transliterated (\`Adä → Adae\`, \`Zürich → Zuerich\`, email lowercased); 65-byte EIP-712 signature; \`kycData\` keeps the ORIGINAL diacritics (\`Adä\`, \`Loveläce\`, \`Zürich\`, \`Bahnhofstraße\`) so ID-verification sees the legal name |
| \`registerWallet\` | POST to \`/v1/realunit/register/wallet\` with \`walletAddress\` in EIP-55 form, a 65-byte signature, and a YYYY-MM-DD \`registrationDate\` |

## What's pinned

- The **split treatment** of personal data is the load-bearing invariant: the SIGNED envelope copy is ASCII-transliterated (because BitBox firmware rejects non-ASCII), but \`kycData\` keeps the original diacritics so the ID-verification provider sees the legal name. Pinned by asserting both halves of the body.
- Email gets \`toLowerCase()\` + \`toBitboxSafeAscii()\` — \`AdA@ExAmPlE.COM\` → \`ada@example.com\`.
- Signature length pin (132 chars including \`0x\`) catches a regression that drops the trailing \`v\` byte.

## Test plan

- [x] \`flutter test test/packages/service/dfx/real_unit_registration_service_happy_test.dart\` — 2 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green