### PR TITLE
test(dashboard/widgets): DashboardPendingTransactionsView (+3 tests)

### DIFF
--- a/test/screens/dashboard/widgets/sections/dashboard_pending_transactions_view_test.dart
+++ b/test/screens/dashboard/widgets/sections/dashboard_pending_transactions_view_test.dart
@@ -1,0 +1,79 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/transactions/dto/transactions_dto.dart';
+import 'package:realunit_wallet/screens/dashboard/bloc/pending_transactions_cubit.dart';
+import 'package:realunit_wallet/screens/dashboard/widgets/pending_transaction_row.dart';
+import 'package:realunit_wallet/screens/dashboard/widgets/sections/dashboard_pending_transactions.dart';
+
+import '../../../../helper/helper.dart';
+
+class _MockPendingCubit extends MockCubit<List<TransactionDto>>
+    implements PendingTransactionsCubit {}
+
+TransactionDto _tx({int id = 1, TransactionType type = TransactionType.buy}) =>
+    TransactionDto(
+      id: id,
+      type: type,
+      state: TransactionState.processing,
+      date: DateTime.utc(2026, 5, 15),
+    );
+
+void main() {
+  late _MockPendingCubit cubit;
+
+  setUp(() {
+    cubit = _MockPendingCubit();
+  });
+
+  Widget host() => BlocProvider<PendingTransactionsCubit>.value(
+        value: cubit,
+        child: const Scaffold(body: DashboardPendingTransactionsView()),
+      );
+
+  group('$DashboardPendingTransactionsView', () {
+    testWidgets('empty list: renders SizedBox.shrink (no PendingTransactionRow)',
+        (tester) async {
+      when(() => cubit.state).thenReturn([]);
+
+      await tester.pumpApp(host());
+
+      expect(find.byType(PendingTransactionRow), findsNothing);
+    });
+
+    testWidgets('non-empty list: renders one PendingTransactionRow per tx',
+        (tester) async {
+      when(() => cubit.state).thenReturn([
+        _tx(id: 1),
+        _tx(id: 2, type: TransactionType.sell),
+        _tx(id: 3),
+      ]);
+
+      await tester.pumpApp(host());
+
+      expect(find.byType(PendingTransactionRow), findsNWidgets(3));
+    });
+
+    testWidgets('non-empty list also renders a section header above the rows',
+        (tester) async {
+      when(() => cubit.state).thenReturn([_tx()]);
+
+      await tester.pumpApp(host());
+
+      // Header position: the first Text widget is rendered before the
+      // PendingTransactionRow's children. We only pin that the header Text
+      // exists outside any PendingTransactionRow.
+      final headerCount = find
+          .descendant(
+            of: find.byType(Column).first,
+            matching: find.byType(Text),
+          )
+          .evaluate()
+          .length;
+      expect(headerCount, greaterThan(0));
+      expect(find.byType(PendingTransactionRow), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 93 of the coverage push. View component of the dashboard pending-transactions section, driven by \`MockCubit\`.

## Cases

| Target | Cases |
| --- | --- |
| \`DashboardPendingTransactionsView\` | 3 — empty list → \`SizedBox.shrink\`; non-empty list → one \`PendingTransactionRow\` per tx; non-empty list renders a section header above the rows |

## What's pinned

- The empty-list early return keeps the dashboard from showing an orphan section header when there are no pending transactions. Pinned via \`findsNothing\`.
- The row count is the per-transaction contract — pinned via \`findsNWidgets(3)\` for three sample transactions.

## Test plan

- [x] \`flutter test\` — 3 pass
- [x] \`flutter analyze\` clean
- [ ] CI green