### PR TITLE
test(widgets): TextLinkSpan.link (+3 tests)

### DIFF
--- a/test/widgets/text_link_span_test.dart
+++ b/test/widgets/text_link_span_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/widgets/text_link_span.dart';
+
+void main() {
+  group('$TextLinkSpan.link', () {
+    testWidgets('returns a TextSpan carrying the text and a TapGestureRecognizer',
+        (tester) async {
+      late TextSpan span;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                span = TextLinkSpan.link(
+                  context,
+                  text: 'click me',
+                  uri: Uri.parse('https://example.com'),
+                );
+                return Text.rich(span);
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(span.text, 'click me');
+      expect(span.recognizer, isA<TapGestureRecognizer>());
+    });
+
+    testWidgets('defaults to an underlined style when no style is given',
+        (tester) async {
+      late TextSpan span;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                span = TextLinkSpan.link(
+                  context,
+                  text: 'click me',
+                  uri: Uri.parse('https://example.com'),
+                );
+                return Text.rich(span);
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(span.style!.decoration, TextDecoration.underline);
+    });
+
+    testWidgets('honours a custom style override', (tester) async {
+      const customStyle = TextStyle(color: Colors.red, fontSize: 18);
+      late TextSpan span;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                span = TextLinkSpan.link(
+                  context,
+                  text: 'click me',
+                  uri: Uri.parse('https://example.com'),
+                  style: customStyle,
+                );
+                return Text.rich(span);
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(span.style, customStyle);
+      // No default underline when a custom style is given.
+      expect(span.style!.decoration, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 69 of the coverage push. Static \`TextSpan\` builder used to embed tappable links inside legal copy.

## Cases

| Target | Cases |
| --- | --- |
| \`TextLinkSpan.link\` | 3 — returns a TextSpan with the text + a \`TapGestureRecognizer\`; defaults to underlined style; custom style override drops the default underline |

## What's pinned

- A custom \`style\` REPLACES the default underline rather than merging with it. Pinned via \`decoration\` being null when a custom style without an explicit decoration is supplied — surfaces a regression to a \`.merge\` call.
- The recognizer is always attached (the link is always tappable) — the underlying \`_launchLink\` URL behaviour is platform-coupled and stays out of scope here.

## Test plan

- [x] \`flutter test test/widgets/text_link_span_test.dart\` — 3 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green