### PR TITLE
test(receive): QRAddressWidget (+4 tests)

### DIFF
--- a/test/screens/receive/widgets/qr_address_widget_test.dart
+++ b/test/screens/receive/widgets/qr_address_widget_test.dart
@@ -11,7 +11,7 @@ void main() {
   group('$QRAddressWidget', () {
     testWidgets('renders a QrImageView for the uri', (tester) async {
       await tester.pumpWidget(_host(
-        QRAddressWidget(uri: 'ethereum:$_address', subtitle: _address),
+        const QRAddressWidget(uri: 'ethereum:$_address', subtitle: _address),
       ));
 
       expect(find.byType(QrImageView), findsOneWidget);
@@ -20,7 +20,7 @@ void main() {
     testWidgets('renders the address as one Text.rich containing all chunks',
         (tester) async {
       await tester.pumpWidget(_host(
-        QRAddressWidget(uri: '', subtitle: _address),
+        const QRAddressWidget(uri: '', subtitle: _address),
       ));
 
       // RichText is rendered with concatenated text — find.textContaining
@@ -31,7 +31,7 @@ void main() {
 
     testWidgets('renders a copy icon next to the address', (tester) async {
       await tester.pumpWidget(_host(
-        QRAddressWidget(uri: '', subtitle: _address),
+        const QRAddressWidget(uri: '', subtitle: _address),
       ));
 
       expect(find.byIcon(Icons.copy_outlined), findsOneWidget);
@@ -40,7 +40,7 @@ void main() {
     testWidgets('tapping the address row is wrapped in a tappable InkWell',
         (tester) async {
       await tester.pumpWidget(_host(
-        QRAddressWidget(uri: '', subtitle: _address),
+        const QRAddressWidget(uri: '', subtitle: _address),
       ));
 
       // Tapping should not throw (clipboard plugin is no-op in test bindings).

--- a/test/screens/receive/widgets/qr_address_widget_test.dart
+++ b/test/screens/receive/widgets/qr_address_widget_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+import 'package:realunit_wallet/screens/receive/widgets/qr_address_widget.dart';
+
+const _address = '0x9F5713DEacB8e9CAB6c2d3FaE1AFc2715F8D2D71';
+
+Widget _host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('$QRAddressWidget', () {
+    testWidgets('renders a QrImageView for the uri', (tester) async {
+      await tester.pumpWidget(_host(
+        QRAddressWidget(uri: 'ethereum:$_address', subtitle: _address),
+      ));
+
+      expect(find.byType(QrImageView), findsOneWidget);
+    });
+
+    testWidgets('renders the address as one Text.rich containing all chunks',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        QRAddressWidget(uri: '', subtitle: _address),
+      ));
+
+      // RichText is rendered with concatenated text — find.textContaining
+      // walks descendants, hitting the rendered TextSpan tree.
+      expect(find.textContaining(_address.substring(0, 6)), findsAtLeastNWidgets(1));
+      expect(find.textContaining(_address.substring(36)), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('renders a copy icon next to the address', (tester) async {
+      await tester.pumpWidget(_host(
+        QRAddressWidget(uri: '', subtitle: _address),
+      ));
+
+      expect(find.byIcon(Icons.copy_outlined), findsOneWidget);
+    });
+
+    testWidgets('tapping the address row is wrapped in a tappable InkWell',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        QRAddressWidget(uri: '', subtitle: _address),
+      ));
+
+      // Tapping should not throw (clipboard plugin is no-op in test bindings).
+      await tester.tap(find.byType(InkWell));
+      await tester.pump();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 76 of the coverage push. Address-display QR code with tappable copy area for the receive screen.

## Cases

| Target | Cases |
| --- | --- |
| \`QRAddressWidget\` | 4 — renders a \`QrImageView\` for the uri; renders the address chunks (prefix + suffix at minimum); renders a copy icon; address row wrapped in a tappable \`InkWell\` |

## Excluded (and why)

- The chunk-split styling (bold prefix + bold suffix at indices \`[0..6]\` + \`[36..]\`) is fiddly to assert through the rendered TextSpan tree because Flutter wraps the spans through several layout passes. The visible chunks are pinned via \`find.textContaining\`; styling is left to future widget-tree-snapshot tests if needed.

## Test plan

- [x] \`flutter test\` — 4 pass
- [x] \`flutter analyze\` clean
- [ ] CI green