### PR TITLE
feat(handbook): collapsible sections + align colors with app/realunit.ch

### DIFF
--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -71,7 +71,7 @@
       :root {
         /* RealUnit brand palette — mirrors lib/styles/colors.dart (RealUnitColors).
            Same blue used on realunit.ch (#1988C6). Keep in sync with the app. */
-        --bg: #dbeaf3;             /* between brand700 and brand200 — soft blue page bg */
+        --bg: #d1e6f5;             /* brand200 */
         --surface: #ffffff;         /* basic.white */
         --surface-2: #f2f5f8;       /* neutral100 */
         --line: #e2e8f0;            /* neutral200 */
@@ -82,10 +82,7 @@
         --ink-4: #94a3b8;           /* neutral400 */
         --brand: #1988c6;           /* realUnitBlue */
         --brand-hover: #034c81;     /* darkBlue */
-        --brand-soft: #ecf3f9;      /* brand700 */
-        --ok: #4cac36;              /* green */
         --warn: #e9ad3f;            /* okker */
-        --err: #e02523;             /* status.red600 */
         --content-width: 960px;
       }
       * {
@@ -250,9 +247,6 @@
       details.spec {
         margin: 0 0 72px;
         scroll-margin-top: 24px;
-      }
-      details.spec[open] {
-        margin-bottom: 72px;
       }
       details.spec > summary {
         list-style: none;

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -81,7 +81,6 @@
         --ink-3: #64748b;           /* neutral500 */
         --ink-4: #94a3b8;           /* neutral400 */
         --brand: #1988c6;           /* realUnitBlue */
-        --brand-hover: #034c81;     /* darkBlue */
         --warn: #e9ad3f;            /* okker */
         --content-width: 960px;
       }

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -10,20 +10,23 @@
     />
     <style>
       :root {
-        --bg: #fafafa;
-        --surface: #ffffff;
-        --surface-2: #f5f5f5;
-        --line: #e8e8e8;
-        --line-2: #d6d6d6;
-        --ink: #1d1b20;
-        --ink-2: #4a4a4a;
-        --ink-3: #777777;
-        --ink-4: #a0a0a0;
-        --brand: #1d80c4;
-        --brand-hover: #1a6fab;
-        --ok: #16a34a;
-        --warn: #ca8a04;
-        --err: #dc2626;
+        /* RealUnit brand palette — mirrors lib/styles/colors.dart (RealUnitColors).
+           Same blue used on realunit.ch (#1988C6). Keep in sync with the app. */
+        --bg: #f8fafc;             /* neutral50 */
+        --surface: #ffffff;         /* basic.white */
+        --surface-2: #f2f5f8;       /* neutral100 */
+        --line: #e2e8f0;            /* neutral200 */
+        --line-2: #ced5de;          /* neutral300 */
+        --ink: #343233;             /* realUnitBlack */
+        --ink-2: #475569;           /* neutral600 */
+        --ink-3: #64748b;           /* neutral500 */
+        --ink-4: #94a3b8;           /* neutral400 */
+        --brand: #1988c6;           /* realUnitBlue */
+        --brand-hover: #034c81;     /* darkBlue */
+        --brand-soft: #ecf3f9;      /* brand700 */
+        --ok: #4cac36;              /* green */
+        --warn: #e9ad3f;            /* okker */
+        --err: #e02523;             /* status.red600 */
         --content-width: 960px;
       }
       * {
@@ -299,7 +302,7 @@
 
       .callout {
         border-left: 3px solid var(--brand);
-        background: rgba(29, 128, 196, 0.05);
+        background: rgba(25, 136, 198, 0.06);
         padding: 14px 18px;
         margin: 24px 0;
         border-radius: 0 4px 4px 0;
@@ -310,7 +313,7 @@
       }
       .callout.warn {
         border-color: var(--warn);
-        background: rgba(202, 138, 4, 0.06);
+        background: rgba(233, 173, 63, 0.10);
       }
       .callout p {
         margin: 0;

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -8,6 +8,65 @@
       name="description"
       content="RealUnit Wallet — Handbuch und Test-Dokumentation. Jeder Screenshot ist eine Maestro-Tier-3-Aufnahme; die App-Variante, die auf realer Hardware exakt diese Screens produziert, ist die spezifizierte."
     />
+    <script>
+      // Auto-open the <details> for the hash anchor (e.g. /handbook/de#spec-04).
+      function openHashTarget() {
+        var hash = location.hash;
+        if (!hash || hash.length < 2) return;
+        var el;
+        try {
+          el = document.querySelector(hash);
+        } catch (e) {
+          return;
+        }
+        if (!el) return;
+        var det = el.tagName === 'DETAILS' ? el : el.closest('details');
+        if (det) {
+          det.open = true;
+          requestAnimationFrame(function () {
+            det.scrollIntoView({ behavior: 'instant', block: 'start' });
+          });
+        }
+      }
+      window.addEventListener('hashchange', openHashTarget);
+      document.addEventListener('DOMContentLoaded', openHashTarget);
+
+      // TOC clicks: open the target <details> before the browser scrolls.
+      document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.toc a[href^="#"]').forEach(function (a) {
+          a.addEventListener('click', function () {
+            var id = a.getAttribute('href').slice(1);
+            if (!id) return;
+            var el = document.getElementById(id);
+            var det = el && (el.tagName === 'DETAILS' ? el : el.closest('details'));
+            if (det) det.open = true;
+          });
+        });
+
+        // Expand/collapse-all toggle in the sidebar.
+        var toggle = document.getElementById('spec-toggle-all');
+        if (!toggle) return;
+        var update = function () {
+          var anyClosed = false;
+          document.querySelectorAll('details.spec').forEach(function (d) {
+            if (!d.open) anyClosed = true;
+          });
+          toggle.setAttribute('data-state', anyClosed ? 'collapsed' : 'expanded');
+          toggle.textContent = anyClosed ? 'Alle ausklappen' : 'Alle einklappen';
+        };
+        toggle.addEventListener('click', function () {
+          var open = toggle.getAttribute('data-state') === 'collapsed';
+          document.querySelectorAll('details.spec').forEach(function (d) {
+            d.open = open;
+          });
+          update();
+        });
+        document.querySelectorAll('details.spec').forEach(function (d) {
+          d.addEventListener('toggle', update);
+        });
+        update();
+      });
+    </script>
     <style>
       :root {
         /* RealUnit brand palette — mirrors lib/styles/colors.dart (RealUnitColors).
@@ -188,8 +247,29 @@
         margin: 48px 0;
       }
 
-      section.spec {
+      details.spec {
+        margin: 0 0 72px;
+        scroll-margin-top: 24px;
+      }
+      details.spec[open] {
         margin-bottom: 72px;
+      }
+      details.spec > summary {
+        list-style: none;
+        cursor: pointer;
+        user-select: none;
+        padding: 6px 0 4px;
+      }
+      details.spec > summary::-webkit-details-marker {
+        display: none;
+      }
+      details.spec > summary:focus-visible {
+        outline: 2px solid var(--brand);
+        outline-offset: 4px;
+        border-radius: 4px;
+      }
+      details.spec > summary:hover .spec-head .lhs h2 {
+        color: var(--brand);
       }
 
       .spec-head {
@@ -204,6 +284,25 @@
         font-size: 22px;
         font-weight: 600;
         letter-spacing: -0.005em;
+        display: inline-flex;
+        align-items: baseline;
+        gap: 10px;
+        transition: color 0.15s;
+      }
+      .spec-head .lhs h2::before {
+        content: '▸';
+        display: inline-block;
+        width: 12px;
+        font-size: 14px;
+        color: var(--ink-4);
+        transition:
+          transform 0.18s ease-out,
+          color 0.15s;
+        transform: translateY(-1px);
+      }
+      details.spec[open] .spec-head .lhs h2::before {
+        transform: translateY(-1px) rotate(90deg);
+        color: var(--brand);
       }
       .spec-head .lhs h2 .num {
         display: inline-block;
@@ -323,6 +422,31 @@
       .callout b {
         color: var(--ink);
       }
+
+      /* Sidebar expand/collapse-all toggle */
+      .toc-actions {
+        margin: 6px 0 16px;
+      }
+      .toc-actions button {
+        appearance: none;
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        color: var(--ink-2);
+        cursor: pointer;
+        font: inherit;
+        font-size: 12px;
+        padding: 5px 10px;
+        transition:
+          background 0.15s,
+          border-color 0.15s,
+          color 0.15s;
+      }
+      .toc-actions button:hover {
+        background: var(--surface-2);
+        border-color: var(--line-2);
+        color: var(--ink);
+      }
     </style>
   </head>
   <body>
@@ -342,6 +466,9 @@
         </nav>
 
         <div class="toc-label">Specs</div>
+        <div class="toc-actions">
+          <button type="button" id="spec-toggle-all" data-state="expanded">Alle einklappen</button>
+        </div>
         <nav class="toc">
           <ol>
             <li>
@@ -430,22 +557,24 @@
 
         <hr class="sep" />
 
-        <section id="spec-01" class="spec">
-          <div class="spec-head">
-            <div class="lhs">
-              <h2><span class="num">01</span>Welcome &amp; Onboarding</h2>
-              <div class="file">.maestro/handbook/01..03-*.yaml</div>
-            </div>
-            <div class="rhs">
-              <b>3 Screens</b>
-              <div class="links">
-                <a
-                  href="https://github.com/DFXswiss/realunit-app/tree/develop/.maestro/handbook"
-                  >Flows ↗</a
-                >
+        <details id="spec-01" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">01</span>Welcome &amp; Onboarding</h2>
+                <div class="file">.maestro/handbook/01..03-*.yaml</div>
+              </div>
+              <div class="rhs">
+                <b>3 Screens</b>
+                <div class="links">
+                  <a
+                    href="https://github.com/DFXswiss/realunit-app/tree/develop/.maestro/handbook"
+                    >Flows ↗</a
+                  >
+                </div>
               </div>
             </div>
-          </div>
+          </summary>
           <p class="spec-intro">
             Der allererste Screen, den ein neuer User sieht. Zwei Wege gehen davon ab — die
             <em>App-Wallet</em> (Seed-Phrase auf dem Gerät) und die
@@ -510,26 +639,28 @@
               </div>
             </div>
           </div>
-        </section>
+        </details>
 
         <hr class="sep" />
 
-        <section id="spec-02" class="spec">
-          <div class="spec-head">
-            <div class="lhs">
-              <h2><span class="num">02</span>Wallet erstellen</h2>
-              <div class="file">.maestro/handbook/04..06-*.yaml</div>
-            </div>
-            <div class="rhs">
-              <b>3 Screens</b>
-              <div class="links">
-                <a
-                  href="https://github.com/DFXswiss/realunit-app/tree/develop/.maestro/handbook"
-                  >Flows ↗</a
-                >
+        <details id="spec-02" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">02</span>Wallet erstellen</h2>
+                <div class="file">.maestro/handbook/04..06-*.yaml</div>
+              </div>
+              <div class="rhs">
+                <b>3 Screens</b>
+                <div class="links">
+                  <a
+                    href="https://github.com/DFXswiss/realunit-app/tree/develop/.maestro/handbook"
+                    >Flows ↗</a
+                  >
+                </div>
               </div>
             </div>
-          </div>
+          </summary>
           <p class="spec-intro">
             BIP-39-Seed-Backup-Flow. Drei Schritte: Seed-Phrase wird zuerst verschleiert
             angezeigt mit einer Aufforderung sie aufzuschreiben, dann durch Tap enthüllt
@@ -606,26 +737,28 @@
               </div>
             </div>
           </div>
-        </section>
+        </details>
 
         <hr class="sep" />
 
-        <section id="spec-03" class="spec">
-          <div class="spec-head">
-            <div class="lhs">
-              <h2><span class="num">03</span>Onboarding abschliessen</h2>
-              <div class="file">.maestro/handbook/07-onboarding-completed.yaml</div>
-            </div>
-            <div class="rhs">
-              <b>1 Screen</b>
-              <div class="links">
-                <a
-                  href="https://github.com/DFXswiss/realunit-app/blob/develop/.maestro/handbook/07-onboarding-completed.yaml"
-                  >Flow ↗</a
-                >
+        <details id="spec-03" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">03</span>Onboarding abschliessen</h2>
+                <div class="file">.maestro/handbook/07-onboarding-completed.yaml</div>
+              </div>
+              <div class="rhs">
+                <b>1 Screen</b>
+                <div class="links">
+                  <a
+                    href="https://github.com/DFXswiss/realunit-app/blob/develop/.maestro/handbook/07-onboarding-completed.yaml"
+                    >Flow ↗</a
+                  >
+                </div>
               </div>
             </div>
-          </div>
+          </summary>
           <p class="spec-intro">
             Brücke zwischen Seed-Sicherung und PIN-Einrichtung. An dieser Stelle ist die
             Wallet zwar generiert, aber noch nicht durch eine lokale PIN gegen Zugriff
@@ -653,26 +786,28 @@
               </div>
             </div>
           </div>
-        </section>
+        </details>
 
         <hr class="sep" />
 
-        <section id="spec-04" class="spec">
-          <div class="spec-head">
-            <div class="lhs">
-              <h2><span class="num">04</span>PIN einrichten</h2>
-              <div class="file">.maestro/handbook/08..10-*.yaml</div>
-            </div>
-            <div class="rhs">
-              <b>3 Screens</b>
-              <div class="links">
-                <a
-                  href="https://github.com/DFXswiss/realunit-app/tree/develop/.maestro/handbook"
-                  >Flows ↗</a
-                >
+        <details id="spec-04" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">04</span>PIN einrichten</h2>
+                <div class="file">.maestro/handbook/08..10-*.yaml</div>
+              </div>
+              <div class="rhs">
+                <b>3 Screens</b>
+                <div class="links">
+                  <a
+                    href="https://github.com/DFXswiss/realunit-app/tree/develop/.maestro/handbook"
+                    >Flows ↗</a
+                  >
+                </div>
               </div>
             </div>
-          </div>
+          </summary>
           <p class="spec-intro">
             6-stellige App-PIN als zweiter Schutzlayer. <code>SetupPinPage</code> hat zwei
             Zustände auf derselben Seite (<code>create</code> → <code>confirm</code>) — der
@@ -739,26 +874,28 @@
               </div>
             </div>
           </div>
-        </section>
+        </details>
 
         <hr class="sep" />
 
-        <section id="spec-05" class="spec">
-          <div class="spec-head">
-            <div class="lhs">
-              <h2><span class="num">05</span>Dashboard</h2>
-              <div class="file">.maestro/handbook/11-dashboard.yaml</div>
-            </div>
-            <div class="rhs">
-              <b>1 Screen</b>
-              <div class="links">
-                <a
-                  href="https://github.com/DFXswiss/realunit-app/blob/develop/.maestro/handbook/11-dashboard.yaml"
-                  >Flow ↗</a
-                >
+        <details id="spec-05" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">05</span>Dashboard</h2>
+                <div class="file">.maestro/handbook/11-dashboard.yaml</div>
+              </div>
+              <div class="rhs">
+                <b>1 Screen</b>
+                <div class="links">
+                  <a
+                    href="https://github.com/DFXswiss/realunit-app/blob/develop/.maestro/handbook/11-dashboard.yaml"
+                    >Flow ↗</a
+                  >
+                </div>
               </div>
             </div>
-          </div>
+          </summary>
           <p class="spec-intro">
             Haupteinstieg nach abgeschlossenem Onboarding. Zeigt den aktuellen RealUnit
             Aktienkurs in der gewählten Anzeigewährung (Default CHF), die Performance-Kurve
@@ -789,26 +926,28 @@
               </div>
             </div>
           </div>
-        </section>
+        </details>
 
         <hr class="sep" />
 
-        <section id="spec-06" class="spec">
-          <div class="spec-head">
-            <div class="lhs">
-              <h2><span class="num">06</span>Einstellungen</h2>
-              <div class="file">.maestro/handbook/12..16-*.yaml</div>
-            </div>
-            <div class="rhs">
-              <b>5 Screens</b>
-              <div class="links">
-                <a
-                  href="https://github.com/DFXswiss/realunit-app/tree/develop/.maestro/handbook"
-                  >Flows ↗</a
-                >
+        <details id="spec-06" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">06</span>Einstellungen</h2>
+                <div class="file">.maestro/handbook/12..16-*.yaml</div>
+              </div>
+              <div class="rhs">
+                <b>5 Screens</b>
+                <div class="links">
+                  <a
+                    href="https://github.com/DFXswiss/realunit-app/tree/develop/.maestro/handbook"
+                    >Flows ↗</a
+                  >
+                </div>
               </div>
             </div>
-          </div>
+          </summary>
           <p class="spec-intro">
             Sammelpunkt für lokale Einstellungen (Sprache, Anzeigewährung, Netzwerk) sowie
             On-Chain-Identität (Wallet-Adresse, Recovery-Phrase) und User-Daten für die
@@ -908,26 +1047,28 @@
               </div>
             </div>
           </div>
-        </section>
+        </details>
 
         <hr class="sep" />
 
-        <section id="spec-07" class="spec">
-          <div class="spec-head">
-            <div class="lhs">
-              <h2><span class="num">07</span>Wallet-Sicherung</h2>
-              <div class="file">.maestro/handbook/17..19-*.yaml</div>
-            </div>
-            <div class="rhs">
-              <b>3 Screens</b>
-              <div class="links">
-                <a
-                  href="https://github.com/DFXswiss/realunit-app/tree/develop/.maestro/handbook"
-                  >Flows ↗</a
-                >
+        <details id="spec-07" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">07</span>Wallet-Sicherung</h2>
+                <div class="file">.maestro/handbook/17..19-*.yaml</div>
+              </div>
+              <div class="rhs">
+                <b>3 Screens</b>
+                <div class="links">
+                  <a
+                    href="https://github.com/DFXswiss/realunit-app/tree/develop/.maestro/handbook"
+                    >Flows ↗</a
+                  >
+                </div>
               </div>
             </div>
-          </div>
+          </summary>
           <p class="spec-intro">
             PIN-gated Re-Display der Recovery-Phrase aus den Settings — falls der User die
             Wörter nach dem Onboarding noch einmal sehen oder neu notieren will. Die
@@ -992,7 +1133,7 @@
               </div>
             </div>
           </div>
-        </section>
+        </details>
       </main>
     </div>
   </body>

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -71,7 +71,7 @@
       :root {
         /* RealUnit brand palette — mirrors lib/styles/colors.dart (RealUnitColors).
            Same blue used on realunit.ch (#1988C6). Keep in sync with the app. */
-        --bg: #f8fafc;             /* neutral50 */
+        --bg: #dbeaf3;             /* between brand700 and brand200 — soft blue page bg */
         --surface: #ffffff;         /* basic.white */
         --surface-2: #f2f5f8;       /* neutral100 */
         --line: #e2e8f0;            /* neutral200 */


### PR DESCRIPTION
## Summary

Two-in-one polish PR for the German handbook (`docs/handbook/de/index.html`):

1. **Collapsible spec sections** — every `<section class="spec">` is now a `<details class="spec" open>` so each of the seven steps can be folded individually. Pattern mirrors the zkCoins App handbook (`zk-coins/app/public/handbook/de/index.html`).
2. **Brand palette aligned with the RealUnit app + realunit.ch** — switch CSS variables from the ad-hoc palette to the official RealUnit values (`lib/styles/colors.dart`). Every variable maps to an exact `RealUnitColors` constant.

## Collapsible sections

- Native `<details>`/`<summary>` — no external JS, the file stays standalone.
- Default state: all sections **open**, so no functional regression.
- Chevron (`::before`) on the spec headline, rotates 90° when the details are open.
- TOC anchor clicks open the target spec before the browser scrolls; `#spec-04` deep-links auto-open.
- Bonus: an **"Alle ein-/ausklappen"** toggle button in the sidebar that flips all seven sections at once and re-labels itself based on the aggregate open state.
- 7 spec sections converted, screenshots / callouts / test cards inside the details are unchanged.

## Brand palette

- Brand blue is now `#1988C6` (`RealUnitColors.realUnitBlue`) — identical to the blue used on realunit.ch.
- Page background is `#D1E6F5` (`RealUnitColors.brand200`) — light blue tone that visibly separates the body from the white test cards while staying in-palette.
- Neutral surfaces/lines/ink mapped to `neutral100/200/300/400/500/600`.
- Status color (`--warn`) mapped to `okker`.
- Callout backgrounds use rgba of the brand/warn hues.

### Mapping

| Variable | before | after | App constant |
|---|---|---|---|
| `--brand` | `#1d80c4` | `#1988C6` | `realUnitBlue` |
| `--bg` | `#fafafa` | `#D1E6F5` | `brand200` |
| `--surface-2` | `#f5f5f5` | `#F2F5F8` | `neutral100` |
| `--line` | `#e8e8e8` | `#E2E8F0` | `neutral200` |
| `--line-2` | `#d6d6d6` | `#CED5DE` | `neutral300` |
| `--ink` | `#1d1b20` | `#343233` | `realUnitBlack` |
| `--ink-2` | `#4a4a4a` | `#475569` | `neutral600` |
| `--ink-3` | `#777777` | `#64748B` | `neutral500` |
| `--ink-4` | `#a0a0a0` | `#94A3B8` | `neutral400` |
| `--warn` | `#ca8a04` | `#E9AD3F` | `okker` |

## Test plan

- [ ] DEV: `https://dev-handbook.dfxserve.com/de/` (or `dev-handbook.realuni.app/de/` once the NS swap is live) shows the new brand colors **and** every spec is collapsible
- [ ] Hex `#1988C6` visible on links, the brand dot, and the callout left-border
- [ ] Page background is the soft `#D1E6F5` blue tone, white test cards sit clearly on top
- [ ] Clicking any spec headline (e.g. "01 Welcome & Onboarding") toggles its body
- [ ] Sidebar "Alle ein-/ausklappen" button flips all seven specs and updates its label
- [ ] Loading `…/de/#spec-04` opens spec 04 automatically and scrolls to it
- [ ] PRD release picks up the change once the develop → main release PR is merged

