### PR TITLE
chore(deps): bump bitbox_flutter v0.0.5 → v0.0.7

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,8 +69,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v0.0.5"
-      resolved-ref: "99b31247416b9333a4e89f4b32b2f4565622a4b0"
+      ref: "v0.0.7"
+      resolved-ref: ebe0fb04e0fb1d56ae6fa815277598c980ac1940
       url: "https://github.com/DFXswiss/bitbox_flutter.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,7 +74,7 @@ dependencies:
   bitbox_flutter:
     git:
       url: https://github.com/DFXswiss/bitbox_flutter.git
-      ref: v0.0.5
+      ref: v0.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Pure dependency bump of `bitbox_flutter` from `v0.0.5` to `v0.0.7`.

v0.0.7 adds the public `installSimulatedBitboxPlatform` testing helper
(lib/testing.dart) and ships matching plugin tests. The
`BitboxUsbPlatform` abstract interface is API-compatible with v0.0.5 —
the diff is only formatting changes to method signatures; no breaking
changes for in-tree callers.

## Why now

Unblocks a follow-up PR that replaces the current ad-hoc mocktail
BitBox mocks with the plugin's official simulator, enabling proper
service-lifecycle and observer-timer coverage.

## Verification

- `flutter pub get` resolves to v0.0.7 (`pubspec.lock` updated).
- `flutter analyze` on `lib/packages/hardware_wallet/`,
  `lib/screens/hardware_connect_bitbox/`, and matching test dirs —
  clean.
- Existing BitBox-related test suites all pass:
  `flutter test test/packages/hardware_wallet/ \
    test/screens/hardware_connect_bitbox/ \
    test/packages/service/wallet_service_test.dart`

## Out of scope

- No new tests; no new app code. Tests come in the follow-up PR.

## Test plan
- [x] `flutter pub get` succeeds
- [x] `flutter analyze` clean on BitBox-touching files
- [x] Existing BitBox tests green locally
- [ ] CI green (will run once PR is marked ready)