### PR TITLE
test(states): transaction receipt + settings contact/tax-report (+8 tests)

### DIFF
--- a/test/screens/transaction_receipt_settings_states_test.dart
+++ b/test/screens/transaction_receipt_settings_states_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/screens/settings_contact/cubit/settings_contact_cubit.dart';
+import 'package:realunit_wallet/screens/settings_tax_report/cubit/settings_tax_report_cubit.dart';
+import 'package:realunit_wallet/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit.dart';
+import 'package:realunit_wallet/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit.dart';
+
+void main() {
+  group('$SettingsContactState', () {
+    test('Success defaults emailSet to false', () {
+      const state = SettingsContactSuccess();
+      expect(state.emailSet, isFalse);
+    });
+
+    test('Success.copyWith preserves untouched field', () {
+      const base = SettingsContactSuccess(emailSet: true);
+      final next = base.copyWith();
+      expect(next.emailSet, isTrue);
+    });
+
+    test('Success Equatable props pin emailSet', () {
+      expect(
+        const SettingsContactSuccess(emailSet: true),
+        const SettingsContactSuccess(emailSet: true),
+      );
+      expect(
+        const SettingsContactSuccess(emailSet: true),
+        isNot(const SettingsContactSuccess()),
+      );
+    });
+  });
+
+  group('$TransactionHistoryReceiptState', () {
+    test('Success props pin the receiptPath', () {
+      expect(
+        const TransactionHistoryReceiptSuccess('/tmp/a.pdf'),
+        const TransactionHistoryReceiptSuccess('/tmp/a.pdf'),
+      );
+      expect(
+        const TransactionHistoryReceiptSuccess('/tmp/a.pdf'),
+        isNot(const TransactionHistoryReceiptSuccess('/tmp/b.pdf')),
+      );
+    });
+
+    test('Initial and Loading are distinct singletons', () {
+      expect(const TransactionHistoryReceiptInitial(),
+          const TransactionHistoryReceiptInitial());
+      expect(const TransactionHistoryReceiptInitial(),
+          isNot(const TransactionHistoryReceiptLoading()));
+    });
+  });
+
+  group('$TransactionHistoryMultiReceiptState', () {
+    test('Success props pin the receiptPath', () {
+      expect(
+        const TransactionHistoryMultiReceiptSuccess('/tmp/a.pdf'),
+        const TransactionHistoryMultiReceiptSuccess('/tmp/a.pdf'),
+      );
+      expect(
+        const TransactionHistoryMultiReceiptSuccess('/tmp/a.pdf'),
+        isNot(const TransactionHistoryMultiReceiptSuccess('/tmp/b.pdf')),
+      );
+    });
+  });
+
+  group('$SettingsTaxReportState', () {
+    test('Success props pin the taxReportPath', () {
+      expect(
+        const SettingsTaxReportSuccess('/tmp/tax.pdf'),
+        const SettingsTaxReportSuccess('/tmp/tax.pdf'),
+      );
+      expect(
+        const SettingsTaxReportSuccess('/tmp/tax.pdf'),
+        isNot(const SettingsTaxReportSuccess('/tmp/other.pdf')),
+      );
+    });
+
+    test('Initial and Loading are distinct singletons', () {
+      expect(const SettingsTaxReportInitial(), const SettingsTaxReportInitial());
+      expect(
+        const SettingsTaxReportInitial(),
+        isNot(const SettingsTaxReportLoading()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stage 112 of the coverage push. Pins state contracts on the file-IO-coupled cubits (we can't drive the cubits themselves until \`path_provider\` is mocked, but the states are pure data).

## Cases

| Hierarchy | Cases |
| --- | --- |
| \`SettingsContactState\` | 3 — Success defaults; Success.copyWith non-destructive; Success.props pin emailSet |
| \`TransactionHistoryReceiptState\` | 2 — Success.props pin receiptPath; Initial vs Loading distinct |
| \`TransactionHistoryMultiReceiptState\` | 1 — Success.props pin receiptPath |
| \`SettingsTaxReportState\` | 2 — Success.props pin taxReportPath; Initial vs Loading distinct |

## Test plan

- [x] \`flutter test\` — 8 pass
- [x] \`flutter analyze\` clean
- [ ] CI green