### PR TITLE
test(pin/widgets): ForgotPinBottomSheet (+4 tests)

### DIFF
--- a/test/screens/pin/widgets/forgot_pin_bottom_sheet_test.dart
+++ b/test/screens/pin/widgets/forgot_pin_bottom_sheet_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/screens/pin/widgets/forgot_pin_bottom_sheet.dart';
+import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
+
+import '../../../helper/helper.dart';
+
+void main() {
+  group('$ForgotPinBottomSheet', () {
+    testWidgets('renders exactly two AppFilledButtons (Close + Reset)',
+        (tester) async {
+      await tester.pumpApp(const ForgotPinBottomSheet());
+
+      expect(find.byType(AppFilledButton), findsNWidgets(2));
+    });
+
+    testWidgets('the close button (first) uses the secondary variant',
+        (tester) async {
+      await tester.pumpApp(const ForgotPinBottomSheet());
+
+      final buttons = tester.widgetList<AppFilledButton>(find.byType(AppFilledButton)).toList();
+      expect(buttons[0].variant, FilledButtonVariant.secondary);
+    });
+
+    testWidgets('the reset button (second) uses the primary variant',
+        (tester) async {
+      await tester.pumpApp(const ForgotPinBottomSheet());
+
+      final buttons = tester.widgetList<AppFilledButton>(find.byType(AppFilledButton)).toList();
+      expect(buttons[1].variant, FilledButtonVariant.primary);
+    });
+
+    testWidgets('both buttons have non-null onPressed callbacks', (tester) async {
+      await tester.pumpApp(const ForgotPinBottomSheet());
+
+      final buttons = tester.widgetList<AppFilledButton>(find.byType(AppFilledButton)).toList();
+      expect(buttons[0].onPressed, isNotNull);
+      expect(buttons[1].onPressed, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 102 of the coverage push. PIN-reset confirmation bottom sheet shown after too many wrong PIN attempts.

## Cases

| Target | Cases |
| --- | --- |
| \`ForgotPinBottomSheet\` | 4 — exactly two \`AppFilledButton\` (Close + Reset); Close uses the secondary variant; Reset uses the primary variant; both have non-null \`onPressed\` callbacks |

## What's pinned

- The two-button layout splits the destructive action (Reset, primary) from the cancel action (Close, secondary). Pinned per-variant so a refactor that flips the visual emphasis surfaces here.

## Test plan

- [x] \`flutter test\` — 4 pass
- [x] \`flutter analyze\` clean
- [ ] CI green