### PR TITLE
refactor(bitbox): type BitboxNotConnectedException in credentials sign paths

### DIFF
--- a/lib/packages/hardware_wallet/bitbox_credentials.dart
+++ b/lib/packages/hardware_wallet/bitbox_credentials.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:bitbox_flutter/bitbox_manager.dart';
 import 'package:convert/convert.dart' as convert;
+import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:web3dart/crypto.dart';
 import 'package:web3dart/web3dart.dart';
 
@@ -57,9 +58,7 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
     bool isEIP1559 = false,
   }) {
     return _synchronizeSign(() async {
-      if (bitboxManager == null) {
-        throw Exception('Bitbox not connected');
-      }
+      if (!isConnected) throw const BitboxNotConnectedException();
 
       if (isEIP1559) payload = payload.sublist(1);
       final sig = await bitboxManager!.signETHRLPTransaction(
@@ -101,7 +100,7 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
   @override
   Future<Uint8List> signPersonalMessage(Uint8List payload, {int? chainId}) {
     return _synchronizeSign(() async {
-      if (!isConnected) throw Exception('Bitbox not connected');
+      if (!isConnected) throw const BitboxNotConnectedException();
       return await bitboxManager!.signETHMessage(chainId ?? 1, derivationPath!, payload);
     });
   }
@@ -112,7 +111,7 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
 
   Future<String> signTypedDataV4(int chainId, String jsonData) {
     return _synchronizeSign(() async {
-      if (!isConnected) throw Exception('Bitbox not connected');
+      if (!isConnected) throw const BitboxNotConnectedException();
 
       final signatureBytes = await bitboxManager!.signETHTypedMessage(
         chainId,

--- a/lib/packages/service/dfx/dfx_auth_service.dart
+++ b/lib/packages/service/dfx/dfx_auth_service.dart
@@ -41,6 +41,12 @@ abstract class DFXAuthService {
     }
   }
 
+  // Exceptions this method can throw on the BitBox path:
+  //   * `BitboxNotConnectedException` — `BitboxCredentials.signPersonalMessage`
+  //     aborts up front when the device is disconnected (BLE link dropped).
+  //   * `SigningCancelledException` — the user cancels on the device, so the
+  //     BitBox swift wrapper returns empty bytes / `'0x'`, normalised here.
+  //   * `TimeoutException` — the user never confirms within `_signMessageTimeout`.
   Future<String> getSignature(String message) async {
     final cached = appStore.sessionCache.signature;
     final cachedAddress = appStore.sessionCache.signatureAddress;

--- a/lib/packages/service/dfx/real_unit_registration_service.dart
+++ b/lib/packages/service/dfx/real_unit_registration_service.dart
@@ -2,10 +2,8 @@ import 'dart:convert';
 
 import 'package:intl/intl.dart';
 import 'package:realunit_wallet/packages/config/api_config.dart';
-import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
-import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/dto/real_unit_registration_email_request_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/dto/real_unit_registration_email_response_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/dto/real_unit_registration_register_wallet_request_dto.dart';
@@ -54,9 +52,6 @@ class RealUnitRegistrationService extends DFXAuthService {
   /// registers a wallet and and adds the wallet to the new user
   Future<RegistrationStatus> completeRegistration(Registration registration) async {
     final credentials = appStore.wallet.primaryAccount.primaryAddress;
-    if (credentials is BitboxCredentials && !credentials.isConnected) {
-      throw const BitboxNotConnectedException();
-    }
     // BitBox firmware rejects non-ASCII bytes in EIP-712 string fields.
     // Transliterate everything that goes into the signed envelope AND the
     // matching DTO copy so the signed hash matches the backend-stored data
@@ -145,9 +140,6 @@ class RealUnitRegistrationService extends DFXAuthService {
     RealUnitUserDataDto userData,
   ) async {
     final credentials = appStore.wallet.primaryAccount.primaryAddress;
-    if (credentials is BitboxCredentials && !credentials.isConnected) {
-      throw const BitboxNotConnectedException();
-    }
     final registrationDate = DateFormat('yyyy-MM-dd').format(DateTime.now());
     // Same ASCII guard as completeRegistration — see comment there.
     final signature = await Eip712Signer.signRegistration(

--- a/test/helper/fake_bitbox_credentials.dart
+++ b/test/helper/fake_bitbox_credentials.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:eth_sig_util_plus/eth_sig_util_plus.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
 import 'package:web3dart/crypto.dart';
 import 'package:web3dart/web3dart.dart';
@@ -19,7 +20,9 @@ enum FakeBitboxBehavior {
   cancel,
 
   /// BLE link drops before/during the ceremony — the credentials report
-  /// `isConnected == false` and the sign throws.
+  /// `isConnected == false` and the sign throws `BitboxNotConnectedException`,
+  /// mirroring what the real `BitboxCredentials` does when `bitboxManager` is
+  /// null.
   disconnect,
 
   /// The device hangs and never responds — the sign awaits forever (caller
@@ -83,7 +86,7 @@ class FakeBitboxCredentials extends BitboxCredentials {
       case FakeBitboxBehavior.cancel:
         return '0x';
       case FakeBitboxBehavior.disconnect:
-        throw const SigningCancelledException();
+        throw const BitboxNotConnectedException();
       case FakeBitboxBehavior.timeout:
         await Completer<void>().future;
         return '';
@@ -103,7 +106,7 @@ class FakeBitboxCredentials extends BitboxCredentials {
       case FakeBitboxBehavior.cancel:
         return Uint8List(0);
       case FakeBitboxBehavior.disconnect:
-        throw const SigningCancelledException();
+        throw const BitboxNotConnectedException();
       case FakeBitboxBehavior.timeout:
         await Completer<void>().future;
         return Uint8List(0);
@@ -125,8 +128,9 @@ class FakeBitboxCredentials extends BitboxCredentials {
         final pk = EthPrivateKey.fromHex(_testPrivateKeyHex);
         return pk.signToSignature(payload, chainId: chainId, isEIP1559: isEIP1559);
       case FakeBitboxBehavior.cancel:
-      case FakeBitboxBehavior.disconnect:
         throw const SigningCancelledException();
+      case FakeBitboxBehavior.disconnect:
+        throw const BitboxNotConnectedException();
       case FakeBitboxBehavior.timeout:
         await Completer<void>().future;
         return MsgSignature(BigInt.zero, BigInt.zero, 0);

--- a/test/helper/fake_bitbox_credentials_test.dart
+++ b/test/helper/fake_bitbox_credentials_test.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
-import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 
 import 'fake_bitbox_credentials.dart';
 
@@ -58,7 +58,7 @@ void main() {
         expect(sig, '0x');
       });
 
-      test('disconnect: throws SigningCancelledException', () async {
+      test('disconnect: throws BitboxNotConnectedException', () async {
         final fake = FakeBitboxCredentials(
           behavior: FakeBitboxBehavior.disconnect,
           signDelay: Duration.zero,
@@ -66,7 +66,7 @@ void main() {
 
         expect(
           () => fake.signTypedDataV4(1, _typedData),
-          throwsA(isA<SigningCancelledException>()),
+          throwsA(isA<BitboxNotConnectedException>()),
         );
       });
 
@@ -131,7 +131,7 @@ void main() {
 
         await expectLater(
           fake.signTypedDataV4(1, _typedData),
-          throwsA(isA<SigningCancelledException>()),
+          throwsA(isA<BitboxNotConnectedException>()),
         );
 
         fake.behavior = FakeBitboxBehavior.success;
@@ -162,7 +162,7 @@ void main() {
         expect(sig, isEmpty);
       });
 
-      test('disconnect: throws SigningCancelledException', () async {
+      test('disconnect: throws BitboxNotConnectedException', () async {
         final fake = FakeBitboxCredentials(
           behavior: FakeBitboxBehavior.disconnect,
           signDelay: Duration.zero,
@@ -170,7 +170,7 @@ void main() {
 
         expect(
           () => fake.signPersonalMessage(Uint8List.fromList([1, 2, 3])),
-          throwsA(isA<SigningCancelledException>()),
+          throwsA(isA<BitboxNotConnectedException>()),
         );
       });
     });

--- a/test/integration/kyc_sign_flow_test.dart
+++ b/test/integration/kyc_sign_flow_test.dart
@@ -4,7 +4,8 @@
 // touches end-to-end and that have all had production bugs in the past
 // month (PR #312, #316, #318, #319):
 //
-//   FakeBitboxCredentials → Eip712Signer.signRegistration → SigningCancelledException
+//   FakeBitboxCredentials → Eip712Signer.signRegistration →
+//   { SigningCancelledException on cancel, BitboxNotConnectedException on disconnect }
 //
 // They run headless (no device, no simulator), so they live under
 // `test/integration/` and run as part of `flutter test`. Future scenarios
@@ -12,6 +13,7 @@
 // will move to a top-level `integration_test/` directory.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:realunit_wallet/packages/wallet/eip712_signer.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
 
@@ -67,7 +69,7 @@ void main() {
     );
 
     test(
-      'BLE disconnect: fake throws SigningCancelledException directly',
+      'BLE disconnect: fake throws BitboxNotConnectedException directly',
       () async {
         final fake = FakeBitboxCredentials(
           behavior: FakeBitboxBehavior.disconnect,
@@ -76,7 +78,7 @@ void main() {
 
         await expectLater(
           _signRegistration(fake),
-          throwsA(isA<SigningCancelledException>()),
+          throwsA(isA<BitboxNotConnectedException>()),
         );
       },
     );
@@ -91,7 +93,7 @@ void main() {
 
         await expectLater(
           _signRegistration(fake),
-          throwsA(isA<SigningCancelledException>()),
+          throwsA(isA<BitboxNotConnectedException>()),
         );
 
         fake.behavior = FakeBitboxBehavior.success;

--- a/test/packages/hardware_wallet/bitbox_credentials_test.dart
+++ b/test/packages/hardware_wallet/bitbox_credentials_test.dart
@@ -4,6 +4,7 @@ import 'package:bitbox_flutter/bitbox_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 
 class _MockBitboxManager extends Mock implements BitboxManager {}
 
@@ -35,11 +36,11 @@ void main() {
       expect(c.isConnected, isFalse);
     });
 
-    test('signToSignature throws when bitboxManager is null', () {
+    test('signToSignature throws BitboxNotConnectedException when bitboxManager is null', () {
       final c = BitboxCredentials('0x000000000000000000000000000000000000dead');
       expect(
         () => c.signToSignature(Uint8List.fromList(List.filled(32, 0))),
-        throwsException,
+        throwsA(isA<BitboxNotConnectedException>()),
       );
     });
 
@@ -104,11 +105,11 @@ void main() {
       expect(sig.v, 38);
     });
 
-    test('signPersonalMessage throws when not connected', () {
+    test('signPersonalMessage throws BitboxNotConnectedException when not connected', () {
       final c = BitboxCredentials('0x000000000000000000000000000000000000dead');
       expect(
         () => c.signPersonalMessage(Uint8List.fromList([1, 2, 3])),
-        throwsException,
+        throwsA(isA<BitboxNotConnectedException>()),
       );
     });
 
@@ -131,11 +132,11 @@ void main() {
       expect(captured[1], "m/44'/60'/0'/0/0");
     });
 
-    test('signTypedDataV4 throws when not connected', () {
+    test('signTypedDataV4 throws BitboxNotConnectedException when not connected', () {
       final c = BitboxCredentials('0x000000000000000000000000000000000000dead');
       expect(
         () => c.signTypedDataV4(1, '{"primaryType":"Foo"}'),
-        throwsException,
+        throwsA(isA<BitboxNotConnectedException>()),
       );
     });
 


### PR DESCRIPTION
## Summary

The three sign methods on `BitboxCredentials` (`signToSignature`, `signPersonalMessage`, `signTypedDataV4`) used to throw an untyped `Exception('Bitbox not connected')` when the device was disconnected. The rest of the codebase had already moved to a dedicated `BitboxNotConnectedException` for this case, so callers had to either pre-check `isConnected` upstream (which `RealUnitRegistrationService` did twice) or string-match the message. This PR makes the typed exception flow from the credentials themselves, which lets us delete the redundant pre-checks.

## Changes

- `BitboxCredentials`: all three sign methods now throw `BitboxNotConnectedException` via a uniform `if (!isConnected)` guard (was a mixed `bitboxManager == null` / `!isConnected` style).
- `RealUnitRegistrationService.completeRegistration` / `registerWallet`: removed the redundant pre-checks. The exception is now raised by `BitboxCredentials` when the EIP-712 sign is attempted; the cheap ASCII-transliteration block above it is safe to run regardless of connection state. Dropping the duplicated guard also drops the now-unused `BitboxCredentials` / `BitboxNotConnectedException` imports.
- `FakeBitboxCredentials.disconnect` now throws `BitboxNotConnectedException` (was `SigningCancelledException`) to mirror the real hardware behaviour. `cancel` on `signToSignature` keeps `SigningCancelledException` since it models the device-confirm cancel path, not a disconnect.
- `DFXAuthService.getSignature`: added a comment documenting the three exception types the BitBox path can throw (`BitboxNotConnectedException`, `SigningCancelledException`, `TimeoutException`).

## Behaviour preservation

- Catch blocks matching `Exception` still match because `BitboxNotConnectedException` implements `Exception`.
- Catch blocks already matching `BitboxNotConnectedException` (e.g. `KycRegistrationSubmitCubit`) keep firing — they now catch the throw from the actual sign rather than from the removed upstream pre-check, which is the same observable behaviour from the caller's perspective.

## Verification

- ``grep -n \"throw Exception('Bitbox not connected')\" lib/ test/`` returns 0 matches.
- `flutter analyze` clean on touched files (only pre-existing info-level lints in `lib/generated/`).
- `flutter test` passes locally (1354 tests).

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` all green locally (1354 tests)
- [ ] CI green
- [ ] Smoke-test on a real BitBox: disconnected device on KYC submit emits `KycRegistrationSubmitBitboxRequired` (unchanged observable behaviour)