### PR TITLE
ci(bitbox-audit): surface firmware-quirk coverage on every PR

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -83,3 +83,49 @@ jobs:
           name: coverage-lcov
           path: coverage/lcov.info
           if-no-files-found: warn
+
+  # Runs the bitbox-audit CLI from DFXswiss/bitbox-testkit to surface which
+  # of the documented BitBox firmware quirks are statically detected in this
+  # repo and which still need runtime coverage. Intentionally non-blocking
+  # and not part of required_status_checks — purely informational.
+  bitbox-audit:
+    name: BitBox quirks audit
+    # Same guard pattern as `build`: skip drafts, always run on push/dispatch.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Install bitbox-audit
+        continue-on-error: true
+        run: go install github.com/DFXswiss/bitbox-testkit/go/cmd/bitbox-audit@main
+
+      - name: Run bitbox-audit
+        continue-on-error: true
+        run: |
+          "$(go env GOPATH)/bin/bitbox-audit" \
+            --repo . \
+            --format markdown \
+            --output bitbox-audit-report.md
+
+      - name: Inline report into run summary
+        if: always()
+        continue-on-error: true
+        run: |
+          if [ -f bitbox-audit-report.md ]; then
+            cat bitbox-audit-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "bitbox-audit-report.md not produced — see job logs." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bitbox-audit-report
+          path: bitbox-audit-report.md
+          if-no-files-found: warn

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -98,11 +98,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - name: Install bitbox-audit
         continue-on-error: true
-        run: go install github.com/DFXswiss/bitbox-testkit/go/cmd/bitbox-audit@main
+        run: go install github.com/DFXswiss/bitbox-testkit/go/cmd/bitbox-audit@v0.5.0
 
       - name: Run bitbox-audit
         continue-on-error: true


### PR DESCRIPTION
## Summary

Adds a non-blocking ubuntu-latest job to `pull-request.yaml` that runs `bitbox-audit` from `DFXswiss/bitbox-testkit` against the repo. Reports static-detection coverage and runtime-only quirks as a workflow artifact and inline in the run summary.

## Why

The bitbox-testkit ships a documented knowledge base of 31 BitBox firmware quirks with severity, source citation, and (where possible) static-detection rules. Today nobody runs it against this repo, so we don't know which quirks are guarded by tests and which are silent risks. Wiring it into PR CI makes coverage visible without changing anything else.

## Properties

- Runs on ubuntu-latest (Go binary; macOS minutes preserved)
- Non-blocking: `continue-on-error` on the audit step; upload uses `if: always()`
- Not added to `required_status_checks` — informational only
- Report is both an artifact (`bitbox-audit-report`) and inlined into the GitHub Actions run summary

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pull-request.yaml'))"`)
- [ ] Once marked ready, the new job runs and produces an artifact
- [ ] Existing `Analyze & Test` job is unaffected