### PR TITLE
test(settings/widgets): SettingsSections (+4 tests)

### DIFF
--- a/test/screens/settings/widgets/settings_section_test.dart
+++ b/test/screens/settings/widgets/settings_section_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/screens/settings/widgets/settings_section.dart';
+
+Widget _host(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('$SettingsSections', () {
+    testWidgets('renders one row per option with title + subtitle when given',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        SettingsSections(
+          settings: [
+            SettingOption(title: 'Language', subtitle: 'English', onTap: () {}),
+            SettingOption(title: 'Currency', onTap: () {}),
+          ],
+        ),
+      ));
+
+      expect(find.text('Language'), findsOneWidget);
+      expect(find.text('English'), findsOneWidget);
+      expect(find.text('Currency'), findsOneWidget);
+    });
+
+    testWidgets('tap on an enabled option fires onTap', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(_host(
+        SettingsSections(
+          settings: [
+            SettingOption(title: 'Language', onTap: () => taps++),
+          ],
+        ),
+      ));
+
+      await tester.tap(find.text('Language'));
+      await tester.pump();
+
+      expect(taps, 1);
+    });
+
+    testWidgets('disabled option (onTap == null): InkWell.onTap is null and Opacity is 0.5',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        const SettingsSections(
+          settings: [
+            SettingOption(title: 'Greyed out'),
+          ],
+        ),
+      ));
+
+      final inkWell = tester.widget<InkWell>(find.byType(InkWell));
+      expect(inkWell.onTap, isNull);
+
+      final opacity = tester.widget<Opacity>(find.byType(Opacity));
+      expect(opacity.opacity, 0.5);
+    });
+
+    testWidgets('enabled option: InkWell.onTap is non-null and Opacity is 1.0',
+        (tester) async {
+      await tester.pumpWidget(_host(
+        SettingsSections(
+          settings: [
+            SettingOption(title: 'Active', onTap: () {}),
+          ],
+        ),
+      ));
+
+      final inkWell = tester.widget<InkWell>(find.byType(InkWell));
+      expect(inkWell.onTap, isNotNull);
+
+      final opacity = tester.widget<Opacity>(find.byType(Opacity));
+      expect(opacity.opacity, 1.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 92 of the coverage push. Settings list row widget with disabled-state styling.

## Cases

| Target | Cases |
| --- | --- |
| \`SettingsSections\` | 4 — renders one row per option with title + subtitle when given; tap fires \`onTap\`; disabled (\`onTap == null\`): \`InkWell.onTap\` null + \`Opacity\` 0.5; enabled: \`InkWell.onTap\` non-null + \`Opacity\` 1.0 |

## What's pinned

- The disabled state has two coupled signals: \`InkWell.onTap\` becomes null AND the row wraps in \`Opacity(0.5)\`. Both branches are pinned so a refactor that only updates one half surfaces here.

## Test plan

- [x] \`flutter test\` — 4 pass
- [x] \`flutter analyze\` clean
- [ ] CI green