### PR TITLE
feat: show app version in settings footer

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -245,6 +245,7 @@
   "sellSuccessDescription": "Der Betrag wird Ihnen auf das angegebene Bankkonto ausgezahlt.",
   "sending": "Wird gesendet",
   "settings": "Einstellungen",
+  "settingsAppVersion": "Version ${version} (${build})",
   "settingsCurrency": "Währung",
   "settingsDeleteWallet": "Geschäftsbeziehung beenden",
   "settingsLanguages": "Sprachen",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -245,6 +245,7 @@
   "sellSuccessDescription": "The amount will be paid into the bank account you have specified.",
   "sending": "Sending",
   "settings": "Settings",
+  "settingsAppVersion": "Version ${version} (${build})",
   "settingsCurrency": "Currency",
   "settingsDeleteWallet": "Terminate business relationship",
   "settingsLanguages": "Languages",

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
@@ -15,14 +16,30 @@ import 'package:realunit_wallet/setup/routing/routes/settings_routes.dart';
 import 'package:realunit_wallet/styles/colors.dart';
 import 'package:realunit_wallet/styles/icons.dart';
 
-class SettingsPage extends StatelessWidget {
+class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
 
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
   static const _forwardIcon = Icon(
     Icons.arrow_forward_ios,
     size: 20,
     color: RealUnitColors.realUnitBlack,
   );
+
+  PackageInfo? _packageInfo;
+
+  @override
+  void initState() {
+    super.initState();
+    PackageInfo.fromPlatform().then((info) {
+      if (!mounted) return;
+      setState(() => _packageInfo = info);
+    });
+  }
 
   @override
   Widget build(BuildContext context) => Scaffold(
@@ -140,6 +157,20 @@ class SettingsPage extends StatelessWidget {
               ),
             ],
           ),
+          if (_packageInfo != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 20),
+              child: Text(
+                S.of(context).settingsAppVersion(
+                  _packageInfo!.version,
+                  _packageInfo!.buildNumber,
+                ),
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: RealUnitColors.neutral500,
+                ),
+              ),
+            ),
         ],
       ),
     ),

--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -35,10 +37,14 @@ class _SettingsPageState extends State<SettingsPage> {
   @override
   void initState() {
     super.initState();
-    PackageInfo.fromPlatform().then((info) {
-      if (!mounted) return;
-      setState(() => _packageInfo = info);
-    });
+    PackageInfo.fromPlatform()
+        .then((info) {
+          if (!mounted) return;
+          setState(() => _packageInfo = info);
+        })
+        .catchError((Object e) {
+          developer.log('Failed to load package info', error: e);
+        });
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1055,6 +1055,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   local_auth: ^3.0.0
   no_screenshot: ^1.1.0
   open_file: ^3.5.11
+  package_info_plus: ^8.1.0
   path: ^1.9.0
   path_provider: 2.1.5
   pointycastle: ^3.9.1


### PR DESCRIPTION
## Summary
- Add app version (with build number) at the bottom of the settings screen so users and support can identify which build they're running.
- Uses `package_info_plus` to read the version dynamically from the bundle.
- New i18n key `settingsAppVersion` (en + de): `Version ${version} (${build})`.

## Why
Users currently have no in-app way to find their installed version, which makes triage of version-specific bugs harder (e.g. the recent iOS BitBox visibility issue that was fixed in v0.0.30).

## Test plan
- [ ] Open Settings on iOS, scroll to bottom → see `Version x.y.z (n)` centered below the "Terminate business relationship" section.
- [ ] Same on Android.
- [ ] Verify both German and English builds.