### PR TITLE
ci: deploy to Play Store Internal + TestFlight on develop merges

### DIFF
--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -1,4 +1,4 @@
-name: Beta Release
+name: Release
 
 on:
   workflow_dispatch:
@@ -99,9 +99,9 @@ jobs:
       # Build & Deploy
       # -------------------
 
-      - name: Deploy to Play Store (Beta)
+      - name: Upload to Play Store
         run: bundle exec fastlane beta
-        working-directory: ./android
+        working-directory: android
         env:
           NEW_VERSION: ${{ github.ref_name }}
 
@@ -192,13 +192,13 @@ jobs:
       # Build & Deploy
       # -------------------
 
-      - name: Deploy to App Store (Beta)
+      - name: Upload to TestFlight
         run: bundle exec fastlane beta --verbose
         working-directory: ios
         env:
           NEW_VERSION: ${{ github.ref_name }}
 
-      - name: Upload ipa artifact
+      - name: Upload IPA artifact
         uses: actions/upload-artifact@v4
         with:
           name: ios-ipa
@@ -219,23 +219,23 @@ jobs:
               "template": "#{{CHANGELOG}}",
               "categories": [
                 {
-                  "title": "## 🚀 Features",
+                  "title": "## Features",
                   "labels": ["feat", "feature"]
                 },
                 {
-                  "title": "## 🐛 Fixes",
+                  "title": "## Fixes",
                   "labels": ["fix", "bug"]
                 },
                 {
-                  "title": "## 📦 Refactor",
+                  "title": "## Refactor",
                   "labels": ["refactor"]
                 },
                 {
-                  "title": "## 📦 Others",
+                  "title": "## Others",
                   "labels": ["chore"]
                 },
                 {
-                  "title": "## 🌀 Not labelled",
+                  "title": "## Not labelled",
                   "labels": []
                 }
               ],

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -5,13 +5,17 @@ on:
   push:
     tags:
       - "v*"
+      - "!v*-beta*"
 
 permissions:
   contents: write
 
+concurrency:
+  group: store-release
+  cancel-in-progress: false
+
 jobs:
   android-deploy:
-    if: ${{ !contains(github.ref_name, 'beta') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -108,7 +112,6 @@ jobs:
           path: build/app/outputs/flutter-apk/realunit-*.apk
 
   ios-deploy:
-    if: ${{ !contains(github.ref_name, 'beta') }}
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
@@ -202,7 +205,6 @@ jobs:
           path: ios/realunit-*.ipa
 
   github-release:
-    if: ${{ !contains(github.ref_name, 'beta') }}
     needs: [android-deploy, ios-deploy]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/develop-release.yaml
+++ b/.github/workflows/develop-release.yaml
@@ -1,4 +1,4 @@
-name: Develop Beta Release
+name: Beta Release
 
 on:
   workflow_dispatch:
@@ -98,9 +98,9 @@ jobs:
       # Build & Deploy
       # -------------------
 
-      - name: Deploy to Play Store (Internal)
+      - name: Upload to Play Store
         run: bundle exec fastlane beta
-        working-directory: ./android
+        working-directory: android
         env:
           NEW_VERSION: ${{ github.ref_name }}
 
@@ -191,13 +191,13 @@ jobs:
       # Build & Deploy
       # -------------------
 
-      - name: Deploy to TestFlight
+      - name: Upload to TestFlight
         run: bundle exec fastlane beta --verbose
         working-directory: ios
         env:
           NEW_VERSION: ${{ github.ref_name }}
 
-      - name: Upload ipa artifact
+      - name: Upload IPA artifact
         uses: actions/upload-artifact@v4
         with:
           name: ios-ipa

--- a/.github/workflows/develop-release.yaml
+++ b/.github/workflows/develop-release.yaml
@@ -9,8 +9,12 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: store-release
+  cancel-in-progress: false
+
 jobs:
-  android-apk:
+  android-deploy:
     runs-on: ubuntu-latest
 
     steps:
@@ -48,10 +52,26 @@ jobs:
           gomobile init
         working-directory: ${{ github.workspace }}
 
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+          working-directory: android
+
+      - name: Install Bundler
+        run: gem install bundler -v 2.7.2
+
+      - name: Install Gems
+        run: bundle _2.7.2_ install
+        working-directory: android
+
       - name: Decode Secrets
         env:
+          PLAY_STORE_JSON: ${{ secrets.PLAY_STORE_JSON_BASE64 }}
           ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
+          echo "$PLAY_STORE_JSON" | base64 --decode > android/credentials.json
           echo "$ANDROID_KEYSTORE" | base64 --decode > android/app/upload-keystore.jks
 
       - name: Create key.properties
@@ -75,29 +95,14 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       # -------------------
-      # Build APK
+      # Build & Deploy
       # -------------------
 
-      - name: Extract version
-        id: version
-        run: |
-          VERSION_NAME="${{ github.ref_name }}"
-          VERSION_NAME="${VERSION_NAME#v}"
-          echo "version_name=$VERSION_NAME" >> $GITHUB_OUTPUT
-
-      - name: Build APK
-        run: |
-          flutter build apk \
-            --release \
-            --build-name=${{ steps.version.outputs.version_name }} \
-            --no-tree-shake-icons \
-            --obfuscate \
-            --split-debug-info=build/debug_info
-
-      - name: Rename APK
-        run: |
-          mv build/app/outputs/flutter-apk/app-release.apk \
-             build/app/outputs/flutter-apk/realunit-${{ steps.version.outputs.version_name }}.apk
+      - name: Deploy to Play Store (Internal)
+        run: bundle exec fastlane beta
+        working-directory: ./android
+        env:
+          NEW_VERSION: ${{ github.ref_name }}
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
@@ -105,8 +110,101 @@ jobs:
           name: android-apk
           path: build/app/outputs/flutter-apk/realunit-*.apk
 
+  ios-deploy:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      # -------------------
+      # Setup Environment
+      # -------------------
+
+      - name: Setup SSH access for Fastlane Match
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MATCH_SSH_KEY }}
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.6"
+          channel: "stable"
+          cache: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.5"
+
+      - name: Init GoMobile
+        run: |
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+          go install golang.org/x/mobile/cmd/gomobile@latest
+          gomobile init
+        working-directory: ${{ github.workspace }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+          working-directory: ios
+
+      - name: Install Bundler
+        run: gem install bundler -v 2.7.2
+
+      - name: Install Gems
+        run: bundle _2.7.2_ install
+        working-directory: ios
+
+      - name: Install Flutter Dependencies
+        run: |
+          flutter pub get
+          dart run tool/generate_localization.dart
+          dart run build_runner build --delete-conflicting-outputs
+        working-directory: ${{ github.workspace }}
+
+      - name: Setup Pods (CocoaPods)
+        run: pod install --repo-update
+        working-directory: ios
+
+      - name: Setup App Store Connect API Key
+        run: |
+          # Use an absolute path for reliability
+          KEY_PATH="${{ github.workspace }}/AuthKey.p8"
+
+          # Create the .p8 file
+          echo "${{ secrets.APP_STORE_CONNECT_KEY }}" > "$KEY_PATH"
+
+          # Export Environment Variables GLOBALLY for all subsequent steps (including match)
+          echo "FASTLANE_APPLE_API_KEY_PATH=$KEY_PATH" >> $GITHUB_ENV
+          echo "FASTLANE_APPLE_API_KEY_ID=${{ secrets.APP_STORE_CONNECT_KEY_ID }}" >> $GITHUB_ENV
+          echo "FASTLANE_APPLE_API_ISSUER_ID=${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}" >> $GITHUB_ENV
+          echo "MATCH_PASSWORD=${{ secrets.MATCH_PASSWORD }}" >> $GITHUB_ENV
+        env:
+          APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+
+      # -------------------
+      # Build & Deploy
+      # -------------------
+
+      - name: Deploy to TestFlight
+        run: bundle exec fastlane beta --verbose
+        working-directory: ios
+        env:
+          NEW_VERSION: ${{ github.ref_name }}
+
+      - name: Upload ipa artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ipa
+          path: ios/realunit-*.ipa
+
   github-release:
-    needs: [android-apk]
+    needs: [android-deploy, ios-deploy]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -158,12 +256,20 @@ jobs:
           name: android-apk
           path: .
 
+      - name: Download iOS artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-ipa
+          path: .
+
       - name: Create Pre-Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.changelog }}
-          files: realunit-*.apk
+          files: |
+            realunit-*.apk
+            realunit-*.ipa
           generate_release_notes: false
           draft: false
           prerelease: true

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -34,30 +34,35 @@ platform :android do
 
   desc "Build and upload to Play Store Beta"
   lane :beta do
+    # Tag (e.g. "v0.0.42-beta.123") -> tag_name "0.0.42-beta.123" -> marketing "0.0.42".
+    # Play Store accepts free-form versionName, but we mirror the iOS split for
+    # consistency: marketing version is what users see, build number disambiguates.
     new_build_number = next_build_number
     raw_version_name = ENV["NEW_VERSION"] || "v0.0.0"
-    new_version_name = raw_version_name.delete('v')
+    tag_name = raw_version_name.sub(/^v/, '')
+    marketing_version = tag_name.split('-').first
 
     Dir.chdir("..") do
-      sh("flutter", "build", "appbundle", 
+      sh("flutter", "build", "appbundle",
          "--release",
-         "--build-name=#{new_version_name}", 
-         "--build-number=#{new_build_number}", 
-         "--no-tree-shake-icons", 
-         "--obfuscate", 
+         "--build-name=#{marketing_version}",
+         "--build-number=#{new_build_number}",
+         "--no-tree-shake-icons",
+         "--obfuscate",
          "--split-debug-info=build/debug_info"
       )
-      sh("flutter", "build", "apk", 
+      sh("flutter", "build", "apk",
          "--release",
-         "--build-name=#{new_version_name}", 
-         "--build-number=#{new_build_number}", 
-         "--no-tree-shake-icons", 
-         "--obfuscate", 
+         "--build-name=#{marketing_version}",
+         "--build-number=#{new_build_number}",
+         "--no-tree-shake-icons",
+         "--obfuscate",
          "--split-debug-info=build/debug_info"
       )
-    File.rename(
-      "../build/app/outputs/flutter-apk/app-release.apk", 
-      "../build/app/outputs/flutter-apk/realunit-#{new_version_name}.apk")
+      File.rename(
+        "../build/app/outputs/flutter-apk/app-release.apk",
+        "../build/app/outputs/flutter-apk/realunit-#{tag_name}.apk"
+      )
     end
 
     upload_to_play_store(

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -28,8 +28,12 @@ platform :ios do
   lane :beta do
     setup_ci
 
+    # Tag (e.g. "v0.0.42-beta.123") -> tag_name "0.0.42-beta.123" -> marketing "0.0.42".
+    # CFBundleShortVersionString must be three integers (App Store ITMS-90060);
+    # the -beta.N suffix lives in the IPA filename and the TestFlight build number.
     raw_version_name = ENV["NEW_VERSION"] || "v0.0.0"
-    new_version_name = raw_version_name.delete('v')
+    tag_name = raw_version_name.sub(/^v/, '')
+    marketing_version = tag_name.split('-').first
     latest_build = latest_testflight_build_number(api_key: get_api_key)
 
     sync_code_signing(
@@ -40,19 +44,19 @@ platform :ios do
     )
 
     increment_version_number(
-      version_number: new_version_name,
+      version_number: marketing_version,
       xcodeproj: "Runner.xcodeproj"
     )
-    
+
     increment_build_number(
-      build_number: latest_build + 1,  
+      build_number: latest_build + 1,
       xcodeproj: "Runner.xcodeproj"
     )
-    
+
     gym(
       workspace: "Runner.xcworkspace",
       scheme: "Runner",
-      output_name: "realunit-#{new_version_name}.ipa",
+      output_name: "realunit-#{tag_name}.ipa",
       xcargs: "-verbose",
       verbose: true
     )


### PR DESCRIPTION
## Summary

Mirror the Android+iOS deploy steps from `beta-release.yaml` into `develop-release.yaml` so that **every merge to `develop`** (which produces a `vX.Y.Z-beta.N` tag via `auto-tag.yaml`) deploys directly to:

- Google Play **Internal Testing** track (Android, `fastlane beta` → `track: "internal"`)
- **TestFlight** (iOS, `fastlane beta` → `upload_to_testflight`)
- GitHub **Pre-Release** with both `.apk` and `.ipa` attached

`main` merges (`vX.Y.Z` tags) follow the same path — same Play Store Internal track, same TestFlight — only the GitHub release is a non-pre-release and the tag has no `-beta.N` suffix. Distinction between develop and main builds happens via the version tag, not via separate store tracks. Promotion to Play Store production / App Store submission stays manual in the store consoles.

## Why

Today: `develop` merge → `v*-beta*` tag → APK-only build + GitHub Pre-Release, no store push. Store push only happens on `main` merge.

New: testers (TestFlight + Google internal) should receive every `develop` build automatically. `main` merges stay reserved for larger updates and end up on the same internal tracks for one final round of testing before manual promotion.

## Changes

### `develop-release.yaml`
- Replaced the standalone `android-apk` build job with a full `android-deploy` job that runs `bundle exec fastlane beta` (uploads to Play Store internal).
- New `ios-deploy` job that runs `bundle exec fastlane beta --verbose` (uploads to TestFlight).
- `github-release` job now depends on both deploy jobs and attaches `.apk` + `.ipa` to the Pre-Release.

### `beta-release.yaml`
- Trigger now excludes beta tags via `tags: ["v*", "!v*-beta*"]`. Previously the workflow triggered on every `v*` and the per-job `if: !contains(github.ref_name, 'beta')` filtered jobs out — the workflow still enqueued as "skipped" on every beta tag push.
- Removed the now-redundant `if: !contains(...)` guards on all three jobs.

### Consistency pass
Both workflows were aligned so they diverge only in semantic essentials (trigger tag pattern, `prerelease` flag, Release vs Pre-Release step name):
- Unified step names (`Upload to Play Store`, `Upload to TestFlight`).
- Identical changelog config (emojis dropped for a cleaner production release format).
- `working-directory: android` (no leading `./`) on both sides.
- Workflow display names: `develop-release.yaml` → "Beta Release", `beta-release.yaml` → "Release".

### Both workflows
- Shared `concurrency.group: store-release` with `cancel-in-progress: false`. Prevents race conditions on `google_play_track_version_codes` (Android) and `latest_testflight_build_number + 1` (iOS) when two tags land in quick succession.

### Fastlane (fixes #455)
Pre-release tags like `v0.0.42-beta.123` would have been written verbatim into `CFBundleShortVersionString` via `agvtool new-marketing-version`. App Store Connect rejects that server-side with `ITMS-90060`. The local build succeeds; `upload_to_testflight` is what fails.

- `ios/fastlane/Fastfile`: split the tag at the first `-`. Marketing version (`0.0.42`) goes into Info.plist and stays App-Store-compliant; full tag (`0.0.42-beta.123`) is kept for the IPA filename. Build uniqueness comes from `latest_testflight_build_number + 1`.
- `android/fastlane/Fastfile`: same split for symmetry. Play Store accepts free-form `versionName`, but mirroring iOS keeps the two lanes shaped the same.
- `raw.delete('v')` → `raw.sub(/^v/, '')`: the old form stripped every `v` anywhere in the tag.

## Test plan

- [ ] Push a manual `v0.0.0-beta.test` tag (or `workflow_dispatch`) on a throwaway commit and confirm both store uploads succeed end-to-end (no ITMS-90060).
- [ ] Confirm `beta-release.yaml` is **not** triggered on the beta tag push (only `develop-release.yaml`).
- [ ] Confirm the `github-release` Pre-Release appears with both APK and IPA attached.
- [ ] On next `main` merge: confirm `beta-release.yaml` runs (and `develop-release.yaml` does not).

## Out of scope

- `actions/checkout@v4`/`@v5` mix intra-workflow — pre-existing, identical in both files.
- `gomobile @latest` ungepinnt, `pod install --repo-update` every run — pre-existing.
- `next_build_number` in `android/fastlane/Fastfile` still only queries the `internal` track. Fine as long as nothing is promoted past internal automatically.