### PR TITLE
feat(handbook): nginx image + DEV/PRD Docker Hub publish

### DIFF
--- a/.github/workflows/handbook-dev.yaml
+++ b/.github/workflows/handbook-dev.yaml
@@ -1,0 +1,46 @@
+name: Handbook DEV image
+
+# Builds and publishes the handbook nginx image to Docker Hub on every push
+# to develop. Tag: dfxswiss/realunit-app-handbook:beta.
+#
+# Deployment to dfxdev (dev-handbook.realuni.app via Cloudflare Tunnel) is
+# wired up in the DFXswiss/server repo once the realuni.app zone and the
+# realunit-app-handbook compose stack are in place.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "docs/handbook/**"
+      - "Dockerfile.handbook"
+      - ".github/workflows/handbook-dev.yaml"
+  workflow_dispatch:
+
+env:
+  DOCKER_TAGS: dfxswiss/realunit-app-handbook:beta
+
+jobs:
+  build-and-push:
+    name: Build and push handbook image (beta)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push handbook image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.handbook
+          push: true
+          tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/arm64

--- a/.github/workflows/handbook-prd.yaml
+++ b/.github/workflows/handbook-prd.yaml
@@ -1,0 +1,46 @@
+name: Handbook PRD image
+
+# Builds and publishes the handbook nginx image to Docker Hub on every push
+# to main. Tag: dfxswiss/realunit-app-handbook:latest.
+#
+# Deployment to dfxprd (handbook.realuni.app via Cloudflare Tunnel) is wired
+# up in the DFXswiss/server repo once the realuni.app zone and the
+# realunit-app-handbook compose stack are in place.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/handbook/**"
+      - "Dockerfile.handbook"
+      - ".github/workflows/handbook-prd.yaml"
+  workflow_dispatch:
+
+env:
+  DOCKER_TAGS: dfxswiss/realunit-app-handbook:latest
+
+jobs:
+  build-and-push:
+    name: Build and push handbook image (latest)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push handbook image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.handbook
+          push: true
+          tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/arm64

--- a/Dockerfile.handbook
+++ b/Dockerfile.handbook
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+#
+# Static nginx host for docs/handbook/ — served at handbook.realuni.app (PRD)
+# and dev-handbook.realuni.app (DEV) via Cloudflare Tunnel.
+#
+# Built independently of the Flutter app: no Flutter toolchain, no app code.
+# Build context is the repo root; only docs/handbook/ is copied in.
+
+FROM nginx:1.27-alpine
+
+COPY docs/handbook/ /usr/share/nginx/html/
+COPY handbook.nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 8080

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 8080 default_server;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index de/index.html;
+
+    location = / {
+        return 302 /de/;
+    }
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}


### PR DESCRIPTION
## Summary

Container image and build workflows that publish the handbook to Docker Hub so it can be served online via Cloudflare Tunnel (target hosts: \`handbook.realuni.app\` / \`dev-handbook.realuni.app\`). The hosting side — compose stack + tunnel ingress + DNS — is a separate PR against \`DFXswiss/server\`.

- \`Dockerfile.handbook\` + \`handbook.nginx.conf\`: \`nginx:1.27-alpine\` serving \`docs/handbook/\`, redirects \`/\` → \`/de/\`.
- \`.github/workflows/handbook-dev.yaml\`: on push to \`develop\` (paths-filtered to \`docs/handbook/\`, the Dockerfile, or the workflow itself) → build + push \`dfxswiss/realunit-app-handbook:beta\`.
- \`.github/workflows/handbook-prd.yaml\`: same for \`:latest\` on \`main\`.
- No SSH-deploy step yet. The pull side lives in \`DFXswiss/server\` and gets wired up once the compose stack + tunnel ingress exist for \`realunit-app-handbook\`.

## Why split this from the handbook content PR (#441)?

#441 is purely local artefacts (Maestro flows, screenshots, HTML). This PR is hosting infrastructure with org-level secrets (\`DOCKER_USERNAME\` / \`DOCKER_PASSWORD\`) and a different review surface.

## Test plan

- [x] Dockerfile builds locally (deferred — OrbStack not running on this machine; CI will validate)
- [ ] CI: \`Handbook DEV image\` workflow succeeds on first run via \`workflow_dispatch\` after merge
- [ ] Image \`dfxswiss/realunit-app-handbook:beta\` exists on Docker Hub
- [ ] \`docker run -p 8080:8080 dfxswiss/realunit-app-handbook:beta\` serves the handbook on http://localhost:8080/de/

## Follow-ups

- \`DFXswiss/server\` PR: \`realuni.app\` Cloudflare zone + DNS, tunnel ingress (\`handbook.realuni.app\` → dfxprd, \`dev-handbook.realuni.app\` → dfxdev), \`dfxdev/realunit-app-handbook/\` + \`dfxprd/realunit-app-handbook/\` compose stacks, \`domains.md\` entry. **Prerequisite for that PR**: \`realuni.app\` zone must exist in the DFX Cloudflare account, NS pointed from Infomaniak to Cloudflare.