### PR TITLE
test(support/widgets): SupportChatMessageBubble (+4 tests)

### DIFF
--- a/test/screens/support/widgets/support_chat_message_bubble_test.dart
+++ b/test/screens/support/widgets/support_chat_message_bubble_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/support/support_message.dart';
+import 'package:realunit_wallet/screens/support/widgets/support_chat_message_bubble.dart';
+import 'package:realunit_wallet/styles/colors.dart';
+
+Widget _host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+SupportMessage _msg({
+  String? author,
+  String? body = 'Hello',
+  DateTime? created,
+}) =>
+    SupportMessage(
+      id: 1,
+      author: author,
+      message: body,
+      created: created ?? DateTime.utc(2026, 5, 15, 10),
+    );
+
+void main() {
+  group('$SupportChatMessageBubble', () {
+    testWidgets('user message: blue bubble, aligned to end', (tester) async {
+      await tester.pumpWidget(_host(
+        SupportChatMessageBubble(supportMessage: _msg(author: 'user-1')),
+      ));
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.color, RealUnitColors.realUnitBlue);
+
+      // The wrapping Row aligns to MainAxisAlignment.end for the user bubble.
+      final row = tester.widget<Row>(find.byType(Row));
+      expect(row.mainAxisAlignment, MainAxisAlignment.end);
+    });
+
+    testWidgets('support message: neutral grey bubble, aligned to start',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        SupportChatMessageBubble(supportMessage: _msg(author: null)),
+      ));
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.color, RealUnitColors.neutral100);
+
+      final row = tester.widget<Row>(find.byType(Row));
+      expect(row.mainAxisAlignment, MainAxisAlignment.start);
+    });
+
+    testWidgets('renders the message body', (tester) async {
+      await tester.pumpWidget(_host(
+        SupportChatMessageBubble(
+          supportMessage: _msg(author: 'user-1', body: 'Where is my withdrawal?'),
+        ),
+      ));
+
+      expect(find.text('Where is my withdrawal?'), findsOneWidget);
+    });
+
+    testWidgets('null body: no message Text rendered (only the timestamp)',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        SupportChatMessageBubble(
+          supportMessage: _msg(author: null, body: null),
+        ),
+      ));
+
+      // Only the timestamp Text remains.
+      expect(find.byType(Text), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 91 of the coverage push. Chat bubble for the support conversation.

## Cases

| Branch | What's pinned |
| --- | --- |
| author != null | blue bubble + aligned to end (user side) |
| author == null | neutral grey bubble + aligned to start (support side) |
| message body | rendered verbatim |
| null body | only the timestamp Text remains |

## What's pinned

- The author-null → support-side rule is the public contract used by \`SupportMessage.isFromSupport\`. Pinned via both the bubble color and the Row's main-axis alignment so a refactor to either branch surfaces here.
- The bubble must keep rendering even when the message body is null (file-attachment-only messages) — pinned via the single-Text fallback.

## Test plan

- [x] \`flutter test\` — 4 pass
- [x] \`flutter analyze\` clean
- [ ] CI green