### PR TITLE
fix(handbook): emit relative redirect Location so / works behind Tunnel

### DIFF
--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -2,6 +2,12 @@ server {
     listen 8080 default_server;
     server_name _;
 
+    # Emit relative Location headers so redirects work behind the
+    # Cloudflare Tunnel — otherwise nginx prepends the internal
+    # listen address (http://localhost:8080/...) and the browser
+    # follows the link to a host it can't reach.
+    absolute_redirect off;
+
     root /usr/share/nginx/html;
     index de/index.html;
 


### PR DESCRIPTION
## Summary

Smoke-testing the freshly deployed `realunit-app-handbook` container on dfxdev surfaced a redirect bug: the existing `return 302 /de/;` made nginx auto-build the Location header from its own listen address, producing `http://localhost:8080/de/`. Behind the Cloudflare Tunnel the browser would have followed that to a host it cannot reach.

`absolute_redirect off;` keeps the Location header relative; the browser resolves it against the public hostname (`https://dev-handbook.realuni.app/de/` → handbook).

## Test plan

- [x] `docker run --rm -v handbook.nginx.conf:/etc/nginx/conf.d/default.conf nginx:1.27-alpine nginx -t` → syntax ok, test successful
- [x] actionlint on `handbook-dev.yaml` / `handbook-prd.yaml` → exit 0
- [ ] After merge: `Handbook DEV image` rebuilds, auto-deploy refreshes the dfxdev container, `curl -i http://localhost:6130/` on dfxdev returns `HTTP 302` with `Location: /de/` (relative, no host)