### PR TITLE
ci: BitBox02 simulator workflow + slash trigger

### DIFF
--- a/.github/workflows/bitbox-simulator-slash.yml
+++ b/.github/workflows/bitbox-simulator-slash.yml
@@ -86,6 +86,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.guard.outputs.sha }}
-      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.4
+      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.6
         with:
           testkit-ref: ${{ needs.guard.outputs.testkit-ref }}

--- a/.github/workflows/bitbox-simulator-slash.yml
+++ b/.github/workflows/bitbox-simulator-slash.yml
@@ -86,6 +86,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.guard.outputs.sha }}
-      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.4.1
+      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.4.3
         with:
           testkit-ref: ${{ needs.guard.outputs.testkit-ref }}

--- a/.github/workflows/bitbox-simulator-slash.yml
+++ b/.github/workflows/bitbox-simulator-slash.yml
@@ -6,7 +6,7 @@ name: bitbox-simulator (slash)
 # user-triggered.
 #
 # Variants:
-#   /bitbox-simulator            — defaults (testkit v0.3.4)
+#   /bitbox-simulator            — defaults (testkit v0.4.5)
 #   /bitbox-simulator ref=main   — bleeding-edge scenarios
 
 on:
@@ -60,7 +60,7 @@ jobs:
           script: |
             const body = (context.payload.comment.body || '').trim();
             const args = body.replace(/^\/bitbox-simulator\s*/, '').split(/\s+/).filter(Boolean);
-            let testkitRef = 'v0.3.4';
+            let testkitRef = 'v0.4.5';
             for (const tok of args) {
               const [k, v] = tok.split('=');
               if (k === 'ref' && v) testkitRef = v;
@@ -86,6 +86,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.guard.outputs.sha }}
-      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.4.3
+      - uses: DFXswiss/bitbox-testkit/.github/actions/bitbox-simulator@a573ab07ad55884005458683cafc153fd0bf3b0a # v0.4.5
         with:
           testkit-ref: ${{ needs.guard.outputs.testkit-ref }}

--- a/.github/workflows/bitbox-simulator-slash.yml
+++ b/.github/workflows/bitbox-simulator-slash.yml
@@ -86,6 +86,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.guard.outputs.sha }}
-      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.9
+      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.4.1
         with:
           testkit-ref: ${{ needs.guard.outputs.testkit-ref }}

--- a/.github/workflows/bitbox-simulator-slash.yml
+++ b/.github/workflows/bitbox-simulator-slash.yml
@@ -86,6 +86,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.guard.outputs.sha }}
-      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.6
+      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.9
         with:
           testkit-ref: ${{ needs.guard.outputs.testkit-ref }}

--- a/.github/workflows/bitbox-simulator-slash.yml
+++ b/.github/workflows/bitbox-simulator-slash.yml
@@ -1,0 +1,91 @@
+name: bitbox-simulator (slash)
+
+# Comment "/bitbox-simulator" on any PR to launch the official BitBox02
+# simulator and run the testkit's baseline scenarios against real
+# firmware logic on demand. Same engine as bitbox-simulator.yml but
+# user-triggered.
+#
+# Variants:
+#   /bitbox-simulator            — defaults (testkit v0.3.4)
+#   /bitbox-simulator ref=main   — bleeding-edge scenarios
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: bitbox-simulator-slash-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    if: >
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/bitbox-simulator')
+    runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.authz.outputs.authorized }}
+      sha: ${{ steps.parse.outputs.sha }}
+      testkit-ref: ${{ steps.parse.outputs.testkit_ref }}
+    steps:
+      - name: Authorization
+        id: authz
+        uses: actions/github-script@v7
+        env:
+          ASSOC: ${{ github.event.comment.author_association }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        with:
+          script: |
+            const allowed = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const ok = allowed.includes(process.env.ASSOC);
+            core.setOutput('authorized', ok ? 'true' : 'false');
+            if (!ok) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: `:no_entry_sign: \`@${process.env.ACTOR}\` is not authorized to run \`/bitbox-simulator\`.`,
+              });
+            }
+
+      - name: Parse + resolve PR head
+        id: parse
+        if: steps.authz.outputs.authorized == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = (context.payload.comment.body || '').trim();
+            const args = body.replace(/^\/bitbox-simulator\s*/, '').split(/\s+/).filter(Boolean);
+            let testkitRef = 'v0.3.4';
+            for (const tok of args) {
+              const [k, v] = tok.split('=');
+              if (k === 'ref' && v) testkitRef = v;
+            }
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('sha', pr.head.sha);
+            core.setOutput('testkit_ref', testkitRef);
+            await github.rest.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+  simulator:
+    needs: guard
+    if: needs.guard.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.guard.outputs.sha }}
+      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.4
+        with:
+          testkit-ref: ${{ needs.guard.outputs.testkit-ref }}

--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -51,6 +51,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.4.3
+      - uses: DFXswiss/bitbox-testkit/.github/actions/bitbox-simulator@a573ab07ad55884005458683cafc153fd0bf3b0a # v0.4.5
         with:
-          testkit-ref: v0.4.2
+          testkit-ref: v0.4.5

--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -51,6 +51,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.4
+      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.6
         with:
-          testkit-ref: v0.3.4
+          testkit-ref: v0.3.5

--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -53,4 +53,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.6
         with:
-          testkit-ref: v0.3.7
+          testkit-ref: v0.3.8

--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -1,0 +1,56 @@
+name: bitbox-simulator
+
+# Launches the official BitBox02 simulator
+# (https://github.com/BitBoxSwiss/bitbox02-firmware/releases) and runs
+# the bitbox-testkit baseline scenarios against real firmware logic.
+#
+# What this validates for realunit-app:
+#   • bitbox-api ↔ BitBox02 firmware Noise handshake round-trip.
+#   • ETH-address derivation on chainId=1 AND chainId=137 (the
+#     multi-byte-v boundary that has historically broken EIP-155
+#     consumers).
+#   • ETH personal-message signing at the firmware-doc 1024-byte upper
+#     boundary.
+#   • EIP-1559 sign happy path.
+#
+# What this does NOT validate: realunit-app's Dart code talking to
+# the BitBox via the bitbox_flutter plugin against real hardware.
+# That still requires a physical BitBox02 (or a future TCP-to-USB
+# shim). The simulator covers the FIRMWARE side of the protocol;
+# bitbox_flutter at ref v0.0.3 is the consumer side.
+#
+# Runs on every PR that touches BitBox surface AND on manual trigger.
+# For ad-hoc maintainer validation, bitbox-simulator-slash.yml
+# accepts /bitbox-simulator on any PR.
+
+on:
+  pull_request:
+    paths:
+      - 'lib/packages/hardware_wallet/**'
+      - 'lib/packages/wallet/**'
+      - 'lib/screens/hardware_connect_bitbox/**'
+      - 'test/packages/hardware_wallet/**'
+      - 'test/packages/wallet/**'
+      - 'test/screens/hardware_connect_bitbox/**'
+      - 'pubspec.yaml'
+      - '.github/workflows/bitbox-simulator.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: bitbox-simulator-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  simulator:
+    name: BitBox02 simulator (real firmware)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.4
+        with:
+          testkit-ref: v0.3.4

--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -53,4 +53,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.6
         with:
-          testkit-ref: v0.3.5
+          testkit-ref: v0.3.7

--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -51,6 +51,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.9
+      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.4.1
         with:
-          testkit-ref: v0.3.8
+          testkit-ref: v0.4.0

--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -51,6 +51,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.6
+      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.3.9
         with:
           testkit-ref: v0.3.8

--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -51,6 +51,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.4.1
+      - uses: joshuakrueger-dfx/bitbox-testkit/.github/actions/bitbox-simulator@v0.4.3
         with:
-          testkit-ref: v0.4.0
+          testkit-ref: v0.4.2


### PR DESCRIPTION
## Summary

Wires this repo to the [`joshuakrueger-dfx/bitbox-testkit`](https://github.com/joshuakrueger-dfx/bitbox-testkit) v0.3.4 BitBox02 simulator — adds real-firmware test coverage on top of the existing mocked Flutter tests.

Two workflows:

1. **`.github/workflows/bitbox-simulator.yml`** — auto-trigger on PRs that touch BitBox surface (`lib/packages/hardware_wallet/**`, `lib/packages/wallet/**`, `lib/screens/hardware_connect_bitbox/**`, related tests, or `pubspec.yaml`). Launches the official BitBox02 simulator binary (SHA-pinned by the testkit, v9.19.0–v9.26.1 known) and runs the baseline scenarios against the real Noise+Protobuf protocol. Posts a sticky PR comment with pass/fail per scenario.

2. **`.github/workflows/bitbox-simulator-slash.yml`** — on-demand trigger. Comment `/bitbox-simulator` on any PR and the scenarios re-run against the PR head.

## How to run it

| Trigger | What it does |
| --- | --- |
| Push to a PR touching BitBox code | Auto-runs, sticky comment |
| Comment `/bitbox-simulator` | Re-runs against PR head |
| Comment `/bitbox-simulator ref=main` | Use bleeding-edge testkit scenarios |

Authorization on the slash trigger: `author_association ∈ {OWNER, MEMBER, COLLABORATOR}`.

## What this validates that the existing Flutter test suite does NOT

The 96 BitBox-related Flutter tests in `test/packages/hardware_wallet/`, `test/packages/wallet/`, `test/screens/hardware_connect_bitbox/` etc. all pass against `FakeBitboxCredentials` — a mocked implementation. That covers the **Dart consumer code**.

The simulator workflow covers the other side of the channel:

- bitbox-api ↔ BitBox02 firmware Noise XX handshake round-trip
- `ETHPub` / `ETHSign*` protocol over the real Noise channel
- Multi-byte `v` handling at `chainId > 110` (Polygon=137, Arbitrum=42161, Optimism=10, BSC=56) — the boundary case for EIP-155 signature recovery that has historically broken consumers
- EIP-1559 sign happy path against actual firmware semantics
- ETH personal-message signing at the firmware-documented 1024-byte upper boundary

## What it still does NOT validate

This repo's Dart code talking to a BitBox via the [`bitbox_flutter`](https://github.com/DFXswiss/bitbox_flutter) plugin against real hardware. The simulator covers the **firmware side**; `bitbox_flutter@v0.0.3` is the **consumer side**. Physical-device validation remains the final checkpoint.

Cross-platform: the simulator binary is Linux/amd64 only, so the action skips cleanly on macOS / Windows runners.

## Baseline scenarios run

| Scenario | What it probes |
| --- | --- |
| `pair_and_device_info` | Pre-init Noise + DeviceInfo |
| `init_device_with_fresh_seed` | Setup flow |
| `eth_address_mainnet` | chainId=1, BIP-44 path |
| `eth_address_polygon_multibyte_v` | chainId=137 boundary |
| `eth_sign_message_ascii` | Short message + signature shape |
| `eth_sign_message_boundary_1024` | Firmware-doc max |
| `eth_sign_eip1559_mainnet` | Full type-2 sign happy path |

## Test plan

- [ ] Open this PR → auto-trigger fires
- [ ] Sticky comment shows 7/7 scenarios pass against firmware v9.26.1
- [ ] Comment `/bitbox-simulator` to verify the slash trigger
- [ ] Manual `workflow_dispatch` from the Actions tab works