### PR TITLE
test(widgets): AppTextButton + AppFilledButton (+10 tests)

### DIFF
--- a/test/widgets/buttons/app_buttons_test.dart
+++ b/test/widgets/buttons/app_buttons_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
+import 'package:realunit_wallet/widgets/buttons/app_text_button.dart';
+
+Widget _host(Widget child) => MaterialApp(
+      home: Scaffold(body: Center(child: child)),
+    );
+
+void main() {
+  group('$AppTextButton', () {
+    testWidgets('renders the label and triggers onPressed', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_host(
+        AppTextButton(label: 'Cancel', onPressed: () => taps++),
+      ));
+
+      expect(find.text('Cancel'), findsOneWidget);
+      await tester.tap(find.byType(AppTextButton));
+      await tester.pump();
+      expect(taps, 1);
+    });
+
+    testWidgets('icon-less variant uses plain TextButton (no Icon in tree)',
+        (tester) async {
+      await tester.pumpWidget(_host(const AppTextButton(label: 'X')));
+
+      expect(find.byType(TextButton), findsOneWidget);
+      expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets('icon variant renders an Icon next to the label', (tester) async {
+      await tester.pumpWidget(_host(
+        const AppTextButton(label: 'Add', icon: Icons.add),
+      ));
+
+      expect(find.byIcon(Icons.add), findsOneWidget);
+      expect(find.text('Add'), findsOneWidget);
+    });
+
+    testWidgets('fullWidth: true wraps the button in a SizedBox(width=∞)',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        const AppTextButton(label: 'Wide'),
+      ));
+
+      // Find a SizedBox ancestor that wraps the button with infinite width.
+      final sizedBoxes = tester.widgetList<SizedBox>(find.byType(SizedBox)).toList();
+      final hasInfiniteWidth = sizedBoxes.any((s) => s.width == double.infinity);
+      expect(hasInfiniteWidth, isTrue);
+    });
+
+    testWidgets('fullWidth: false does NOT wrap in an infinite-width SizedBox',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        const AppTextButton(label: 'Narrow', fullWidth: false),
+      ));
+
+      final sizedBoxes = tester.widgetList<SizedBox>(find.byType(SizedBox)).toList();
+      final hasInfiniteWidth = sizedBoxes.any((s) => s.width == double.infinity);
+      expect(hasInfiniteWidth, isFalse);
+    });
+  });
+
+  group('$AppFilledButton (FilledButtonState)', () {
+    testWidgets('idle: tap fires onPressed', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_host(
+        AppFilledButton(label: 'Go', onPressed: () => taps++),
+      ));
+
+      await tester.tap(find.byType(AppFilledButton));
+      await tester.pump();
+      expect(taps, 1);
+    });
+
+    testWidgets('loading: shows CupertinoActivityIndicator, disables onPressed',
+        (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_host(
+        AppFilledButton(
+          label: 'Submitting',
+          state: FilledButtonState.loading,
+          onPressed: () => taps++,
+        ),
+      ));
+
+      expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+      await tester.tap(find.byType(AppFilledButton));
+      await tester.pump();
+      // _loadingButton hardcodes onPressed: null, so the callback is ignored.
+      expect(taps, 0);
+    });
+
+    testWidgets('success: button is non-tappable (onPressed: null)', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_host(
+        AppFilledButton(
+          label: 'Done',
+          state: FilledButtonState.success,
+          onPressed: () => taps++,
+        ),
+      ));
+
+      await tester.tap(find.byType(AppFilledButton));
+      await tester.pump();
+      expect(taps, 0);
+    });
+
+    testWidgets('error: button is non-tappable (onPressed: null)', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_host(
+        AppFilledButton(
+          label: 'Retry?',
+          state: FilledButtonState.error,
+          onPressed: () => taps++,
+        ),
+      ));
+
+      await tester.tap(find.byType(AppFilledButton));
+      await tester.pump();
+      expect(taps, 0);
+    });
+
+    testWidgets('icon variant renders the Icon in idle state', (tester) async {
+      await tester.pumpWidget(_host(
+        const AppFilledButton(label: 'Add', icon: Icons.add),
+      ));
+
+      expect(find.byIcon(Icons.add), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 63 of the coverage push. Widget tests for the app's shared button primitives used across buy/sell/KYC flows.

## Cases

| Target | Cases |
| --- | --- |
| \`AppTextButton\` | 5 — renders label + triggers \`onPressed\`; icon-less uses plain \`TextButton\`; icon variant renders an \`Icon\` next to the label; \`fullWidth: true\` wraps in a \`SizedBox(width=∞)\`; \`fullWidth: false\` does NOT wrap |
| \`AppFilledButton\` | 5 — idle: tap fires \`onPressed\`; loading: \`CupertinoActivityIndicator\` + disabled tap; success: non-tappable; error: non-tappable; icon variant renders the \`Icon\` in idle state |

## What's pinned

- \`AppFilledButton\` hard-codes \`onPressed: null\` for the non-idle states (loading / success / error). The three non-idle tap-disabled tests pin this so a future refactor that wires \`onPressed\` through any of those branches surfaces here — users must not be able to re-submit during loading or after success.
- The \`fullWidth\` wrapping behaviour is observable from the tree (\`SizedBox(width: double.infinity)\`). Both branches pinned.
- The icon vs no-icon split swaps between \`TextButton\` / \`TextButton.icon\` and \`FilledButton\` / \`FilledButton.icon\`. The icon-presence assertion pins both halves.

## Test plan

- [x] \`flutter test test/widgets/buttons/app_buttons_test.dart\` — 10 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green