### PR TITLE
chore(ci): bump bitbox-testkit pin to v0.5.0

### DIFF
--- a/.github/workflows/bitbox-simulator-slash.yml
+++ b/.github/workflows/bitbox-simulator-slash.yml
@@ -6,7 +6,7 @@ name: bitbox-simulator (slash)
 # user-triggered.
 #
 # Variants:
-#   /bitbox-simulator            — defaults (testkit v0.4.5)
+#   /bitbox-simulator            — defaults (testkit v0.5.0)
 #   /bitbox-simulator ref=main   — bleeding-edge scenarios
 
 on:
@@ -60,7 +60,7 @@ jobs:
           script: |
             const body = (context.payload.comment.body || '').trim();
             const args = body.replace(/^\/bitbox-simulator\s*/, '').split(/\s+/).filter(Boolean);
-            let testkitRef = 'v0.4.5';
+            let testkitRef = 'v0.5.0';
             for (const tok of args) {
               const [k, v] = tok.split('=');
               if (k === 'ref' && v) testkitRef = v;
@@ -86,6 +86,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.guard.outputs.sha }}
-      - uses: DFXswiss/bitbox-testkit/.github/actions/bitbox-simulator@a573ab07ad55884005458683cafc153fd0bf3b0a # v0.4.5
+      - uses: DFXswiss/bitbox-testkit/.github/actions/bitbox-simulator@45a1253d23b545d801cf5a1f42c040b85e389c7d # v0.5.0
         with:
           testkit-ref: ${{ needs.guard.outputs.testkit-ref }}

--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -51,6 +51,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: DFXswiss/bitbox-testkit/.github/actions/bitbox-simulator@a573ab07ad55884005458683cafc153fd0bf3b0a # v0.4.5
+      - uses: DFXswiss/bitbox-testkit/.github/actions/bitbox-simulator@45a1253d23b545d801cf5a1f42c040b85e389c7d # v0.5.0
         with:
-          testkit-ref: v0.4.5
+          testkit-ref: v0.5.0


### PR DESCRIPTION
## Summary

Bumps the bitbox-testkit composite-action pin from v0.4.5 to v0.5.0. SHA `45a1253d23b545d801cf5a1f42c040b85e389c7d`.

## What v0.5.0 brings

- **5 new baseline scenarios**: BTC P2WPKH (`bc1q…`), P2TR (`bc1p…`), BTC message signing, BIP-84 ZPUB, legacy Polygon ETH-sign exercising the EIP-155 multi-byte v path, and a deterministic root-fingerprint contract (`0x4c00739d`) so seed drifts surface as one canonical failure instead of N derived ones.
- **Firmware matrix**: 14 scenarios × 8 firmware versions (v9.19.0 → v9.26.1) run per push on testkit CI. Catches regressions on the production firmware tail.
- **Conventional-Commits auto-tag** + **dual `vX.Y.Z` / `go/vX.Y.Z`** tagging — strictly testkit-side, doesn't change anything in this repo.

## Changes

Two files touched, all three pin sites updated in lockstep:

- `.github/workflows/bitbox-simulator.yml`: SHA + `testkit-ref`
- `.github/workflows/bitbox-simulator-slash.yml`: SHA + slash-default JS literal + version mention in the banner comment

## Risk

Composite-action surface is the same; the only widened input is `firmware:` (default unchanged). Existing simulator runs against `master` firmware behave identically.

The `/bitbox-simulator` slash now defaults to v0.5.0 — same flow as before, just newer scenarios.