### PR TITLE
test(widgets): PaymentActionRequired (+2 tests)

### DIFF
--- a/test/screens/buy/widgets/payment_action_required_test.dart
+++ b/test/screens/buy/widgets/payment_action_required_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/screens/buy/widgets/payment_action_required.dart';
+import 'package:realunit_wallet/styles/colors.dart';
+
+void main() {
+  group('$PaymentActionRequired', () {
+    testWidgets('renders title + description + info icon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PaymentActionRequired(
+              title: 'KYC required',
+              description: 'Please complete identity verification.',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('KYC required'), findsOneWidget);
+      expect(find.text('Please complete identity verification.'), findsOneWidget);
+      expect(find.byIcon(Icons.info), findsOneWidget);
+    });
+
+    testWidgets('icon carries the RealUnit blue brand color', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PaymentActionRequired(
+              title: 't',
+              description: 'd',
+            ),
+          ),
+        ),
+      );
+
+      final icon = tester.widget<Icon>(find.byIcon(Icons.info));
+      expect(icon.color, RealUnitColors.realUnitBlue);
+      expect(icon.size, 24);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 62 of the coverage push. Pure-visual contract test for the KYC/registration prompt rendered in the buy flow.

## Cases

| Target | Cases |
| --- | --- |
| \`PaymentActionRequired\` | 2 — renders title + description + \`Icons.info\`; icon carries \`RealUnitColors.realUnitBlue\` at 24px |

## What's pinned

- The brand color + icon size is the only behaviour the widget owns — everything else is layout. Pin those to keep the prompt visually consistent across the buy flow.

## Test plan

- [x] \`flutter test test/screens/buy/widgets/payment_action_required_test.dart\` — 2 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green