### PR TITLE
test(bitbox): harden observer + migrate lifecycle suite to fakeAsync

### DIFF
--- a/lib/packages/hardware_wallet/bitbox.dart
+++ b/lib/packages/hardware_wallet/bitbox.dart
@@ -46,7 +46,17 @@ class BitboxService {
   void startConnectionStatusObserver() {
     _connectionStatusObserver?.cancel();
     _connectionStatusObserver = Timer.periodic(_connectionStatusInterval, (_) async {
-      final devices = await getAllUsbDevices();
+      final List<BitboxDevice> devices;
+      try {
+        devices = await getAllUsbDevices();
+      } catch (e) {
+        // Transient BLE/USB hiccups inside the periodic callback used to
+        // surface as uncaught async errors and kill the recovery loop. Log
+        // and wait for the next tick — only an explicit empty device list
+        // is allowed to trigger the device-loss path below.
+        developer.log('device probe failed in observer tick: $e', name: '$BitboxService');
+        return;
+      }
       if (devices.isEmpty) {
         _isConnected = false;
         _credentials?.clearBitbox();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -348,7 +348,7 @@ packages:
     source: hosted
     version: "0.0.10"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,7 @@ dev_dependencies:
   bloc_test: ^10.0.0
   build_runner: ^2.13.0
   drift_dev: ^2.32.1
+  fake_async: ^1.3.3
 
   flutter_launcher_icons: ^0.14.3
   flutter_lints: ^6.0.0

--- a/test/packages/hardware_wallet/bitbox_service_test.dart
+++ b/test/packages/hardware_wallet/bitbox_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:bitbox_flutter/bitbox_flutter.dart';
 import 'package:bitbox_flutter/testing.dart';
 import 'package:bitbox_flutter/usb/bitbox_usb_platform_interface.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
 
@@ -9,13 +10,20 @@ import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
 // the same code paths the real plugin runs, with deterministic device-loss
 // and reconnect timing controlled from the test.
 //
+// Observer-driven cases run inside fakeAsync so virtual time is advanced
+// via async.elapse(...) instead of wall-clock Future.delayed — eliminates
+// the 50ms/150ms flake risk on loaded CI runners and makes tick counting
+// fully deterministic. Microtask-driven setup (pairedService) is pumped
+// inside the same zone via async.flushMicrotasks() so the periodic timer
+// is bound to the fake clock.
+//
 // Each test installs and restores the platform in setUp/tearDown so suites
 // running in parallel don't bleed simulator state into each other.
 void main() {
   late BitboxUsbPlatform previousPlatform;
   late SimulatedBitboxPlatform platform;
 
-  // 50ms keeps the observer-tick latency well under each test's wall-clock
+  // 50ms keeps the observer-tick latency well under each test's virtual
   // budget while still leaving room for the simulator's microtask hops.
   const fastInterval = Duration(milliseconds: 50);
   const observerSettleTime = Duration(milliseconds: 150);
@@ -31,10 +39,16 @@ void main() {
     BitboxUsbPlatform.instance = previousPlatform;
   });
 
-  Future<BitboxService> pairedService() async {
+  // Pair the service inside an existing fakeAsync zone. Must NOT be called
+  // outside fakeAsync — the Timer.periodic the service installs has to be
+  // bound to the fake clock, otherwise async.elapse won't pump it.
+  BitboxService pairedServiceSync(FakeAsync async) {
     final service = BitboxService(connectionStatusInterval: fastInterval);
-    final devices = await service.getAllUsbDevices();
-    await service.init(devices.single);
+    late List<BitboxDevice> devices;
+    service.getAllUsbDevices().then((d) => devices = d);
+    async.flushMicrotasks();
+    service.init(devices.single);
+    async.flushMicrotasks();
     return service;
   }
 
@@ -45,149 +59,271 @@ void main() {
       expect(credentials.isConnected, isFalse);
     });
 
-    test('init() promotes credentials handed out before connect (P461 #1)', () async {
+    test('init() promotes credentials handed out before connect (P461 #1)', () {
       // Regression guard: pre-fix, BitboxService only attached the manager to
       // credentials returned *after* _isConnected was set, so a wallet built
       // from persistence before pairing stayed permanently disconnected and
       // every sign threw BitboxNotConnectedException.
-      final service = BitboxService(connectionStatusInterval: fastInterval);
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
 
-      final credentials = service.getCredentials(knownAddress);
-      expect(credentials.isConnected, isFalse);
+        final credentials = service.getCredentials(knownAddress);
+        expect(credentials.isConnected, isFalse);
 
-      final devices = await service.getAllUsbDevices();
-      await service.init(devices.single);
+        late List<BitboxDevice> devices;
+        service.getAllUsbDevices().then((d) => devices = d);
+        async.flushMicrotasks();
+        service.init(devices.single);
+        async.flushMicrotasks();
 
-      expect(
-        credentials.isConnected,
-        isTrue,
-        reason: 'init() must re-attach the manager to pre-existing credentials',
-      );
+        expect(
+          credentials.isConnected,
+          isTrue,
+          reason: 'init() must re-attach the manager to pre-existing credentials',
+        );
+      });
     });
 
-    test('observer clears credentials and closes transport when device vanishes', () async {
+    test('observer clears credentials and closes transport when device vanishes', () {
       // Bug-class: observer used to null the _credentials reference and skip
       // closing the transport, which on Android left the USB FD claimed and
       // blocked the next connect(). The fix clears the credentials in place
       // (preserving the reference for reconnect) and calls disconnect().
-      final service = await pairedService();
-      final credentials = service.getCredentials(knownAddress);
-      expect(credentials.isConnected, isTrue);
+      fakeAsync((async) {
+        final service = pairedServiceSync(async);
+        final credentials = service.getCredentials(knownAddress);
+        expect(credentials.isConnected, isTrue);
 
-      platform.when(
-        SimulatedBitboxMethod.getDevices,
-        (_) async => const <BitboxDevice>[],
-      );
+        platform.when(
+          SimulatedBitboxMethod.getDevices,
+          (_) async => const <BitboxDevice>[],
+        );
 
-      service.startConnectionStatusObserver();
-      await Future<void>.delayed(observerSettleTime);
+        service.startConnectionStatusObserver();
+        async.elapse(observerSettleTime);
 
-      expect(credentials.isConnected, isFalse,
-          reason: 'observer must clear the credentials on device-loss');
-      expect(platform.count(SimulatedBitboxMethod.close), greaterThanOrEqualTo(1),
-          reason: 'observer must release the USB transport on device-loss');
+        expect(credentials.isConnected, isFalse,
+            reason: 'observer must clear the credentials on device-loss');
+        expect(platform.count(SimulatedBitboxMethod.close), greaterThanOrEqualTo(1),
+            reason: 'observer must release the USB transport on device-loss');
+      });
     });
 
-    test('observer preserves the credentials reference so reconnect can heal them', () async {
+    test('observer preserves the credentials reference so reconnect can heal them', () {
       // Critical to P461 #1: if the observer nulls _credentials, the next
       // init() has nothing to re-attach and the wallet stays broken.
-      final service = await pairedService();
-      final credentials = service.getCredentials(knownAddress);
+      fakeAsync((async) {
+        final service = pairedServiceSync(async);
+        final credentials = service.getCredentials(knownAddress);
 
-      platform.when(
-        SimulatedBitboxMethod.getDevices,
-        (_) async => const <BitboxDevice>[],
-      );
-      service.startConnectionStatusObserver();
-      await Future<void>.delayed(observerSettleTime);
-      expect(credentials.isConnected, isFalse);
+        platform.when(
+          SimulatedBitboxMethod.getDevices,
+          (_) async => const <BitboxDevice>[],
+        );
+        service.startConnectionStatusObserver();
+        async.elapse(observerSettleTime);
+        expect(credentials.isConnected, isFalse);
 
-      // Device reappears — clear the override so the simulator's default
-      // device list applies again, then re-init.
-      platform.clearError(SimulatedBitboxMethod.getDevices);
-      platform.when(SimulatedBitboxMethod.getDevices, (_) async => platform.devices);
-      final devices = await service.getAllUsbDevices();
-      await service.init(devices.single);
+        // Device reappears — re-arm the simulator's default device list and
+        // re-init on the same credentials reference.
+        platform.when(SimulatedBitboxMethod.getDevices, (_) async => platform.devices);
+        late List<BitboxDevice> devices;
+        service.getAllUsbDevices().then((d) => devices = d);
+        async.flushMicrotasks();
+        service.init(devices.single);
+        async.flushMicrotasks();
 
-      expect(
-        credentials.isConnected,
-        isTrue,
-        reason: 'the same credentials instance must re-attach on reconnect',
-      );
+        expect(
+          credentials.isConnected,
+          isTrue,
+          reason: 'the same credentials instance must re-attach on reconnect',
+        );
+      });
     });
 
-    test('observer stops ticking after a single device-loss event', () async {
-      final service = await pairedService();
-      platform.when(
-        SimulatedBitboxMethod.getDevices,
-        (_) async => const <BitboxDevice>[],
-      );
+    test('observer stops ticking after a single device-loss event', () {
+      fakeAsync((async) {
+        final service = pairedServiceSync(async);
+        platform.when(
+          SimulatedBitboxMethod.getDevices,
+          (_) async => const <BitboxDevice>[],
+        );
 
-      service.startConnectionStatusObserver();
-      await Future<void>.delayed(observerSettleTime);
-      final ticksAtLoss = platform.count(SimulatedBitboxMethod.getDevices);
+        service.startConnectionStatusObserver();
+        async.elapse(observerSettleTime);
+        final ticksAtLoss = platform.count(SimulatedBitboxMethod.getDevices);
 
-      await Future<void>.delayed(observerSettleTime * 2);
-      expect(
-        platform.count(SimulatedBitboxMethod.getDevices),
-        ticksAtLoss,
-        reason: 'observer must self-cancel after detecting device-loss',
-      );
+        async.elapse(observerSettleTime * 2);
+        expect(
+          platform.count(SimulatedBitboxMethod.getDevices),
+          ticksAtLoss,
+          reason: 'observer must self-cancel after detecting device-loss',
+        );
+      });
     });
 
-    test('observer swallows transport-close errors instead of crashing', () async {
+    test('observer swallows transport-close errors instead of crashing', () {
       // Android plugin can throw on close() if the FD is already gone; the
       // observer must catch that so the device-loss recovery still completes.
-      final service = await pairedService();
-      final credentials = service.getCredentials(knownAddress);
+      fakeAsync((async) {
+        final service = pairedServiceSync(async);
+        final credentials = service.getCredentials(knownAddress);
 
-      platform.when(
-        SimulatedBitboxMethod.getDevices,
-        (_) async => const <BitboxDevice>[],
-      );
-      platform.throwOn(SimulatedBitboxMethod.close, Exception('USB busy'));
+        platform.when(
+          SimulatedBitboxMethod.getDevices,
+          (_) async => const <BitboxDevice>[],
+        );
+        platform.throwOn(SimulatedBitboxMethod.close, Exception('USB busy'));
 
-      service.startConnectionStatusObserver();
-      await Future<void>.delayed(observerSettleTime);
+        service.startConnectionStatusObserver();
+        async.elapse(observerSettleTime);
 
-      expect(credentials.isConnected, isFalse,
-          reason: 'clearBitbox must still run even when close() throws');
+        expect(credentials.isConnected, isFalse,
+            reason: 'clearBitbox must still run even when close() throws');
+      });
     });
 
-    test('stopConnectionStatusObserver cancels the active periodic', () async {
-      final service = await pairedService();
-      service.startConnectionStatusObserver();
-      service.stopConnectionStatusObserver();
+    test('stopConnectionStatusObserver cancels the active periodic', () {
+      fakeAsync((async) {
+        final service = pairedServiceSync(async);
+        service.startConnectionStatusObserver();
+        service.stopConnectionStatusObserver();
 
-      final ticksAfterStop = platform.count(SimulatedBitboxMethod.getDevices);
-      await Future<void>.delayed(observerSettleTime * 2);
+        final ticksAfterStop = platform.count(SimulatedBitboxMethod.getDevices);
+        async.elapse(observerSettleTime * 2);
 
-      expect(
-        platform.count(SimulatedBitboxMethod.getDevices),
-        ticksAfterStop,
-        reason: 'no further device probing after explicit stop',
-      );
+        expect(
+          platform.count(SimulatedBitboxMethod.getDevices),
+          ticksAfterStop,
+          reason: 'no further device probing after explicit stop',
+        );
+      });
     });
 
-    test('startConnectionStatusObserver replaces any prior periodic', () async {
+    test('startConnectionStatusObserver replaces any prior periodic', () {
       // Defensive: callers may re-arm the observer; the implementation cancels
       // the previous timer before installing the new one. Without that, two
-      // periodics would race and double-tick.
-      final service = await pairedService();
-      service.startConnectionStatusObserver();
-      service.startConnectionStatusObserver();
+      // periodics would race and double-tick. Asserted by counting probes
+      // across two full intervals: with one active timer that's exactly 2
+      // ticks; with both timers alive concurrently it would be 4.
+      fakeAsync((async) {
+        final service = pairedServiceSync(async);
+        final ticksBeforeStart = platform.count(SimulatedBitboxMethod.getDevices);
 
-      await Future<void>.delayed(observerSettleTime);
-      service.stopConnectionStatusObserver();
+        service.startConnectionStatusObserver();
+        service.startConnectionStatusObserver();
 
-      final ticksAfterStop = platform.count(SimulatedBitboxMethod.getDevices);
-      await Future<void>.delayed(observerSettleTime);
+        async.elapse(fastInterval * 2);
+        final probesAcrossTwoIntervals =
+            platform.count(SimulatedBitboxMethod.getDevices) - ticksBeforeStart;
+        expect(
+          probesAcrossTwoIntervals,
+          lessThanOrEqualTo(2),
+          reason: 'both periodics alive would double-tick: expected <= 2 probes / 2 intervals',
+        );
 
-      expect(
-        platform.count(SimulatedBitboxMethod.getDevices),
-        ticksAfterStop,
-        reason: 'both periodics must be cancelled — neither may tick after stop',
-      );
+        service.stopConnectionStatusObserver();
+        final ticksAfterStop = platform.count(SimulatedBitboxMethod.getDevices);
+        async.elapse(observerSettleTime);
+
+        expect(
+          platform.count(SimulatedBitboxMethod.getDevices),
+          ticksAfterStop,
+          reason: 'both periodics must be cancelled — neither may tick after stop',
+        );
+      });
+    });
+
+    test('observer survives a thrown getAllUsbDevices and keeps probing on the next tick', () {
+      // Drives the production fix: a transient plugin error in the device
+      // probe used to become an uncaught async exception inside the periodic
+      // callback. The recovery loop now logs and waits for the next tick;
+      // only an explicit empty device list triggers the device-loss path.
+      fakeAsync((async) {
+        final service = pairedServiceSync(async);
+        final credentials = service.getCredentials(knownAddress);
+        expect(credentials.isConnected, isTrue);
+
+        platform.throwOn(SimulatedBitboxMethod.getDevices, Exception('transient BLE'));
+
+        service.startConnectionStatusObserver();
+        async.elapse(observerSettleTime);
+
+        expect(credentials.isConnected, isTrue,
+            reason: 'a throw must not trigger the device-loss path');
+        expect(platform.count(SimulatedBitboxMethod.close), 0,
+            reason: 'no transport close on a transient probe failure');
+        final ticksUnderError = platform.count(SimulatedBitboxMethod.getDevices);
+        expect(ticksUnderError, greaterThanOrEqualTo(1),
+            reason: 'the observer must have at least attempted one probe');
+
+        // Recovery: probe stops throwing. The next tick must fire — proving
+        // the observer survived the prior exception instead of dying silent.
+        platform.clearError(SimulatedBitboxMethod.getDevices);
+        async.elapse(observerSettleTime);
+
+        expect(
+          platform.count(SimulatedBitboxMethod.getDevices),
+          greaterThan(ticksUnderError),
+          reason: 'observer must keep probing after a transient error',
+        );
+        expect(credentials.isConnected, isTrue,
+            reason: 'devices are present again — connection must stay alive');
+
+        service.stopConnectionStatusObserver();
+      });
+    });
+
+    test('init() failure leaves credentials un-attached', () {
+      // Coverage gap: if initBitBox() returns false the service throws
+      // 'Failed to init' and must NOT promote _isConnected. Subsequent
+      // getCredentials() calls must still hand out disconnected instances.
+      fakeAsync((async) {
+        platform.when(SimulatedBitboxMethod.initBitBox, (_) async => false);
+
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        final preInit = service.getCredentials(knownAddress);
+        expect(preInit.isConnected, isFalse);
+
+        late List<BitboxDevice> devices;
+        service.getAllUsbDevices().then((d) => devices = d);
+        async.flushMicrotasks();
+
+        Object? caught;
+        service.init(devices.single).catchError((Object e) {
+          caught = e;
+          return false;
+        });
+        async.flushMicrotasks();
+
+        expect(caught, isA<Exception>(),
+            reason: 'init() must throw when initBitBox returns false');
+        expect(preInit.isConnected, isFalse,
+            reason: 'failed init must not promote pre-existing credentials');
+
+        final postInit = service.getCredentials(knownAddress);
+        expect(postInit.isConnected, isFalse,
+            reason: 'failed init must leave _isConnected false for future hand-outs');
+      });
+    });
+
+    test('getCredentials called twice with the same address while connected returns equally-connected instances', () {
+      // Defensive pin: the observer's clearBitbox() operates on whichever
+      // BitboxCredentials reference is currently stored in _credentials. A
+      // future refactor that caches and returns the same instance across
+      // calls would break that contract — each hand-out must be a fresh
+      // instance so the observer always targets the latest one.
+      fakeAsync((async) {
+        final service = pairedServiceSync(async);
+
+        final first = service.getCredentials(knownAddress);
+        final second = service.getCredentials(knownAddress);
+
+        expect(first.isConnected, isTrue);
+        expect(second.isConnected, isTrue);
+        expect(second, isNot(same(first)),
+            reason: 'each getCredentials call must produce a distinct instance');
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to #470 — addresses every caveat raised in the post-merge code review:

| Caveat | Resolution |
|---|---|
| wall-clock 50ms/150ms timing → flake risk on loaded CI | Suite migrated to `package:fake_async`; `async.elapse(...)` replaces `Future.delayed` |
| "replaces any prior periodic" assertion didn't fully back the docstring | Now counts active ticks across two intervals, catches concurrent double-ticks |
| dead `platform.clearError(getDevices)` line in reconnect-heal test | Removed |
| uncovered: `getAllUsbDevices()` throws inside the timer callback | **Real bug found by review** — production code now wraps in try/catch and logs; new test guards the fix |
| uncovered: `init()` failure path leaves `_credentials` un-attached | New test |
| uncovered: double `getCredentials` while connected | New test pinning "always operate on latest reference" |

## Production code change

`BitboxService.startConnectionStatusObserver` now wraps `getAllUsbDevices()` in `try/catch`. A transient plugin error in the device probe used to become an uncaught async exception inside the `Timer.periodic` callback — the recovery loop now logs via `developer.log` and waits for the next tick. Only `devices.isEmpty` still triggers the device-loss path. Default behaviour for in-tree callers is unchanged.

## Test plan
- [x] `flutter analyze` clean on touched files
- [x] Lifecycle suite: 11/11 green deterministically (ran twice locally to confirm no flake)
- [x] Surrounding suites in `test/packages/hardware_wallet/` and `test/screens/hardware_connect_bitbox/` green
- [ ] CI green once marked ready