### PR TITLE
ci(handbook): smoke-test canonical realunit.app URLs

### DIFF
--- a/.github/workflows/handbook-dev.yaml
+++ b/.github/workflows/handbook-dev.yaml
@@ -75,13 +75,18 @@ jobs:
       # this step blocks the auto-release PR from collecting a green
       # check and surfaces the regression in CI. Mirrors the pattern
       # from zkcoins/server `deploy-dev.yaml`.
+      #
+      # Probes the canonical root URL with `curl -L` so the default-locale
+      # redirect (`/` → `/de/`) is followed end to end: nginx up, root
+      # routing intact, locale `index.html` served. Pinning a specific
+      # locale path would re-rot if the locale layout ever changes.
       - name: Smoke test public endpoint
         env:
-          SMOKE_URL: https://dev-handbook.realunit.app/de/
+          SMOKE_URL: https://dev-handbook.realunit.app/
         run: |
           set -euo pipefail
           for i in $(seq 1 30); do
-            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE_URL" || echo "000")
+            code=$(curl -sS -L --max-redirs 3 -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE_URL" || echo "000")
             if [ "$code" = "200" ]; then
               echo "DEV handbook responded 200 after ${i} attempt(s)"
               exit 0

--- a/.github/workflows/handbook-dev.yaml
+++ b/.github/workflows/handbook-dev.yaml
@@ -77,7 +77,7 @@ jobs:
       # from zkcoins/server `deploy-dev.yaml`.
       - name: Smoke test public endpoint
         env:
-          SMOKE_URL: https://dev-handbook.dfxserve.com/de/
+          SMOKE_URL: https://dev-handbook.realunit.app/de/
         run: |
           set -euo pipefail
           for i in $(seq 1 30); do

--- a/.github/workflows/handbook-prd.yaml
+++ b/.github/workflows/handbook-prd.yaml
@@ -73,13 +73,18 @@ jobs:
       # deploy can lie — a misconfigured nginx leaves the container
       # Up-but-unresponsive while the workflow reports success. Mirrors
       # the pattern from zkcoins/server `deploy-dev.yaml`.
+      #
+      # Probes the canonical root URL with `curl -L` so the default-locale
+      # redirect (`/` → `/de/`) is followed end to end: nginx up, root
+      # routing intact, locale `index.html` served. Pinning a specific
+      # locale path would re-rot if the locale layout ever changes.
       - name: Smoke test public endpoint
         env:
-          SMOKE_URL: https://handbook.realunit.app/de/
+          SMOKE_URL: https://handbook.realunit.app/
         run: |
           set -euo pipefail
           for i in $(seq 1 30); do
-            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE_URL" || echo "000")
+            code=$(curl -sS -L --max-redirs 3 -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE_URL" || echo "000")
             if [ "$code" = "200" ]; then
               echo "PRD handbook responded 200 after ${i} attempt(s)"
               exit 0

--- a/.github/workflows/handbook-prd.yaml
+++ b/.github/workflows/handbook-prd.yaml
@@ -75,7 +75,7 @@ jobs:
       # the pattern from zkcoins/server `deploy-dev.yaml`.
       - name: Smoke test public endpoint
         env:
-          SMOKE_URL: https://handbook.dfxserve.com/de/
+          SMOKE_URL: https://handbook.realunit.app/de/
         run: |
           set -euo pipefail
           for i in $(seq 1 30); do


### PR DESCRIPTION
## Summary

- Switch the handbook DEV/PRD post-deploy smoke tests from the provisional `*.dfxserve.com` aliases to the canonical product domain `handbook.realunit.app` / `dev-handbook.realunit.app`.
- The `dfxserve.com` aliases remain configured on the Cloudflare Tunnel side as a zero-downtime fallback for now (to be removed in a follow-up once the new endpoints have been observed green for a few days).

The canonical Cloudflare records and the typo correction (`realuni.app` → `realunit.app`) live in the server repo.

## Test plan

- [ ] DEV smoke test (`handbook-dev.yaml`) passes against `https://dev-handbook.realunit.app/de/`
- [ ] PRD smoke test (`handbook-prd.yaml`) passes against `https://handbook.realunit.app/de/` after release-PR merge