### PR TITLE
test(widgets): NumberPad (+5 tests)

### DIFF
--- a/test/widgets/number_pad_test.dart
+++ b/test/widgets/number_pad_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/widgets/number_pad.dart';
+
+Widget _host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('$NumberPad', () {
+    testWidgets('renders digit buttons 0-9 + delete', (tester) async {
+      await tester.pumpWidget(_host(
+        NumberPad(onNumberPressed: (_) {}, onDeletePressed: () {}),
+      ));
+
+      for (var d = 0; d <= 9; d++) {
+        expect(find.text('$d'), findsOneWidget);
+      }
+      expect(find.byIcon(Icons.arrow_back_ios_new), findsOneWidget);
+    });
+
+    testWidgets('decimal button rendered only when onDecimalPressed is provided',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        NumberPad(onNumberPressed: (_) {}, onDeletePressed: () {}),
+      ));
+      expect(find.text('.'), findsNothing);
+
+      await tester.pumpWidget(_host(
+        NumberPad(
+          onNumberPressed: (_) {},
+          onDeletePressed: () {},
+          onDecimalPressed: () {},
+        ),
+      ));
+      expect(find.text('.'), findsOneWidget);
+    });
+
+    testWidgets('tapping a digit fires onNumberPressed with that digit',
+        (tester) async {
+      final pressed = <int>[];
+      await tester.pumpWidget(_host(
+        NumberPad(
+          onNumberPressed: pressed.add,
+          onDeletePressed: () {},
+        ),
+      ));
+
+      await tester.tap(find.text('1'));
+      await tester.tap(find.text('5'));
+      await tester.tap(find.text('0'));
+      await tester.pump();
+
+      expect(pressed, [1, 5, 0]);
+    });
+
+    testWidgets('tapping delete fires onDeletePressed', (tester) async {
+      var deletes = 0;
+      await tester.pumpWidget(_host(
+        NumberPad(
+          onNumberPressed: (_) {},
+          onDeletePressed: () => deletes++,
+        ),
+      ));
+
+      await tester.tap(find.byIcon(Icons.arrow_back_ios_new));
+      await tester.pump();
+
+      expect(deletes, 1);
+    });
+
+    testWidgets('tapping the decimal fires onDecimalPressed when provided',
+        (tester) async {
+      var dots = 0;
+      await tester.pumpWidget(_host(
+        NumberPad(
+          onNumberPressed: (_) {},
+          onDeletePressed: () {},
+          onDecimalPressed: () => dots++,
+        ),
+      ));
+
+      await tester.tap(find.text('.'));
+      await tester.pump();
+
+      expect(dots, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 67 of the coverage push. PIN entry keypad widget.

## Cases

| Target | Cases |
| --- | --- |
| \`NumberPad\` | 5 — renders digit buttons 0-9 + delete (arrow icon); decimal button rendered ONLY when \`onDecimalPressed\` is provided; tapping each digit fires \`onNumberPressed(digit)\`; tapping delete fires \`onDeletePressed\`; tapping decimal fires \`onDecimalPressed\` |

## What's pinned

- The decimal slot is **optional** — when \`onDecimalPressed\` is null, the slot renders a 60×60 placeholder \`SizedBox\` (no '.' text). Pinned via \`find.text('.'), findsNothing\` so a refactor that always renders the dot surfaces here.
- The digit-press callback receives the actual int (\`1\` not \`'1'\`) — pinned by accumulating to a typed \`List<int>\`.

## Test plan

- [x] \`flutter test test/widgets/number_pad_test.dart\` — 5 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green