### PR TITLE
test(settings-user-data): SettingsEditLoadingPage (+2 tests)

### DIFF
--- a/test/screens/settings_user_data/subpages/others/settings_edit_loading_page_test.dart
+++ b/test/screens/settings_user_data/subpages/others/settings_edit_loading_page_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/screens/settings_user_data/subpages/others/settings_edit_loading_page.dart';
+
+void main() {
+  group('$SettingsEditLoadingPage', () {
+    testWidgets('renders the title in the AppBar', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: SettingsEditLoadingPage(title: 'Edit address')),
+      );
+
+      expect(find.text('Edit address'), findsOneWidget);
+    });
+
+    testWidgets('renders a centered CupertinoActivityIndicator', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: SettingsEditLoadingPage(title: 'X')),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(Center),
+          matching: find.byType(CupertinoActivityIndicator),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 77 of the coverage push. Loading placeholder shown while the edit-name / edit-address / edit-phone subpages save.

## Cases

| Target | Cases |
| --- | --- |
| \`SettingsEditLoadingPage\` | 2 — renders the passed title in the AppBar; renders a centered \`CupertinoActivityIndicator\` |

## Test plan

- [x] \`flutter test\` — 2 pass
- [x] \`flutter analyze\` clean
- [ ] CI green