### PR TITLE
test(exceptions): SigningCancelled + BitboxNotConnected (+5 tests)

### DIFF
--- a/test/packages/exceptions/exception_classes_test.dart
+++ b/test/packages/exceptions/exception_classes_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
+import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
+
+void main() {
+  group('$SigningCancelledException', () {
+    test('is an Exception', () {
+      expect(const SigningCancelledException(), isA<Exception>());
+    });
+
+    test('toString returns "SigningCancelledException"', () {
+      expect(const SigningCancelledException().toString(), 'SigningCancelledException');
+    });
+
+    test('const constructor produces the same identity', () {
+      // Pinned because callers compare by identity / type, not deep equality.
+      const a = SigningCancelledException();
+      const b = SigningCancelledException();
+      expect(identical(a, b), isTrue);
+    });
+  });
+
+  group('$BitboxNotConnectedException', () {
+    test('is an Exception', () {
+      expect(const BitboxNotConnectedException(), isA<Exception>());
+    });
+
+    test('const constructor produces the same identity', () {
+      const a = BitboxNotConnectedException();
+      const b = BitboxNotConnectedException();
+      expect(identical(a, b), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 89 of the coverage push. Tiny exception classes used in BitBox + sign flows.

## Cases

| Target | Cases |
| --- | --- |
| \`SigningCancelledException\` | 3 — is \`Exception\`; \`toString\` returns the literal name; \`const\` identity stable |
| \`BitboxNotConnectedException\` | 2 — is \`Exception\`; \`const\` identity stable |

## What's pinned

- The literal \`toString()\` is the user-visible diagnostic when a sign ceremony is aborted. Pinned so a refactor that switches to runtimeType output doesn't change cancellation logging.
- Const identity guarantees that callers comparing instances by identity (which the cubits do) still match.

## Test plan

- [x] \`flutter test\` — 5 pass
- [x] \`flutter analyze\` clean
- [ ] CI green