### PR TITLE
ci(handbook): post-deploy smoke test against the public endpoint

### DIFF
--- a/.github/workflows/handbook-dev.yaml
+++ b/.github/workflows/handbook-dev.yaml
@@ -67,3 +67,27 @@ jobs:
             -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
             ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
             "${{ env.DEPLOY_SERVICE }}"
+
+      # Post-deploy smoke test: poll the public endpoint until the nginx
+      # container answers 200, or give up. Without this step a "green"
+      # deploy can lie — a misconfigured nginx leaves the container
+      # Up-but-unresponsive while the workflow reports success. Failing
+      # this step blocks the auto-release PR from collecting a green
+      # check and surfaces the regression in CI. Mirrors the pattern
+      # from zkcoins/server `deploy-dev.yaml`.
+      - name: Smoke test public endpoint
+        env:
+          SMOKE_URL: https://dev-handbook.dfxserve.com/de/
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE_URL" || echo "000")
+            if [ "$code" = "200" ]; then
+              echo "DEV handbook responded 200 after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "[$i/30] $SMOKE_URL -> ${code} (waiting 10 s)"
+            sleep 10
+          done
+          echo "::error::DEV handbook never returned 200 within ~5 min after deploy"
+          exit 1

--- a/.github/workflows/handbook-prd.yaml
+++ b/.github/workflows/handbook-prd.yaml
@@ -67,3 +67,25 @@ jobs:
             -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
             ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
             "${{ env.DEPLOY_SERVICE }}"
+
+      # Post-deploy smoke test: poll the public endpoint until the nginx
+      # container answers 200, or give up. Without this step a "green"
+      # deploy can lie — a misconfigured nginx leaves the container
+      # Up-but-unresponsive while the workflow reports success. Mirrors
+      # the pattern from zkcoins/server `deploy-dev.yaml`.
+      - name: Smoke test public endpoint
+        env:
+          SMOKE_URL: https://handbook.dfxserve.com/de/
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE_URL" || echo "000")
+            if [ "$code" = "200" ]; then
+              echo "PRD handbook responded 200 after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "[$i/30] $SMOKE_URL -> ${code} (waiting 10 s)"
+            sleep 10
+          done
+          echo "::error::PRD handbook never returned 200 within ~5 min after deploy"
+          exit 1


### PR DESCRIPTION
## Summary

Add a post-deploy smoke test to both `handbook-dev.yaml` and `handbook-prd.yaml`. Mirrors the pattern from zkcoins/server `deploy-dev.yaml`.

After the SSH-deploy step, the workflow polls the public endpoint (`dev-handbook.dfxserve.com/de/` for DEV, `handbook.dfxserve.com/de/` for PRD) up to 30 × 10 s until it answers HTTP 200. If the endpoint never responds with 200 the step fails and the run is red — blocks a misleadingly "green" deploy that left the container Up-but-unresponsive.

## Why this matters

The release PR (develop → main) aggregates the DEV-deploy status check. Without a smoke test, a broken nginx config can ship to PRD because the deploy step itself succeeded.

## Why dfxserve.com and not realuni.app

The canonical `realuni.app` URLs are not yet live — Infomaniak NS swap is pending. Once the swap completes, both DEV and PRD will also be reachable under `dev-handbook.realuni.app` / `handbook.realuni.app`. The smoke test can be migrated then; today only `dfxserve.com` resolves publicly.

## Test plan

- [ ] Trigger `handbook-dev.yaml` manually → smoke-test step reports 200 on first attempt (endpoint is currently live).
- [ ] After merge to `develop` the regular auto-deploy runs through the new step.
- [ ] Simulate failure: temporarily point the env var at a non-existent host (e.g. `https://dev-handbook.dfxserve.com/nope-404`) and confirm the workflow goes red after ~5 min. (Don't merge that.)