### PR TITLE
test(bitbox): guard exception surface + lock-in P1 channel-hash ordering

### DIFF
--- a/test/packages/service/dfx/exceptions/exception_surface_test.dart
+++ b/test/packages/service/dfx/exceptions/exception_surface_test.dart
@@ -1,11 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
+import 'package:realunit_wallet/packages/wallet/exceptions/wallet_locked_exception.dart';
 
 // Guard against a recurring failure mode: an Exception subclass without a
 // toString() override gets rendered as `Instance of '...'` whenever a cubit
 // or service falls back to surfacing the raw error string. Every typed
-// exception in this app must therefore expose a human-readable message.
+// exception in this app must therefore expose a human-readable message, and
+// every one of them must be listed below so drift is caught at test time.
 //
 // Add new typed exceptions to this list as they are introduced.
 void main() {
@@ -13,6 +16,8 @@ void main() {
     final exceptions = <Object>[
       const BitboxNotConnectedException(),
       const SigningCancelledException(),
+      const WalletLockedException(),
+      const ApiException(code: 'TEST', message: 'test'),
     ];
 
     for (final ex in exceptions) {

--- a/test/packages/service/dfx/exceptions/exception_surface_test.dart
+++ b/test/packages/service/dfx/exceptions/exception_surface_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
+import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
+
+// Guard against a recurring failure mode: an Exception subclass without a
+// toString() override gets rendered as `Instance of '...'` whenever a cubit
+// or service falls back to surfacing the raw error string. Every typed
+// exception in this app must therefore expose a human-readable message.
+//
+// Add new typed exceptions to this list as they are introduced.
+void main() {
+  group('exception toString surface', () {
+    final exceptions = <Object>[
+      const BitboxNotConnectedException(),
+      const SigningCancelledException(),
+    ];
+
+    for (final ex in exceptions) {
+      test('${ex.runtimeType} renders a readable string', () {
+        final rendered = ex.toString();
+        expect(
+          rendered,
+          isNot(contains('Instance of')),
+          reason:
+              '${ex.runtimeType} is missing a toString() override and would '
+              'surface as "Instance of ..." if it leaked to the UI.',
+        );
+        expect(rendered, isNotEmpty);
+      });
+    }
+  });
+}

--- a/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
+++ b/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
@@ -227,6 +227,35 @@ void main() {
       verifyNever(() => service.confirmPairing());
     });
 
+    // BitBox quirk P1 (pairing-channel-hash-before-confirm): the channel hash
+    // must reach the UI before the host calls confirmPairing on the device,
+    // otherwise the user has no way to verify the hash matches the device
+    // display. The cubit enforces this by emitting BitboxCheckHash before
+    // user-driven confirmPairing() ever invokes the service.
+    test('emits BitboxCheckHash before service.confirmPairing is called (P1)', () async {
+      var pollCount = 0;
+      when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
+      when(() => service.init(any())).thenAnswer((_) async => true);
+      when(() => service.getChannelHash()).thenAnswer((_) async {
+        pollCount++;
+        return pollCount < 3 ? '' : 'HASH-VISIBLE-TO-USER';
+      });
+      when(() => service.confirmPairing()).thenAnswer((_) async {});
+
+      final cubit = makeCubit();
+      addTearDown(cubit.close);
+
+      await waitForState<BitboxCheckHash>(cubit);
+      expect(
+        (cubit.state as BitboxCheckHash).channelHash,
+        'HASH-VISIBLE-TO-USER',
+      );
+      verifyNever(() => service.confirmPairing());
+
+      await cubit.confirmPairing();
+      verify(() => service.confirmPairing()).called(1);
+    });
+
     test('bounces to NotConnected when createBitboxWallet hangs past the timeout', () async {
       var pollCount = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);


### PR DESCRIPTION
## Summary

Two cheap, plugin-independent test additions that close concrete drift risks identified during the PR #461 review.

### 1. Exception surface guard

`BitboxNotConnectedException` had no `toString()` override. Any code path that surfaces the raw exception (snackbar fallback, log line, `error.toString()`) therefore rendered the default `Instance of '...'` Dart string instead of a human-readable message — a real failure mode observed in the BitBox-disconnect flows.

- Adds `toString() => 'BitBox is not connected'`.
- New `test/packages/service/dfx/exceptions/exception_surface_test.dart` enumerates every typed exception in the app (`BitboxNotConnectedException`, `SigningCancelledException`) and asserts the rendered string contains no `Instance of` and is non-empty. New typed exceptions just need to be appended to the list.

### 2. P1 channel-hash-before-confirm drift test

BitBox firmware quirk **P1** (critical, per `DFXswiss/bitbox-testkit`): the pairing channel hash must reach the UI *before* the host calls `confirmPairing()` on the device — otherwise the user has no opportunity to verify the hash against the on-device display.

`ConnectBitboxCubit` already does the right thing today (`BitboxCheckHash` is emitted before user-driven `confirmPairing()`), but nothing prevents a future refactor from silently inverting the order. The new test in `connect_bitbox_cubit_test.dart` pins this ordering with a `verifyNever(() => service.confirmPairing())` assertion at the `BitboxCheckHash` state.

## Out of scope (follow-up PRs)

- `bitbox_flutter` v0.0.5 → v0.0.7 bump (unlocks the `installSimulatedBitboxPlatform` helper) — separate dependency-bump PR
- `BitboxService` lifecycle suite (re-attach on reconnect, observer behavior, USB-FD release) — depends on the bump above

## Test plan
- [x] `dart run tool/generate_localization.dart`
- [x] `flutter analyze` on touched files — clean
- [x] `flutter test test/packages/service/dfx/exceptions/exception_surface_test.dart test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart` — 11/11 green
- [ ] Full `flutter test` in CI