### PR TITLE
feat: jump marketing version to 1.0.0

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -60,10 +60,11 @@ jobs:
           NEW_PATCH=$((PATCH + 1))
           NEXT_VERSION="v${MAJOR}.${MINOR}.${NEW_PATCH}"
 
-          # Floor: marketing version from pubspec.yaml (strip "+buildNumber").
-          # If pubspec is ahead of the patch-bumped tag, jump to pubspec instead.
-          # Lets us bump major/minor by editing pubspec.yaml in a PR.
-          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | cut -d+ -f1)
+          # Floor for major/minor jumps: when pubspec.yaml is ahead of the
+          # patch-bumped tag, use pubspec instead. Patch increments still come
+          # from the tag history; pubspec is only consulted to trigger jumps.
+          PUBSPEC_VERSION=$(grep -E '^version:[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+' pubspec.yaml \
+            | awk '{print $2}' | cut -d+ -f1)
           if [ -n "$PUBSPEC_VERSION" ]; then
             HIGHEST=$(printf '%s\n%s\n' "${NEXT_VERSION#v}" "$PUBSPEC_VERSION" | sort -V | tail -n 1)
             NEXT_VERSION="v${HIGHEST}"

--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -56,9 +56,19 @@ jobs:
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           PATCH=$(echo "$VERSION" | cut -d. -f3)
 
-          # Next release version
+          # Default: patch-bump on top of latest tag
           NEW_PATCH=$((PATCH + 1))
           NEXT_VERSION="v${MAJOR}.${MINOR}.${NEW_PATCH}"
+
+          # Floor: marketing version from pubspec.yaml (strip "+buildNumber").
+          # If pubspec is ahead of the patch-bumped tag, jump to pubspec instead.
+          # Lets us bump major/minor by editing pubspec.yaml in a PR.
+          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | cut -d+ -f1)
+          if [ -n "$PUBSPEC_VERSION" ]; then
+            HIGHEST=$(printf '%s\n%s\n' "${NEXT_VERSION#v}" "$PUBSPEC_VERSION" | sort -V | tail -n 1)
+            NEXT_VERSION="v${HIGHEST}"
+            echo "::notice::pubspec marketing version: $PUBSPEC_VERSION; resolved next: $NEXT_VERSION"
+          fi
 
           if [ "$BRANCH" = "main" ]; then
             NEW_TAG="$NEXT_VERSION"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.1+2
+version: 1.0.0+29
 
 environment:
   sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
## Summary
Big version jump: `0.0.x` → `1.0.0`. The app has been in production for months and the `0.0.x` track no longer reflects its maturity.

### Changes
- **`pubspec.yaml`**: `0.0.1+2` → `1.0.0+29`
  - Marketing version `1.0.0` is what the App Store / Play Store will surface from now on.
  - Build number `29` continues seamlessly from the current TestFlight build `28` so the App Store accepts the next upload.
- **`.github/workflows/auto-tag.yaml`**: pubspec marketing version is now a floor for the next tag.
  - If pubspec is ahead of the patch-bumped latest tag, the workflow picks pubspec instead.
  - Lets us trigger major/minor jumps in the future by bumping pubspec in a PR — no more out-of-band tag surgery.

### Resulting tag flow
| Event                                  | Resulting tag      |
|----------------------------------------|--------------------|
| Merge this PR (develop)                | `v1.0.0-beta.1`    |
| Subsequent develop merges              | `v1.0.0-beta.N+1`  |
| First main merge after PR              | `v1.0.0`           |
| Future develop merges (after `v1.0.0`) | `v1.0.1-beta.N`    |
| Future main merges                     | `v1.0.1`, …        |

Fastlane on iOS/Android keeps deriving build numbers from TestFlight/Play Store + 1, so the build counter stays monotonic automatically.

## Why
- App is past the "alpha-ish 0.0.x" stage; calling production builds `1.0.0` is more honest.
- Coupling the auto-tag floor to `pubspec.yaml` makes future major/minor bumps reviewable in a normal PR instead of a manual tag push.

## Test plan
- [ ] Merge → confirm `auto-tag` workflow creates `v1.0.0-beta.1` (not `v0.0.42-beta.x`).
- [ ] Beta-release workflow on that tag produces a TestFlight build with marketing version `1.0.0`.
- [ ] Settings footer (PR #457) shows `Version 1.0.0 (29)` (or whatever build TestFlight assigns).
- [ ] Next develop merge after that picks up `v1.0.0-beta.2`.