### PR TITLE
chore(ci): refresh bitbox-simulator header comment

### DIFF
--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -15,9 +15,12 @@ name: bitbox-simulator
 #
 # What this does NOT validate: realunit-app's Dart code talking to
 # the BitBox via the bitbox_flutter plugin against real hardware.
-# That still requires a physical BitBox02 (or a future TCP-to-USB
-# shim). The simulator covers the FIRMWARE side of the protocol;
-# bitbox_flutter at ref v0.0.3 is the consumer side.
+# That still requires a physical BitBox02. The simulator covers the
+# FIRMWARE side of the protocol; the Dart consumer side is exercised
+# by Tier 1 (`test/integration/kyc_sign_flow_test.dart`) with the
+# SDK-boundary fake, and ultimately by Tier 3 Maestro flows on real
+# hardware (issue #314). The pinned bitbox_flutter version lives in
+# pubspec.yaml.
 #
 # Runs on every PR that touches BitBox surface AND on manual trigger.
 # For ad-hoc maintainer validation, bitbox-simulator-slash.yml

--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -17,10 +17,11 @@ name: bitbox-simulator
 # the BitBox via the bitbox_flutter plugin against real hardware.
 # That still requires a physical BitBox02. The simulator covers the
 # FIRMWARE side of the protocol; the Dart consumer side is exercised
-# by Tier 1 (`test/integration/kyc_sign_flow_test.dart`) with the
-# SDK-boundary fake, and ultimately by Tier 3 Maestro flows on real
-# hardware (issue #314). The pinned bitbox_flutter version lives in
-# pubspec.yaml.
+# by Tier 1 (SDK-boundary fake, cross-layer tests under
+# `test/integration/`) and ultimately by Tier 3 Maestro flows on
+# real hardware. See `docs/testing.md` for the four-tier model and
+# issue #314 for the rollout plan. The pinned bitbox_flutter version
+# lives in `pubspec.yaml`.
 #
 # Runs on every PR that touches BitBox surface AND on manual trigger.
 # For ad-hoc maintainer validation, bitbox-simulator-slash.yml


### PR DESCRIPTION
## Summary

The header comment in `.github/workflows/bitbox-simulator.yml` claimed *"bitbox_flutter at ref v0.0.3 is the consumer side"*. The actual pin in `pubspec.yaml` is `v0.0.5`, latest tag is `v0.0.7` (2026-05-18).

Rather than chasing the version every bump, this PR makes the comment version-independent:
- Points to `pubspec.yaml` as the source of truth for the pinned version.
- Reframes the Dart-consumer-side coverage via Tier 1 (SDK-boundary fake at `test/integration/kyc_sign_flow_test.dart`) and Tier 3 (Maestro hardware) per the four-tier model in `docs/testing.md` and issue #314.

## Why

Surfaced during the issue #314 rewrite audit (see https://github.com/DFXswiss/realunit-app/issues/314). No code or workflow behaviour changes — comment-only.

## Test plan

- [ ] `actionlint` clean on the changed file.
- [ ] No behavioural change expected from CI; the `bitbox-simulator` job remains path-filtered identical to before.