### PR TITLE
fix(handbook): use plain index.html so /de/ serves the handbook

### DIFF
--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -9,7 +9,10 @@ server {
     absolute_redirect off;
 
     root /usr/share/nginx/html;
-    index de/index.html;
+    # nginx joins `index` against the request path, so `index de/index.html`
+    # makes /de/ look up /de/de/index.html (→ 403). Use plain index.html and
+    # let the explicit /-redirect below route to /de/.
+    index index.html;
 
     location = / {
         return 302 /de/;


### PR DESCRIPTION
## Summary

Second redirect/routing bug discovered after PR #445 deployed: a request to `/de/` returned **403 Forbidden** instead of the handbook HTML.

Root cause: the `index` directive was set to `de/index.html` (a relative path with a leading segment). nginx joins `index` values against the request path, so for `/de/` it tried to serve `/de/de/index.html` — which does not exist → 403.

Changed to `index index.html`:
- `/` → matches `location = /` → 302 → `/de/` (no change in this PR)
- `/de/` → nginx looks for `/de/index.html` → exists → 200

## Test plan

- [x] `docker run --rm -v ./handbook.nginx.conf:/etc/nginx/conf.d/default.conf nginx:1.27-alpine nginx -t` → syntax ok, test successful
- [x] Probe container on dfxdev with new config mounted into `dfxswiss/realunit-app-handbook:beta`:
  - `/` → 302, Location relative → `/de/`
  - `/de/` → 200, 36521 B
  - `/de/index.html` → 200, 36521 B
- [x] actionlint on `handbook-dev.yaml` / `handbook-prd.yaml` → exit 0
- [ ] After merge: `Handbook DEV image` rebuilds, dfxdev compose pull + recreate, smoke test confirms `/de/` returns 200 from the live container