### PR TITLE
fix(kyc): existing DFX customer merge — close misroute, surface failures

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -202,7 +202,7 @@
   "registerEmailVerificationButton": "Ich habe meine E-Mail bestätigt",
   "registerEmailVerificationDescription": "Wie es aussieht, haben Sie bereits ein Konto. Wir haben Ihnen gerade eine E-Mail geschickt. Um mit Ihrem bestehenden Konto fortzufahren, bestätigen Sie bitte Ihre E-Mail-Adresse, indem Sie auf den zugesandten Link klicken.",
   "registerEmailVerificationFailed": "Sie haben Ihre E-Mail noch nicht bestätigt.",
-  "registerEmailVerificationRegistrationFailed": "Ihre neue Wallet konnte Ihrem Account zugeordnet, jedoch konnte die Wallet nicht registriert werden. Bitte melden Sie sich beim Support.",
+  "registerEmailVerificationRegistrationFailed": "Die Wallet-Registrierung wurde noch nicht abgeschlossen. Bitte versuchen Sie es in wenigen Sekunden erneut. Falls das Problem weiterhin besteht, kontaktieren Sie den Support.",
   "registerEmailVerificationTitle": "Willkommen zurück!",
   "registerPhoneNumberInvalid": "Telefonnummer ist erforderlich",
   "registerPhoneNumberOnlyDigits": "Nur Zahlen sind erlaubt",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -202,7 +202,7 @@
   "registerEmailVerificationButton": "I have confirmed my email address",
   "registerEmailVerificationDescription": "It looks like you already have an account. We have just sent you an email. To continue with your existing account, please confirm your email address by clicking on the link in the email.",
   "registerEmailVerificationFailed": "You have not yet confirmed your email address.",
-  "registerEmailVerificationRegistrationFailed": "Your new wallet has been assigned to your account, but the wallet could not be registered. Please contact support.",
+  "registerEmailVerificationRegistrationFailed": "Wallet registration is not yet complete. Please try again in a few seconds. If the issue persists, contact support.",
   "registerEmailVerificationTitle": "Welcome back!",
   "registerPhoneNumberInvalid": "Phone number is required",
   "registerPhoneNumberOnlyDigits": "Only numbers are allowed",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -53,7 +53,7 @@ blocTest<KycCubit, KycState>(
   build: buildCubit,
   act: (cubit) async {
     cubit.markLegalDisclaimerAccepted();
-    cubit.markBitboxConfirmed();
+    cubit.markRegistrationSignProduced();
     await cubit.checkKyc();
   },
   expect: () => [const KycLoading(), const KycCompleted()],

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -31,10 +31,13 @@ class KycCubit extends Cubit<KycState> {
   bool _legalDisclaimerAccepted = false;
   bool _emailRegistrationAttempted = false;
 
-  // Per-cubit-instance gate. Reset on every KYC entry because `KycPageManager`
-  // creates a fresh `KycCubit` via `BlocProvider(create:)`, so each entry
-  // forces a fresh hardware-wallet confirmation before sensitive steps.
-  bool _bitboxConfirmed = false;
+  // Tracks whether the EIP-712 registration signature has been produced in
+  // *this* KYC entry. Wallet-agnostic — for software wallets the sign is a
+  // silent local operation, for BitBox it is the visible 13-step ceremony.
+  // Per-cubit-instance by design: `KycPageManager` creates a fresh `KycCubit`
+  // via `BlocProvider(create:)`, so every `/kyc` entry forces a fresh sign
+  // before sensitive steps and stale sessions cannot be re-used.
+  bool _registrationSignProduced = false;
 
   // `Future.timeout` does not cancel the underlying work, so a late HTTP
   // response from an earlier call can still resume and emit state after a
@@ -101,17 +104,17 @@ class KycCubit extends Cubit<KycState> {
         return;
       }
 
-      // Disclaimer + form (name/address) + EIP-712 13-step sign always
-      // precede every state past the email step, even when the user is
-      // already at `>= requiredLevel`. The hardware-wallet ceremony is the
-      // security gate, not the backend KYC level — without the sign a
-      // returning user with a high level would otherwise be granted
-      // sensitive actions on this device without ever touching the BitBox.
+      // Disclaimer + EIP-712 registration sign always precede every state
+      // past the email step, even when the user is already at
+      // `>= requiredLevel`. The sign is the per-session security gate, not
+      // the backend KYC level — without it a returning user with a high
+      // level would otherwise be granted sensitive actions on this device
+      // without re-proving ownership of the wallet key.
       if (!_legalDisclaimerAccepted) {
         emit(const KycSuccess(currentStep: KycStep.legalDisclaimer));
         return;
       }
-      if (!_bitboxConfirmed) {
+      if (!_registrationSignProduced) {
         emit(const KycSuccess(currentStep: KycStep.registration));
         return;
       }
@@ -190,8 +193,12 @@ class KycCubit extends Cubit<KycState> {
     _legalDisclaimerAccepted = true;
   }
 
-  void markBitboxConfirmed() {
-    _bitboxConfirmed = true;
+  /// Records that the EIP-712 registration signature has been produced in
+  /// this session, so subsequent [checkKyc] calls pass the sign gate.
+  /// Callers: any code path that triggers the sign — currently the
+  /// new-registration form submit and the existing-customer merge confirm.
+  void markRegistrationSignProduced() {
+    _registrationSignProduced = true;
   }
 
   /// should only be called after realunit registration was completed

--- a/lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart
+++ b/lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart
@@ -14,6 +14,24 @@ class KycEmailVerificationCubit extends Cubit<KycEmailVerificationState> {
   final RealUnitWalletService _walletService;
   final RealUnitRegistrationService _registrationService;
 
+  // `Future.timeout` does not cancel the underlying work, so a late HTTP
+  // response from an earlier call can still resume after a retry. Each
+  // `checkEmailVerification` captures its own generation; any continuation
+  // bails when its generation no longer matches the current one. Acts as a
+  // cancellation token for non-cancellable HTTP work, and lets a fast
+  // double-tap supersede the in-flight call instead of racing two emit
+  // sequences. Pattern mirrors `KycCubit._runGeneration`.
+  int _runGeneration = 0;
+
+  // Once the JWT account-id change has confirmed the merge, the auth side
+  // is settled — re-running the account-id comparison on a retry would just
+  // emit `Failure` ("email not yet confirmed") because `getAuthToken` keeps
+  // returning the new (merged) account. The remaining work that can still
+  // race is `getWalletStatus` propagation on the user-data side, so a retry
+  // after a `RegistrationFailure` should skip the auth-side check and go
+  // straight to `_completeRegistration`.
+  bool _mergeDetected = false;
+
   KycEmailVerificationCubit({
     required DFXAuthService dfxService,
     required RealUnitWalletService walletService,
@@ -24,28 +42,66 @@ class KycEmailVerificationCubit extends Cubit<KycEmailVerificationState> {
        super(const KycEmailVerificationInitial());
 
   Future<void> checkEmailVerification() async {
+    final generation = ++_runGeneration;
+    if (isClosed) return;
     emit(const KycEmailVerificationLoading());
 
-    final currentAccountId = await getAccountId();
-    _dfxService.invalidateAuthToken();
-    final newAccountId = await getAccountId();
+    if (!_mergeDetected) {
+      final currentAccountId = await getAccountId();
+      if (isClosed || generation != _runGeneration) return;
+      _dfxService.invalidateAuthToken();
+      final newAccountId = await getAccountId();
+      if (isClosed || generation != _runGeneration) return;
 
-    if (currentAccountId != newAccountId) {
-      await _completeRegistration();
-      emit(const KycEmailVerificationSuccess());
-    } else {
-      emit(const KycEmailVerificationFailure());
+      if (currentAccountId == newAccountId) {
+        // Email link not yet clicked, or token still cached. The user can
+        // retry by tapping again once the link in the confirmation mail has
+        // actually been visited.
+        emit(const KycEmailVerificationFailure());
+        return;
+      }
+      _mergeDetected = true;
     }
+
+    // JWT account changed → backend recognised the merge. Now associate the
+    // new wallet with the merged user via the EIP-712 registration signature.
+    if (await _completeRegistration(generation)) {
+      if (isClosed || generation != _runGeneration) return;
+      emit(const KycEmailVerificationSuccess());
+    }
+    // else: _completeRegistration already emitted RegistrationFailure; we
+    // intentionally do NOT emit Success here so the verification page stays
+    // open and the user can retry without the failure being papered over.
   }
 
-  Future<void> _completeRegistration() async {
+  /// Returns `true` when the wallet was successfully registered with the
+  /// (now-merged) user account. On failure the cubit is already in
+  /// [KycEmailVerificationRegistrationFailure] so the listener can show the
+  /// error to the user.
+  Future<bool> _completeRegistration(int generation) async {
     try {
       final status = await _walletService.getWalletStatus();
-      if (status.realUnitUserDataDto == null) throw Exception('No existing user data');
+      if (isClosed || generation != _runGeneration) return false;
+      if (status.realUnitUserDataDto == null) {
+        // Backend race: the auth service reports the merged account while the
+        // user-data service hasn't propagated yet. Surface as a recoverable
+        // failure so the user can retry by tapping the confirmation button
+        // again — by then propagation will usually have completed, and the
+        // retry path skips the auth-side check thanks to `_mergeDetected`.
+        developer.log(
+          'getWalletStatus returned null realUnitUserDataDto after merge',
+        );
+        emit(const KycEmailVerificationRegistrationFailure());
+        return false;
+      }
       await _registrationService.registerWallet(status.realUnitUserDataDto!);
+      if (isClosed || generation != _runGeneration) return false;
+      return true;
     } catch (e) {
-      developer.log(e.toString());
+      if (isClosed || generation != _runGeneration) return false;
+      developer.log('registerWallet failed: $e');
       emit(const KycEmailVerificationRegistrationFailure());
+      return false;
     }
   }
 

--- a/lib/screens/kyc/steps/email/kyc_email_page.dart
+++ b/lib/screens/kyc/steps/email/kyc_email_page.dart
@@ -80,6 +80,15 @@ class _KycEmailFormState extends State<KycEmailForm> {
               ),
             );
             if (isConfirmed == true && context.mounted) {
+              // A successful merge confirmation produced the EIP-712
+              // registration signature via
+              // `KycEmailVerificationCubit._completeRegistration` →
+              // `RealUnitRegistrationService.registerWallet`. The verification
+              // page only pops with `true` when that succeeded, so the sign
+              // gate is safe to mark — without this, existing DFX customers
+              // would be misrouted back to the empty registration form after
+              // the disclaimer step.
+              context.read<KycCubit>().markRegistrationSignProduced();
               context.read<KycCubit>().checkKyc();
             }
           }

--- a/lib/screens/kyc/steps/registration/kyc_registration_page.dart
+++ b/lib/screens/kyc/steps/registration/kyc_registration_page.dart
@@ -104,9 +104,9 @@ class _KycRegistrationViewState extends State<KycRegistrationView> {
         listener: (context, state) async {
           if (state is KycRegistrationSubmitSuccess) {
             if (state.status == RegistrationStatus.completed) {
-              // completeRegistration already produced the BitBox 13-step sign,
-              // so skip the security ceremony on the next checkKyc.
-              context.read<KycCubit>().markBitboxConfirmed();
+              // completeRegistration already produced the EIP-712 registration
+              // signature, so the sign gate is satisfied for this session.
+              context.read<KycCubit>().markRegistrationSignProduced();
               context.read<KycCubit>().checkKyc();
             }
           }

--- a/lib/screens/kyc/steps/registration/steps/kyc_registration_address_step.dart
+++ b/lib/screens/kyc/steps/registration/steps/kyc_registration_address_step.dart
@@ -61,6 +61,10 @@ class KycRegistrationAddressStep extends StatelessWidget {
                         controller: addressNumberCtrl,
                         label: S.of(context).number,
                         keyboardType: TextInputType.streetAddress,
+                        validator: (value) {
+                          if (value == null || value.isEmpty) return '';
+                          return null;
+                        },
                       ),
                     ),
                   ],

--- a/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
+++ b/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
@@ -128,7 +128,7 @@ void main() {
     );
 
     blocTest<KycCubit, KycState>(
-      'emits KycSuccess(registration) when disclaimer accepted but BitBox not confirmed',
+      'emits KycSuccess(registration) when disclaimer accepted but registration sign not yet produced',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
           (_) async => _kycStatus(level: KycLevel.level20),
@@ -165,7 +165,7 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       expect: () => [
@@ -190,7 +190,7 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       expect: () => [
@@ -215,7 +215,7 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       expect: () => [const KycLoading(), const KycPending(KycStep.dfxApproval)],
@@ -240,7 +240,7 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       expect: () => [
@@ -268,7 +268,7 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       expect: () => [
@@ -288,14 +288,14 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       expect: () => [const KycLoading(), const KycCompleted()],
     );
 
     blocTest<KycCubit, KycState>(
-      'returning user at level >= required still routes through the BitBox gate first',
+      'returning user at level >= required still routes through the sign gate first',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
           (_) async => _kycStatus(level: KycLevel.level50),
@@ -386,7 +386,7 @@ void main() {
       build: () => buildCubit(requiredLevel: 10),
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       expect: () => [const KycLoading(), const KycCompleted()],
@@ -430,7 +430,7 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       expect: () => [const KycLoading(), const KycCompleted()],
@@ -462,7 +462,7 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       verify: (cubit) {
@@ -487,7 +487,7 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       expect: () => [
@@ -510,7 +510,7 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       expect: () => [const KycLoading(), const KycPending(KycStep.ident)],
@@ -527,7 +527,7 @@ void main() {
       build: buildCubit,
       act: (cubit) async {
         cubit.markLegalDisclaimerAccepted();
-        cubit.markBitboxConfirmed();
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
       expect: () => [const KycLoading(), const KycPending(KycStep.ident)],
@@ -559,7 +559,7 @@ void main() {
 
         final cubit = KycCubit(kycService, registrationService)
           ..markLegalDisclaimerAccepted()
-          ..markBitboxConfirmed();
+          ..markRegistrationSignProduced();
 
         final states = <KycState>[];
         final sub = cubit.stream.listen(states.add);
@@ -610,9 +610,9 @@ void main() {
     );
   });
 
-  group('$KycCubit markLegalDisclaimerAccepted / markBitboxConfirmed', () {
+  group('$KycCubit markLegalDisclaimerAccepted / markRegistrationSignProduced', () {
     blocTest<KycCubit, KycState>(
-      'progresses past the BitBox gate once both marks are set',
+      'progresses past the sign gate once both marks are set',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
           (_) async => _kycStatus(level: KycLevel.level30),
@@ -623,8 +623,8 @@ void main() {
       act: (cubit) async {
         await cubit.checkKyc(); // expects legalDisclaimer
         cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc(); // expects registration (BitBox gate)
-        cubit.markBitboxConfirmed();
+        await cubit.checkKyc(); // expects registration (sign gate)
+        cubit.markRegistrationSignProduced();
         await cubit.checkKyc(); // expects KycCompleted
       },
       expect: () => [

--- a/test/screens/kyc/steps/email/kyc_email_verification_cubit_test.dart
+++ b/test/screens/kyc/steps/email/kyc_email_verification_cubit_test.dart
@@ -129,8 +129,8 @@ void main() {
     );
 
     blocTest<KycEmailVerificationCubit, KycEmailVerificationState>(
-      'changed account id but no userData → cubit settles on Success (Registration'
-      'Failure is intermediate, overwritten by the outer Success emit)',
+      'changed account id but no userData → RegistrationFailure, no Success '
+      '(propagation race: user can retry by tapping the confirm button again)',
       setUp: () {
         final tokens = [_fakeJwt(1), _fakeJwt(2)];
         var i = 0;
@@ -144,11 +144,19 @@ void main() {
       },
       build: build,
       act: (c) => c.checkEmailVerification(),
-      verify: (c) => expect(c.state, isA<KycEmailVerificationSuccess>()),
+      expect: () => [
+        isA<KycEmailVerificationLoading>(),
+        isA<KycEmailVerificationRegistrationFailure>(),
+      ],
+      verify: (_) {
+        verifyNever(() => registrationService.registerWallet(any()));
+      },
     );
 
     blocTest<KycEmailVerificationCubit, KycEmailVerificationState>(
-      'registerWallet throws: cubit still settles on Success (does not crash)',
+      'registerWallet throws → RegistrationFailure, no Success '
+      '(failure is surfaced so the user can retry instead of proceeding '
+      'with a wallet that is not actually registered)',
       setUp: () {
         final tokens = [_fakeJwt(1), _fakeJwt(2)];
         var i = 0;
@@ -164,8 +172,54 @@ void main() {
       },
       build: build,
       act: (c) => c.checkEmailVerification(),
-      verify: (c) {
-        expect(c.state, isA<KycEmailVerificationSuccess>());
+      expect: () => [
+        isA<KycEmailVerificationLoading>(),
+        isA<KycEmailVerificationRegistrationFailure>(),
+      ],
+      verify: (_) => verify(() => registrationService.registerWallet(_userData)).called(1),
+    );
+
+    blocTest<KycEmailVerificationCubit, KycEmailVerificationState>(
+      'retry after null-userData race: second call skips account-id check '
+      '(propagation completed → registerWallet succeeds → Success)',
+      setUp: () {
+        // First call: account-id changes, userData not yet propagated.
+        // Second call: same account-id (already merged), userData now present.
+        // Without the `_mergeDetected` short-circuit the second call would
+        // hit the same-account-id guard and emit Failure ("email not yet
+        // confirmed") — verifying the retry path works.
+        final tokens = [_fakeJwt(1), _fakeJwt(2), _fakeJwt(2), _fakeJwt(2)];
+        var i = 0;
+        when(() => auth.getAuthToken()).thenAnswer((_) async => tokens[i++]);
+        var walletStatusCallCount = 0;
+        when(() => walletService.getWalletStatus()).thenAnswer((_) async {
+          walletStatusCallCount++;
+          return walletStatusCallCount == 1
+              ? RealUnitWalletStatusDto(
+                  isRegistered: false,
+                  realUnitUserDataDto: null,
+                )
+              : RealUnitWalletStatusDto(
+                  isRegistered: true,
+                  realUnitUserDataDto: _userData,
+                );
+        });
+        when(() => registrationService.registerWallet(any()))
+            .thenAnswer((_) async => RegistrationStatus.completed);
+      },
+      build: build,
+      act: (c) async {
+        await c.checkEmailVerification();
+        await c.checkEmailVerification();
+      },
+      expect: () => [
+        isA<KycEmailVerificationLoading>(),
+        isA<KycEmailVerificationRegistrationFailure>(),
+        isA<KycEmailVerificationLoading>(),
+        isA<KycEmailVerificationSuccess>(),
+      ],
+      verify: (_) {
+        verify(() => registrationService.registerWallet(_userData)).called(1);
       },
     );
   });

--- a/test/screens/kyc/steps/kyc_email_page_test.dart
+++ b/test/screens/kyc/steps/kyc_email_page_test.dart
@@ -1,10 +1,16 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/generated/i18n.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/registration/registration_email_status.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
+import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
 import 'package:realunit_wallet/screens/kyc/cubits/kyc/kyc_cubit.dart';
 import 'package:realunit_wallet/screens/kyc/steps/email/cubits/email_step/kyc_email_step_cubit.dart';
 import 'package:realunit_wallet/screens/kyc/steps/email/kyc_email_page.dart';
@@ -16,24 +22,63 @@ class MockKycEmailStepCubit extends MockCubit<KycEmailStepState> implements KycE
 
 class MockKycCubit extends MockCubit<KycState> implements KycCubit {}
 
+class MockHomeBloc extends MockBloc<HomeEvent, HomeState> implements HomeBloc {}
+
 class MockRealUnitRegistrationService extends Mock implements RealUnitRegistrationService {}
+
+class MockRealUnitWalletService extends Mock implements RealUnitWalletService {}
+
+class MockDfxWidgetService extends Mock implements DfxWidgetService {}
+
+/// Pops the first pushed sub-route with the configured [value], so a test can
+/// simulate the merge-confirmation page returning success without having to
+/// fully mount [KycEmailVerificationPage] and drive its button. The first
+/// `didPush` from `pumpWidget` itself (the test's own root route) is skipped.
+class _AutoPopObserver extends NavigatorObserver {
+  _AutoPopObserver({this.value});
+
+  final Object? value;
+  bool _seenRoot = false;
+  bool _popped = false;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    if (!_seenRoot) {
+      _seenRoot = true;
+      return;
+    }
+    if (_popped) return;
+    _popped = true;
+    // Pop on the next microtask so the route gets fully mounted first —
+    // matches how a real user would tap "I've confirmed" after the page
+    // appears.
+    Future.microtask(() => route.navigator?.pop<bool>(value as bool?));
+  }
+}
 
 void main() {
   late KycEmailStepCubit kycEmailStepCubit;
   late KycCubit kycCubit;
+  late HomeBloc homeBloc;
 
   setUp(() {
     kycEmailStepCubit = MockKycEmailStepCubit();
     kycCubit = MockKycCubit();
+    homeBloc = MockHomeBloc();
 
     when(() => kycEmailStepCubit.state).thenReturn(const KycEmailStepInitial());
     when(() => kycCubit.state).thenReturn(const KycInitial());
     when(() => kycCubit.checkKyc()).thenAnswer((_) => Future.value());
+    when(() => kycCubit.markRegistrationSignProduced()).thenAnswer((_) {});
+    when(() => homeBloc.state).thenReturn(const HomeState());
   });
 
   void setupDependencyInjection() {
     final getIt = GetIt.instance;
     getIt.registerSingleton<RealUnitRegistrationService>(MockRealUnitRegistrationService());
+    getIt.registerSingleton<RealUnitWalletService>(MockRealUnitWalletService());
+    getIt.registerSingleton<DfxWidgetService>(MockDfxWidgetService());
   }
 
   setUpAll(() {
@@ -47,6 +92,7 @@ void main() {
       providers: [
         BlocProvider.value(value: kycCubit),
         BlocProvider.value(value: kycEmailStepCubit),
+        BlocProvider.value(value: homeBloc),
       ],
       child: child,
     );
@@ -108,5 +154,71 @@ void main() {
 
       expect(find.byType(SnackBar), findsOne);
     });
+
+    testWidgets(
+      'marks registration sign produced and re-runs checkKyc after merge confirm pops with true',
+      (tester) async {
+        whenListen(
+          kycEmailStepCubit,
+          Stream.fromIterable([
+            const KycEmailStepSuccess(RegistrationEmailStatus.mergeRequested),
+          ]),
+          initialState: const KycEmailStepInitial(),
+        );
+
+        // Wrap directly so we can install a NavigatorObserver that auto-pops
+        // the verification page with `true` — simulating a successful merge
+        // confirmation. `pumpApp` doesn't expose observers.
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: const [
+              S.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: S.delegate.supportedLocales,
+            navigatorObservers: [_AutoPopObserver(value: true)],
+            home: buildSubject(const KycEmailView()),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        verify(() => kycCubit.markRegistrationSignProduced()).called(1);
+        verify(() => kycCubit.checkKyc()).called(1);
+      },
+    );
+
+    testWidgets(
+      'does NOT mark registration sign produced when merge confirm pops with false / null',
+      (tester) async {
+        whenListen(
+          kycEmailStepCubit,
+          Stream.fromIterable([
+            const KycEmailStepSuccess(RegistrationEmailStatus.mergeRequested),
+          ]),
+          initialState: const KycEmailStepInitial(),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: const [
+              S.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: S.delegate.supportedLocales,
+            // Pop with `null` (e.g. user backs out of the verification page).
+            navigatorObservers: [_AutoPopObserver(value: null)],
+            home: buildSubject(const KycEmailView()),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        verifyNever(() => kycCubit.markRegistrationSignProduced());
+        verifyNever(() => kycCubit.checkKyc());
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Fixes two related bugs in the KYC merge flow for existing DFX customers plus a missing validator in the registration form. Closes #464, refs #465.

- **Bug A (#464)** — `KycCubit._registrationSignProduced` (formerly `_bitboxConfirmed`) was never marked after a successful DFX-merge email confirmation, even though the merge path produces the same EIP-712 signature as the new-registration path. After accepting the disclaimer, the user was routed to an empty personal-data form for data already on file at DFX. Submit would have produced a fresh EIP-712 sign over user-typed data, attaching potentially-divergent values (diacritics, address abbreviations, phone format) to the existing DFX account.
- **Bug B (#465)** — `KycEmailVerificationCubit.checkEmailVerification` emitted `Success` unconditionally after `_completeRegistration`, silently swallowing both the null-userData case (likely a backend propagation race) and `registerWallet` throws. The user perceived the merge as successful while the wallet was not actually signed and registered.
- **Address-number validator** — `KycRegistrationAddressStep.addressNumberCtrl` had no validator at all; empty values would pass form validation and reach the backend. Mirrors the validator pattern used by the other fields in the same step.

## Commits

- `3d98c8d` — `fix(kyc): close existing-customer merge misroute, rename sign gate flag`
- `e71f71e` — `fix(kyc-email-verification): surface failures, add generation guard + retry path`
- `4d44c21` — `fix(kyc): require street number in registration address form`

## What changed

### Bug A

- Rename `_bitboxConfirmed` → `_registrationSignProduced`, `markBitboxConfirmed()` → `markRegistrationSignProduced()`. The flag is wallet-agnostic — silent local sign for software wallets, 13-step ceremony for BitBox. The old name routinely misled readers.
- Call `markRegistrationSignProduced()` from `kyc_email_page.dart` on a successful merge confirmation pop, before re-running `checkKyc`. Without this, the existing-DFX-customer flow would still hit the gate after the disclaimer step.
- Update the doc comment around the gate to focus on per-session sign semantics rather than the hardware-wallet UX surface.
- Fix `docs/testing.md:56` — the code example referenced the renamed method (would not compile if copied).
- Update `kyc_cubit_test.dart` references and group name.
- Add widget tests in `kyc_email_page_test.dart` that verify the setter is called when the merge-confirmation pop returns `true` and is **not** called on `false` / `null`. Without these a future refactor could remove the setter call again without any test failing.

### Bug B

- `_completeRegistration` now returns `Future<bool>` indicating whether the wallet was actually registered.
- `checkEmailVerification` only emits `Success` when `_completeRegistration` returned `true`; on failure the cubit stays in `RegistrationFailure` so the verification page stays open and the user can retry.
- Add `_runGeneration` cancellation-token (mirrors `KycCubit`): guards every emit against stale calls and against `isClosed`, prevents a late HTTP response from emitting after a retry, and lets a fast double-tap supersede the in-flight call instead of racing two emit sequences.
- Add `_mergeDetected` short-circuit so the retry path actually retries. Once the JWT account-id change has confirmed the merge, the auth side is settled — a retry after a null-userData race should not re-run the account-id comparison (which would emit `Failure` because `getAuthToken` keeps returning the merged account). Subsequent retries skip the auth check and go straight to `_completeRegistration`, where the propagation race usually resolves.
- Rewrite the misleading `registerEmailVerificationRegistrationFailed` i18n strings (DE + EN). Old text claimed the wallet had been assigned to the account — only true on the `registerWallet` throw path, not on the null-userData branch. New text is neutral and actionable for both failure modes.
- Update the two existing tests that asserted the silent-Success behaviour to assert the new, correct behaviour: failures surface to the UI.
- Add a new test for the retry path: two consecutive calls with a null-userData first response and a populated second response end in Success.

### Address-number validator

- Add an empty/null-rejecting validator on `addressNumberCtrl` in `kyc_registration_address_step.dart`, matching the existing validators on street, postal code, city, country.

## What did **not** change

- The per-cubit-instance security model is preserved: every `/kyc` entry still constructs a fresh `KycCubit` and the gate still requires a fresh sign before sensitive steps. The fix encodes a fact the merge path was already producing, it does not loosen the gate.
- For users who legitimately hit `KycStep.registration` (genuinely new users without DFX data) the flow is identical.
- The page-level listener in `kyc_email_verification_page.dart` already handled all three states (`Failure`, `RegistrationFailure`, `Success`) correctly — Failure shows a snackbar and stays open, Success pops with `true`. No changes needed.
- Backend contracts: untouched.

## Local verification

- `flutter analyze` — clean (`No issues found! (ran in 1.6s)`)
- `flutter test` — **1398 / 1398 passed** (1395 develop baseline + 3 new tests)

## Test plan

- [ ] **Manual on Android** — existing DFX customer flow (the reproduction from #464):
  - [ ] dashboard → Buy → Next → enter DFX email → confirm via email link → tap "I've confirmed" → accept disclaimer wizard (5 steps) → **lands on dashboard / next KYC step, not on the empty form**
  - [ ] cancel mid-flow → return → flow remains coherent
- [ ] **Manual on Android** — new user (non-DFX) flow:
  - [ ] dashboard → Buy → Next → enter fresh email → continue → fill registration form → submit → flow completes
  - [ ] try submitting with empty street-number field → blocked by validator
- [ ] **Manual on Android** — Bug B regression check:
  - [ ] If reachable in test env, simulate a `registerWallet` failure (network kill, backend 5xx) → user sees the snackbar and the verification page stays open → user can retry
  - [ ] If a null-userData propagation race can be induced, verify the second tap on "I've confirmed" goes through

## Items deliberately deferred to a separate PR

Surfaced during review of #466 but kept out-of-scope to keep this PR coherent:

- Re-frame Bug A commit-message wording from "security" to "UX/data integrity" — already reflected in the rewritten commit message of `3d98c8d`. Bug B's mechanism is the more severe of the two (wallet not registered presented as success); Bug A is misroute + data-integrity risk via form submit.
- Backend idempotency for `/register/wallet` when the wallet is already registered — out of scope for the app repo.

## Related

- Closes #464
- Refs #465
- Touches code introduced by PR #312 (`fix: gate sensitive KYC steps behind BitBox EIP-712 sign`) — the merge case appears to have been overlooked at that time
- Compatible with PR #317 (`fix(kyc): prevent stale state leak in KycCubit on retry`) — extends the same `_runGeneration` pattern to `KycEmailVerificationCubit`