### PR TITLE
feat(handbook): production-grade image + auto-deploy pipeline

### DIFF
--- a/.github/workflows/handbook-dev.yaml
+++ b/.github/workflows/handbook-dev.yaml
@@ -1,11 +1,9 @@
-name: Handbook DEV image
+name: Handbook DEV CI/CD
 
-# Builds and publishes the handbook nginx image to Docker Hub on every push
-# to develop. Tag: dfxswiss/realunit-app-handbook:beta.
+# Builds the handbook nginx image, publishes dfxswiss/realunit-app-handbook:beta
+# to Docker Hub, and tells the dev server to pull + recreate the container.
 #
-# Deployment to dfxdev (dev-handbook.realuni.app via Cloudflare Tunnel) is
-# wired up in the DFXswiss/server repo once the realuni.app zone and the
-# realunit-app-handbook compose stack are in place.
+# Mirrors infrastructure/templates/ssh-deploy-dev.yaml from DFXServer/server.
 
 on:
   push:
@@ -17,12 +15,16 @@ on:
       - ".github/workflows/handbook-dev.yaml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DOCKER_TAGS: dfxswiss/realunit-app-handbook:beta
+  DEPLOY_SERVICE: realunit-app-handbook
 
 jobs:
-  build-and-push:
-    name: Build and push handbook image (beta)
+  build-and-deploy:
+    name: Build and deploy to DEV
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
@@ -45,3 +47,23 @@ jobs:
           push: true
           tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/arm64
+
+      - name: Install cloudflared
+        env:
+          CLOUDFLARED_VERSION: "2025.4.0"
+          CLOUDFLARED_SHA256: "2561391ee9abdc828afcc52f5ac314b6551a9a6a31ff59cbc64efc63aec04615"
+        run: |
+          curl -fsSL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-arm64" -o /usr/local/bin/cloudflared
+          echo "${CLOUDFLARED_SHA256}  /usr/local/bin/cloudflared" | sha256sum -c -
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to server
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
+            ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"

--- a/.github/workflows/handbook-prd.yaml
+++ b/.github/workflows/handbook-prd.yaml
@@ -1,11 +1,9 @@
-name: Handbook PRD image
+name: Handbook PRD CI/CD
 
-# Builds and publishes the handbook nginx image to Docker Hub on every push
-# to main. Tag: dfxswiss/realunit-app-handbook:latest.
+# Builds the handbook nginx image, publishes dfxswiss/realunit-app-handbook:latest
+# to Docker Hub, and tells the prd server to pull + recreate the container.
 #
-# Deployment to dfxprd (handbook.realuni.app via Cloudflare Tunnel) is wired
-# up in the DFXswiss/server repo once the realuni.app zone and the
-# realunit-app-handbook compose stack are in place.
+# Mirrors infrastructure/templates/ssh-deploy-prd.yaml from DFXServer/server.
 
 on:
   push:
@@ -17,12 +15,16 @@ on:
       - ".github/workflows/handbook-prd.yaml"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DOCKER_TAGS: dfxswiss/realunit-app-handbook:latest
+  DEPLOY_SERVICE: realunit-app-handbook
 
 jobs:
-  build-and-push:
-    name: Build and push handbook image (latest)
+  build-and-deploy:
+    name: Build and deploy to PRD
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
@@ -45,3 +47,23 @@ jobs:
           push: true
           tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/arm64
+
+      - name: Install cloudflared
+        env:
+          CLOUDFLARED_VERSION: "2025.4.0"
+          CLOUDFLARED_SHA256: "2561391ee9abdc828afcc52f5ac314b6551a9a6a31ff59cbc64efc63aec04615"
+        run: |
+          curl -fsSL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-arm64" -o /usr/local/bin/cloudflared
+          echo "${CLOUDFLARED_SHA256}  /usr/local/bin/cloudflared" | sha256sum -c -
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to server
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"

--- a/Dockerfile.handbook
+++ b/Dockerfile.handbook
@@ -6,9 +6,12 @@
 # Built independently of the Flutter app: no Flutter toolchain, no app code.
 # Build context is the repo root; only docs/handbook/ is copied in.
 
-FROM nginx:1.27-alpine
+FROM nginx:1.27.5-alpine
 
 COPY docs/handbook/ /usr/share/nginx/html/
 COPY handbook.nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget -qO- --timeout=3 http://127.0.0.1:8080/de/ >/dev/null || exit 1

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -14,6 +14,28 @@ server {
     # let the explicit /-redirect below route to /de/.
     index index.html;
 
+    # Hide nginx version in Server header.
+    server_tokens off;
+
+    # Security headers for a static, embed-safe handbook.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Cache-Control "public, max-age=300" always;
+
+    # Gzip text assets — screenshots are PNG and skip compression.
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    # text/html is gzipped by default; do not list it again.
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        application/javascript
+        application/json
+        image/svg+xml;
+
     location = / {
         return 302 /de/;
     }


### PR DESCRIPTION
## Summary

Brings the handbook deployment up to the standard pattern shared across DFX product repos (compare \`DFXswiss/rangekeeper\`, \`d-EURO/api\`, \`JuiceSwapxyz/juiceswap-protocol\`).

### Workflows

- Mirror \`infrastructure/templates/ssh-deploy-{dev,prd}.yaml\` from \`DFXServer/server\`: pinned \`cloudflared 2025.4.0\` with SHA256 verification, restricted SSH key, generic \`DEPLOY_*\` secrets, \`permissions: contents: read\`.
- After a successful image push, ssh through the Cloudflare Tunnel into the target server and invoke \`deploy.sh realunit-app-handbook\` so the new image is pulled and the container recreated.

### Image

- Pin base to \`nginx:1.27.5-alpine\` (was \`1.27-alpine\`).
- Add \`HEALTHCHECK\` probing \`/de/\` — surfaces broken nginx config to Docker before traffic hits.

### nginx config

- \`server_tokens off\` (do not advertise nginx version).
- Static-site security headers: \`X-Content-Type-Options nosniff\`, \`X-Frame-Options SAMEORIGIN\`, \`Referrer-Policy strict-origin-when-cross-origin\`, \`Cache-Control public max-age=300\`.
- \`gzip on\` for text assets (PNG screenshots are not gzipped).

## Test plan

- [x] \`actionlint .github/workflows/handbook-*.yaml\` → exit 0
- [x] On dfxdev: \`docker run --rm -v ./handbook.nginx.conf:/etc/nginx/conf.d/default.conf nginx:1.27.5-alpine nginx -t\` → syntax ok, no warnings
- [x] Probe container on dfxdev with \`dfxswiss/realunit-app-handbook:beta\` + new config:
  - \`/\` → 302 with relative Location
  - \`/de/\` → 200, 36521 B, all 4 security headers present
- [x] \`DEPLOY_{DEV,PRD}_SSH_KEY\`, \`_SSH_KNOWN_HOSTS\`, \`_HOST\`, \`_USER\` GitHub secrets provisioned in this repo
- [ ] **Blocked on**: \`DFXServer/server\` PR adding \`realunit-app-handbook\` case to \`deploy.sh\` on dfxdev and dfxprd (otherwise the SSH step exits with \`Unknown command\`)
- [ ] After both merged: pushing a doc tweak to develop triggers the workflow → image pushed → SSH-deploy → container recreated → \`curl http://localhost:6130/de/\` on dfxdev returns 200 from the new image