### PR TITLE
ci(coverage): scope lcov filter to README activated surface + post summary

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -60,22 +60,48 @@ jobs:
       - run: flutter analyze
       - run: flutter test --coverage
 
-      # Strip generated and unreachable-from-tests files before reporting so
-      # the artifact reflects only the activated surface we actually intend
-      # to cover. Threshold enforcement is not yet wired (see README
-      # "Coverage infrastructure roadmap"); this step only produces a
-      # measurable baseline.
-      - name: Filter coverage report
+      # Narrow the coverage report to the README-defined activated surface:
+      #   lib/packages/**             — services, repositories, signers, utils
+      #   lib/screens/**/cubit(s)/**  — Cubit logic per feature
+      #   lib/screens/**/bloc/**      — Bloc logic per feature
+      # Widget files (lib/screens/**/*_page.dart, lib/widgets/**) are covered
+      # by `testWidgets` specs and excluded from the line-coverage scope by
+      # design — see README "Coverage scope". Threshold enforcement is the
+      # next step (see README "Coverage infrastructure roadmap"); this step
+      # only produces the scoped baseline + a human-readable summary.
+      - name: Filter coverage to README scope
         run: |
-          if [ -f coverage/lcov.info ]; then
-            brew install lcov >/dev/null
-            lcov --remove coverage/lcov.info \
-              'lib/generated/**' \
-              'lib/main.dart' \
-              --output-file coverage/lcov.info \
-              --ignore-errors unused
-            lcov --summary coverage/lcov.info || true
+          if [ ! -f coverage/lcov.info ]; then
+            echo "::warning::coverage/lcov.info not found — skipping coverage filter"
+            exit 0
           fi
+          brew install lcov >/dev/null
+          lcov --extract coverage/lcov.info \
+            'lib/packages/*' \
+            'lib/screens/*/cubit/*' \
+            'lib/screens/*/cubits/*' \
+            'lib/screens/*/bloc/*' \
+            --output-file coverage/lcov.info \
+            --ignore-errors unused
+          lcov --summary coverage/lcov.info | tee coverage/lcov.summary
+
+      - name: Report coverage summary
+        if: always()
+        run: |
+          if [ ! -f coverage/lcov.summary ]; then
+            exit 0
+          fi
+          {
+            echo "## Coverage report (README scope)"
+            echo
+            echo "Scope: \`lib/packages/**\` + \`lib/screens/**/cubit(s)/**\` + \`lib/screens/**/bloc/**\`"
+            echo
+            echo '```'
+            cat coverage/lcov.summary
+            echo '```'
+            echo
+            echo "_Threshold enforcement is not yet wired — see README \"Coverage infrastructure roadmap\"._"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage report
         if: always()

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -69,6 +69,20 @@ jobs:
       # design — see README "Coverage scope". Threshold enforcement is the
       # next step (see README "Coverage infrastructure roadmap"); this step
       # only produces the scoped baseline + a human-readable summary.
+      #
+      # The extract patterns use lcov's fnmatch matcher, where `*` is greedy
+      # across `/` — so `lib/packages/*` matches arbitrarily deep paths under
+      # that prefix, and `lib/screens/*/cubit/*` matches any feature subtree
+      # (including nested ones like `lib/screens/kyc/steps/email/cubits/...`).
+      # `--ignore-errors unused,empty` covers both a missing prefix after a
+      # rename and a refactor that empties the extracted file — the latter
+      # would otherwise hard-fail on newer lcov versions.
+      #
+      # Note vs. the previous step: `lcov --summary` is no longer guarded by
+      # `|| true`, so a summary failure (e.g. corrupt tracefile) now surfaces
+      # as a red step instead of being silently swallowed. Intentional: the
+      # filtered baseline is the input to the next roadmap item (threshold
+      # check), and silent failures upstream would invalidate that signal.
       - name: Filter coverage to README scope
         run: |
           if [ ! -f coverage/lcov.info ]; then
@@ -82,7 +96,7 @@ jobs:
             'lib/screens/*/cubits/*' \
             'lib/screens/*/bloc/*' \
             --output-file coverage/lcov.info \
-            --ignore-errors unused
+            --ignore-errors unused,empty
           lcov --summary coverage/lcov.info | tee coverage/lcov.summary
 
       - name: Report coverage summary

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ The four-tier testing model (Tier 0 Cubit unit · Tier 1 FakeBitbox integration 
 
 The 100% rule above is the target state. Until the items below land, it is aspirational and not yet CI-enforced:
 
-- [ ] `flutter test --coverage` step in `.github/workflows/pull-request.yaml`
+- [x] `flutter test --coverage` step in `.github/workflows/pull-request.yaml`
+- [x] lcov filter narrowed to the activated surface (`lib/packages/**` + `lib/screens/**/cubit(s)/**` + `lib/screens/**/bloc/**`) and a per-run summary posted to the workflow step summary
 - [ ] lcov threshold check (e.g. via `very_good_cli` or a custom `lcov` parser) failing the build below 100% on the scope above
 - [ ] GitHub branch protection on `develop` requiring the coverage check
 - [ ] Build-time feature-flag mechanism (analogous to `EXPO_PUBLIC_ENABLE_*` in `dfx-wallet`) so non-MVP features can be gated out of the activated surface — required before the 100% rule is realistic across all feature areas


### PR DESCRIPTION
## Summary

First two checkboxes of the README "Coverage infrastructure roadmap". Two narrow changes to `pull-request.yaml`:

- **Narrow the lcov filter from a blacklist to a whitelist matching the README "Coverage scope".** The previous filter only dropped `lib/generated/**` and `lib/main.dart`, so the reported number silently included pages, widgets, models, styles, setup and the rest of the tree — all of which the README explicitly excludes from the line-coverage gate. The new whitelist:

  ```
  lib/packages/**             — services, repositories, signers, utils
  lib/screens/**/cubit(s)/**  — Cubit logic per feature
  lib/screens/**/bloc/**      — Bloc logic per feature
  ```

  Widget files keep being covered by `testWidgets` specs — they count as `widget` coverage in the feature matrix, not as line %.

- **Post the lcov summary into the workflow run summary.** Reviewers see line / function / branch numbers on the PR checks page without downloading the artifact.

Pattern semantics, error-mode hardening and the deliberate behaviour change relative to the previous step are documented inline in the workflow.

## What is intentionally NOT included

- **Not a new `flutter test --coverage` step.** That step has been in `pull-request.yaml` for some time; the README "Coverage infrastructure roadmap" checkbox for it was simply never ticked. This PR fixes the README sync as a side-effect — the actual new behaviour is the scoped filter + summary.
- **Not a threshold gate.** The next checkbox in the README roadmap (`lcov threshold check`) is the follow-up. Picking a sensible starting floor needs a few runs of the scoped baseline to inform the cut-off, and triaging the deferred-feature gaps the README already lists.
- **Not a `ci:full` / heavy-job split.** No self-hosted runner gate to justify it today; current jobs are all fast.

## Deliberate behaviour change

`lcov --summary` is no longer guarded by `|| true`. A summary failure (corrupt tracefile, lcov version regression, …) now turns the step red instead of being silently swallowed. The filtered baseline feeds the next roadmap item, so silent upstream failures would invalidate that signal.

## README

"Coverage infrastructure roadmap" — two checkboxes flipped:
- `flutter test --coverage` step (was already wired, README was stale)
- lcov filter scoped + summary posted to step summary (new in this PR)

The remaining items (threshold check, branch protection, feature-flag gating, `coverage:ignore-*` annotations) stay open as the gradual phase-in.

## CI verification

The PR is Draft, so `pull-request.yaml` skips itself by design. Both head SHAs were verified via `workflow_dispatch` — see the dispatch-run links pinned in the [CI verification comment](https://github.com/DFXswiss/realunit-app/pull/481#issuecomment-4505699588).

## Test plan

- [x] CI on the Draft PR itself is skipped (matches the existing `pull-request.yaml` guard).
- [x] `workflow_dispatch` run is green and posts the scoped lcov summary into the workflow run summary.
- [ ] PR marked ready → CI fires once and posts the summary on the PR checks page.
- [ ] Coverage artifact still uploads with the scoped tracefile.