### PR TITLE
test(verify-seed/widgets): VerifySeedButton (+4 tests)

### DIFF
--- a/test/screens/verify_seed/widgets/verify_seed_button_test.dart
+++ b/test/screens/verify_seed/widgets/verify_seed_button_test.dart
@@ -1,0 +1,80 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/screens/verify_seed/cubit/verify_seed_cubit.dart';
+import 'package:realunit_wallet/screens/verify_seed/widgets/verify_seed_button.dart';
+import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
+
+import '../../../helper/helper.dart';
+
+class _MockVerifySeedCubit extends MockCubit<VerifySeedState>
+    implements VerifySeedCubit {}
+
+Widget _host(VerifySeedCubit cubit) => BlocProvider<VerifySeedCubit>.value(
+      value: cubit,
+      child: const VerifySeedButton(),
+    );
+
+void main() {
+  late _MockVerifySeedCubit cubit;
+
+  setUp(() {
+    cubit = _MockVerifySeedCubit();
+  });
+
+  AppFilledButton button(WidgetTester tester) =>
+      tester.widget<AppFilledButton>(find.byType(AppFilledButton));
+
+  group('$VerifySeedButton', () {
+    testWidgets('hasError: renders the error-variant AppFilledButton',
+        (tester) async {
+      when(() => cubit.state).thenReturn(const VerifySeedState(hasError: true));
+
+      await tester.pumpApp(_host(cubit));
+
+      expect(button(tester).state, FilledButtonState.error);
+    });
+
+    testWidgets('isVerified: renders the success-variant AppFilledButton with a check icon',
+        (tester) async {
+      when(() => cubit.state).thenReturn(const VerifySeedState(isVerified: true));
+
+      await tester.pumpApp(_host(cubit));
+
+      final b = button(tester);
+      expect(b.state, FilledButtonState.success);
+      expect(b.icon, Icons.check);
+    });
+
+    testWidgets(
+      'idle + canVerify=false: idle button with onPressed: null',
+      (tester) async {
+        when(() => cubit.state).thenReturn(const VerifySeedState());
+
+        await tester.pumpApp(_host(cubit));
+
+        final b = button(tester);
+        expect(b.state, FilledButtonState.idle);
+        expect(b.onPressed, isNull);
+      },
+    );
+
+    testWidgets(
+      'idle + canVerify=true: idle button with a non-null onPressed callback',
+      (tester) async {
+        when(() => cubit.state).thenReturn(const VerifySeedState(
+          wordIndices: [1, 2, 3, 4],
+          enteredWords: ['a', 'b', 'c', 'd'],
+        ));
+
+        await tester.pumpApp(_host(cubit));
+
+        final b = button(tester);
+        expect(b.state, FilledButtonState.idle);
+        expect(b.onPressed, isNotNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Stage 85 of the coverage push. State-driven \`AppFilledButton\` variant on the seed-verification screen.

## Cases

| State | Button variant |
| --- | --- |
| \`hasError\` | error |
| \`isVerified\` | success + \`Icons.check\` |
| idle, \`canVerify=false\` | idle, \`onPressed: null\` |
| idle, \`canVerify=true\` | idle, non-null \`onPressed\` |

## What's pinned

- The four-way visual state of the button must follow the cubit. The disabled-when-not-ready branch is the load-bearing one: it stops users from triggering verification with empty inputs.

## Test plan

- [x] \`flutter test\` — 4 pass
- [x] \`flutter analyze\` clean
- [ ] CI green