### PR TITLE
test(exceptions): complete surface coverage with KYC + registration variants

### DIFF
--- a/test/packages/service/dfx/exceptions/exception_surface_test.dart
+++ b/test/packages/service/dfx/exceptions/exception_surface_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/payment/buy_exceptions.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/wallet_locked_exception.dart';
 
@@ -18,6 +19,13 @@ void main() {
       const SigningCancelledException(),
       const WalletLockedException(),
       const ApiException(code: 'TEST', message: 'test'),
+      const RegistrationRequiredException(code: 'TEST', message: 'test'),
+      const KycLevelRequiredException(
+        code: 'TEST',
+        message: 'test',
+        requiredLevel: 1,
+        currentLevel: 0,
+      ),
     ];
 
     for (final ex in exceptions) {


### PR DESCRIPTION
## Summary

The exception-surface drift test shipped in #467 enumerates only 4 of the 6 typed `Exception` classes that actually exist in `lib/`. Two `ApiException` subclasses — `RegistrationRequiredException` and `KycLevelRequiredException` — both define their own `toString()` override but were not listed in the surface guard. A regression on either would not be caught.

Adds both to the list. Test count moves from 4 → 6.

Discovered during the independent review of #476 (`docs(contributing)`), which pointed at this test as the canonical example for Convention 2. The convention can't honestly reference an incomplete enumeration.

## Test plan
- [x] All 6 typed exceptions enumerated
- [x] `flutter analyze` clean
- [x] `flutter test` green on the touched file
- [ ] CI once marked ready