### PR TITLE
test(pin/widgets): EnableBiometricBottomSheet (+4 tests)

### DIFF
--- a/test/screens/pin/widgets/enable_biometric_bottom_sheet_test.dart
+++ b/test/screens/pin/widgets/enable_biometric_bottom_sheet_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/screens/pin/widgets/enable_biometric_bottom_sheet.dart';
+import 'package:realunit_wallet/styles/colors.dart';
+import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
+import 'package:realunit_wallet/widgets/buttons/app_text_button.dart';
+
+import '../../../helper/helper.dart';
+
+void main() {
+  group('$EnableBiometricBottomSheet', () {
+    testWidgets('renders the fingerprint icon (blue, size 64)', (tester) async {
+      await tester.pumpApp(const EnableBiometricBottomSheet());
+
+      final icon = tester.widget<Icon>(find.byIcon(Icons.fingerprint));
+      expect(icon.color, RealUnitColors.realUnitBlue);
+      expect(icon.size, 64);
+    });
+
+    testWidgets('renders an AppFilledButton (Enable) + AppTextButton (Skip)',
+        (tester) async {
+      await tester.pumpApp(const EnableBiometricBottomSheet());
+
+      expect(find.byType(AppFilledButton), findsOneWidget);
+      expect(find.byType(AppTextButton), findsOneWidget);
+    });
+
+    testWidgets('Enable button has a non-null onPressed callback', (tester) async {
+      await tester.pumpApp(const EnableBiometricBottomSheet());
+
+      final button = tester.widget<AppFilledButton>(find.byType(AppFilledButton));
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('Skip button has a non-null onPressed callback', (tester) async {
+      await tester.pumpApp(const EnableBiometricBottomSheet());
+
+      final button = tester.widget<AppTextButton>(find.byType(AppTextButton));
+      expect(button.onPressed, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 104 of the coverage push. Bottom sheet that prompts the user to opt into Touch/Face ID after setting up the PIN.

## Cases

| Target | Cases |
| --- | --- |
| \`EnableBiometricBottomSheet\` | 4 — fingerprint icon (blue, size 64); Enable AppFilledButton + Skip AppTextButton; both buttons have non-null \`onPressed\` callbacks |

## What's pinned

- The two-button layout splits the affirmative action (Enable, prominent) from the dismiss (Skip, subdued text button). Pinned by widget type so a refactor that swaps button hierarchies surfaces here.

## Test plan

- [x] \`flutter test\` — 4 pass
- [x] \`flutter analyze\` clean
- [ ] CI green