### PR TITLE
test(sell-bitbox/widgets): EthStep state rendering (+5 tests)

### DIFF
--- a/test/screens/sell_bitbox/widgets/sell_bitbox_eth_step_test.dart
+++ b/test/screens/sell_bitbox/widgets/sell_bitbox_eth_step_test.dart
@@ -1,0 +1,75 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/screens/sell_bitbox/cubit/sell_bitbox_cubit.dart';
+import 'package:realunit_wallet/screens/sell_bitbox/widgets/sell_bitbox_eth_step.dart';
+
+import '../../../helper/helper.dart';
+
+class _MockSellBitboxCubit extends MockCubit<SellBitboxState>
+    implements SellBitboxCubit {}
+
+Widget _host(SellBitboxCubit cubit) => BlocProvider<SellBitboxCubit>.value(
+      value: cubit,
+      child: const SellBitboxEthStep(),
+    );
+
+void main() {
+  late _MockSellBitboxCubit cubit;
+
+  setUp(() {
+    cubit = _MockSellBitboxCubit();
+  });
+
+  group('$SellBitboxEthStep', () {
+    testWidgets('CheckingEth: shows a CupertinoActivityIndicator', (tester) async {
+      when(() => cubit.state).thenReturn(SellBitboxCheckingEth());
+
+      await tester.pumpApp(_host(cubit));
+
+      expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+    });
+
+    testWidgets('RequestingFaucet: also shows a CupertinoActivityIndicator',
+        (tester) async {
+      when(() => cubit.state).thenReturn(SellBitboxRequestingFaucet());
+
+      await tester.pumpApp(_host(cubit));
+
+      expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+    });
+
+    testWidgets('WaitingForEth: hourglass icon + disabled Next button',
+        (tester) async {
+      when(() => cubit.state).thenReturn(SellBitboxWaitingForEth());
+
+      await tester.pumpApp(_host(cubit));
+
+      expect(find.byIcon(Icons.hourglass_bottom_rounded), findsOneWidget);
+      final next = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(next.onPressed, isNull);
+    });
+
+    testWidgets('EthReady: check_circle icon + enabled Next button', (tester) async {
+      when(() => cubit.state).thenReturn(SellBitboxEthReady());
+
+      await tester.pumpApp(_host(cubit));
+
+      expect(find.byIcon(Icons.check_circle_outline_rounded), findsOneWidget);
+      final next = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(next.onPressed, isNotNull);
+    });
+
+    testWidgets('unrelated state: renders nothing (SizedBox.shrink)', (tester) async {
+      when(() => cubit.state).thenReturn(SellBitboxPreparingSwap());
+
+      await tester.pumpApp(_host(cubit));
+
+      expect(find.byType(CupertinoActivityIndicator), findsNothing);
+      expect(find.byType(FilledButton), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 81 of the coverage push. State-driven rendering of the BitBox sell ETH-gas check step via \`MockCubit\` + \`pumpApp\` (i18n).

## Cases

| State | What renders |
| --- | --- |
| \`CheckingEth\` | \`CupertinoActivityIndicator\` |
| \`RequestingFaucet\` | \`CupertinoActivityIndicator\` (same loader branch) |
| \`WaitingForEth\` | \`Icons.hourglass_bottom_rounded\` + disabled \`Next\` button (\`onPressed: null\`) |
| \`EthReady\` | \`Icons.check_circle_outline_rounded\` + enabled \`Next\` button |
| anything else | \`SizedBox.shrink\` — no indicator, no button |

## What's pinned

- The "still waiting" Next button must stay disabled — pinned via \`onPressed == null\`. Re-enabling it would let the user advance before the faucet drip lands.
- The fallback \`SizedBox.shrink\` for unrelated states keeps the widget composable without throwing.

## Test plan

- [x] \`flutter test\` — 5 pass
- [x] \`flutter analyze\` clean
- [ ] CI green