### PR TITLE
test(kyc/subpages): KycAccountMergePage (+2 tests)

### DIFF
--- a/test/screens/kyc/subpages/kyc_account_merge_page_test.dart
+++ b/test/screens/kyc/subpages/kyc_account_merge_page_test.dart
@@ -1,0 +1,49 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/screens/kyc/cubits/kyc/kyc_cubit.dart';
+import 'package:realunit_wallet/screens/kyc/subpages/kyc_account_merge_page.dart';
+import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
+
+import '../../../helper/helper.dart';
+
+class _MockKycCubit extends MockCubit<KycState> implements KycCubit {}
+
+Widget _host(KycCubit cubit) => BlocProvider<KycCubit>.value(
+      value: cubit,
+      child: const KycAccountMergePage(),
+    );
+
+void main() {
+  late _MockKycCubit cubit;
+
+  setUp(() {
+    cubit = _MockKycCubit();
+    when(() => cubit.state).thenReturn(const KycInitial());
+    when(() => cubit.checkKyc()).thenAnswer((_) async {});
+  });
+
+  group('$KycAccountMergePage', () {
+    testWidgets('renders an AppBar + headline + body + refresh button',
+        (tester) async {
+      await tester.pumpApp(_host(cubit));
+
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.byType(AppFilledButton), findsOneWidget);
+      // Headline + description + button label = 4 Texts (AppBar title + 2
+      // copy lines + button label).
+      expect(find.byType(Text), findsNWidgets(4));
+    });
+
+    testWidgets('tapping refresh fires KycCubit.checkKyc', (tester) async {
+      await tester.pumpApp(_host(cubit));
+
+      await tester.tap(find.byType(AppFilledButton));
+      await tester.pump();
+
+      verify(() => cubit.checkKyc()).called(1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 98 of the coverage push. Account-merge KYC subpage with a Refresh button.

## Cases

| Target | Cases |
| --- | --- |
| \`KycAccountMergePage\` | 2 — renders AppBar + headline + description + Refresh button; tapping Refresh fires \`KycCubit.checkKyc\` |

## Test plan

- [x] \`flutter test\` — 2 pass
- [x] \`flutter analyze\` clean
- [ ] CI green