### PR TITLE
test(dashboard/widgets): PendingTransactionRow (+3 tests)

### DIFF
--- a/test/screens/dashboard/widgets/pending_transaction_row_test.dart
+++ b/test/screens/dashboard/widgets/pending_transaction_row_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/transactions/dto/transactions_dto.dart';
+import 'package:realunit_wallet/screens/dashboard/widgets/pending_transaction_row.dart';
+
+import '../../../helper/helper.dart';
+
+TransactionDto _tx({
+  TransactionType? type,
+  TransactionState? state,
+  double? inputAmount,
+  String? inputAsset,
+}) =>
+    TransactionDto(
+      id: 1,
+      type: type,
+      state: state,
+      inputAmount: inputAmount,
+      inputAsset: inputAsset,
+      date: DateTime.utc(2026, 5, 15, 10),
+    );
+
+void main() {
+  group('$PendingTransactionRow', () {
+    testWidgets('always renders a CupertinoActivityIndicator (still pending)',
+        (tester) async {
+      await tester.pumpApp(Scaffold(
+        body: PendingTransactionRow(
+          transaction: _tx(type: TransactionType.buy, state: TransactionState.processing),
+        ),
+      ));
+
+      expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+    });
+
+    testWidgets('buy vs sell produce DIFFERENT first-line labels', (tester) async {
+      await tester.pumpApp(Scaffold(
+        body: PendingTransactionRow(
+          transaction: _tx(type: TransactionType.buy, state: TransactionState.processing),
+        ),
+      ));
+      // Capture buy line.
+      final buyLine = tester.widgetList<Text>(find.byType(Text)).first.data;
+
+      await tester.pumpApp(Scaffold(
+        body: PendingTransactionRow(
+          transaction: _tx(type: TransactionType.sell, state: TransactionState.processing),
+        ),
+      ));
+      final sellLine = tester.widgetList<Text>(find.byType(Text)).first.data;
+
+      expect(buyLine, isNotNull);
+      expect(sellLine, isNotNull);
+      expect(buyLine, isNot(sellLine));
+    });
+
+    testWidgets('state=waitingForPayment vs other state produces DIFFERENT second-line labels',
+        (tester) async {
+      await tester.pumpApp(Scaffold(
+        body: PendingTransactionRow(
+          transaction: _tx(
+            type: TransactionType.buy,
+            state: TransactionState.waitingForPayment,
+          ),
+        ),
+      ));
+      final waitingSecondLine = tester.widgetList<Text>(find.byType(Text)).elementAt(1).data;
+
+      await tester.pumpApp(Scaffold(
+        body: PendingTransactionRow(
+          transaction: _tx(
+            type: TransactionType.buy,
+            state: TransactionState.processing,
+          ),
+        ),
+      ));
+      final processingSecondLine =
+          tester.widgetList<Text>(find.byType(Text)).elementAt(1).data;
+
+      expect(waitingSecondLine, isNotNull);
+      expect(processingSecondLine, isNotNull);
+      expect(waitingSecondLine, isNot(processingSecondLine));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 88 of the coverage push. Pending transaction list row on the dashboard.

## Cases

| Target | Cases |
| --- | --- |
| \`PendingTransactionRow\` | 3 — always renders a \`CupertinoActivityIndicator\`; buy vs sell produce different first-line labels; \`waitingForPayment\` vs other states produce different second-line labels |

## What's pinned

- The widget uses two i18n switches (buy/sell + waiting/processing). Both produce locale-dependent strings, so the tests pin behaviour via **differential** assertions (\`buy != sell\`, \`waiting != processing\`) rather than literal text.

## Test plan

- [x] \`flutter test\` — 3 pass
- [x] \`flutter analyze\` clean
- [ ] CI green