### PR TITLE
polish: PR #472 follow-ups — real race test + DRY + visibility + in-flight dedup

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -53,6 +53,7 @@
   "connectBitboxContent": "Bitte verbinden Sie Ihre BitBox02 mit Ihrem Smartphone.",
   "connectBitboxContentIos": "Bitte verbinden Sie Ihre BitBox02 mit Ihrem Smartphone und aktivieren Sie zusätzlich Bluetooth.",
   "connectBitboxFailed": "Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+  "connectBitboxSignInHint": "Nach der Code-Überprüfung wird die BitBox um eine zusätzliche Bestätigung zur Anmeldung gebeten.",
   "connectBitboxTitle": "BitBox02 verbinden",
   "connected": "Verbunden",
   "connectedBitboxContent": "Bitte bestätigen Sie und folgen nun den letzten Anweisungen auf Ihrer BitBox02.",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -53,6 +53,7 @@
   "connectBitboxContent": "Please connect your BitBox02 with your Smartphone.",
   "connectBitboxContentIos": "Please connect your BitBox02 with your Smartphone and activate Bluetooth.",
   "connectBitboxFailed": "Something went wrong. Please try to connect again.",
+  "connectBitboxSignInHint": "After verifying the code, the BitBox will ask for one additional confirmation to sign you in.",
   "connectBitboxTitle": "Connect BitBox02",
   "connected": "Connected",
   "connectedBitboxContent": "Please confirm and follow the last steps on your BitBox02.",

--- a/lib/packages/hardware_wallet/bitbox.dart
+++ b/lib/packages/hardware_wallet/bitbox.dart
@@ -14,11 +14,19 @@ class BitboxService {
   final BitboxManager bitboxManager = BitboxManager();
   final Duration _connectionStatusInterval;
   bool _isConnected = false;
-  // Keyed by EIP-55 address so multi-wallet (future) reconnect re-attaches
-  // every active set of credentials, not just the most recently handed out.
+  // Keyed by the lowercased address so multi-wallet (future) reconnect
+  // re-attaches every active set of credentials, not just the most recently
+  // handed out. Lowercase invariant: callers may hand in EIP-55-mixed or raw
+  // hex — we normalise via [_key] on every read/write so a checksum-flip
+  // can't fork the map.
   final Map<String, BitboxCredentials> _credentialsByAddress = {};
   Timer? _connectionStatusObserver;
   Future<void>? _pendingDisconnect;
+
+  /// Normalises an address into the form used as the map key. Lowercase is
+  /// the cheapest robust choice — EIP-55 checksum differs in casing only, so
+  /// `0xAbC` and `0xabc` collapse to the same entry.
+  String _key(String address) => address.toLowerCase();
 
   Future<List<BitboxDevice>> getAllUsbDevices() => bitboxManager.devices;
 
@@ -26,7 +34,7 @@ class BitboxService {
 
   BitboxCredentials getCredentials(String address) {
     final credentials = _credentialsByAddress.putIfAbsent(
-      address,
+      _key(address),
       () => BitboxCredentials(address),
     );
     if (_isConnected) {

--- a/lib/packages/hardware_wallet/bitbox.dart
+++ b/lib/packages/hardware_wallet/bitbox.dart
@@ -77,6 +77,11 @@ class BitboxService {
         return;
       }
       if (devices.isEmpty) {
+        // Two ticks can fire back-to-back if the body's awaits straddle the
+        // next interval — bail if the previous tick already entered the
+        // device-loss path. _isConnected acts as the single-writer flag
+        // because we set it to false before any further work.
+        if (!_isConnected) return;
         _isConnected = false;
         for (final credentials in _credentialsByAddress.values) {
           credentials.clearBitbox();

--- a/lib/packages/hardware_wallet/bitbox.dart
+++ b/lib/packages/hardware_wallet/bitbox.dart
@@ -14,16 +14,21 @@ class BitboxService {
   final BitboxManager bitboxManager = BitboxManager();
   final Duration _connectionStatusInterval;
   bool _isConnected = false;
-  BitboxCredentials? _credentials;
+  // Keyed by EIP-55 address so multi-wallet (future) reconnect re-attaches
+  // every active set of credentials, not just the most recently handed out.
+  final Map<String, BitboxCredentials> _credentialsByAddress = {};
   Timer? _connectionStatusObserver;
+  Future<void>? _pendingDisconnect;
 
   Future<List<BitboxDevice>> getAllUsbDevices() => bitboxManager.devices;
 
   Future<bool> startScan() => bitboxManager.startScan();
 
   BitboxCredentials getCredentials(String address) {
-    final credentials = BitboxCredentials(address);
-    _credentials = credentials;
+    final credentials = _credentialsByAddress.putIfAbsent(
+      address,
+      () => BitboxCredentials(address),
+    );
     if (_isConnected) {
       credentials.setBitbox(bitboxManager);
     }
@@ -31,15 +36,21 @@ class BitboxService {
   }
 
   Future<bool> init(BitboxDevice device) async {
+    // The disconnect observer fires .disconnect() asynchronously when the
+    // device drops. If the user re-plugs immediately we'd race two ops on the
+    // same SDK manager and the result is undefined. Wait for any in-flight
+    // disconnect to finish first.
+    await _pendingDisconnect;
     await bitboxManager.connect(device);
     final didInit = await bitboxManager.initBitBox();
     if (!didInit) throw Exception('Failed to init');
     _isConnected = true;
-    // Restore the bitbox manager on any credentials handed out before this
-    // (re-)connect — otherwise existing wallets keep a cleared credentials
-    // instance and the next sign throws BitboxNotConnectedException even
-    // though the device is back online.
-    _credentials?.setBitbox(bitboxManager);
+    // Re-attach the manager to every active credentials instance so existing
+    // wallets heal automatically on reconnect. The previous derivationPath is
+    // preserved inside setBitbox().
+    for (final credentials in _credentialsByAddress.values) {
+      credentials.setBitbox(bitboxManager);
+    }
     return didInit;
   }
 
@@ -59,21 +70,27 @@ class BitboxService {
       }
       if (devices.isEmpty) {
         _isConnected = false;
-        _credentials?.clearBitbox();
-        // Keep the _credentials reference so init() can re-attach the manager
-        // on the same instance after a reconnect.
+        for (final credentials in _credentialsByAddress.values) {
+          credentials.clearBitbox();
+        }
         stopConnectionStatusObserver();
         // Close the underlying transport. Required on Android so the USB
         // file-descriptor is released — otherwise the next connect() can
         // fail because the OS still considers the device claimed. Safe on
         // iOS where the BLE link is already gone at this point.
-        try {
-          await bitboxManager.disconnect();
-        } catch (e) {
-          developer.log('disconnect after device-loss failed: $e', name: '$BitboxService');
-        }
+        _pendingDisconnect = _disconnectAndForget();
+        await _pendingDisconnect;
+        _pendingDisconnect = null;
       }
     });
+  }
+
+  Future<void> _disconnectAndForget() async {
+    try {
+      await bitboxManager.disconnect();
+    } on Exception catch (e) {
+      developer.log('disconnect after device-loss failed: $e', name: '$BitboxService');
+    }
   }
 
   void stopConnectionStatusObserver() {

--- a/lib/packages/hardware_wallet/bitbox_credentials.dart
+++ b/lib/packages/hardware_wallet/bitbox_credentials.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer' as developer;
 import 'dart:typed_data';
 
 import 'package:bitbox_flutter/bitbox_manager.dart';
@@ -12,6 +13,8 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
   // Single device, single noise cipher — concurrent signs would advance the
   // nonce out of order and break decryption permanently.
   static Future<void> _signQueue = Future.value();
+
+  static const _defaultDerivationPath = "m/44'/60'/0'/0/0";
 
   final String _address;
 
@@ -37,14 +40,18 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
   @override
   EthereumAddress get address => EthereumAddress.fromHex(_address);
 
+  /// Attaches (or re-attaches) a manager. Preserves an existing
+  /// [derivationPath] across reconnects — multi-account / non-default-index
+  /// wallets would silently revert to the default path otherwise.
   void setBitbox(BitboxManager connection, [String? derivationPath_]) {
     bitboxManager = connection;
-    derivationPath = derivationPath_ ?? "m/44'/60'/0'/0/0";
+    derivationPath = derivationPath_ ?? derivationPath ?? _defaultDerivationPath;
   }
 
   void clearBitbox() {
     bitboxManager = null;
-    derivationPath = null;
+    // Keep [derivationPath] so a re-attach via setBitbox() with no path argument
+    // restores the same one the caller originally chose.
   }
 
   @override
@@ -58,13 +65,20 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
     bool isEIP1559 = false,
   }) {
     return _synchronizeSign(() async {
-      if (!isConnected) throw const BitboxNotConnectedException();
+      // Snapshot the manager + path up-front so an observer-driven null-out
+      // between the connection check and the sign call doesn't NoSuchMethod.
+      final manager = bitboxManager;
+      final path = derivationPath;
+      if (manager == null || path == null) {
+        throw const BitboxNotConnectedException();
+      }
 
       if (isEIP1559) payload = payload.sublist(1);
       final sig = await _runOrThrowDisconnect(
-        () => bitboxManager!.signETHRLPTransaction(
+        manager,
+        () => manager.signETHRLPTransaction(
           chainId ?? 1,
-          derivationPath!,
+          path,
           bytesToHex(payload),
           isEIP1559,
         ),
@@ -102,9 +116,14 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
   @override
   Future<Uint8List> signPersonalMessage(Uint8List payload, {int? chainId}) {
     return _synchronizeSign(() async {
-      if (!isConnected) throw const BitboxNotConnectedException();
+      final manager = bitboxManager;
+      final path = derivationPath;
+      if (manager == null || path == null) {
+        throw const BitboxNotConnectedException();
+      }
       return await _runOrThrowDisconnect(
-        () => bitboxManager!.signETHMessage(chainId ?? 1, derivationPath!, payload),
+        manager,
+        () => manager.signETHMessage(chainId ?? 1, path, payload),
       );
     });
   }
@@ -115,12 +134,17 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
 
   Future<String> signTypedDataV4(int chainId, String jsonData) {
     return _synchronizeSign(() async {
-      if (!isConnected) throw const BitboxNotConnectedException();
+      final manager = bitboxManager;
+      final path = derivationPath;
+      if (manager == null || path == null) {
+        throw const BitboxNotConnectedException();
+      }
 
       final signatureBytes = await _runOrThrowDisconnect(
-        () => bitboxManager!.signETHTypedMessage(
+        manager,
+        () => manager.signETHTypedMessage(
           chainId,
-          derivationPath!,
+          path,
           Uint8List.fromList(utf8.encode(jsonData)),
         ),
       );
@@ -128,14 +152,24 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
     });
   }
 
-  /// Wrap a sign call so that a BLE/USB drop mid-operation surfaces as
-  /// [BitboxNotConnectedException] instead of a raw plugin error. If the
-  /// device is still reachable after the failure, the original error wins.
-  Future<T> _runOrThrowDisconnect<T>(Future<T> Function() op) async {
+  /// Wraps a sign call so a BLE/USB drop mid-operation surfaces as
+  /// [BitboxNotConnectedException]. Narrowed to [Exception] so genuine bugs
+  /// in the sign path (encoding error, type cast, assert) keep their type
+  /// and stack instead of being silently re-labelled as a disconnect.
+  Future<T> _runOrThrowDisconnect<T>(
+    BitboxManager manager,
+    Future<T> Function() op,
+  ) async {
     try {
       return await op();
-    } catch (_) {
-      if (await _deviceLost()) {
+    } on Exception catch (e, st) {
+      if (await _deviceLost(manager)) {
+        developer.log(
+          'sign failed during disconnect: $e',
+          name: '$BitboxCredentials',
+          error: e,
+          stackTrace: st,
+        );
         clearBitbox();
         throw const BitboxNotConnectedException();
       }
@@ -143,13 +177,11 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
     }
   }
 
-  Future<bool> _deviceLost() async {
-    final manager = bitboxManager;
-    if (manager == null) return true;
+  Future<bool> _deviceLost(BitboxManager manager) async {
     try {
       final devices = await manager.devices;
       return devices.isEmpty;
-    } catch (_) {
+    } on Exception {
       // Probing the device list itself failed — treat as lost.
       return true;
     }

--- a/lib/packages/service/app_store.dart
+++ b/lib/packages/service/app_store.dart
@@ -10,12 +10,6 @@ class AppStore {
 
   AWallet? _wallet;
 
-  /// Callback that decrypts the mnemonic and returns a fully unlocked
-  /// [SoftwareWallet]. Wired up after DI registers `WalletService`; null until
-  /// then. Used by [ensureUnlocked] so callers don't have to import the
-  /// service layer just to upgrade a view-wallet.
-  Future<AWallet> Function()? _unlocker;
-
   AppStore(this.getApiConfig, this.sessionCache);
 
   set wallet(AWallet wallet_) => _wallet = wallet_;
@@ -28,19 +22,4 @@ class AppStore {
   ApiConfig get apiConfig => getApiConfig();
 
   String get primaryAddress => wallet.currentAccount.primaryAddress.address.hex;
-
-  void attachUnlocker(Future<AWallet> Function() unlocker) {
-    _unlocker = unlocker;
-  }
-
-  /// Upgrades the current wallet from [SoftwareViewWallet] (address only) to a
-  /// fully unlocked [SoftwareWallet] (mnemonic in memory) so the next sign
-  /// operation can run. No-op for wallets that aren't locked, or when no
-  /// unlocker has been wired (e.g. tests).
-  Future<void> ensureUnlocked() async {
-    if (_wallet is! SoftwareViewWallet) return;
-    final unlocker = _unlocker;
-    if (unlocker == null) return;
-    _wallet = await unlocker();
-  }
 }

--- a/lib/packages/service/dfx/dfx_auth_service.dart
+++ b/lib/packages/service/dfx/dfx_auth_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer' as developer;
 
 import 'package:http/http.dart' as http;
 import 'package:realunit_wallet/packages/config/api_config.dart';
@@ -7,6 +8,30 @@ import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
+
+/// Fire-and-forget pre-warm of the auth signature, shared by every onboarding
+/// flow (create / restore / BitBox-pair). The lazy path in
+/// [DFXAuthService.getSignature] is still the safety net — this just primes
+/// the cache so the first authenticated call doesn't have to round-trip
+/// through the hardware wallet again. Failures surface at SEVERE so support
+/// has a debug-log breadcrumb when a fresh BitBox confirmation pops up
+/// unexpectedly on the next call.
+Future<void> warmAuthSignature(
+  DFXAuthService authService,
+  AWalletAccount account, {
+  required String loggerName,
+}) async {
+  try {
+    await authService.ensureSignatureFor(account);
+  } catch (e) {
+    developer.log(
+      'initial signature capture failed — next authenticated call '
+      'will trigger a fresh signature request: $e',
+      name: loggerName,
+      level: 1000, // SEVERE
+    );
+  }
+}
 
 abstract class DFXAuthService {
   static const walletName = 'RealUnit';

--- a/lib/packages/service/dfx/dfx_auth_service.dart
+++ b/lib/packages/service/dfx/dfx_auth_service.dart
@@ -79,15 +79,21 @@ abstract class DFXAuthService {
 
     // Cache miss — we actually need the private key. Decrypt the mnemonic on
     // demand if the currently loaded wallet is a view-only software wallet.
+    // try/finally so a throw from sign / saveSignature can't leave the mnemonic
+    // resident for the 60 s idle window — matches the pattern in
+    // RealUnitSellPaymentInfoService.confirmPayment and
+    // RealUnitRegistrationService.completeRegistration / registerWallet.
     await walletService.ensureCurrentWalletUnlocked();
-    final signature = await wallet.signMessage(message).timeout(_signMessageTimeout);
-    if (signature.isEmpty || signature == '0x') {
-      throw const SigningCancelledException();
+    try {
+      final signature = await wallet.signMessage(message).timeout(_signMessageTimeout);
+      if (signature.isEmpty || signature == '0x') {
+        throw const SigningCancelledException();
+      }
+      await appStore.sessionCache.saveSignature(walletAddress, signature);
+      return signature;
+    } finally {
+      await walletService.lockCurrentWallet();
     }
-    await appStore.sessionCache.saveSignature(walletAddress, signature);
-    await walletService.lockCurrentWallet();
-
-    return signature;
   }
 
   Future<Map<String, dynamic>> getAuthResponse([bool sendWalletName = true]) async {

--- a/lib/packages/service/dfx/dfx_auth_service.dart
+++ b/lib/packages/service/dfx/dfx_auth_service.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:realunit_wallet/packages/config/api_config.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 
@@ -15,8 +16,9 @@ abstract class DFXAuthService {
   final String signMessagePath = '/v1/auth/signMessage';
   final String authPath = '/v1/auth';
   final AppStore appStore;
+  final WalletService walletService;
 
-  DFXAuthService(this.appStore);
+  DFXAuthService(this.appStore, this.walletService);
 
   String get host => appStore.apiConfig.apiHost;
 
@@ -77,12 +79,13 @@ abstract class DFXAuthService {
 
     // Cache miss — we actually need the private key. Decrypt the mnemonic on
     // demand if the currently loaded wallet is a view-only software wallet.
-    await appStore.ensureUnlocked();
+    await walletService.ensureCurrentWalletUnlocked();
     final signature = await wallet.signMessage(message).timeout(_signMessageTimeout);
     if (signature.isEmpty || signature == '0x') {
       throw const SigningCancelledException();
     }
     await appStore.sessionCache.saveSignature(walletAddress, signature);
+    await walletService.lockCurrentWallet();
 
     return signature;
   }

--- a/lib/packages/service/dfx/dfx_bank_account_service.dart
+++ b/lib/packages/service/dfx/dfx_bank_account_service.dart
@@ -8,7 +8,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/bank_account/dto/ban
 class DfxBankAccountService extends DFXAuthService {
   static const _bankAccountPath = 'v1/bankAccount';
 
-  DfxBankAccountService(super.appStore);
+  DfxBankAccountService(super.appStore, super.walletService);
 
   Future<List<BankAccountDto>> getBankAccounts() async {
     final uri = buildUri(host, _bankAccountPath);

--- a/lib/packages/service/dfx/dfx_blockchain_api_service.dart
+++ b/lib/packages/service/dfx/dfx_blockchain_api_service.dart
@@ -9,7 +9,7 @@ class DfxBlockchainApiService extends DFXAuthService {
 
   String get _blockchain => appStore.apiConfig.asset.chainId == 1 ? 'Ethereum' : 'Sepolia';
 
-  DfxBlockchainApiService(super.appStore);
+  DfxBlockchainApiService(super.appStore, super.walletService);
 
   Future<double> getEthBalance(String address) async {
     final uri = buildUri(host, _balancesPath);

--- a/lib/packages/service/dfx/dfx_brokerbot_service.dart
+++ b/lib/packages/service/dfx/dfx_brokerbot_service.dart
@@ -15,7 +15,7 @@ class DfxBrokerbotService extends DFXAuthService {
   static const _sellPricePath = '/v1/realunit/brokerbot/sellPrice';
   static const _sellSharesPath = '/v1/realunit/brokerbot/sellShares';
 
-  DfxBrokerbotService(super.appStore);
+  DfxBrokerbotService(super.appStore, super.walletService);
 
   /// Convert REALU shares → CHF
   Future<BrokerbotBuyPriceDto> getBuyPrice(String sharesInput, Currency currency) async {

--- a/lib/packages/service/dfx/dfx_faucet_service.dart
+++ b/lib/packages/service/dfx/dfx_faucet_service.dart
@@ -8,7 +8,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/faucet/faucet_respon
 class DfxFaucetService extends DFXAuthService {
   static const _faucetPath = 'v1/faucet';
 
-  DfxFaucetService(super.appStore);
+  DfxFaucetService(super.appStore, super.walletService);
 
   Future<FaucetResponseDto> requestFaucet() async {
     final uri = buildUri(host, _faucetPath);

--- a/lib/packages/service/dfx/dfx_kyc_service.dart
+++ b/lib/packages/service/dfx/dfx_kyc_service.dart
@@ -14,7 +14,7 @@ class DfxKycService extends DFXAuthService {
   static const _userPath = '/v2/user';
   static const _kycPath = 'v2/kyc';
 
-  DfxKycService(super.appStore);
+  DfxKycService(super.appStore, super.walletService);
 
   Future<UserDto> getUser() async {
     final uri = buildUri(host, _userPath);

--- a/lib/packages/service/dfx/dfx_support_service.dart
+++ b/lib/packages/service/dfx/dfx_support_service.dart
@@ -10,7 +10,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/support/support_issu
 class DfxSupportService extends DFXAuthService {
   static const _supportPath = '/v1/support/issue';
 
-  DfxSupportService(super.appStore);
+  DfxSupportService(super.appStore, super.walletService);
 
   Future<List<SupportIssueDto>> getTickets() async {
     final uri = buildUri(host, _supportPath);

--- a/lib/packages/service/dfx/dfx_widget_service.dart
+++ b/lib/packages/service/dfx/dfx_widget_service.dart
@@ -1,7 +1,7 @@
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
 
 class DfxWidgetService extends DFXAuthService {
-  DfxWidgetService(super.appStore);
+  DfxWidgetService(super.appStore, super.walletService);
 
   bool get isAvailable => appStore.sessionCache.authToken != null;
 }

--- a/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
@@ -13,7 +13,7 @@ class RealUnitBuyPaymentInfoService extends DFXAuthService {
   static const _buyPaymentInfoPath = '/v1/realunit/buy';
   static String _confirmPaymentPath(int id) => '/v1/realunit/buy/$id/confirm';
 
-  RealUnitBuyPaymentInfoService(super.appStore);
+  RealUnitBuyPaymentInfoService(super.appStore, super.walletService);
 
   Future<BuyPaymentInfo> getPaymentInfo(int amount, {Currency currency = Currency.chf}) async {
     final buyDto = RealUnitBuyDto(amount: amount, currency: currency);

--- a/lib/packages/service/dfx/real_unit_pdf_service.dart
+++ b/lib/packages/service/dfx/real_unit_pdf_service.dart
@@ -15,7 +15,7 @@ class RealUnitPdfService extends DFXAuthService {
   static const _transactionsReceiptMultiPath = 'v1/realunit/transactions/receipt/multi';
   static const _transactionsReceiptSinglePath = '/v1/realunit/transactions/receipt/single';
 
-  RealUnitPdfService(super.appStore);
+  RealUnitPdfService(super.appStore, super.walletService);
 
   Future<PdfDto> getBalanceReport({
     required DateTime date,

--- a/lib/packages/service/dfx/real_unit_registration_service.dart
+++ b/lib/packages/service/dfx/real_unit_registration_service.dart
@@ -52,8 +52,18 @@ class RealUnitRegistrationService extends DFXAuthService {
   /// registers a wallet and and adds the wallet to the new user
   Future<RegistrationStatus> completeRegistration(Registration registration) async {
     // EIP-712 registration signature requires the private key — promote the
-    // view-wallet (if any) to a fully unlocked SoftwareWallet first.
+    // view-wallet (if any) to a fully unlocked SoftwareWallet first, then
+    // lock back down in the finally so a throw mid-sequence doesn't leave the
+    // key resident.
     await walletService.ensureCurrentWalletUnlocked();
+    try {
+      return await _completeRegistration(registration);
+    } finally {
+      await walletService.lockCurrentWallet();
+    }
+  }
+
+  Future<RegistrationStatus> _completeRegistration(Registration registration) async {
     final credentials = appStore.wallet.primaryAccount.primaryAddress;
     // BitBox firmware rejects non-ASCII bytes in EIP-712 string fields.
     // Transliterate everything that goes into the signed envelope AND the
@@ -134,10 +144,6 @@ class RealUnitRegistrationService extends DFXAuthService {
       throw ApiException.fromJson(errorJson, httpStatusCode: response.statusCode);
     }
 
-    // Drop the mnemonic from memory now that the registration signature is
-    // submitted. The auth-token path keeps working off the cached session
-    // signature.
-    await walletService.lockCurrentWallet();
     final responseDto = RealUnitRegistrationResponseDto.fromJson(jsonDecode(response.body));
     return responseDto.status;
   }
@@ -147,6 +153,14 @@ class RealUnitRegistrationService extends DFXAuthService {
     RealUnitUserDataDto userData,
   ) async {
     await walletService.ensureCurrentWalletUnlocked();
+    try {
+      return await _registerWallet(userData);
+    } finally {
+      await walletService.lockCurrentWallet();
+    }
+  }
+
+  Future<RegistrationStatus> _registerWallet(RealUnitUserDataDto userData) async {
     final credentials = appStore.wallet.primaryAccount.primaryAddress;
     final registrationDate = DateFormat('yyyy-MM-dd').format(DateTime.now());
     // Same ASCII guard as completeRegistration — see comment there.
@@ -187,7 +201,6 @@ class RealUnitRegistrationService extends DFXAuthService {
       throw ApiException.fromJson(errorJson, httpStatusCode: response.statusCode);
     }
 
-    await walletService.lockCurrentWallet();
     final responseDto = RealUnitRegistrationResponseDto.fromJson(jsonDecode(response.body));
     return responseDto.status;
   }

--- a/lib/packages/service/dfx/real_unit_registration_service.dart
+++ b/lib/packages/service/dfx/real_unit_registration_service.dart
@@ -18,7 +18,7 @@ import 'package:realunit_wallet/packages/utils/ascii_transliterate.dart';
 import 'package:realunit_wallet/packages/wallet/eip712_signer.dart';
 
 class RealUnitRegistrationService extends DFXAuthService {
-  RealUnitRegistrationService(super.appStore);
+  RealUnitRegistrationService(super.appStore, super.walletService);
 
   static const _registerEmailPath = '/v1/realunit/register/email';
   static const _registerCompletionPath = '/v1/realunit/register/complete';
@@ -53,7 +53,7 @@ class RealUnitRegistrationService extends DFXAuthService {
   Future<RegistrationStatus> completeRegistration(Registration registration) async {
     // EIP-712 registration signature requires the private key — promote the
     // view-wallet (if any) to a fully unlocked SoftwareWallet first.
-    await appStore.ensureUnlocked();
+    await walletService.ensureCurrentWalletUnlocked();
     final credentials = appStore.wallet.primaryAccount.primaryAddress;
     // BitBox firmware rejects non-ASCII bytes in EIP-712 string fields.
     // Transliterate everything that goes into the signed envelope AND the
@@ -134,6 +134,10 @@ class RealUnitRegistrationService extends DFXAuthService {
       throw ApiException.fromJson(errorJson, httpStatusCode: response.statusCode);
     }
 
+    // Drop the mnemonic from memory now that the registration signature is
+    // submitted. The auth-token path keeps working off the cached session
+    // signature.
+    await walletService.lockCurrentWallet();
     final responseDto = RealUnitRegistrationResponseDto.fromJson(jsonDecode(response.body));
     return responseDto.status;
   }
@@ -142,6 +146,7 @@ class RealUnitRegistrationService extends DFXAuthService {
   Future<RegistrationStatus> registerWallet(
     RealUnitUserDataDto userData,
   ) async {
+    await walletService.ensureCurrentWalletUnlocked();
     final credentials = appStore.wallet.primaryAccount.primaryAddress;
     final registrationDate = DateFormat('yyyy-MM-dd').format(DateTime.now());
     // Same ASCII guard as completeRegistration — see comment there.
@@ -182,6 +187,7 @@ class RealUnitRegistrationService extends DFXAuthService {
       throw ApiException.fromJson(errorJson, httpStatusCode: response.statusCode);
     }
 
+    await walletService.lockCurrentWallet();
     final responseDto = RealUnitRegistrationResponseDto.fromJson(jsonDecode(response.body));
     return responseDto.status;
   }

--- a/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
@@ -26,7 +26,7 @@ class RealUnitSellPaymentInfoService extends DFXAuthService {
   static const _metaMaskDelegatorAddress = '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b';
   static const _delegationManagerAddress = '0xdb9b1e94b5b69df7e401ddbede43491141047db3';
 
-  RealUnitSellPaymentInfoService(super.appStore);
+  RealUnitSellPaymentInfoService(super.appStore, super.walletService);
 
   Future<SellPaymentInfo> getPaymentInfo(
     int amount,
@@ -81,40 +81,47 @@ class RealUnitSellPaymentInfoService extends DFXAuthService {
     // EIP-712 + EIP-7702 typed-data signing requires the private key; promote
     // the view-wallet to a fully unlocked SoftwareWallet before reading
     // credentials.
-    await appStore.ensureUnlocked();
-    final credentials = appStore.wallet.currentAccount.primaryAddress;
-    _validateEip7702Data(paymentInfo.eip7702, credentials.address.hexEip55, paymentInfo.amount);
+    await walletService.ensureCurrentWalletUnlocked();
+    try {
+      final credentials = appStore.wallet.currentAccount.primaryAddress;
+      _validateEip7702Data(paymentInfo.eip7702, credentials.address.hexEip55, paymentInfo.amount);
 
-    final delegationSignature = await Eip712Signer.signDelegation(
-      credentials: credentials,
-      eip7702Data: paymentInfo.eip7702,
-    );
-    final authorizationSignature = Eip7702Signer.signAuthorization(
-      credentials: credentials,
-      eip7702Data: paymentInfo.eip7702,
-    );
-    await _sendConfirm(
-      paymentInfo.id,
-      RealUnitSellConfirmDto(
-        eip7702ConfirmDto: Eip7702ConfirmDto(
-          delegation: Eip7702DelegationDto(
-            delegate: paymentInfo.eip7702.relayerAddress,
-            delegator: paymentInfo.eip7702.message.delegator,
-            authority: paymentInfo.eip7702.message.authority,
-            salt: '${paymentInfo.eip7702.message.salt}',
-            signature: delegationSignature,
-          ),
-          authorization: Eip7702AuthorizationDto(
-            chainId: paymentInfo.eip7702.domain.chainId,
-            address: paymentInfo.eip7702.delegatorAddress,
-            nonce: paymentInfo.eip7702.userNonce,
-            r: '0x${authorizationSignature.r.toRadixString(16)}',
-            s: '0x${authorizationSignature.s.toRadixString(16)}',
-            yParity: authorizationSignature.yParity,
+      final delegationSignature = await Eip712Signer.signDelegation(
+        credentials: credentials,
+        eip7702Data: paymentInfo.eip7702,
+      );
+      final authorizationSignature = Eip7702Signer.signAuthorization(
+        credentials: credentials,
+        eip7702Data: paymentInfo.eip7702,
+      );
+      await _sendConfirm(
+        paymentInfo.id,
+        RealUnitSellConfirmDto(
+          eip7702ConfirmDto: Eip7702ConfirmDto(
+            delegation: Eip7702DelegationDto(
+              delegate: paymentInfo.eip7702.relayerAddress,
+              delegator: paymentInfo.eip7702.message.delegator,
+              authority: paymentInfo.eip7702.message.authority,
+              salt: '${paymentInfo.eip7702.message.salt}',
+              signature: delegationSignature,
+            ),
+            authorization: Eip7702AuthorizationDto(
+              chainId: paymentInfo.eip7702.domain.chainId,
+              address: paymentInfo.eip7702.delegatorAddress,
+              nonce: paymentInfo.eip7702.userNonce,
+              r: '0x${authorizationSignature.r.toRadixString(16)}',
+              s: '0x${authorizationSignature.s.toRadixString(16)}',
+              yParity: authorizationSignature.yParity,
+            ),
           ),
         ),
-      ),
-    );
+      );
+    } finally {
+      // Drop the mnemonic from memory as soon as signing is done — see
+      // [WalletService.lockCurrentWallet]. Runs on the throw path too so an
+      // EIP-712 validation failure mid-sequence doesn't leave the key resident.
+      await walletService.lockCurrentWallet();
+    }
   }
 
   Future<RealUnitUnsignedTransactionsRequestDto> createUnsignedTransactions(int id) async {

--- a/lib/packages/service/dfx/real_unit_wallet_service.dart
+++ b/lib/packages/service/dfx/real_unit_wallet_service.dart
@@ -6,7 +6,7 @@ import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.da
 import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_wallet_status_dto.dart';
 
 class RealUnitWalletService extends DFXAuthService {
-  RealUnitWalletService(super.appStore);
+  RealUnitWalletService(super.appStore, super.walletService);
 
   static const _walletStatusPath = '/v1/realunit/wallet/status';
 

--- a/lib/packages/service/transaction_history_service.dart
+++ b/lib/packages/service/transaction_history_service.dart
@@ -16,7 +16,7 @@ class TransactionHistoryService extends DFXAuthService {
 
   final TransactionRepository _transactionRepository;
 
-  TransactionHistoryService(super.appStore, this._transactionRepository);
+  TransactionHistoryService(super.appStore, super.walletService, this._transactionRepository);
 
   Future<void> apiBasedSync() async {
     final results = await Future.wait([

--- a/lib/packages/service/wallet_service.dart
+++ b/lib/packages/service/wallet_service.dart
@@ -13,15 +13,16 @@ class WalletService {
   final BitboxService _bitboxService;
   final AppStore _appStore;
 
-  /// Auto-lock the unlocked software wallet after this long if no explicit
-  /// [lockCurrentWallet] has fired. Sized to comfortably outlast a normal
-  /// sign-then-broadcast round-trip while still capping how long the mnemonic
-  /// can sit resident on the heap.
-  static const Duration _idleLockTimeout = Duration(seconds: 60);
+  /// Auto-lock 60 s after each unlock, regardless of subsequent activity. The
+  /// timer is armed in [ensureCurrentWalletUnlocked] and is NOT reset by user
+  /// interaction — it caps the maximum lifetime of the in-memory mnemonic
+  /// after an explicit unlock, not an idle window. Sized to comfortably
+  /// outlast a normal sign-then-broadcast round-trip.
+  static const Duration _postUnlockLockTimeout = Duration(seconds: 60);
 
-  /// Cancellation guard for [_idleLockTimer] so a lock-during-test or a
+  /// Cancellation guard for the post-unlock timer so a lock-during-test or a
   /// concurrent explicit lock doesn't double-fire.
-  Timer? _idleLockTimer;
+  Timer? _postUnlockLockTimer;
 
   WalletService(
     this._bitboxService,
@@ -126,32 +127,32 @@ class WalletService {
     if (_appStore.wallet is! SoftwareViewWallet) return;
     _appStore.wallet = await unlockCurrentWallet();
     // Safety net: if a caller forgets to call lockCurrentWallet() after the
-    // sign, drop the mnemonic anyway once the idle window elapses. The reviewer
-    // flagged "user sells once then leaves the app foregrounded" — that path
-    // now caps at [_idleLockTimeout].
-    _scheduleIdleLock();
+    // sign, drop the mnemonic anyway once the post-unlock window elapses. The
+    // reviewer flagged "user sells once then leaves the app foregrounded" —
+    // that path now caps at [_postUnlockLockTimeout].
+    _schedulePostUnlockLock();
   }
 
   /// Replaces the in-memory [SoftwareWallet] with its lock-screen-safe
   /// [SoftwareViewWallet] counterpart, dropping the mnemonic. Called after a
-  /// sign operation completes or [_idleLockTimer] fires so the private key
-  /// isn't kept resident for the rest of the foreground session. No-op for
-  /// wallet types that don't hold a mnemonic.
+  /// sign operation completes or the post-unlock timer fires so the private
+  /// key isn't kept resident for the rest of the foreground session. No-op
+  /// for wallet types that don't hold a mnemonic.
   Future<void> lockCurrentWallet() async {
-    _idleLockTimer?.cancel();
-    _idleLockTimer = null;
+    _postUnlockLockTimer?.cancel();
+    _postUnlockLockTimer = null;
     final current = _appStore.wallet;
     if (current is! SoftwareWallet) return;
     final address = current.currentAccount.primaryAddress.address.hexEip55;
     _appStore.wallet = SoftwareViewWallet(current.id, current.name, address);
   }
 
-  void _scheduleIdleLock() {
-    _idleLockTimer?.cancel();
-    _idleLockTimer = Timer(_idleLockTimeout, () {
-      _idleLockTimer = null;
-      lockCurrentWallet();
-    });
+  void _schedulePostUnlockLock() {
+    _postUnlockLockTimer?.cancel();
+    // Bind directly to lockCurrentWallet — it cancels + nulls the timer field
+    // itself, so a redundant null in this callback would just couple two
+    // pieces of code to the same invariant.
+    _postUnlockLockTimer = Timer(_postUnlockLockTimeout, lockCurrentWallet);
   }
 
   Future<void> deleteCurrentWallet() async {

--- a/lib/packages/service/wallet_service.dart
+++ b/lib/packages/service/wallet_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bip39/bip39.dart' as bip39;
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
 import 'package:realunit_wallet/packages/repository/settings_repository.dart';
@@ -11,7 +13,17 @@ class WalletService {
   final BitboxService _bitboxService;
   final AppStore _appStore;
 
-  const WalletService(
+  /// Auto-lock the unlocked software wallet after this long if no explicit
+  /// [lockCurrentWallet] has fired. Sized to comfortably outlast a normal
+  /// sign-then-broadcast round-trip while still capping how long the mnemonic
+  /// can sit resident on the heap.
+  static const Duration _idleLockTimeout = Duration(seconds: 60);
+
+  /// Cancellation guard for [_idleLockTimer] so a lock-during-test or a
+  /// concurrent explicit lock doesn't double-fire.
+  Timer? _idleLockTimer;
+
+  WalletService(
     this._bitboxService,
     this._repository,
     this._settingsRepository,
@@ -113,18 +125,33 @@ class WalletService {
   Future<void> ensureCurrentWalletUnlocked() async {
     if (_appStore.wallet is! SoftwareViewWallet) return;
     _appStore.wallet = await unlockCurrentWallet();
+    // Safety net: if a caller forgets to call lockCurrentWallet() after the
+    // sign, drop the mnemonic anyway once the idle window elapses. The reviewer
+    // flagged "user sells once then leaves the app foregrounded" — that path
+    // now caps at [_idleLockTimeout].
+    _scheduleIdleLock();
   }
 
   /// Replaces the in-memory [SoftwareWallet] with its lock-screen-safe
   /// [SoftwareViewWallet] counterpart, dropping the mnemonic. Called after a
-  /// sign operation completes or an idle timer fires so the private key isn't
-  /// kept resident for the rest of the foreground session. No-op for wallet
-  /// types that don't hold a mnemonic.
+  /// sign operation completes or [_idleLockTimer] fires so the private key
+  /// isn't kept resident for the rest of the foreground session. No-op for
+  /// wallet types that don't hold a mnemonic.
   Future<void> lockCurrentWallet() async {
+    _idleLockTimer?.cancel();
+    _idleLockTimer = null;
     final current = _appStore.wallet;
     if (current is! SoftwareWallet) return;
     final address = current.currentAccount.primaryAddress.address.hexEip55;
     _appStore.wallet = SoftwareViewWallet(current.id, current.name, address);
+  }
+
+  void _scheduleIdleLock() {
+    _idleLockTimer?.cancel();
+    _idleLockTimer = Timer(_idleLockTimeout, () {
+      _idleLockTimer = null;
+      lockCurrentWallet();
+    });
   }
 
   Future<void> deleteCurrentWallet() async {

--- a/lib/packages/service/wallet_service.dart
+++ b/lib/packages/service/wallet_service.dart
@@ -24,6 +24,17 @@ class WalletService {
   /// concurrent explicit lock doesn't double-fire.
   Timer? _postUnlockLockTimer;
 
+  /// Active holders of the unlocked-wallet contract. Incremented on every
+  /// [ensureCurrentWalletUnlocked] call, decremented on every matching
+  /// [lockCurrentWallet] — the wallet only flips back to a view-wallet once
+  /// the last holder has released. Closes the race where flow A locks
+  /// between flow B's ensure and its sign, leaving B with a
+  /// [SoftwareViewWallet] mid-flight and an [UnsupportedError] from the
+  /// locked-credentials sentinel. The post-unlock timer bypasses the counter
+  /// via [_forceLock] so the 60s safety net still caps the mnemonic lifetime
+  /// even if a caller forgets to release.
+  int _activeUnlockHolders = 0;
+
   WalletService(
     this._bitboxService,
     this._repository,
@@ -123,9 +134,15 @@ class WalletService {
   ///
   /// Owning the lifecycle here — instead of behind a callback wired onto
   /// [AppStore] — keeps the latter as a pure state container.
+  ///
+  /// Every call increments [_activeUnlockHolders]; callers must pair with
+  /// exactly one [lockCurrentWallet] in a finally so concurrent sign flows
+  /// don't tear the unlocked state out from under each other.
   Future<void> ensureCurrentWalletUnlocked() async {
-    if (_appStore.wallet is! SoftwareViewWallet) return;
-    _appStore.wallet = await unlockCurrentWallet();
+    _activeUnlockHolders++;
+    if (_appStore.wallet is SoftwareViewWallet) {
+      _appStore.wallet = await unlockCurrentWallet();
+    }
     // Safety net: if a caller forgets to call lockCurrentWallet() after the
     // sign, drop the mnemonic anyway once the post-unlock window elapses. The
     // reviewer flagged "user sells once then leaves the app foregrounded" —
@@ -135,24 +152,40 @@ class WalletService {
 
   /// Replaces the in-memory [SoftwareWallet] with its lock-screen-safe
   /// [SoftwareViewWallet] counterpart, dropping the mnemonic. Called after a
-  /// sign operation completes or the post-unlock timer fires so the private
-  /// key isn't kept resident for the rest of the foreground session. No-op
-  /// for wallet types that don't hold a mnemonic.
+  /// sign operation completes so the private key isn't kept resident for the
+  /// rest of the foreground session. No-op for wallet types that don't hold
+  /// a mnemonic.
+  ///
+  /// Respects [_activeUnlockHolders] — a second concurrent caller still
+  /// holding the unlocked contract keeps the wallet unlocked. The 60s safety
+  /// net runs through [_forceLock] instead so it can bypass the counter.
   Future<void> lockCurrentWallet() async {
+    if (_activeUnlockHolders > 0) _activeUnlockHolders--;
+    if (_activeUnlockHolders > 0) return;
     _postUnlockLockTimer?.cancel();
     _postUnlockLockTimer = null;
-    final current = _appStore.wallet;
-    if (current is! SoftwareWallet) return;
-    final address = current.currentAccount.primaryAddress.address.hexEip55;
-    _appStore.wallet = SoftwareViewWallet(current.id, current.name, address);
+    _lockWalletInPlace();
   }
 
   void _schedulePostUnlockLock() {
     _postUnlockLockTimer?.cancel();
-    // Bind directly to lockCurrentWallet — it cancels + nulls the timer field
-    // itself, so a redundant null in this callback would just couple two
-    // pieces of code to the same invariant.
-    _postUnlockLockTimer = Timer(_postUnlockLockTimeout, lockCurrentWallet);
+    _postUnlockLockTimer = Timer(_postUnlockLockTimeout, _forceLock);
+  }
+
+  /// Hard cap on the in-memory mnemonic lifetime. Bypasses
+  /// [_activeUnlockHolders] so a stuck holder can't keep the key resident
+  /// past the safety window.
+  void _forceLock() {
+    _activeUnlockHolders = 0;
+    _postUnlockLockTimer = null;
+    _lockWalletInPlace();
+  }
+
+  void _lockWalletInPlace() {
+    final current = _appStore.wallet;
+    if (current is! SoftwareWallet) return;
+    final address = current.currentAccount.primaryAddress.address.hexEip55;
+    _appStore.wallet = SoftwareViewWallet(current.id, current.name, address);
   }
 
   Future<void> deleteCurrentWallet() async {

--- a/lib/packages/service/wallet_service.dart
+++ b/lib/packages/service/wallet_service.dart
@@ -2,14 +2,21 @@ import 'package:bip39/bip39.dart' as bip39;
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
 import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/repository/wallet_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 
 class WalletService {
   final WalletRepository _repository;
   final SettingsRepository _settingsRepository;
   final BitboxService _bitboxService;
+  final AppStore _appStore;
 
-  const WalletService(this._bitboxService, this._repository, this._settingsRepository);
+  const WalletService(
+    this._bitboxService,
+    this._repository,
+    this._settingsRepository,
+    this._appStore,
+  );
 
   Future<SoftwareWallet> createSeedWallet(String name) async {
     final mnemonic = bip39.generateMnemonic();
@@ -95,6 +102,29 @@ class WalletService {
   Future<SoftwareWallet> unlockCurrentWallet() async {
     final id = _settingsRepository.currentWalletId!;
     return unlockWalletById(id);
+  }
+
+  /// Promotes the currently loaded wallet from [SoftwareViewWallet] (address
+  /// only) to a fully unlocked [SoftwareWallet] (mnemonic in memory) so the
+  /// next sign operation can run. No-op for wallets that aren't locked.
+  ///
+  /// Owning the lifecycle here — instead of behind a callback wired onto
+  /// [AppStore] — keeps the latter as a pure state container.
+  Future<void> ensureCurrentWalletUnlocked() async {
+    if (_appStore.wallet is! SoftwareViewWallet) return;
+    _appStore.wallet = await unlockCurrentWallet();
+  }
+
+  /// Replaces the in-memory [SoftwareWallet] with its lock-screen-safe
+  /// [SoftwareViewWallet] counterpart, dropping the mnemonic. Called after a
+  /// sign operation completes or an idle timer fires so the private key isn't
+  /// kept resident for the rest of the foreground session. No-op for wallet
+  /// types that don't hold a mnemonic.
+  Future<void> lockCurrentWallet() async {
+    final current = _appStore.wallet;
+    if (current is! SoftwareWallet) return;
+    final address = current.currentAccount.primaryAddress.address.hexEip55;
+    _appStore.wallet = SoftwareViewWallet(current.id, current.name, address);
   }
 
   Future<void> deleteCurrentWallet() async {

--- a/lib/packages/service/wallet_service.dart
+++ b/lib/packages/service/wallet_service.dart
@@ -35,6 +35,12 @@ class WalletService {
   /// even if a caller forgets to release.
   int _activeUnlockHolders = 0;
 
+  /// Shared future for the currently-in-flight unlock, so two overlapping
+  /// [ensureCurrentWalletUnlocked] calls reuse the same DB read + AES-GCM
+  /// decrypt instead of triggering it twice. Cleared in `finally` so the
+  /// next post-lock ensure starts a fresh unlock.
+  Future<SoftwareWallet>? _unlockInFlight;
+
   WalletService(
     this._bitboxService,
     this._repository,
@@ -141,7 +147,16 @@ class WalletService {
   Future<void> ensureCurrentWalletUnlocked() async {
     _activeUnlockHolders++;
     if (_appStore.wallet is SoftwareViewWallet) {
-      _appStore.wallet = await unlockCurrentWallet();
+      // Coalesce overlapping unlocks onto a single in-flight future so we
+      // don't hammer the DB and re-run AES-GCM for every concurrent caller.
+      final inFlight = _unlockInFlight ??= unlockCurrentWallet();
+      try {
+        _appStore.wallet = await inFlight;
+      } finally {
+        // Only the caller that started the unlock clears the slot; later
+        // joiners observe the field already nulled and skip the clear.
+        if (identical(_unlockInFlight, inFlight)) _unlockInFlight = null;
+      }
     }
     // Safety net: if a caller forgets to call lockCurrentWallet() after the
     // sign, drop the mnemonic anyway once the post-unlock window elapses. The

--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -47,10 +47,12 @@ class SecureStorage {
   // hardware-backed boundary. Online brute-force against the app UI is bounded
   // by the lockout cascade in `verify_pin_cubit.dart`. The stronger guarantee
   // for the actual private key comes from the OS-keystore-managed mnemonic
-  // encryption key — not from this hash. Earlier 10k / 600k hashes are still
-  // accepted and transparently upgraded to [_pinHashIterations].
-  static const _pinHashIterations = 100000;
-  static const _legacyIterationCandidates = <int>[600000, 10000];
+  // encryption key — not from this hash. 250k roughly doubles the offline
+  // brute-force cost vs. 100k while staying perceptibly sub-second on the
+  // median target phone. Earlier 100k / 600k / 10k hashes are still accepted
+  // and transparently rehashed to [_pinHashIterations].
+  static const _pinHashIterations = 250000;
+  static const _legacyIterationCandidates = <int>[600000, 100000, 10000];
 
   static String hashPin(String pin, Uint8List salt, {int iterations = _pinHashIterations}) {
     final derivator = KeyDerivator('SHA-256/HMAC/PBKDF2');

--- a/lib/packages/wallet/exceptions/wallet_locked_exception.dart
+++ b/lib/packages/wallet/exceptions/wallet_locked_exception.dart
@@ -1,9 +1,0 @@
-/// Thrown when a sign operation hits a [SoftwareViewWallet] — the mnemonic is
-/// still encrypted on disk and the caller must unlock the wallet (via
-/// `WalletService.unlockCurrentWallet`) before signing.
-class WalletLockedException implements Exception {
-  const WalletLockedException();
-
-  @override
-  String toString() => 'Wallet is locked';
-}

--- a/lib/packages/wallet/wallet.dart
+++ b/lib/packages/wallet/wallet.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 import 'package:bip32/bip32.dart';
 import 'package:bip39/bip39.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
-import 'package:realunit_wallet/packages/wallet/exceptions/wallet_locked_exception.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:web3dart/crypto.dart';
 import 'package:web3dart/web3dart.dart';
@@ -70,6 +69,11 @@ class SoftwareViewWallet extends AWallet {
   }
 }
 
+// Every sign path is unreachable while [WalletService.ensureCurrentWalletUnlocked]
+// runs before the credentials are used. Hitting any of these would mean a new
+// caller forgot to call it — surface that immediately in dev via [assert] and
+// fall through to a plain [StateError] (programmer error) in release, instead
+// of a typed exception that the rest of the app would have to catch and route.
 class _LockedCredentials extends CredentialsWithKnownAddress {
   final EthereumAddress _address;
 
@@ -79,21 +83,33 @@ class _LockedCredentials extends CredentialsWithKnownAddress {
   EthereumAddress get address => _address;
 
   @override
-  MsgSignature signToEcSignature(Uint8List payload, {int? chainId, bool isEIP1559 = false}) =>
-      throw const WalletLockedException();
+  MsgSignature signToEcSignature(Uint8List payload, {int? chainId, bool isEIP1559 = false}) {
+    assert(false, _viewWalletProgrammerError);
+    throw StateError(_viewWalletProgrammerError);
+  }
 
   @override
-  Future<MsgSignature> signToSignature(Uint8List payload, {int? chainId, bool isEIP1559 = false}) =>
-      throw const WalletLockedException();
+  Future<MsgSignature> signToSignature(Uint8List payload, {int? chainId, bool isEIP1559 = false}) {
+    assert(false, _viewWalletProgrammerError);
+    throw StateError(_viewWalletProgrammerError);
+  }
 
   @override
-  Future<Uint8List> signPersonalMessage(Uint8List payload, {int? chainId}) =>
-      throw const WalletLockedException();
+  Future<Uint8List> signPersonalMessage(Uint8List payload, {int? chainId}) {
+    assert(false, _viewWalletProgrammerError);
+    throw StateError(_viewWalletProgrammerError);
+  }
 
   @override
-  Uint8List signPersonalMessageToUint8List(Uint8List payload, {int? chainId}) =>
-      throw const WalletLockedException();
+  Uint8List signPersonalMessageToUint8List(Uint8List payload, {int? chainId}) {
+    assert(false, _viewWalletProgrammerError);
+    throw StateError(_viewWalletProgrammerError);
+  }
 }
+
+const _viewWalletProgrammerError =
+    'SoftwareViewWallet credentials reached a sign call — '
+    'every signing path must await WalletService.ensureCurrentWalletUnlocked() first.';
 
 class BitboxWallet extends AWallet {
   @override

--- a/lib/packages/wallet/wallet.dart
+++ b/lib/packages/wallet/wallet.dart
@@ -111,6 +111,22 @@ const _viewWalletProgrammerError =
     'SoftwareViewWallet credentials reached a sign call — '
     'every signing path must await WalletService.ensureCurrentWalletUnlocked() first.';
 
+class SoftwareViewWalletAccount extends AWalletAccount {
+  SoftwareViewWalletAccount(super.accountIndex, super.primaryAddress);
+
+  // Programmer error: callers must await WalletService.ensureCurrentWalletUnlocked
+  // before signing. The locked credentials on this account already assert on the
+  // same path, so this method is reachable only when the caller bypasses the
+  // wallet's primaryAddress and calls signMessage directly.
+  @override
+  Future<String> signMessage(String message, {int addressIndex = 0}) {
+    assert(false, 'SoftwareViewWalletAccount.signMessage called without first '
+        'awaiting WalletService.ensureCurrentWalletUnlocked()');
+    throw StateError('SoftwareViewWalletAccount cannot sign while the mnemonic '
+        'is locked — call WalletService.ensureCurrentWalletUnlocked() first.');
+  }
+}
+
 class BitboxWallet extends AWallet {
   @override
   WalletType get walletType => WalletType.bitbox;

--- a/lib/packages/wallet/wallet_account.dart
+++ b/lib/packages/wallet/wallet_account.dart
@@ -39,19 +39,3 @@ class BitboxWalletAccount extends AWalletAccount {
   Future<String> signMessage(String message, {int addressIndex = 0}) async =>
       '0x${hex.encode(await primaryAddress.signPersonalMessage(utf8.encode(message)))}';
 }
-
-class SoftwareViewWalletAccount extends AWalletAccount {
-  SoftwareViewWalletAccount(super.accountIndex, super.primaryAddress);
-
-  // Programmer error: callers must await WalletService.ensureCurrentWalletUnlocked
-  // before signing. The locked credentials on this account already assert on the
-  // same path, so this method is reachable only when the caller bypasses the
-  // wallet's primaryAddress and calls signMessage directly.
-  @override
-  Future<String> signMessage(String message, {int addressIndex = 0}) {
-    assert(false, 'SoftwareViewWalletAccount.signMessage called without first '
-        'awaiting WalletService.ensureCurrentWalletUnlocked()');
-    throw StateError('SoftwareViewWalletAccount cannot sign while the mnemonic '
-        'is locked — call WalletService.ensureCurrentWalletUnlocked() first.');
-  }
-}

--- a/lib/packages/wallet/wallet_account.dart
+++ b/lib/packages/wallet/wallet_account.dart
@@ -2,7 +2,6 @@ import 'dart:convert' show utf8;
 
 import 'package:bip32/bip32.dart';
 import 'package:convert/convert.dart';
-import 'package:realunit_wallet/packages/wallet/exceptions/wallet_locked_exception.dart';
 import 'package:web3dart/web3dart.dart';
 
 abstract class AWalletAccount {
@@ -44,7 +43,15 @@ class BitboxWalletAccount extends AWalletAccount {
 class SoftwareViewWalletAccount extends AWalletAccount {
   SoftwareViewWalletAccount(super.accountIndex, super.primaryAddress);
 
+  // Programmer error: callers must await WalletService.ensureCurrentWalletUnlocked
+  // before signing. The locked credentials on this account already assert on the
+  // same path, so this method is reachable only when the caller bypasses the
+  // wallet's primaryAddress and calls signMessage directly.
   @override
-  Future<String> signMessage(String message, {int addressIndex = 0}) =>
-      throw const WalletLockedException();
+  Future<String> signMessage(String message, {int addressIndex = 0}) {
+    assert(false, 'SoftwareViewWalletAccount.signMessage called without first '
+        'awaiting WalletService.ensureCurrentWalletUnlocked()');
+    throw StateError('SoftwareViewWalletAccount cannot sign while the mnemonic '
+        'is locked — call WalletService.ensureCurrentWalletUnlocked() first.');
+  }
 }

--- a/lib/screens/create_wallet/bloc/create_wallet_cubit.dart
+++ b/lib/screens/create_wallet/bloc/create_wallet_cubit.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -15,10 +16,14 @@ class CreateWalletCubit extends Cubit<CreateWalletState> {
 
   void createWallet() async {
     final wallet = await _service.createSeedWallet('Obi-Wallet-Kenobi');
+    // Fire-and-forget the auth-signature capture — the lazy path in
+    // DFXAuthService.getSignature is the safety net, and a 20 s HTTP timeout
+    // shouldn't gate the "creating wallet" UI.
+    unawaited(_warmAuthSignature(wallet));
+    emit(state.copyWith(wallet: wallet));
+  }
 
-    // Capture the DFX auth signature while the freshly generated mnemonic is
-    // still in memory — same rationale as the BitBox pairing flow. Non-fatal
-    // on failure; the lazy path in DFXAuthService.getSignature recovers later.
+  Future<void> _warmAuthSignature(SoftwareWallet wallet) async {
     try {
       await _authService.ensureSignatureFor(wallet.currentAccount);
     } catch (e) {
@@ -27,8 +32,6 @@ class CreateWalletCubit extends Cubit<CreateWalletState> {
         name: '$CreateWalletCubit',
       );
     }
-
-    emit(state.copyWith(wallet: wallet));
   }
 
   void toggleShowSeed() {

--- a/lib/screens/create_wallet/bloc/create_wallet_cubit.dart
+++ b/lib/screens/create_wallet/bloc/create_wallet_cubit.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:developer' as developer;
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
@@ -19,19 +18,14 @@ class CreateWalletCubit extends Cubit<CreateWalletState> {
     // Fire-and-forget the auth-signature capture — the lazy path in
     // DFXAuthService.getSignature is the safety net, and a 20 s HTTP timeout
     // shouldn't gate the "creating wallet" UI.
-    unawaited(_warmAuthSignature(wallet));
+    unawaited(
+      warmAuthSignature(
+        _authService,
+        wallet.currentAccount,
+        loggerName: '$CreateWalletCubit',
+      ),
+    );
     emit(state.copyWith(wallet: wallet));
-  }
-
-  Future<void> _warmAuthSignature(SoftwareWallet wallet) async {
-    try {
-      await _authService.ensureSignatureFor(wallet.currentAccount);
-    } catch (e) {
-      developer.log(
-        'initial signature capture failed: $e',
-        name: '$CreateWalletCubit',
-      );
-    }
   }
 
   void toggleShowSeed() {

--- a/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
+++ b/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
@@ -152,20 +152,13 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
               '${_createWalletTimeout.inSeconds}s. Try disconnecting and re-pairing.',
             ),
           );
-      // Capture the DFX auth signature now, while the BitBox is guaranteed
-      // connected. Once persisted, every later buy / KYC / user-data call runs
-      // off the cached signature without needing the hardware wallet present.
-      // A failure here is non-fatal: we still complete pairing and rely on the
-      // lazy-create path in DFXAuthService.getSignature as a fallback.
-      try {
-        await _authService.ensureSignatureFor(wallet.currentAccount);
-      } catch (e) {
-        developer.log(
-          'initial signature capture failed: $e',
-          name: '$ConnectBitboxCubit',
-        );
-      }
       _service.startConnectionStatusObserver();
+      // Fire-and-forget the auth-signature capture. Once persisted, every
+      // later buy / KYC / user-data call runs off the cached signature without
+      // needing the hardware wallet present. Awaiting would block the pairing
+      // UI for the EIP-191 BitBox confirmation + the 20 s HTTP timeout; if it
+      // fails the lazy path in DFXAuthService.getSignature still recovers.
+      unawaited(_warmAuthSignature(wallet));
       emit(BitboxConnected(wallet));
     } catch (e) {
       developer.log(e.toString(), name: '$ConnectBitboxCubit');
@@ -180,6 +173,23 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
     final currentState = state;
     if (currentState is! BitboxConnected) return;
     emit(BitboxFinishSetup(currentState.wallet));
+  }
+
+  Future<void> _warmAuthSignature(AWallet wallet) async {
+    try {
+      await _authService.ensureSignatureFor(wallet.currentAccount);
+    } catch (e) {
+      // Visible-to-support log so the failure shows up in any later debug
+      // session: signature-cache misses on the first authenticated call would
+      // trigger a fresh BitBox button press, which is the failure mode #461
+      // was supposed to remove.
+      developer.log(
+        'initial signature capture failed — next authenticated call '
+        'will trigger a fresh BitBox confirmation: $e',
+        name: '$ConnectBitboxCubit',
+        level: 1000, // SEVERE
+      );
+    }
   }
 
   @override

--- a/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
+++ b/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
@@ -158,7 +158,13 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
       // needing the hardware wallet present. Awaiting would block the pairing
       // UI for the EIP-191 BitBox confirmation + the 20 s HTTP timeout; if it
       // fails the lazy path in DFXAuthService.getSignature still recovers.
-      unawaited(_warmAuthSignature(wallet));
+      unawaited(
+        warmAuthSignature(
+          _authService,
+          wallet.currentAccount,
+          loggerName: '$ConnectBitboxCubit',
+        ),
+      );
       emit(BitboxConnected(wallet));
     } catch (e) {
       developer.log(e.toString(), name: '$ConnectBitboxCubit');
@@ -173,23 +179,6 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
     final currentState = state;
     if (currentState is! BitboxConnected) return;
     emit(BitboxFinishSetup(currentState.wallet));
-  }
-
-  Future<void> _warmAuthSignature(AWallet wallet) async {
-    try {
-      await _authService.ensureSignatureFor(wallet.currentAccount);
-    } catch (e) {
-      // Visible-to-support log so the failure shows up in any later debug
-      // session: signature-cache misses on the first authenticated call would
-      // trigger a fresh BitBox button press, which is the failure mode #461
-      // was supposed to remove.
-      developer.log(
-        'initial signature capture failed — next authenticated call '
-        'will trigger a fresh BitBox confirmation: $e',
-        name: '$ConnectBitboxCubit',
-        level: 1000, // SEVERE
-      );
-    }
   }
 
   @override

--- a/lib/screens/hardware_connect_bitbox/connect_bitbox_view.dart
+++ b/lib/screens/hardware_connect_bitbox/connect_bitbox_view.dart
@@ -87,6 +87,13 @@ class ConnectBitboxView extends StatelessWidget {
                               style: Theme.of(context).textTheme.headlineSmall,
                             ),
                           ),
+                          Text(
+                            S.of(context).connectBitboxSignInHint,
+                            textAlign: .center,
+                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: RealUnitColors.neutral500,
+                            ),
+                          ),
                         ],
                       ),
                     ),

--- a/lib/screens/restore_wallet/cubit/restore_wallet/restore_wallet_cubit.dart
+++ b/lib/screens/restore_wallet/cubit/restore_wallet/restore_wallet_cubit.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:developer' as developer;
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -25,7 +24,13 @@ class RestoreWalletCubit extends Cubit<RestoreWalletState> {
     // Fire-and-forget the auth-signature capture so a 20 s HTTP timeout doesn't
     // block the wallet-restore UI. The lazy path in DFXAuthService.getSignature
     // is the safety net.
-    unawaited(_warmAuthSignature(wallet));
+    unawaited(
+      warmAuthSignature(
+        _authService,
+        wallet.currentAccount,
+        loggerName: '$RestoreWalletCubit',
+      ),
+    );
 
     emit(
       RestoreWalletState(
@@ -33,16 +38,5 @@ class RestoreWalletCubit extends Cubit<RestoreWalletState> {
         wallet: wallet,
       ),
     );
-  }
-
-  Future<void> _warmAuthSignature(SoftwareWallet wallet) async {
-    try {
-      await _authService.ensureSignatureFor(wallet.currentAccount);
-    } catch (e) {
-      developer.log(
-        'initial signature capture failed: $e',
-        name: '$RestoreWalletCubit',
-      );
-    }
   }
 }

--- a/lib/screens/restore_wallet/cubit/restore_wallet/restore_wallet_cubit.dart
+++ b/lib/screens/restore_wallet/cubit/restore_wallet/restore_wallet_cubit.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:equatable/equatable.dart';
@@ -21,10 +22,20 @@ class RestoreWalletCubit extends Cubit<RestoreWalletState> {
     final normalizedSeed = seed.split(' ').where((element) => element.isNotEmpty).join(' ');
 
     final wallet = await _walletService.restoreWallet('Obi-Wallet-Kenobi', normalizedSeed);
+    // Fire-and-forget the auth-signature capture so a 20 s HTTP timeout doesn't
+    // block the wallet-restore UI. The lazy path in DFXAuthService.getSignature
+    // is the safety net.
+    unawaited(_warmAuthSignature(wallet));
 
-    // Capture the DFX auth signature while the freshly restored mnemonic is
-    // still in memory — same rationale as the BitBox pairing flow. Non-fatal
-    // on failure; the lazy path in DFXAuthService.getSignature recovers later.
+    emit(
+      RestoreWalletState(
+        isLoading: false,
+        wallet: wallet,
+      ),
+    );
+  }
+
+  Future<void> _warmAuthSignature(SoftwareWallet wallet) async {
     try {
       await _authService.ensureSignatureFor(wallet.currentAccount);
     } catch (e) {
@@ -33,12 +44,5 @@ class RestoreWalletCubit extends Cubit<RestoreWalletState> {
         name: '$RestoreWalletCubit',
       );
     }
-
-    emit(
-      RestoreWalletState(
-        isLoading: false,
-        wallet: wallet,
-      ),
-    );
   }
 }

--- a/lib/screens/sell/widgets/sell_button.dart
+++ b/lib/screens/sell/widgets/sell_button.dart
@@ -3,12 +3,15 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/bank_account/bank_account.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/payment/payment_info_error.dart';
+import 'package:realunit_wallet/screens/hardware_connect_bitbox/show_bitbox_reconnect_sheet.dart';
 import 'package:realunit_wallet/screens/sell/cubits/sell_converter/sell_converter_cubit.dart';
 import 'package:realunit_wallet/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart';
 import 'package:realunit_wallet/screens/sell/widgets/sell_confirm_sheet.dart';
 import 'package:realunit_wallet/screens/sell/widgets/sell_executed_sheet.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/styles/colors.dart';
+import 'package:realunit_wallet/styles/currency.dart';
 import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
 
 class SellButton extends StatelessWidget {
@@ -31,6 +34,19 @@ class SellButton extends StatelessWidget {
           }
           if (state.error == .registrationRequired) {
             await context.pushNamed(AppRoutes.kyc);
+            return;
+          }
+          if (state.error == .bitboxDisconnected) {
+            final paymentInfoCubit = context.read<SellPaymentInfoCubit>();
+            final converterCurrency = context.read<SellConverterCubit>().state.currency;
+            await showBitboxReconnectSheet(context);
+            if (bankAccount != null && amount.isNotEmpty) {
+              paymentInfoCubit.getPaymentInfo(
+                amount: amount,
+                iban: bankAccount!.iban,
+                currency: converterCurrency,
+              );
+            }
             return;
           }
           if (context.mounted) {

--- a/lib/screens/sell/widgets/sell_button.dart
+++ b/lib/screens/sell/widgets/sell_button.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/bank_account/bank_account.dart';
-import 'package:realunit_wallet/packages/service/dfx/models/payment/payment_info_error.dart';
 import 'package:realunit_wallet/screens/hardware_connect_bitbox/show_bitbox_reconnect_sheet.dart';
 import 'package:realunit_wallet/screens/sell/cubits/sell_converter/sell_converter_cubit.dart';
 import 'package:realunit_wallet/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart';
@@ -11,7 +10,6 @@ import 'package:realunit_wallet/screens/sell/widgets/sell_confirm_sheet.dart';
 import 'package:realunit_wallet/screens/sell/widgets/sell_executed_sheet.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/styles/colors.dart';
-import 'package:realunit_wallet/styles/currency.dart';
 import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
 
 class SellButton extends StatelessWidget {

--- a/lib/screens/sell_bitbox/cubit/sell_bitbox_cubit.dart
+++ b/lib/screens/sell_bitbox/cubit/sell_bitbox_cubit.dart
@@ -107,10 +107,6 @@ class SellBitboxCubit extends Cubit<SellBitboxState> {
       emit(SellBitboxError('BitBox wallet not connected'));
       return;
     }
-    if (!credentials.isConnected) {
-      emit(SellBitboxBitboxRequired());
-      return;
-    }
 
     try {
       emit(SellBitboxSwapping());
@@ -130,10 +126,6 @@ class SellBitboxCubit extends Cubit<SellBitboxState> {
     final credentials = _appStore.wallet.currentAccount.primaryAddress;
     if (credentials is! BitboxCredentials) {
       emit(SellBitboxError('BitBox wallet not connected'));
-      return;
-    }
-    if (!credentials.isConnected) {
-      emit(SellBitboxBitboxRequired());
       return;
     }
 

--- a/lib/screens/settings_seed/bloc/settings_seed_cubit.dart
+++ b/lib/screens/settings_seed/bloc/settings_seed_cubit.dart
@@ -29,6 +29,9 @@ class SettingsSeedCubit extends Cubit<SettingsSeedState> {
     // Revealing the recovery phrase needs the actual mnemonic in memory —
     // promote a view-wallet to its unlocked form before reading the seed.
     await _walletService.ensureCurrentWalletUnlocked();
+    // The user can navigate away during DB decryption — emit() after close()
+    // throws StateError as an unhandled async error, so bail before the cast.
+    if (isClosed) return;
     final wallet = _appStore.wallet as SoftwareWallet;
     // copyWith preserves a [showSeed] toggle that may have raced ahead of the
     // unlock so the user's choice isn't dropped on the floor.

--- a/lib/screens/settings_seed/bloc/settings_seed_cubit.dart
+++ b/lib/screens/settings_seed/bloc/settings_seed_cubit.dart
@@ -1,19 +1,22 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 
 part 'settings_seed_state.dart';
 
 class SettingsSeedCubit extends Cubit<SettingsSeedState> {
   final AppStore _appStore;
+  final WalletService _walletService;
 
   // Seed the state synchronously when the wallet is already a full
   // SoftwareWallet so the first render of MnemonicReadOnlyField sees the
   // 12 words. With the post-#461 view-wallet model the initial state could
   // briefly be empty, which trips MnemonicReadOnlyField's `length == 12`
   // assert and crashes the screen on open.
-  SettingsSeedCubit(this._appStore) : super(SettingsSeedState(_initialSeed(_appStore))) {
+  SettingsSeedCubit(this._appStore, this._walletService)
+      : super(SettingsSeedState(_initialSeed(_appStore))) {
     _loadSeed();
   }
 
@@ -25,10 +28,21 @@ class SettingsSeedCubit extends Cubit<SettingsSeedState> {
   Future<void> _loadSeed() async {
     // Revealing the recovery phrase needs the actual mnemonic in memory —
     // promote a view-wallet to its unlocked form before reading the seed.
-    await _appStore.ensureUnlocked();
+    await _walletService.ensureCurrentWalletUnlocked();
     final wallet = _appStore.wallet as SoftwareWallet;
-    if (state.seed != wallet.seed) emit(SettingsSeedState(wallet.seed));
+    // copyWith preserves a [showSeed] toggle that may have raced ahead of the
+    // unlock so the user's choice isn't dropped on the floor.
+    if (state.seed != wallet.seed) emit(state.copyWith(seed: wallet.seed));
   }
 
   void toggleShowSeed() => emit(state.copyWith(showSeed: !state.showSeed));
+
+  @override
+  Future<void> close() async {
+    // The mnemonic is on screen only while this cubit is alive — once the user
+    // navigates away, drop it back to the locked view so the key isn't
+    // resident for the rest of the foreground session.
+    await _walletService.lockCurrentWallet();
+    return super.close();
+  }
 }

--- a/lib/screens/settings_seed/settings_seed_page.dart
+++ b/lib/screens/settings_seed/settings_seed_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/screens/settings_seed/bloc/settings_seed_cubit.dart';
 import 'package:realunit_wallet/screens/settings_seed/settings_seed_view.dart';
 import 'package:realunit_wallet/setup/di.dart';
@@ -10,7 +11,7 @@ class SettingsSeedPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => BlocProvider(
-    create: (_) => SettingsSeedCubit(getIt<AppStore>()),
+    create: (_) => SettingsSeedCubit(getIt<AppStore>(), getIt<WalletService>()),
     child: const SettingsSeedView(),
   );
 }

--- a/lib/screens/settings_seed/settings_seed_view.dart
+++ b/lib/screens/settings_seed/settings_seed_view.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
@@ -87,10 +88,20 @@ class _SettingsSeedViewState extends State<SettingsSeedView> {
               const SizedBox(height: 16),
               BlocBuilder<SettingsSeedCubit, SettingsSeedState>(
                 builder: (context, state) {
+                  // The cubit starts with an empty seed when the wallet is a
+                  // SoftwareViewWallet (the default production state after
+                  // #461) and only fills it in after the async unlock. Until
+                  // the 12 words are in memory, MnemonicReadOnlyField's
+                  // `length == 12` assert would crash this screen — show a
+                  // spinner instead and rebuild once the seed lands.
+                  final wordCount = state.seed.split(' ').where((w) => w.isNotEmpty).length;
+                  if (wordCount != 12) {
+                    return const Center(child: CupertinoActivityIndicator());
+                  }
                   return SeedBlurCard(
-                    seed: context.read<SettingsSeedCubit>().state.seed,
+                    seed: state.seed,
                     onTap: () => context.read<SettingsSeedCubit>().toggleShowSeed(),
-                    blur: !context.read<SettingsSeedCubit>().state.showSeed,
+                    blur: !state.showSeed,
                   );
                 },
               ),

--- a/lib/setup/di.dart
+++ b/lib/setup/di.dart
@@ -119,46 +119,62 @@ void setupServices() {
     ),
   );
   getIt.registerSingleton(BitboxService());
-  getIt.registerFactory(
+  getIt.registerLazySingleton(
     () => WalletService(
       getIt<BitboxService>(),
       getIt<WalletRepository>(),
       getIt<SettingsRepository>(),
+      getIt<AppStore>(),
     ),
-  );
-  // Wire the lazy-unlock callback so `AppStore.ensureUnlocked()` can promote
-  // a view-wallet to an unlocked SoftwareWallet without the auth-service layer
-  // having to import WalletService directly.
-  getIt<AppStore>().attachUnlocker(
-    () => getIt<WalletService>().unlockCurrentWallet(),
   );
   getIt.registerFactory(
     () => TransactionHistoryService(
       getIt<AppStore>(),
+      getIt<WalletService>(),
       getIt<TransactionRepository>(),
     ),
   );
 
   getIt.registerCachedFactory(() => DfxCountryService(getIt<AppStore>()));
-  getIt.registerFactory(() => DfxBankAccountService(getIt<AppStore>()));
-  getIt.registerFactory(() => DfxBrokerbotService(getIt<AppStore>()));
-  getIt.registerFactory(() => DfxKycService(getIt<AppStore>()));
-  getIt.registerFactory(() => DFXPriceService(getIt<AppStore>()));
-  getIt.registerFactory(() => DfxSupportService(getIt<AppStore>()));
-  getIt.registerFactory(() => DfxFaucetService(getIt<AppStore>()));
-  getIt.registerFactory(() => DfxBlockchainApiService(getIt<AppStore>()));
   getIt.registerFactory(
-    () => DfxWidgetService(
-      getIt<AppStore>(),
-    ),
+    () => DfxBankAccountService(getIt<AppStore>(), getIt<WalletService>()),
+  );
+  getIt.registerFactory(
+    () => DfxBrokerbotService(getIt<AppStore>(), getIt<WalletService>()),
+  );
+  getIt.registerFactory(
+    () => DfxKycService(getIt<AppStore>(), getIt<WalletService>()),
+  );
+  getIt.registerFactory(() => DFXPriceService(getIt<AppStore>()));
+  getIt.registerFactory(
+    () => DfxSupportService(getIt<AppStore>(), getIt<WalletService>()),
+  );
+  getIt.registerFactory(
+    () => DfxFaucetService(getIt<AppStore>(), getIt<WalletService>()),
+  );
+  getIt.registerFactory(
+    () => DfxBlockchainApiService(getIt<AppStore>(), getIt<WalletService>()),
+  );
+  getIt.registerFactory(
+    () => DfxWidgetService(getIt<AppStore>(), getIt<WalletService>()),
   );
 
   getIt.registerFactory(() => RealUnitAccountService(getIt<AppStore>()));
-  getIt.registerFactory(() => RealUnitBuyPaymentInfoService(getIt<AppStore>()));
-  getIt.registerFactory(() => RealUnitPdfService(getIt<AppStore>()));
-  getIt.registerFactory(() => RealUnitRegistrationService(getIt<AppStore>()));
-  getIt.registerFactory(() => RealUnitSellPaymentInfoService(getIt<AppStore>()));
-  getIt.registerFactory(() => RealUnitWalletService(getIt<AppStore>()));
+  getIt.registerFactory(
+    () => RealUnitBuyPaymentInfoService(getIt<AppStore>(), getIt<WalletService>()),
+  );
+  getIt.registerFactory(
+    () => RealUnitPdfService(getIt<AppStore>(), getIt<WalletService>()),
+  );
+  getIt.registerFactory(
+    () => RealUnitRegistrationService(getIt<AppStore>(), getIt<WalletService>()),
+  );
+  getIt.registerFactory(
+    () => RealUnitSellPaymentInfoService(getIt<AppStore>(), getIt<WalletService>()),
+  );
+  getIt.registerFactory(
+    () => RealUnitWalletService(getIt<AppStore>(), getIt<WalletService>()),
+  );
   getIt.registerFactory(() => SettingsService(getIt<SettingsRepository>()));
   getIt.registerFactory(
     () => DebugAuthService(getIt<AppStore>(), getIt<SharedPreferences>()),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -166,10 +166,10 @@ packages:
     dependency: "direct main"
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -915,26 +915,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1408,26 +1408,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/test/packages/hardware_wallet/bitbox_credentials_test.dart
+++ b/test/packages/hardware_wallet/bitbox_credentials_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:bitbox_flutter/bitbox_flutter.dart';
+import 'package:bitbox_flutter/bitbox_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
@@ -8,7 +9,7 @@ import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception
 
 class _MockBitboxManager extends Mock implements BitboxManager {}
 
-class _FakeDevice extends Fake implements BitboxDevice {}
+class _FakeBitboxDevice extends Fake implements BitboxDevice {}
 
 class _ParseError implements Exception {}
 
@@ -21,6 +22,12 @@ void main() {
 
   setUp(() {
     manager = _MockBitboxManager();
+    // _runOrThrowDisconnect probes manager.devices to distinguish a real
+    // disconnect from a sign-internal failure. Tests below that expect the
+    // *original* error to surface must report the device as still connected.
+    when(() => manager.devices).thenAnswer((_) async => <BitboxDevice>[
+          _FakeBitboxDevice(),
+        ]);
   });
 
   BitboxCredentials connected() =>
@@ -179,7 +186,7 @@ void main() {
       // decide whether to relabel the error as BitboxNotConnectedException.
       // Stub it to a non-empty list so the original "first sign explodes"
       // survives — this test exercises the queue, not the disconnect path.
-      when(() => manager.devices).thenAnswer((_) async => [_FakeDevice()]);
+      when(() => manager.devices).thenAnswer((_) async => [_FakeBitboxDevice()]);
 
       var call = 0;
       when(() => manager.signETHTypedMessage(any(), any(), any())).thenAnswer((_) async {

--- a/test/packages/hardware_wallet/bitbox_credentials_test.dart
+++ b/test/packages/hardware_wallet/bitbox_credentials_test.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:bitbox_flutter/bitbox_flutter.dart';
-import 'package:bitbox_flutter/bitbox_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
@@ -234,7 +233,7 @@ void main() {
         when(
           () => manager.signETHRLPTransaction(any(), any(), any(), any()),
         ).thenThrow(_ParseError());
-        when(() => manager.devices).thenAnswer((_) async => [_FakeDevice()]);
+        when(() => manager.devices).thenAnswer((_) async => [_FakeBitboxDevice()]);
 
         final c = connected();
         await expectLater(
@@ -284,5 +283,21 @@ void main() {
         expect(c.isConnected, isFalse, reason: 'clearBitbox must have run on lost device');
       },
     );
+
+    test('sign on cleared credentials throws BitboxNotConnectedException, not NoSuchMethod',
+        () async {
+      // Snapshot semantics (3.2) — the manager may be nulled by the observer
+      // between the connection check and the sign call. The snapshot-on-entry
+      // pattern means the null check fires and the bang-operator path is
+      // never reached.
+      final c = BitboxCredentials('0x000000000000000000000000000000000000dead')
+        ..setBitbox(manager);
+      c.clearBitbox();
+
+      await expectLater(
+        c.signTypedDataV4(1, '{"primaryType":"A"}'),
+        throwsA(isA<BitboxNotConnectedException>()),
+      );
+    });
   });
 }

--- a/test/packages/hardware_wallet/bitbox_service_test.dart
+++ b/test/packages/hardware_wallet/bitbox_service_test.dart
@@ -308,11 +308,12 @@ void main() {
     });
 
     test('getCredentials called twice with the same address while connected returns equally-connected instances', () {
-      // Defensive pin: the observer's clearBitbox() operates on whichever
-      // BitboxCredentials reference is currently stored in _credentials. A
-      // future refactor that caches and returns the same instance across
-      // calls would break that contract — each hand-out must be a fresh
-      // instance so the observer always targets the latest one.
+      // Defensive pin: post-#472 the service caches BitboxCredentials in a
+      // map keyed by lowercased address, and the disconnect observer iterates
+      // every entry to call clearBitbox(). So callers must always see the
+      // same canonical instance for a given address — a refactor that hands
+      // out a fresh instance per call would let the observer clear an
+      // orphaned reference instead of the one the caller is still holding.
       fakeAsync((async) {
         final service = pairedServiceSync(async);
 
@@ -321,8 +322,8 @@ void main() {
 
         expect(first.isConnected, isTrue);
         expect(second.isConnected, isTrue);
-        expect(second, isNot(same(first)),
-            reason: 'each getCredentials call must produce a distinct instance');
+        expect(second, same(first),
+            reason: 'getCredentials must return the cached instance for a given address');
       });
     });
   });

--- a/test/packages/service/dfx/dfx_auth_service_test.dart
+++ b/test/packages/service/dfx/dfx_auth_service_test.dart
@@ -7,6 +7,7 @@ import 'package:realunit_wallet/packages/repository/cache_repository.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:web3dart/web3dart.dart';
@@ -18,6 +19,8 @@ import 'package:web3dart/web3dart.dart';
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockSessionCache extends Mock implements SessionCache {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 class _StubWalletAccount extends AWalletAccount {
   _StubWalletAccount(this._signature)
@@ -39,7 +42,7 @@ class _StubWalletAccount extends AWalletAccount {
 }
 
 class _SignatureTestAuthService extends DFXAuthService {
-  _SignatureTestAuthService(super.appStore, this._wallet, this._address);
+  _SignatureTestAuthService(super.appStore, super.walletService, this._wallet, this._address);
 
   final AWalletAccount _wallet;
   final String _address;
@@ -70,7 +73,7 @@ class _RetryTestAppStore extends AppStore {
 }
 
 class _RetryTestAuthService extends DFXAuthService {
-  _RetryTestAuthService(super.appStore);
+  _RetryTestAuthService(super.appStore, super.walletService);
 
   int authTokenCalls = 0;
   int refreshAuthTokenCalls = 0;
@@ -107,13 +110,18 @@ void main() {
     const address = '0x1111111111111111111111111111111111111111';
     const validSig = '0xdeadbeef';
 
+    late _MockWalletService walletService;
+
     setUp(() {
       appStore = _MockAppStore();
       sessionCache = _MockSessionCache();
       walletAccount = _StubWalletAccount(validSig);
+      walletService = _MockWalletService();
 
       when(() => appStore.sessionCache).thenReturn(sessionCache);
-      when(() => appStore.ensureUnlocked()).thenAnswer((_) async {});
+      when(() => walletService.ensureCurrentWalletUnlocked())
+          .thenAnswer((_) async {});
+      when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
       when(() => sessionCache.signature).thenReturn(null);
       when(() => sessionCache.signatureAddress).thenReturn(null);
       when(() => sessionCache.authToken).thenReturn(null);
@@ -121,7 +129,7 @@ void main() {
     });
 
     _SignatureTestAuthService buildService() =>
-        _SignatureTestAuthService(appStore, walletAccount, address);
+        _SignatureTestAuthService(appStore, walletService, walletAccount, address);
 
     group('getSignature', () {
       test('returns the cached signature when address matches (no re-sign)', () async {
@@ -203,7 +211,7 @@ void main() {
         }
         return http.Response('{"ok":true}', 200);
       });
-      final service = _RetryTestAuthService(_RetryTestAppStore(client));
+      final service = _RetryTestAuthService(_RetryTestAppStore(client), _MockWalletService());
 
       final response = await service.authenticatedGet(
         Uri.parse('https://api.example.test/v1/resource'),
@@ -230,7 +238,7 @@ void main() {
         }
         return http.Response('{"ok":true}', 201);
       });
-      final service = _RetryTestAuthService(_RetryTestAppStore(client));
+      final service = _RetryTestAuthService(_RetryTestAppStore(client), _MockWalletService());
 
       final response = await service.authenticatedPost(
         Uri.parse('https://api.example.test/v1/resource'),
@@ -258,7 +266,7 @@ void main() {
         }
         return http.Response('{"ok":true}', 200);
       });
-      final service = _RetryTestAuthService(_RetryTestAppStore(client));
+      final service = _RetryTestAuthService(_RetryTestAppStore(client), _MockWalletService());
 
       final response = await service.authenticatedPut(
         Uri.parse('https://api.example.test/v1/resource'),
@@ -278,7 +286,7 @@ void main() {
         calls++;
         return http.Response('{"message":"Unauthorized"}', 401);
       });
-      final service = _RetryTestAuthService(_RetryTestAppStore(client));
+      final service = _RetryTestAuthService(_RetryTestAppStore(client), _MockWalletService());
 
       final response = await service.authenticatedGet(
         Uri.parse('https://api.example.test/v1/resource'),
@@ -297,7 +305,7 @@ void main() {
             '{"message":"Unauthorized"}',
             401,
           ));
-      final service = _ThrowingRefreshAuthService(_RetryTestAppStore(client));
+      final service = _ThrowingRefreshAuthService(_RetryTestAppStore(client), _MockWalletService());
 
       await expectLater(
         service.authenticatedGet(Uri.parse('https://api.example.test/v1/resource')),
@@ -309,7 +317,7 @@ void main() {
 }
 
 class _ThrowingRefreshAuthService extends DFXAuthService {
-  _ThrowingRefreshAuthService(super.appStore);
+  _ThrowingRefreshAuthService(super.appStore, super.walletService);
 
   int refreshAuthTokenCalls = 0;
 

--- a/test/packages/service/dfx/dfx_bank_account_service_test.dart
+++ b/test/packages/service/dfx/dfx_bank_account_service_test.dart
@@ -11,10 +11,13 @@ import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_bank_account_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 Map<String, dynamic> _bankAccount({
   int id = 1,
@@ -32,10 +35,12 @@ Map<String, dynamic> _bankAccount({
 
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     // Pre-seed the JWT so `authenticatedGet/Put/Post` short-circuits the
     // `getAuthToken` refresh path (which would otherwise need a fully
@@ -43,11 +48,13 @@ void main() {
     sessionCache.setAuthToken('test-jwt');
     when(() => appStore.sessionCache).thenReturn(sessionCache);
     when(() => appStore.apiConfig).thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   DfxBankAccountService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return DfxBankAccountService(appStore);
+    return DfxBankAccountService(appStore, walletService);
   }
 
   group('$DfxBankAccountService', () {

--- a/test/packages/service/dfx/dfx_blockchain_api_service_test.dart
+++ b/test/packages/service/dfx/dfx_blockchain_api_service_test.dart
@@ -11,28 +11,35 @@ import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_blockchain_api_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
 
+class _MockWalletService extends Mock implements WalletService {}
+
 const _testAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
 
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     when(() => appStore.sessionCache).thenReturn(sessionCache);
     when(() => appStore.apiConfig)
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   DfxBlockchainApiService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return DfxBlockchainApiService(appStore);
+    return DfxBlockchainApiService(appStore, walletService);
   }
 
   group('$DfxBlockchainApiService', () {

--- a/test/packages/service/dfx/dfx_brokerbot_service_test.dart
+++ b/test/packages/service/dfx/dfx_brokerbot_service_test.dart
@@ -11,27 +11,34 @@ import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_brokerbot_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/styles/currency.dart';
 
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
 
+class _MockWalletService extends Mock implements WalletService {}
+
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     when(() => appStore.sessionCache).thenReturn(sessionCache);
     when(() => appStore.apiConfig)
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   DfxBrokerbotService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return DfxBrokerbotService(appStore);
+    return DfxBrokerbotService(appStore, walletService);
   }
 
   group('$DfxBrokerbotService', () {

--- a/test/packages/service/dfx/dfx_faucet_service_test.dart
+++ b/test/packages/service/dfx/dfx_faucet_service_test.dart
@@ -11,26 +11,33 @@ import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_faucet_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
 
+class _MockWalletService extends Mock implements WalletService {}
+
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     when(() => appStore.sessionCache).thenReturn(sessionCache);
     when(() => appStore.apiConfig)
         .thenReturn(const ApiConfig(networkMode: NetworkMode.testnet));
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   DfxFaucetService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return DfxFaucetService(appStore);
+    return DfxFaucetService(appStore, walletService);
   }
 
   group('$DfxFaucetService', () {

--- a/test/packages/service/dfx/dfx_kyc_service_rest_test.dart
+++ b/test/packages/service/dfx/dfx_kyc_service_rest_test.dart
@@ -13,6 +13,7 @@ import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.da
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_financial_data_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:realunit_wallet/styles/language.dart';
@@ -21,6 +22,8 @@ import 'package:web3dart/web3dart.dart';
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 class _StubCreds extends Fake implements CredentialsWithKnownAddress {
   @override
@@ -56,21 +59,25 @@ const _emptySessionJson = {
 
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     sessionCache.setAuthToken('jwt-1');
     when(() => appStore.sessionCache).thenReturn(sessionCache);
     when(() => appStore.apiConfig)
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
     when(() => appStore.wallet).thenReturn(_StubWallet());
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   DfxKycService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return DfxKycService(appStore);
+    return DfxKycService(appStore, walletService);
   }
 
   http.Response userResp() => http.Response(jsonEncode(_userJson), 200);

--- a/test/packages/service/dfx/dfx_kyc_service_test.dart
+++ b/test/packages/service/dfx/dfx_kyc_service_test.dart
@@ -11,6 +11,7 @@ import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:web3dart/web3dart.dart';
@@ -18,6 +19,8 @@ import 'package:web3dart/web3dart.dart';
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 class _StubWalletAccount extends AWalletAccount {
   _StubWalletAccount() : super(0, _StubCreds());
@@ -54,21 +57,25 @@ const _userJson = {
 
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     sessionCache.setAuthToken('jwt-1');
     when(() => appStore.sessionCache).thenReturn(sessionCache);
     when(() => appStore.apiConfig)
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
     when(() => appStore.wallet).thenReturn(_StubWallet());
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   DfxKycService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return DfxKycService(appStore);
+    return DfxKycService(appStore, walletService);
   }
 
   group('$DfxKycService', () {

--- a/test/packages/service/dfx/dfx_support_service_test.dart
+++ b/test/packages/service/dfx/dfx_support_service_test.dart
@@ -13,10 +13,13 @@ import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.da
 import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_reason.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/support/support_issue_type.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 Map<String, dynamic> _ticketJson({String uid = 'uid-1'}) => {
       'uid': uid,
@@ -30,10 +33,12 @@ Map<String, dynamic> _ticketJson({String uid = 'uid-1'}) => {
 
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     // Pre-populate the auth token so the base-class getAuthToken short-
     // circuits without exercising the signing flow.
@@ -41,11 +46,13 @@ void main() {
     when(() => appStore.sessionCache).thenReturn(sessionCache);
     when(() => appStore.apiConfig)
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   DfxSupportService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return DfxSupportService(appStore);
+    return DfxSupportService(appStore, walletService);
   }
 
   group('$DfxSupportService', () {

--- a/test/packages/service/dfx/dfx_widget_service_test.dart
+++ b/test/packages/service/dfx/dfx_widget_service_test.dart
@@ -4,37 +4,44 @@ import 'package:realunit_wallet/packages/repository/cache_repository.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
 
+class _MockWalletService extends Mock implements WalletService {}
+
 const _testMnemonic =
     'test test test test test test test test test test test junk';
 
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
   late SoftwareWallet wallet;
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     wallet = SoftwareWallet(1, 'Main', _testMnemonic);
     when(() => appStore.sessionCache).thenReturn(sessionCache);
     when(() => appStore.wallet).thenReturn(wallet);
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   group('$DfxWidgetService', () {
     test('wallet getter returns appStore.wallet.currentAccount', () {
-      final service = DfxWidgetService(appStore);
+      final service = DfxWidgetService(appStore, walletService);
 
       expect(service.wallet, same(wallet.currentAccount));
     });
 
     test('walletAddress is the EIP-55 hex of the current account primaryAddress', () {
-      final service = DfxWidgetService(appStore);
+      final service = DfxWidgetService(appStore, walletService);
 
       // Hardhat #0 EIP-55.
       expect(
@@ -44,18 +51,18 @@ void main() {
     });
 
     test('isAvailable=false when no auth token is set', () {
-      expect(DfxWidgetService(appStore).isAvailable, isFalse);
+      expect(DfxWidgetService(appStore, walletService).isAvailable, isFalse);
     });
 
     test('isAvailable=true once an auth token is set', () {
       sessionCache.setAuthToken('jwt-1');
 
-      expect(DfxWidgetService(appStore).isAvailable, isTrue);
+      expect(DfxWidgetService(appStore, walletService).isAvailable, isTrue);
     });
 
     test('isAvailable flips back to false after clearAuthToken', () {
       sessionCache.setAuthToken('jwt-1');
-      final service = DfxWidgetService(appStore);
+      final service = DfxWidgetService(appStore, walletService);
       expect(service.isAvailable, isTrue);
 
       sessionCache.clearAuthToken();

--- a/test/packages/service/dfx/exceptions/exception_surface_test.dart
+++ b/test/packages/service/dfx/exceptions/exception_surface_test.dart
@@ -3,7 +3,6 @@ import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.da
 import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/payment/buy_exceptions.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
-import 'package:realunit_wallet/packages/wallet/exceptions/wallet_locked_exception.dart';
 
 // Guard against a recurring failure mode: an Exception subclass without a
 // toString() override gets rendered as `Instance of '...'` whenever a cubit
@@ -17,7 +16,6 @@ void main() {
     final exceptions = <Object>[
       const BitboxNotConnectedException(),
       const SigningCancelledException(),
-      const WalletLockedException(),
       const ApiException(code: 'TEST', message: 'test'),
       const RegistrationRequiredException(code: 'TEST', message: 'test'),
       const KycLevelRequiredException(

--- a/test/packages/service/dfx/real_unit_buy_payment_info_service_test.dart
+++ b/test/packages/service/dfx/real_unit_buy_payment_info_service_test.dart
@@ -9,10 +9,13 @@ import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 
 class MockApiConfig extends Mock implements ApiConfig {}
 
 class MockCacheRepository extends Mock implements CacheRepository {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 class TestAppStore extends AppStore {
   final http.Client client;
@@ -26,12 +29,16 @@ class TestAppStore extends AppStore {
 
 void main() {
   late ApiConfig apiConfig;
+  late _MockWalletService walletService;
   late RealUnitBuyPaymentInfoService service;
 
   setUp(() {
     apiConfig = MockApiConfig();
+    walletService = _MockWalletService();
     when(() => apiConfig.apiHost).thenReturn('dev.api.dfx.swiss');
     when(() => apiConfig.networkMode).thenReturn(NetworkMode.testnet);
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   AppStore buildAppStore(Future<http.Response> Function(http.Request) handler) {
@@ -56,7 +63,7 @@ void main() {
 
         final paymentInfoId = 123;
 
-        service = RealUnitBuyPaymentInfoService(appStore);
+        service = RealUnitBuyPaymentInfoService(appStore, walletService);
         final reference = await service.confirmPayment(paymentInfoId);
 
         expect(capturedMethod, equals('PUT'));
@@ -74,7 +81,7 @@ void main() {
           ),
         );
 
-        final service = RealUnitBuyPaymentInfoService(appStore);
+        final service = RealUnitBuyPaymentInfoService(appStore, walletService);
 
         expect(
           () => service.confirmPayment(999),
@@ -92,7 +99,7 @@ void main() {
           ),
         );
 
-        final service = RealUnitBuyPaymentInfoService(appStore);
+        final service = RealUnitBuyPaymentInfoService(appStore, walletService);
 
         expect(
           () => service.confirmPayment(999),
@@ -107,7 +114,7 @@ void main() {
         final appStore = buildAppStore(
           (request) async => http.Response('{"reference":"$referenceText"}', 200),
         );
-        service = RealUnitBuyPaymentInfoService(appStore);
+        service = RealUnitBuyPaymentInfoService(appStore, walletService);
 
         final reference = await service.confirmPayment(1);
         expect(reference, equals(referenceText));
@@ -118,7 +125,7 @@ void main() {
         final appStore = buildAppStore(
           (request) async => http.Response('{"reference":"$referenceText"}', 201),
         );
-        service = RealUnitBuyPaymentInfoService(appStore);
+        service = RealUnitBuyPaymentInfoService(appStore, walletService);
 
         final reference = await service.confirmPayment(1);
         expect(reference, equals(referenceText));

--- a/test/packages/service/dfx/real_unit_pdf_service_test.dart
+++ b/test/packages/service/dfx/real_unit_pdf_service_test.dart
@@ -11,6 +11,7 @@ import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_pdf_service.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/styles/currency.dart';
 import 'package:realunit_wallet/styles/language.dart';
 
@@ -18,25 +19,31 @@ class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
 
+class _MockWalletService extends Mock implements WalletService {}
+
 const _address = '0x000000000000000000000000000000000000beef';
 
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     when(() => appStore.sessionCache).thenReturn(sessionCache);
     when(() => appStore.apiConfig)
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
     when(() => appStore.primaryAddress).thenReturn(_address);
     sessionCache.setAuthToken('jwt-pdf');
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   RealUnitPdfService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return RealUnitPdfService(appStore);
+    return RealUnitPdfService(appStore, walletService);
   }
 
   group('$RealUnitPdfService', () {

--- a/test/packages/service/dfx/real_unit_registration_service_happy_test.dart
+++ b/test/packages/service/dfx/real_unit_registration_service_happy_test.dart
@@ -16,6 +16,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/registration/registr
 import 'package:realunit_wallet/packages/service/dfx/models/user/dto/real_unit_user_data_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:web3dart/web3dart.dart';
@@ -28,6 +29,8 @@ class _MockAccount extends Mock implements AWalletAccount {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
 
+class _MockWalletService extends Mock implements WalletService {}
+
 const _testPrivateKeyHex =
     'fb1ace12f9801e85f3db1b3935dd47d9f064f98152466f47c701b5e12680e612';
 
@@ -37,12 +40,14 @@ void main() {
   late _MockAppStore appStore;
   late _MockWallet wallet;
   late _MockAccount account;
+  late _MockWalletService walletService;
   late SessionCache session;
 
   setUp(() {
     appStore = _MockAppStore();
     wallet = _MockWallet();
     account = _MockAccount();
+    walletService = _MockWalletService();
     session = SessionCache(_MockCacheRepository());
     session.setAuthToken('jwt-1');
 
@@ -50,14 +55,15 @@ void main() {
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
     when(() => appStore.sessionCache).thenReturn(session);
     when(() => appStore.wallet).thenReturn(wallet);
-    when(() => appStore.ensureUnlocked()).thenAnswer((_) async {});
     when(() => wallet.primaryAccount).thenReturn(account);
     when(() => account.primaryAddress).thenReturn(_privKey);
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   RealUnitRegistrationService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return RealUnitRegistrationService(appStore);
+    return RealUnitRegistrationService(appStore, walletService);
   }
 
   Registration buildRegistration() => const Registration(

--- a/test/packages/service/dfx/real_unit_registration_service_test.dart
+++ b/test/packages/service/dfx/real_unit_registration_service_test.dart
@@ -18,6 +18,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/registration/registr
 import 'package:realunit_wallet/packages/service/dfx/models/user/dto/real_unit_user_data_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/kyc/kyc_personal_data.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 
@@ -31,16 +32,20 @@ class _MockAccount extends Mock implements AWalletAccount {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
 
+class _MockWalletService extends Mock implements WalletService {}
+
 void main() {
   late _MockAppStore appStore;
   late _MockWallet wallet;
   late _MockAccount account;
+  late _MockWalletService walletService;
   late SessionCache session;
 
   setUp(() {
     appStore = _MockAppStore();
     wallet = _MockWallet();
     account = _MockAccount();
+    walletService = _MockWalletService();
     session = SessionCache(_MockCacheRepository());
     session.setAuthToken('jwt-1');
 
@@ -48,13 +53,14 @@ void main() {
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
     when(() => appStore.sessionCache).thenReturn(session);
     when(() => appStore.wallet).thenReturn(wallet);
-    when(() => appStore.ensureUnlocked()).thenAnswer((_) async {});
     when(() => wallet.primaryAccount).thenReturn(account);
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   RealUnitRegistrationService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return RealUnitRegistrationService(appStore);
+    return RealUnitRegistrationService(appStore, walletService);
   }
 
   group('$RealUnitRegistrationService.registerEmail', () {

--- a/test/packages/service/dfx/real_unit_sell_payment_info_service_confirm_test.dart
+++ b/test/packages/service/dfx/real_unit_sell_payment_info_service_confirm_test.dart
@@ -107,8 +107,9 @@ void main() {
     when(() => appStore.wallet).thenReturn(wallet);
     when(() => wallet.currentAccount).thenReturn(account);
     when(() => account.primaryAddress).thenReturn(_privKey);
-    // Wallet is already a full SoftwareWallet in this fixture — ensureUnlocked
-    // is a no-op for non-view wallets, but mocktail still needs a stub.
+    // Wallet is already a full SoftwareWallet in this fixture —
+    // ensureCurrentWalletUnlocked is a no-op for non-view wallets, but
+    // mocktail still needs a stub.
     when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
     when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });

--- a/test/packages/service/dfx/real_unit_sell_payment_info_service_confirm_test.dart
+++ b/test/packages/service/dfx/real_unit_sell_payment_info_service_confirm_test.dart
@@ -14,6 +14,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/rea
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/sell_payment_info.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_sell_payment_info_service.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:realunit_wallet/styles/currency.dart';
@@ -26,6 +27,8 @@ class _MockWallet extends Mock implements AWallet {}
 class _MockAccount extends Mock implements AWalletAccount {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 // Deterministic test private key — same one FakeBitboxCredentials uses.
 // Re-deriving here gives us a real EthPrivateKey credential which the
@@ -87,12 +90,14 @@ void main() {
   late _MockAppStore appStore;
   late _MockWallet wallet;
   late _MockAccount account;
+  late _MockWalletService walletService;
   late SessionCache session;
 
   setUp(() {
     appStore = _MockAppStore();
     wallet = _MockWallet();
     account = _MockAccount();
+    walletService = _MockWalletService();
     session = SessionCache(_MockCacheRepository());
     session.setAuthToken('jwt-1');
 
@@ -100,16 +105,17 @@ void main() {
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
     when(() => appStore.sessionCache).thenReturn(session);
     when(() => appStore.wallet).thenReturn(wallet);
-    // Wallet is already a full SoftwareWallet in this fixture — ensureUnlocked
-    // is a no-op for non-view wallets, but mocktail still needs a stub.
-    when(() => appStore.ensureUnlocked()).thenAnswer((_) async {});
     when(() => wallet.currentAccount).thenReturn(account);
     when(() => account.primaryAddress).thenReturn(_privKey);
+    // Wallet is already a full SoftwareWallet in this fixture — ensureUnlocked
+    // is a no-op for non-view wallets, but mocktail still needs a stub.
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   RealUnitSellPaymentInfoService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return RealUnitSellPaymentInfoService(appStore);
+    return RealUnitSellPaymentInfoService(appStore, walletService);
   }
 
   group('confirmPayment (software wallet happy path)', () {

--- a/test/packages/service/dfx/real_unit_sell_payment_info_service_test.dart
+++ b/test/packages/service/dfx/real_unit_sell_payment_info_service_test.dart
@@ -15,6 +15,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/rea
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/sell_payment_info.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_sell_payment_info_service.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:realunit_wallet/styles/currency.dart';
@@ -27,6 +28,8 @@ class _MockWallet extends Mock implements AWallet {}
 class _MockAccount extends Mock implements AWalletAccount {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 class _StubCreds extends Fake implements CredentialsWithKnownAddress {
   @override
@@ -97,12 +100,14 @@ void main() {
   late _MockAppStore appStore;
   late _MockWallet wallet;
   late _MockAccount account;
+  late _MockWalletService walletService;
   late SessionCache session;
 
   setUp(() {
     appStore = _MockAppStore();
     wallet = _MockWallet();
     account = _MockAccount();
+    walletService = _MockWalletService();
     session = SessionCache(_MockCacheRepository());
     session.setAuthToken('jwt-1');
 
@@ -112,11 +117,13 @@ void main() {
     when(() => appStore.wallet).thenReturn(wallet);
     when(() => wallet.currentAccount).thenReturn(account);
     when(() => account.primaryAddress).thenReturn(_StubCreds());
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   RealUnitSellPaymentInfoService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return RealUnitSellPaymentInfoService(appStore);
+    return RealUnitSellPaymentInfoService(appStore, walletService);
   }
 
   group('getPaymentInfo', () {

--- a/test/packages/service/dfx/real_unit_sell_payment_info_service_validation_test.dart
+++ b/test/packages/service/dfx/real_unit_sell_payment_info_service_validation_test.dart
@@ -112,9 +112,6 @@ void main() {
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
     when(() => appStore.sessionCache).thenReturn(session);
     when(() => appStore.wallet).thenReturn(wallet);
-    // Wallet here is already a non-view software wallet, so ensureUnlocked is
-    // a no-op semantically — mocktail still needs a stub for the call site.
-    when(() => appStore.ensureUnlocked()).thenAnswer((_) async {});
     when(() => wallet.currentAccount).thenReturn(account);
     // Wallet address must match message.delegator for the validation guard
     // to pass the delegator check.

--- a/test/packages/service/dfx/real_unit_sell_payment_info_service_validation_test.dart
+++ b/test/packages/service/dfx/real_unit_sell_payment_info_service_validation_test.dart
@@ -11,6 +11,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/rea
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/sell_payment_info.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_sell_payment_info_service.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:realunit_wallet/styles/currency.dart';
@@ -23,6 +24,8 @@ class _MockWallet extends Mock implements AWallet {}
 class _MockAccount extends Mock implements AWalletAccount {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 class _PrivKeyCreds extends Fake implements CredentialsWithKnownAddress {
   _PrivKeyCreds(this._address);
@@ -94,12 +97,14 @@ void main() {
   late _MockAppStore appStore;
   late _MockWallet wallet;
   late _MockAccount account;
+  late _MockWalletService walletService;
   late SessionCache session;
 
   setUp(() {
     appStore = _MockAppStore();
     wallet = _MockWallet();
     account = _MockAccount();
+    walletService = _MockWalletService();
     session = SessionCache(_MockCacheRepository());
     session.setAuthToken('jwt-1');
 
@@ -114,12 +119,14 @@ void main() {
     // Wallet address must match message.delegator for the validation guard
     // to pass the delegator check.
     when(() => account.primaryAddress).thenReturn(_PrivKeyCreds(_walletAddress));
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   RealUnitSellPaymentInfoService build({http.Client? client}) {
     when(() => appStore.httpClient)
         .thenReturn(client ?? MockClient((_) async => http.Response('{}', 200)));
-    return RealUnitSellPaymentInfoService(appStore);
+    return RealUnitSellPaymentInfoService(appStore, walletService);
   }
 
   group('confirmPayment validation guard', () {

--- a/test/packages/service/dfx/real_unit_wallet_service_test.dart
+++ b/test/packages/service/dfx/real_unit_wallet_service_test.dart
@@ -11,26 +11,33 @@ import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
 
+class _MockWalletService extends Mock implements WalletService {}
+
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     when(() => appStore.sessionCache).thenReturn(sessionCache);
     when(() => appStore.apiConfig)
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   RealUnitWalletService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return RealUnitWalletService(appStore);
+    return RealUnitWalletService(appStore, walletService);
   }
 
   group('$RealUnitWalletService', () {

--- a/test/packages/service/transaction_history_service_sync_test.dart
+++ b/test/packages/service/transaction_history_service_sync_test.dart
@@ -13,12 +13,15 @@ import 'package:realunit_wallet/packages/repository/transaction_repository.dart'
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
 import 'package:realunit_wallet/packages/service/transaction_history_service.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
 
 class _MockTransactionRepository extends Mock implements TransactionRepository {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 class _FakeTransaction extends Fake implements Transaction {}
 
@@ -71,6 +74,7 @@ Map<String, dynamic> _txJson({
 
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
   late _MockTransactionRepository txRepo;
 
@@ -81,6 +85,7 @@ void main() {
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     txRepo = _MockTransactionRepository();
     when(() => appStore.sessionCache).thenReturn(sessionCache);
@@ -92,11 +97,13 @@ void main() {
     when(() => txRepo.insertDfxTransaction(any())).thenAnswer((_) async {});
     when(() => txRepo.updateTransaction(any())).thenAnswer((_) async => 1);
     when(() => txRepo.updateDfxTransaction(any())).thenAnswer((_) async {});
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   TransactionHistoryService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return TransactionHistoryService(appStore, txRepo);
+    return TransactionHistoryService(appStore, walletService, txRepo);
   }
 
   group('$TransactionHistoryService.apiBasedSync', () {

--- a/test/packages/service/transaction_history_service_test.dart
+++ b/test/packages/service/transaction_history_service_test.dart
@@ -11,12 +11,15 @@ import 'package:realunit_wallet/packages/repository/transaction_repository.dart'
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
 import 'package:realunit_wallet/packages/service/transaction_history_service.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 
 class _MockAppStore extends Mock implements AppStore {}
 
 class _MockCacheRepository extends Mock implements CacheRepository {}
 
 class _MockTransactionRepository extends Mock implements TransactionRepository {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 const _wallet = '0x000000000000000000000000000000000000beef';
 const _other = '0x0000000000000000000000000000000000001234';
@@ -44,22 +47,26 @@ Map<String, dynamic> _txJson({
 
 void main() {
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
   late SessionCache sessionCache;
   late _MockTransactionRepository txRepo;
 
   setUp(() {
     appStore = _MockAppStore();
+    walletService = _MockWalletService();
     sessionCache = SessionCache(_MockCacheRepository());
     txRepo = _MockTransactionRepository();
     when(() => appStore.sessionCache).thenReturn(sessionCache);
     when(() => appStore.apiConfig)
         .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
     when(() => appStore.primaryAddress).thenReturn(_wallet);
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   TransactionHistoryService build(http.Client client) {
     when(() => appStore.httpClient).thenReturn(client);
-    return TransactionHistoryService(appStore, txRepo);
+    return TransactionHistoryService(appStore, walletService, txRepo);
   }
 
   group('$TransactionHistoryService', () {

--- a/test/packages/service/wallet_service_test.dart
+++ b/test/packages/service/wallet_service_test.dart
@@ -39,6 +39,7 @@ void main() {
   setUpAll(() {
     // mocktail needs a default for non-primitive types used with `any()`.
     registerFallbackValue(WalletType.software);
+    registerFallbackValue(SoftwareViewWallet(0, '_fallback', _debugAddress) as AWallet);
   });
 
   setUp(() {
@@ -279,6 +280,68 @@ void main() {
         const broken =
             'test test test test test test test test test test test ability';
         expect(service.validateSeed(broken), isFalse);
+      });
+    });
+
+    group('ensureCurrentWalletUnlocked', () {
+      test('promotes a SoftwareViewWallet to a SoftwareWallet', () async {
+        final view = SoftwareViewWallet(7, 'Main', _debugAddress);
+        final stored = <AWallet>[view];
+        when(() => appStore.wallet).thenAnswer((_) => stored.last);
+        when(() => appStore.wallet = any(that: isA<AWallet>())).thenAnswer((inv) {
+          final newWallet = inv.positionalArguments.single as AWallet;
+          stored.add(newWallet);
+          return newWallet;
+        });
+        when(() => settings.currentWalletId).thenReturn(7);
+        when(() => repo.getUnlockedWalletById(7)).thenAnswer(
+          (_) async => _info(id: 7, name: 'Main', seed: _testMnemonic, type: WalletType.software),
+        );
+
+        await service.ensureCurrentWalletUnlocked();
+
+        expect(stored.last, isA<SoftwareWallet>());
+        expect((stored.last as SoftwareWallet).seed, _testMnemonic);
+      });
+
+      test('is a no-op when the current wallet is not a SoftwareViewWallet', () async {
+        final unlocked = SoftwareWallet(7, 'Main', _testMnemonic);
+        when(() => appStore.wallet).thenReturn(unlocked);
+
+        await service.ensureCurrentWalletUnlocked();
+
+        verifyNever(() => repo.getUnlockedWalletById(any()));
+      });
+    });
+
+    group('lockCurrentWallet', () {
+      test('replaces an unlocked SoftwareWallet with its SoftwareViewWallet counterpart',
+          () async {
+        final unlocked = SoftwareWallet(9, 'Main', _testMnemonic);
+        AWallet? written;
+        when(() => appStore.wallet).thenReturn(unlocked);
+        when(() => appStore.wallet = any(that: isA<AWallet>())).thenAnswer((inv) {
+          final newWallet = inv.positionalArguments.single as AWallet;
+          written = newWallet;
+          return newWallet;
+        });
+
+        await service.lockCurrentWallet();
+
+        expect(written, isA<SoftwareViewWallet>());
+        expect(written!.id, 9);
+        expect(written!.name, 'Main');
+      });
+
+      test('is a no-op when the wallet is already locked / not software', () async {
+        when(() => appStore.wallet).thenReturn(
+          SoftwareViewWallet(9, 'Main', _debugAddress),
+        );
+
+        await service.lockCurrentWallet();
+
+        // No write happened.
+        verifyNever(() => appStore.wallet = any(that: isA<AWallet>()));
       });
     });
   });

--- a/test/packages/service/wallet_service_test.dart
+++ b/test/packages/service/wallet_service_test.dart
@@ -3,6 +3,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
 import 'package:realunit_wallet/packages/repository/settings_repository.dart';
 import 'package:realunit_wallet/packages/repository/wallet_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/storage/database.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
@@ -12,6 +13,8 @@ class _MockWalletRepository extends Mock implements WalletRepository {}
 class _MockSettingsRepository extends Mock implements SettingsRepository {}
 
 class _MockBitboxService extends Mock implements BitboxService {}
+
+class _MockAppStore extends Mock implements AppStore {}
 
 const _testMnemonic =
     'test test test test test test test test test test test junk';
@@ -30,6 +33,7 @@ void main() {
   late _MockWalletRepository repo;
   late _MockSettingsRepository settings;
   late _MockBitboxService bitbox;
+  late _MockAppStore appStore;
   late WalletService service;
 
   setUpAll(() {
@@ -41,7 +45,8 @@ void main() {
     repo = _MockWalletRepository();
     settings = _MockSettingsRepository();
     bitbox = _MockBitboxService();
-    service = WalletService(bitbox, repo, settings);
+    appStore = _MockAppStore();
+    service = WalletService(bitbox, repo, settings, appStore);
 
     when(() => settings.saveCurrentWalletId(any())).thenAnswer((_) async => true);
     when(() => settings.removeCurrentWalletId()).thenAnswer((_) async => true);

--- a/test/packages/service/wallet_service_test.dart
+++ b/test/packages/service/wallet_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
@@ -378,6 +380,54 @@ void main() {
         await service.lockCurrentWallet();
         expect(stored.last, isA<SoftwareViewWallet>(),
             reason: 'last holder release flips back to view wallet');
+      });
+
+      // Genuine concurrency race: both ensures are pending on the DB read
+      // when the lock fires between them. Without the holder counter the
+      // lock would observe the (mid-unlock) view wallet, no-op, and the
+      // second ensure would then complete and write the unlocked wallet —
+      // which then never gets locked back because lockCurrentWallet
+      // already returned. With the counter, the lock decrements but does
+      // not flip the wallet because two ensures are still in flight.
+      test('lock between two in-flight ensures preserves the unlocked wallet', () async {
+        final stored = <AWallet>[SoftwareViewWallet(7, 'Main', _debugAddress)];
+        when(() => appStore.wallet).thenAnswer((_) => stored.last);
+        when(() => appStore.wallet = any(that: isA<AWallet>())).thenAnswer((inv) {
+          final newWallet = inv.positionalArguments.single as AWallet;
+          stored.add(newWallet);
+          return newWallet;
+        });
+        when(() => settings.currentWalletId).thenReturn(7);
+
+        // Gate the repository read so we can interleave concurrent calls.
+        final gate = Completer<WalletInfo>();
+        when(() => repo.getUnlockedWalletById(7)).thenAnswer((_) => gate.future);
+
+        // Fire two ensures without awaiting — both block on the gated read.
+        final ensureA = service.ensureCurrentWalletUnlocked();
+        final ensureB = service.ensureCurrentWalletUnlocked();
+
+        // Flow A releases its hold while both unlocks are still pending.
+        // The counter must keep the wallet from being flipped back to a
+        // view wallet because flow B is still holding the contract.
+        await service.lockCurrentWallet();
+
+        // Release the gated read so both ensures can complete.
+        gate.complete(
+          _info(id: 7, name: 'Main', seed: _testMnemonic, type: WalletType.software),
+        );
+        await Future.wait([ensureA, ensureB]);
+
+        expect(stored.last, isA<SoftwareWallet>(),
+            reason: 'lock fired mid-unlock must not shadow the in-flight unlock');
+
+        // Drain the remaining holders. Two more locks: one to match the
+        // second ensure's release, one to confirm the counter clamps at 0
+        // and doesn't go negative.
+        await service.lockCurrentWallet();
+        await service.lockCurrentWallet();
+        expect(stored.last, isA<SoftwareViewWallet>(),
+            reason: 'final holder release flips back to view wallet');
       });
     });
   });

--- a/test/packages/service/wallet_service_test.dart
+++ b/test/packages/service/wallet_service_test.dart
@@ -429,6 +429,35 @@ void main() {
         expect(stored.last, isA<SoftwareViewWallet>(),
             reason: 'final holder release flips back to view wallet');
       });
+
+      // Two overlapping ensures must coalesce onto a single DB read +
+      // AES-GCM decrypt, not trigger the repository twice. Functionally
+      // both versions would land on the same SoftwareWallet, but the
+      // extra decrypt is wasteful.
+      test('two parallel ensures dedupe the repository decrypt', () async {
+        final stored = <AWallet>[SoftwareViewWallet(7, 'Main', _debugAddress)];
+        when(() => appStore.wallet).thenAnswer((_) => stored.last);
+        when(() => appStore.wallet = any(that: isA<AWallet>())).thenAnswer((inv) {
+          final newWallet = inv.positionalArguments.single as AWallet;
+          stored.add(newWallet);
+          return newWallet;
+        });
+        when(() => settings.currentWalletId).thenReturn(7);
+
+        final gate = Completer<WalletInfo>();
+        when(() => repo.getUnlockedWalletById(7)).thenAnswer((_) => gate.future);
+
+        final ensureA = service.ensureCurrentWalletUnlocked();
+        final ensureB = service.ensureCurrentWalletUnlocked();
+
+        gate.complete(
+          _info(id: 7, name: 'Main', seed: _testMnemonic, type: WalletType.software),
+        );
+        await Future.wait([ensureA, ensureB]);
+
+        verify(() => repo.getUnlockedWalletById(7)).called(1);
+        expect(stored.last, isA<SoftwareWallet>());
+      });
     });
   });
 }

--- a/test/packages/service/wallet_service_test.dart
+++ b/test/packages/service/wallet_service_test.dart
@@ -344,5 +344,41 @@ void main() {
         verifyNever(() => appStore.wallet = any(that: isA<AWallet>()));
       });
     });
+
+    group('ensure/lock reentrancy', () {
+      // Race: flow A and flow B both call ensureCurrentWalletUnlocked while
+      // the wallet is locked. A finishes its sign + lock first; B is still
+      // mid-sign and must see an unlocked wallet. Without the holder counter
+      // A's lock would tear the mnemonic out from under B and the next
+      // sign call would hit _LockedCredentials → UnsupportedError.
+      test('two parallel ensures + one lock leave the wallet unlocked', () async {
+        final stored = <AWallet>[SoftwareViewWallet(7, 'Main', _debugAddress)];
+        when(() => appStore.wallet).thenAnswer((_) => stored.last);
+        when(() => appStore.wallet = any(that: isA<AWallet>())).thenAnswer((inv) {
+          final newWallet = inv.positionalArguments.single as AWallet;
+          stored.add(newWallet);
+          return newWallet;
+        });
+        when(() => settings.currentWalletId).thenReturn(7);
+        when(() => repo.getUnlockedWalletById(7)).thenAnswer(
+          (_) async => _info(id: 7, name: 'Main', seed: _testMnemonic, type: WalletType.software),
+        );
+
+        // Flow A: ensure + lock (e.g. confirmPayment finishing first).
+        await service.ensureCurrentWalletUnlocked();
+        // Flow B enters its ensure while A is still holding the contract.
+        await service.ensureCurrentWalletUnlocked();
+        // Flow A releases — B still holds, so the wallet must stay unlocked.
+        await service.lockCurrentWallet();
+
+        expect(stored.last, isA<SoftwareWallet>(),
+            reason: 'second holder must keep the wallet unlocked');
+
+        // Flow B releases — now the wallet locks back to the view form.
+        await service.lockCurrentWallet();
+        expect(stored.last, isA<SoftwareViewWallet>(),
+            reason: 'last holder release flips back to view wallet');
+      });
+    });
   });
 }

--- a/test/packages/wallet/wallet_test.dart
+++ b/test/packages/wallet/wallet_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
@@ -97,6 +99,98 @@ void main() {
       expect(
         () => wallet.primaryAccount.signMessage('payload'),
         throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('$SoftwareViewWallet', () {
+    // Programmer-error tests: any sign path that bypassed
+    // WalletService.ensureCurrentWalletUnlocked() must surface loudly, not
+    // silently return a wrong-type result. In release builds the assert is
+    // stripped and the StateError still fires.
+    const address = '0x0000000000000000000000000000000000000001';
+
+    test('exposes walletType == software', () {
+      final wallet = SoftwareViewWallet(1, 'Main', address);
+
+      expect(wallet.walletType, WalletType.software);
+    });
+
+    test('primaryAccount == currentAccount, both view-wallet specialisations', () {
+      final wallet = SoftwareViewWallet(1, 'Main', address);
+
+      expect(identical(wallet.primaryAccount, wallet.currentAccount), isTrue);
+      expect(wallet.primaryAccount, isA<SoftwareViewWalletAccount>());
+    });
+
+    test('primaryAccount.primaryAddress.address resolves the cached EIP-55 hex', () {
+      final wallet = SoftwareViewWallet(1, 'Main', address);
+
+      expect(wallet.primaryAccount.primaryAddress.address.hex.toLowerCase(), address);
+    });
+
+    test('primaryAccount.signMessage throws StateError instead of signing', () {
+      final wallet = SoftwareViewWallet(1, 'Main', address);
+
+      expect(
+        () => wallet.primaryAccount.signMessage('payload'),
+        // In debug builds the assert(false) fires first and surfaces as an
+        // AssertionError; in release the assert is stripped and the StateError
+        // wins. Both are Error subtypes, which is the contract — _not_ a
+        // typed Exception that callers would catch and route.
+        throwsA(isA<Error>()),
+      );
+    });
+
+    test('credentials.signToSignature throws StateError', () {
+      final wallet = SoftwareViewWallet(1, 'Main', address);
+
+      expect(
+        () => wallet.primaryAccount.primaryAddress.signToSignature(Uint8List(0)),
+        // In debug builds the assert(false) fires first and surfaces as an
+        // AssertionError; in release the assert is stripped and the StateError
+        // wins. Both are Error subtypes, which is the contract — _not_ a
+        // typed Exception that callers would catch and route.
+        throwsA(isA<Error>()),
+      );
+    });
+
+    test('credentials.signPersonalMessage throws StateError', () {
+      final wallet = SoftwareViewWallet(1, 'Main', address);
+
+      expect(
+        () => wallet.primaryAccount.primaryAddress.signPersonalMessage(Uint8List(0)),
+        // In debug builds the assert(false) fires first and surfaces as an
+        // AssertionError; in release the assert is stripped and the StateError
+        // wins. Both are Error subtypes, which is the contract — _not_ a
+        // typed Exception that callers would catch and route.
+        throwsA(isA<Error>()),
+      );
+    });
+
+    test('credentials.signPersonalMessageToUint8List throws StateError', () {
+      final wallet = SoftwareViewWallet(1, 'Main', address);
+
+      expect(
+        () => wallet.primaryAccount.primaryAddress.signPersonalMessageToUint8List(Uint8List(0)),
+        // In debug builds the assert(false) fires first and surfaces as an
+        // AssertionError; in release the assert is stripped and the StateError
+        // wins. Both are Error subtypes, which is the contract — _not_ a
+        // typed Exception that callers would catch and route.
+        throwsA(isA<Error>()),
+      );
+    });
+
+    test('credentials.signToEcSignature throws StateError', () {
+      final wallet = SoftwareViewWallet(1, 'Main', address);
+
+      expect(
+        () => wallet.primaryAccount.primaryAddress.signToEcSignature(Uint8List(0)),
+        // In debug builds the assert(false) fires first and surfaces as an
+        // AssertionError; in release the assert is stripped and the StateError
+        // wins. Both are Error subtypes, which is the contract — _not_ a
+        // typed Exception that callers would catch and route.
+        throwsA(isA<Error>()),
       );
     });
   });

--- a/test/packages/wallet/wallet_test.dart
+++ b/test/packages/wallet/wallet_test.dart
@@ -7,6 +7,14 @@ import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 const _testMnemonic =
     'test test test test test test test test test test test junk';
 
+// Why every sign path on a SoftwareViewWallet throws an Error subtype: in
+// debug builds the assert(false) fires first and surfaces as an
+// AssertionError; in release the assert is stripped and the StateError
+// wins. Both are Error subtypes, which is the contract — _not_ a typed
+// Exception that callers would catch and route.
+const _viewWalletErrorRationale =
+    'assert(false) in debug → AssertionError, StateError in release — both Error subtypes';
+
 void main() {
   group('$SoftwareWallet', () {
     test('exposes walletType == software', () {
@@ -134,11 +142,8 @@ void main() {
 
       expect(
         () => wallet.primaryAccount.signMessage('payload'),
-        // In debug builds the assert(false) fires first and surfaces as an
-        // AssertionError; in release the assert is stripped and the StateError
-        // wins. Both are Error subtypes, which is the contract — _not_ a
-        // typed Exception that callers would catch and route.
         throwsA(isA<Error>()),
+        reason: _viewWalletErrorRationale,
       );
     });
 
@@ -147,11 +152,7 @@ void main() {
 
       expect(
         () => wallet.primaryAccount.primaryAddress.signToSignature(Uint8List(0)),
-        // In debug builds the assert(false) fires first and surfaces as an
-        // AssertionError; in release the assert is stripped and the StateError
-        // wins. Both are Error subtypes, which is the contract — _not_ a
-        // typed Exception that callers would catch and route.
-        throwsA(isA<Error>()),
+        throwsA(isA<Error>()), // see _viewWalletErrorRationale
       );
     });
 
@@ -160,11 +161,7 @@ void main() {
 
       expect(
         () => wallet.primaryAccount.primaryAddress.signPersonalMessage(Uint8List(0)),
-        // In debug builds the assert(false) fires first and surfaces as an
-        // AssertionError; in release the assert is stripped and the StateError
-        // wins. Both are Error subtypes, which is the contract — _not_ a
-        // typed Exception that callers would catch and route.
-        throwsA(isA<Error>()),
+        throwsA(isA<Error>()), // see _viewWalletErrorRationale
       );
     });
 
@@ -173,11 +170,7 @@ void main() {
 
       expect(
         () => wallet.primaryAccount.primaryAddress.signPersonalMessageToUint8List(Uint8List(0)),
-        // In debug builds the assert(false) fires first and surfaces as an
-        // AssertionError; in release the assert is stripped and the StateError
-        // wins. Both are Error subtypes, which is the contract — _not_ a
-        // typed Exception that callers would catch and route.
-        throwsA(isA<Error>()),
+        throwsA(isA<Error>()), // see _viewWalletErrorRationale
       );
     });
 
@@ -186,11 +179,7 @@ void main() {
 
       expect(
         () => wallet.primaryAccount.primaryAddress.signToEcSignature(Uint8List(0)),
-        // In debug builds the assert(false) fires first and surfaces as an
-        // AssertionError; in release the assert is stripped and the StateError
-        // wins. Both are Error subtypes, which is the contract — _not_ a
-        // typed Exception that callers would catch and route.
-        throwsA(isA<Error>()),
+        throwsA(isA<Error>()), // see _viewWalletErrorRationale
       );
     });
   });

--- a/test/screens/create_wallet/create_wallet_page_test.dart
+++ b/test/screens/create_wallet/create_wallet_page_test.dart
@@ -9,6 +9,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
 import 'package:realunit_wallet/screens/create_wallet/bloc/create_wallet_cubit.dart';
 import 'package:realunit_wallet/screens/create_wallet/create_wallet_page.dart';
 import 'package:realunit_wallet/screens/create_wallet/create_wallet_view.dart';
@@ -24,8 +25,14 @@ class MockDfxKycService extends Mock implements DfxKycService {}
 
 class MockWallet extends Mock implements SoftwareWallet {}
 
+class MockWalletAccount extends Mock implements WalletAccount {}
+
 void main() {
   late CreateWalletCubit createWalletCubit;
+
+  setUpAll(() {
+    registerFallbackValue(MockWalletAccount());
+  });
 
   setUp(() {
     createWalletCubit = MockCreateWalletCubit();
@@ -36,13 +43,20 @@ void main() {
   void setupDependencyInjection() {
     final getIt = GetIt.instance;
     final walletService = MockWalletService();
-    when(() => walletService.createSeedWallet(any())).thenAnswer((_) => Future.value(MockWallet()));
+    // The cubit reads wallet.currentAccount synchronously to pass into the
+    // top-level warmAuthSignature helper, so the mock has to surface a real
+    // account or the unstubbed null trips the cast.
+    final stubbedWallet = MockWallet();
+    when(() => stubbedWallet.currentAccount).thenReturn(MockWalletAccount());
+    when(() => walletService.createSeedWallet(any())).thenAnswer((_) async => stubbedWallet);
     getIt.registerSingleton<WalletService>(walletService);
     // CreateWalletCubit now depends on DFXAuthService (via DfxKycService — the
     // smallest registered subclass) to pre-warm the auth signature on
     // pairing. The page is what triggers the cubit, so the page-level test
     // needs the same DI surface.
-    getIt.registerSingleton<DfxKycService>(MockDfxKycService());
+    final kyc = MockDfxKycService();
+    when(() => kyc.ensureSignatureFor(any())).thenAnswer((_) async {});
+    getIt.registerSingleton<DfxKycService>(kyc);
   }
 
   setUpAll(() {

--- a/test/screens/create_wallet/create_wallet_page_test.dart
+++ b/test/screens/create_wallet/create_wallet_page_test.dart
@@ -38,8 +38,10 @@ void main() {
     final walletService = MockWalletService();
     when(() => walletService.createSeedWallet(any())).thenAnswer((_) => Future.value(MockWallet()));
     getIt.registerSingleton<WalletService>(walletService);
-    // `CreateWalletPage.build` reaches for `DfxKycService` to pass to the cubit
-    // as a transport for `ensureSignatureFor`. Register a stub so DI resolves.
+    // CreateWalletCubit now depends on DFXAuthService (via DfxKycService — the
+    // smallest registered subclass) to pre-warm the auth signature on
+    // pairing. The page is what triggers the cubit, so the page-level test
+    // needs the same DI surface.
     getIt.registerSingleton<DfxKycService>(MockDfxKycService());
   }
 

--- a/test/screens/restore_wallet/restore_wallet_page_test.dart
+++ b/test/screens/restore_wallet/restore_wallet_page_test.dart
@@ -50,8 +50,8 @@ void main() {
   void setupDependencyInjection() {
     final getIt = GetIt.instance;
     getIt.registerSingleton<WalletService>(MockWalletService());
-    // `RestoreWalletPage.build` reaches for `DfxKycService` to pass to the
-    // cubit as a transport for `ensureSignatureFor`. Register a stub.
+    // RestoreWalletCubit pulls a DFXAuthService (smallest concrete: DfxKycService)
+    // to pre-warm the auth signature after persisting the mnemonic.
     getIt.registerSingleton<DfxKycService>(MockDfxKycService());
   }
 

--- a/test/screens/settings_seed/settings_seed_cubit_test.dart
+++ b/test/screens/settings_seed/settings_seed_cubit_test.dart
@@ -2,10 +2,13 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/screens/settings_seed/bloc/settings_seed_cubit.dart';
 
 class _MockAppStore extends Mock implements AppStore {}
+
+class _MockWalletService extends Mock implements WalletService {}
 
 // Canonical BIP39 test mnemonic — recommended fixture for any wallet code
 // path that needs a deterministic, well-known seed.
@@ -15,17 +18,20 @@ const _testSeed =
 void main() {
   late SoftwareWallet wallet;
   late _MockAppStore appStore;
+  late _MockWalletService walletService;
 
   setUp(() {
     wallet = SoftwareWallet(1, 'Test', _testSeed);
     appStore = _MockAppStore();
-    when(() => appStore.ensureUnlocked()).thenAnswer((_) async {});
+    walletService = _MockWalletService();
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
     when(() => appStore.wallet).thenReturn(wallet);
   });
 
   group('$SettingsSeedCubit', () {
     test('initial state surfaces the wallet seed; ensureUnlocked is invoked', () async {
-      final cubit = SettingsSeedCubit(appStore);
+      final cubit = SettingsSeedCubit(appStore, walletService);
       // For a wallet that is already a SoftwareWallet the seed is in initial
       // state. `_loadSeed()` still runs and invokes ensureUnlocked — drain
       // the microtask queue so the call is observable to mocktail.
@@ -33,12 +39,21 @@ void main() {
 
       expect(cubit.state.seed, _testSeed);
       expect(cubit.state.showSeed, isFalse);
-      verify(() => appStore.ensureUnlocked()).called(1);
+      verify(() => walletService.ensureCurrentWalletUnlocked()).called(1);
+    });
+
+    test('close() locks the wallet so the mnemonic does not outlive the screen', () async {
+      final cubit = SettingsSeedCubit(appStore, walletService);
+      await Future<void>.delayed(Duration.zero);
+
+      await cubit.close();
+
+      verify(() => walletService.lockCurrentWallet()).called(1);
     });
 
     blocTest<SettingsSeedCubit, SettingsSeedState>(
       'toggleShowSeed flips showSeed and keeps seed unchanged',
-      build: () => SettingsSeedCubit(appStore),
+      build: () => SettingsSeedCubit(appStore, walletService),
       act: (c) => c.toggleShowSeed(),
       verify: (c) {
         expect(c.state.seed, _testSeed);
@@ -48,7 +63,7 @@ void main() {
 
     blocTest<SettingsSeedCubit, SettingsSeedState>(
       'toggleShowSeed twice returns to showSeed=false',
-      build: () => SettingsSeedCubit(appStore),
+      build: () => SettingsSeedCubit(appStore, walletService),
       act: (c) => c
         ..toggleShowSeed()
         ..toggleShowSeed(),

--- a/test/screens/settings_seed/settings_seed_cubit_test.dart
+++ b/test/screens/settings_seed/settings_seed_cubit_test.dart
@@ -30,11 +30,11 @@ void main() {
   });
 
   group('$SettingsSeedCubit', () {
-    test('initial state surfaces the wallet seed; ensureUnlocked is invoked', () async {
+    test('initial state surfaces the wallet seed; ensureCurrentWalletUnlocked is invoked', () async {
       final cubit = SettingsSeedCubit(appStore, walletService);
       // For a wallet that is already a SoftwareWallet the seed is in initial
-      // state. `_loadSeed()` still runs and invokes ensureUnlocked — drain
-      // the microtask queue so the call is observable to mocktail.
+      // state. `_loadSeed()` still runs and invokes ensureCurrentWalletUnlocked
+      // — drain the microtask queue so the call is observable to mocktail.
       await Future<void>.delayed(Duration.zero);
 
       expect(cubit.state.seed, _testSeed);

--- a/test/screens/settings_seed/settings_seed_page_test.dart
+++ b/test/screens/settings_seed/settings_seed_page_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/screens/settings_seed/bloc/settings_seed_cubit.dart';
 import 'package:realunit_wallet/screens/settings_seed/settings_seed_page.dart';
@@ -19,11 +20,14 @@ class MockSettingsSeedCubit extends MockCubit<SettingsSeedState> implements Sett
 
 class MockAppStore extends Mock implements AppStore {}
 
+class MockWalletService extends Mock implements WalletService {}
+
 class MockWallet extends Mock implements SoftwareWallet {}
 
 void main() {
   late SettingsSeedCubit settingsSeedCubit;
   final AppStore appStore = MockAppStore();
+  final WalletService walletService = MockWalletService();
   final SoftwareWallet wallet = MockWallet();
 
   setUp(() {
@@ -42,11 +46,14 @@ void main() {
     when(() => wallet.seed).thenReturn(
       'cheese trigger cannon mention judge hire snack sustain annual predict illness celery',
     );
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });
 
   void setupDependencyInjection() {
     final getIt = GetIt.instance;
     getIt.registerSingleton<AppStore>(appStore);
+    getIt.registerSingleton<WalletService>(walletService);
   }
 
   setUpAll(() {

--- a/test/screens/settings_seed/settings_seed_page_test.dart
+++ b/test/screens/settings_seed/settings_seed_page_test.dart
@@ -39,13 +39,13 @@ void main() {
       ),
     );
     when(() => appStore.wallet).thenReturn(wallet);
-    // Page builds a real SettingsSeedCubit via BlocProvider(create: ...), which
-    // calls ensureUnlocked() before reading the seed. Stub it so mocktail
-    // returns a real Future<void> instead of null.
-    when(() => appStore.ensureUnlocked()).thenAnswer((_) async {});
     when(() => wallet.seed).thenReturn(
       'cheese trigger cannon mention judge hire snack sustain annual predict illness celery',
     );
+    // Page builds a real SettingsSeedCubit via BlocProvider(create: ...), which
+    // calls WalletService.ensureCurrentWalletUnlocked() before reading the
+    // seed and lockCurrentWallet() on close. Stub both so mocktail returns
+    // real Future<void>s instead of null.
     when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
     when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
   });

--- a/test/screens/settings_seed/settings_seed_page_test.dart
+++ b/test/screens/settings_seed/settings_seed_page_test.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -118,6 +120,53 @@ void main() {
           findsOne,
         );
       });
+    });
+
+    // Regression for the first-render crash that bypassed the mocked-cubit
+    // tests above. In production the page boots with a [SoftwareViewWallet],
+    // the real cubit's initial state has an empty seed, and the first frame
+    // used to build SeedBlurCard → MnemonicReadOnlyField([]) which trips the
+    // `length == 12` assert. The view must show a spinner until the unlock
+    // completes, then rebuild with the 12-word seed.
+    testWidgets('first render with SoftwareViewWallet shows spinner, then SeedBlurCard', (tester) async {
+      const seed =
+          'cheese trigger cannon mention judge hire snack sustain annual predict illness celery';
+      final softwareViewWallet = SoftwareViewWallet(
+        1,
+        'Test',
+        '0x0000000000000000000000000000000000000001',
+      );
+      final softwareWallet = SoftwareWallet(1, 'Test', seed);
+      final unlockCompleter = Completer<void>();
+      // Cycle wallet from view → unlocked the same way the real
+      // WalletService.ensureCurrentWalletUnlocked does.
+      AWallet currentWallet = softwareViewWallet;
+      when(() => appStore.wallet).thenAnswer((_) => currentWallet);
+      when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {
+        await unlockCompleter.future;
+        currentWallet = softwareWallet;
+      });
+      when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
+
+      // Drive a real SettingsSeedCubit — the production path — so the empty
+      // initial seed actually shows up in the first frame.
+      await tester.pumpApp(
+        BlocProvider(
+          create: (_) => SettingsSeedCubit(appStore, walletService),
+          child: const SettingsSeedView(),
+        ),
+      );
+
+      // First frame: cubit state.seed is still '', view must not crash.
+      expect(find.byType(CupertinoActivityIndicator), findsOne);
+      expect(find.byType(SeedBlurCard), findsNothing);
+
+      // Unlock resolves; the cubit emits the 12-word seed.
+      unlockCompleter.complete();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CupertinoActivityIndicator), findsNothing);
+      expect(find.byType(SeedBlurCard), findsOne);
     });
   });
 }


### PR DESCRIPTION
> Stacked on #472 — apply only after that merges, or rebase onto develop post-merge.
>
> **Base note:** GitHub couldn't host this PR with `base = fix/pr461-followups` because that branch only exists on Blume1977's fork (not on DFXswiss). So the base falls back to `develop` and the diff therefore includes everything from #472 plus the polish delta below. Once #472 merges, this PR will show only the polish delta.

This collects the iteration-4 audit's "nice-to-have" polish items on top of #472 (`fix/pr461-followups`). The 4 polish items are each their own commit and live on top of `7ef2224` (current tip of #472's branch).

## Polish items

### 1. Real reentrancy race test
`test/packages/service/wallet_service_test.dart`

The existing reentrancy test sequentially `await`s both `ensureCurrentWalletUnlocked()` calls — that exercises the counter, not a true race. Added a `Completer<WalletInfo>`-gated test that holds two `ensureCurrentWalletUnlocked()` calls mid-decrypt, fires a `lockCurrentWallet()` between them, then completes the gate. Asserts the wallet stays unlocked (lock did not shadow the in-flight unlock) and locks back only after the remaining holders are drained. The earlier mechanical test stays in place — they're complementary.

### 2. DRY the `_LockedCredentials` sign-method rationale
`test/packages/wallet/wallet_test.dart`

Five identical ~4-line comments explaining the `assert(false)` + `StateError` contract were extracted into a top-level `_viewWalletErrorRationale` constant. Each test now passes that string as the `reason:` argument (first occurrence) or references the constant by name in a one-line comment. No test bodies changed.

### 3. Visibility consistency: colocate `SoftwareViewWalletAccount` with `_LockedCredentials`
`lib/packages/wallet/wallet.dart` + `lib/packages/wallet/wallet_account.dart`

`DebugWallet`'s analogs (`_DebugCredentials` + `DebugWalletAccount`) live in the same file (`wallet.dart`). The view-wallet analogs were split — `_LockedCredentials` in `wallet.dart`, `SoftwareViewWalletAccount` in `wallet_account.dart`. Moved `SoftwareViewWalletAccount` next to `_LockedCredentials` in `wallet.dart` to match the existing pattern. Safe because `SoftwareViewWalletAccount` is only referenced from `wallet.dart` (production) and one test file that already imports both files. No import changes needed elsewhere.

### 4. Track in-flight unlock to dedupe DB decryption
`lib/packages/service/wallet_service.dart`

Two overlapping `ensureCurrentWalletUnlocked()` calls on a `SoftwareViewWallet` previously each triggered `unlockCurrentWallet()` (DB read + AES-GCM decrypt). Functionally identical results, but wasteful. Added a `Future<SoftwareWallet>? _unlockInFlight` field; the first caller starts the unlock and stores the future, subsequent overlapping callers await the same future. Cleared in `finally` (only by the caller that started it, via `identical` check) so the next post-lock ensure runs a fresh unlock. New test verifies that two parallel ensures only invoke `repository.getUnlockedWalletById` once.

## Test plan

- [x] `flutter analyze` — only pre-existing `lib/generated/` issues (33), no new lint warnings
- [x] `flutter test --coverage` — 1412 tests pass (1410 baseline + 2 new race / dedup tests)
- [ ] Manual smoke: trigger a sign flow, lock, sign again — confirm no `StateError` from `_LockedCredentials` and the in-memory mnemonic still drops on the 60s safety net
