### PR TITLE
docs(contributing): document service-lifecycle, exception-surface, and integration-test conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,35 @@ lib/
 - For BitBox-related code, the layered test strategy (Tier 0–4) is documented in [`docs/testing.md`](docs/testing.md), with concrete patterns for cubit tests, widget tests, service + HTTP tests, and `FakeBitboxCredentials`-backed integration tests.
 - [`docs/testing.md`](docs/testing.md) also lists the surface that needs an infra PR first (Drift repositories, `getIt`-coupled pages, `path_provider`-coupled cubits, the Sumsub SDK, plugin-coupled widgets). Don't try to mock around those without changing the injection point.
 
+### 1. Service-lifecycle tests are mandatory
+
+Any service class with at least one of: a `Timer` (one-shot or periodic), an observer / subscription loop, or a direct platform/MethodChannel dependency MUST have a dedicated test file that instantiates the *real* class (no mock of the service itself) and drives its lifecycle end-to-end. For BitBox-touching code, use `installSimulatedBitboxPlatform` from `bitbox_flutter/testing.dart`. Tests with time-based behaviour MUST use `package:fake_async` rather than wall-clock `Future.delayed`.
+
+Why: mocking the service-under-test hides the very lifecycle bugs (timer leaks, unsubscribed listeners, double-init) these tests exist to catch. Wall-clock delays make tests slow and flaky.
+
+Reference example: `test/packages/hardware_wallet/bitbox_service_test.dart`.
+
+### 2. Exception surface tests are mandatory
+
+Every typed exception in `lib/` (any class that `implements Exception` or `extends Exception`) MUST have a `toString()` override that returns a human-readable message — not the Dart default `Instance of '<ClassName>'`. The shared `test/packages/service/dfx/exceptions/exception_surface_test.dart` enumerates every typed exception and asserts the rendered string is human-readable. When you add a new typed exception, you MUST add it to that list at the same time.
+
+Why: exceptions surface in logs, Sentry, and user-facing error states. A default `Instance of '...'` is useless for debugging and unfriendly for users. Centralising the assertion in one test file keeps the contract visible.
+
+Reference example: `test/packages/service/dfx/exceptions/exception_surface_test.dart`.
+
+### 3. Platform-specific code paths need an integration test (or explicit waiver)
+
+Code paths that depend on Android- or iOS-specific behaviour (USB transports, BLE lifecycle, secure storage, biometric prompts, deep links) MUST either:
+
+1. Have a corresponding `integration_test/` counterpart that exercises the platform behaviour against the real plugin / a vendor simulator, OR
+2. Carry an inline `// @no-integration-test: <reason>` annotation at the top of the file or function block, explicitly stating why a unit-level test is sufficient.
+
+Code review must call out platform-specific code that has neither.
+
+Why: unit tests with mocked platform channels cannot catch real-device regressions (permission prompts, OS-level lifecycle, transport quirks). The annotation makes the absence of an integration test a deliberate, reviewable decision rather than an oversight.
+
+Reference example: forward-looking — no `integration_test/` directory exists yet; the first integration test to land will become the reference.
+
 ## Widget Guidelines
 
 - Prefer `StatelessWidget` unless lifecycle management is truly needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,35 +91,22 @@ lib/
 - Test helper at `test/helper/` (provides `pumpApp`).
 - For BitBox-related code, the layered test strategy (Tier 0–4) is documented in [`docs/testing.md`](docs/testing.md), with concrete patterns for cubit tests, widget tests, service + HTTP tests, and `FakeBitboxCredentials`-backed integration tests.
 - [`docs/testing.md`](docs/testing.md) also lists the surface that needs an infra PR first (Drift repositories, `getIt`-coupled pages, `path_provider`-coupled cubits, the Sumsub SDK, plugin-coupled widgets). Don't try to mock around those without changing the injection point.
+- Service-lifecycle tests are mandatory for any service with a `Timer`, observer/subscription loop, or platform/MethodChannel dependency: instantiate the real class (no mock of the service itself), swap `BitboxUsbPlatform.instance` in `setUp` and restore in `tearDown`, and prefer deterministic time control over wall-clock `Future.delayed` for periodic-timer assertions.[^fake-async]
+  - Why: mocking the service-under-test hides timer leaks, unsubscribed listeners, and double-init bugs; wall-clock delays make tests slow and flaky.
+  - See: `test/packages/hardware_wallet/bitbox_service_test.dart`.
+- Exception surface tests are mandatory: every typed exception in `lib/` (any class that `implements Exception` or `extends Exception`) MUST override `toString()` so the rendered string does not contain `Instance of` and is non-empty (matches the assertions in the surface test), AND MUST be enumerated in the shared surface test the moment it is introduced.[^surface-complete]
+  - Why: exceptions surface in logs, Sentry, and user-facing error states — the Dart default `Instance of '...'` is useless for debugging and unfriendly for users.
+  - See: `test/packages/service/dfx/exceptions/exception_surface_test.dart`.
+- Platform-specific code paths (USB transports, BLE lifecycle, secure storage, biometric prompts, deep links) MUST either ship an `integration_test/` counterpart exercising the real plugin or vendor simulator, OR carry an inline `// @no-integration-test: <reason>` annotation as either a file-level dartdoc comment OR immediately above the function/method declaration.[^integration-test]
+  - Why: unit tests with mocked platform channels cannot catch real-device regressions (permission prompts, OS-level lifecycle, transport quirks); the annotation makes the absence of an integration test a deliberate, reviewable decision.
+  - See: grep the annotation with
+    ```bash
+    rg "^//\s*@no-integration-test:" lib/
+    ```
 
-### 1. Service-lifecycle tests are mandatory
-
-Any service class with at least one of: a `Timer` (one-shot or periodic), an observer / subscription loop, or a direct platform/MethodChannel dependency MUST have a dedicated test file that instantiates the *real* class (no mock of the service itself) and drives its lifecycle end-to-end. For BitBox-touching code, use `installSimulatedBitboxPlatform` from `bitbox_flutter/testing.dart`. Tests with time-based behaviour MUST use `package:fake_async` rather than wall-clock `Future.delayed`.
-
-Why: mocking the service-under-test hides the very lifecycle bugs (timer leaks, unsubscribed listeners, double-init) these tests exist to catch. Wall-clock delays make tests slow and flaky.
-
-Reference example: `test/packages/hardware_wallet/bitbox_service_test.dart`.
-
-### 2. Exception surface tests are mandatory
-
-Every typed exception in `lib/` (any class that `implements Exception` or `extends Exception`) MUST have a `toString()` override that returns a human-readable message — not the Dart default `Instance of '<ClassName>'`. The shared `test/packages/service/dfx/exceptions/exception_surface_test.dart` enumerates every typed exception and asserts the rendered string is human-readable. When you add a new typed exception, you MUST add it to that list at the same time.
-
-Why: exceptions surface in logs, Sentry, and user-facing error states. A default `Instance of '...'` is useless for debugging and unfriendly for users. Centralising the assertion in one test file keeps the contract visible.
-
-Reference example: `test/packages/service/dfx/exceptions/exception_surface_test.dart`.
-
-### 3. Platform-specific code paths need an integration test (or explicit waiver)
-
-Code paths that depend on Android- or iOS-specific behaviour (USB transports, BLE lifecycle, secure storage, biometric prompts, deep links) MUST either:
-
-1. Have a corresponding `integration_test/` counterpart that exercises the platform behaviour against the real plugin / a vendor simulator, OR
-2. Carry an inline `// @no-integration-test: <reason>` annotation at the top of the file or function block, explicitly stating why a unit-level test is sufficient.
-
-Code review must call out platform-specific code that has neither.
-
-Why: unit tests with mocked platform channels cannot catch real-device regressions (permission prompts, OS-level lifecycle, transport quirks). The annotation makes the absence of an integration test a deliberate, reviewable decision rather than an oversight.
-
-Reference example: forward-looking — no `integration_test/` directory exists yet; the first integration test to land will become the reference.
+[^fake-async]: Once PR [#473](https://github.com/DFXswiss/realunit-app/pull/473) (branch `test/bitbox-observer-hardening`) lands — it migrates `bitbox_service_test.dart` to `package:fake_async` and adds the `dev_dependency` — replace the soft wording with `package:fake_async` as the MUST.
+[^surface-complete]: Assumes the complete surface enumeration from branch [`test/exception-surface-complete-coverage`](https://github.com/DFXswiss/realunit-app/tree/test/exception-surface-complete-coverage), which adds the two missing entries (`RegistrationRequiredException`, `KycLevelRequiredException`). Lands together with that PR.
+[^integration-test]: Activates once an `integration_test/` directory exists in the repo; until then, treat option 1 as N/A and the `// @no-integration-test:` annotation as the documenting form.
 
 ## Widget Guidelines
 


### PR DESCRIPTION
## Summary

Documents three test-style conventions in `CONTRIBUTING.md` so the patterns introduced by #467, #470, and #473 don't decay back to ad-hoc mocks over time.

## Conventions added

| # | Rule | Reference example |
|---|---|---|
| 1 | Service-lifecycle tests use the real class as SUT with `installSimulatedBitboxPlatform` + `fake_async`. No mocking of the service itself. | `test/packages/hardware_wallet/bitbox_service_test.dart` |
| 2 | Every typed `Exception` in `lib/` needs a `toString()` override and an entry in the shared surface test. | `test/packages/service/dfx/exceptions/exception_surface_test.dart` |
| 3 | Platform-specific code paths need an `integration_test/` counterpart OR an explicit `// @no-integration-test: <reason>` annotation. | (forward-looking — no `integration_test/` yet) |

## Why

Conventions only stick if they live in the repo, not in PR descriptions. Without this, a future hire would naturally reach for mocktail mocks of `BitboxService` again, the exception surface test would not get appended to as new exceptions land, and platform-specific code would keep slipping through review.

## Test plan
- [x] CONTRIBUTING.md edits visible and well-formatted
- [ ] Reviewer agrees the conventions reflect the patterns shipped in #467/#470/#473