### PR TITLE
fix(handbook): include handbook.nginx.conf in workflow path filter

### DIFF
--- a/.github/workflows/handbook-dev.yaml
+++ b/.github/workflows/handbook-dev.yaml
@@ -13,6 +13,7 @@ on:
     paths:
       - "docs/handbook/**"
       - "Dockerfile.handbook"
+      - "handbook.nginx.conf"
       - ".github/workflows/handbook-dev.yaml"
   workflow_dispatch:
 

--- a/.github/workflows/handbook-prd.yaml
+++ b/.github/workflows/handbook-prd.yaml
@@ -13,6 +13,7 @@ on:
     paths:
       - "docs/handbook/**"
       - "Dockerfile.handbook"
+      - "handbook.nginx.conf"
       - ".github/workflows/handbook-prd.yaml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

The path filters in `handbook-dev.yaml` and `handbook-prd.yaml` did not include `handbook.nginx.conf`. Editing only the nginx config would have silently skipped the image rebuild until someone also touched the Dockerfile or a doc file under `docs/handbook/`.

Adds `handbook.nginx.conf` to the `paths` trigger in both workflows.

## Test plan

- [x] Touching only `handbook.nginx.conf` on develop will now trigger `Handbook DEV image`
- [x] Same for `Handbook PRD image` on main
- [ ] No new CI surface; existing builds unaffected