### PR TITLE
test(pin): PinIndicator (+5 tests)

### DIFF
--- a/test/screens/pin/widgets/pin_indicator_test.dart
+++ b/test/screens/pin/widgets/pin_indicator_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/screens/pin/widgets/pin_indicator.dart';
+import 'package:realunit_wallet/styles/colors.dart';
+
+Widget _host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  List<Container> dots(WidgetTester tester) =>
+      tester.widgetList<Container>(find.byType(Container)).toList();
+
+  group('$PinIndicator', () {
+    testWidgets('renders exactly expectedPinLength circles', (tester) async {
+      await tester.pumpWidget(_host(
+        const PinIndicator(pinLength: 0, expectedPinLength: 6, wrongPin: false),
+      ));
+
+      expect(dots(tester), hasLength(6));
+    });
+
+    testWidgets('fills the first pinLength dots with the foreground color',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        const PinIndicator(pinLength: 3, expectedPinLength: 6, wrongPin: false),
+      ));
+
+      final fills = dots(tester)
+          .map((c) => (c.decoration as BoxDecoration).color)
+          .toList();
+      // First three filled (black), last three transparent.
+      expect(fills.take(3), everyElement(RealUnitColors.realUnitBlack));
+      expect(fills.skip(3), everyElement(Colors.transparent));
+    });
+
+    testWidgets('wrongPin: every border is the status red', (tester) async {
+      await tester.pumpWidget(_host(
+        const PinIndicator(pinLength: 2, expectedPinLength: 6, wrongPin: true),
+      ));
+
+      final borderColors = dots(tester)
+          .map((c) => (c.decoration as BoxDecoration).border!.top.color)
+          .toList();
+
+      expect(borderColors, everyElement(RealUnitColors.status.red600));
+    });
+
+    testWidgets('wrongPin=false: every border is the black foreground',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        const PinIndicator(pinLength: 0, expectedPinLength: 6, wrongPin: false),
+      ));
+
+      final borderColors = dots(tester)
+          .map((c) => (c.decoration as BoxDecoration).border!.top.color)
+          .toList();
+
+      expect(borderColors, everyElement(RealUnitColors.realUnitBlack));
+    });
+
+    testWidgets('fully entered pin fills all dots', (tester) async {
+      await tester.pumpWidget(_host(
+        const PinIndicator(pinLength: 6, expectedPinLength: 6, wrongPin: false),
+      ));
+
+      final fills = dots(tester)
+          .map((c) => (c.decoration as BoxDecoration).color)
+          .toList();
+      expect(fills, everyElement(RealUnitColors.realUnitBlack));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 72 of the coverage push. Dot-row PIN progress indicator used by the setup + verify PIN screens.

## Cases

| Target | Cases |
| --- | --- |
| \`PinIndicator\` | 5 — renders exactly \`expectedPinLength\` dots; fills the first \`pinLength\` dots with the foreground color (transparent thereafter); \`wrongPin=true\`: every border is status-red; \`wrongPin=false\`: every border is black; fully entered pin fills all dots |

## What's pinned

- The fill vs transparent split is the only visual signal the user has during PIN entry — pinned across partial, empty, and full input states.
- The \`wrongPin\` border swap is the error feedback; pinned at both boolean values to catch a regression that drops the swap.

## Test plan

- [x] \`flutter test test/screens/pin/widgets/pin_indicator_test.dart\` — 5 pass
- [x] \`flutter analyze\` clean on the new file
- [ ] CI green