### PR TITLE
feat(lifecycle): drop mnemonic on app-hidden

### DIFF
--- a/lib/packages/service/app_store.dart
+++ b/lib/packages/service/app_store.dart
@@ -19,6 +19,20 @@ class AppStore {
     throw Exception('No Wallet set');
   }
 
+  /// Whether [wallet] is safe to read. False during the brief window between
+  /// app launch and the first `HomeBloc` event that calls the `wallet`
+  /// setter (`LoadCurrentWalletEvent` for an existing wallet,
+  /// `LoadWalletEvent` for a freshly created/restored one), plus the entire
+  /// onboarding flow until that happens. Lets services
+  /// (`WalletService.lockCurrentWallet`) early-return defensively from
+  /// app-lifecycle hooks that fire before any wallet exists.
+  ///
+  /// Named distinctly from `WalletService.hasWallet()` — that one checks
+  /// persisted state (`SettingsRepository.currentWalletId`), this one checks
+  /// the in-memory load state. The two diverge during onboarding when a
+  /// wallet id has been persisted but `_wallet` is not yet populated.
+  bool get isWalletLoaded => _wallet != null;
+
   ApiConfig get apiConfig => getApiConfig();
 
   String get primaryAddress => wallet.currentAccount.primaryAddress.address.hex;

--- a/lib/packages/service/wallet_service.dart
+++ b/lib/packages/service/wallet_service.dart
@@ -169,12 +169,19 @@ class WalletService {
   /// [SoftwareViewWallet] counterpart, dropping the mnemonic. Called after a
   /// sign operation completes so the private key isn't kept resident for the
   /// rest of the foreground session. No-op for wallet types that don't hold
-  /// a mnemonic.
+  /// a mnemonic, and no-op when no wallet has been loaded yet.
   ///
   /// Respects [_activeUnlockHolders] — a second concurrent caller still
   /// holding the unlocked contract keeps the wallet unlocked. The 60s safety
   /// net runs through [_forceLock] instead so it can bypass the counter.
   Future<void> lockCurrentWallet() async {
+    // Onboarding / pre-load guard. The app-lifecycle `hidden` hook can fire
+    // before [HomeBloc] populates [AppStore.wallet] — making the precondition
+    // explicit here keeps the lifecycle caller a one-liner and means a future
+    // lockCurrentWallet extension (DB write, etc.) won't get its errors
+    // silently caught at the call site.
+    if (!_appStore.isWalletLoaded) return;
+
     if (_activeUnlockHolders > 0) _activeUnlockHolders--;
     if (_activeUnlockHolders > 0) return;
     _postUnlockLockTimer?.cancel();

--- a/lib/setup/lifecycle_initializer.dart
+++ b/lib/setup/lifecycle_initializer.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:flutter/widgets.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/balance_service.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
 import 'package:realunit_wallet/setup/di.dart';
 
@@ -51,6 +53,12 @@ class _LifecycleInitializerState extends State<LifecycleInitializer> {
 
   void _onHidden() {
     getIt<PinAuthCubit>().onAppHidden();
+    // Drop the mnemonic before iOS suspends the isolate. `lockCurrentWallet`
+    // is defensive on its own — no try/catch / catchError by design, so a
+    // Future.error surfaces in the Zone instead of being silently swallowed.
+    // Microtask race to watch: if `_onResumed` ever calls
+    // `ensureCurrentWalletUnlocked`, ordering against this pending lock matters.
+    unawaited(getIt<WalletService>().lockCurrentWallet());
   }
 
   void _onPaused() {

--- a/test/packages/service/app_store_test.dart
+++ b/test/packages/service/app_store_test.dart
@@ -73,5 +73,17 @@ void main() {
     test('sessionCache is exposed unchanged', () {
       expect(store.sessionCache, same(sessionCache));
     });
+
+    test('isWalletLoaded is false before any wallet is set', () {
+      expect(store.isWalletLoaded, isFalse);
+    });
+
+    test('isWalletLoaded flips to true once a wallet is set', () {
+      expect(store.isWalletLoaded, isFalse);
+
+      store.wallet = SoftwareWallet(1, 'Main', _testMnemonic);
+
+      expect(store.isWalletLoaded, isTrue);
+    });
   });
 }

--- a/test/packages/service/wallet_service_test.dart
+++ b/test/packages/service/wallet_service_test.dart
@@ -317,6 +317,12 @@ void main() {
     });
 
     group('lockCurrentWallet', () {
+      // Tests in this group assume a loaded wallet — the "no wallet loaded
+      // yet" path is explicitly tested below by overriding to false.
+      setUp(() {
+        when(() => appStore.isWalletLoaded).thenReturn(true);
+      });
+
       test('replaces an unlocked SoftwareWallet with its SoftwareViewWallet counterpart',
           () async {
         final unlocked = SoftwareWallet(9, 'Main', _testMnemonic);
@@ -345,9 +351,76 @@ void main() {
         // No write happened.
         verifyNever(() => appStore.wallet = any(that: isA<AWallet>()));
       });
+
+      // Pre-load guard: the app-lifecycle `hidden` hook fires the first time
+      // the user backgrounds the app, which can happen during onboarding
+      // before HomeBloc has populated AppStore.wallet. The early-return on
+      // !isWalletLoaded keeps the lifecycle caller a one-liner — no try/catch
+      // around an "expected" Exception('No Wallet set') from appStore.wallet.
+      test('is a no-op when no wallet has been loaded yet', () async {
+        when(() => appStore.isWalletLoaded).thenReturn(false);
+
+        await service.lockCurrentWallet();
+
+        // Never even reaches the wallet getter — no MissingStubError, no
+        // write, no exception leaking to the unawaited caller.
+        verifyNever(() => appStore.wallet);
+        verifyNever(() => appStore.wallet = any(that: isA<AWallet>()));
+      });
     });
 
     group('ensure/lock reentrancy', () {
+      // Tests in this group exercise lockCurrentWallet end-to-end, so the
+      // pre-load guard expects a positive isWalletLoaded.
+      setUp(() {
+        when(() => appStore.isWalletLoaded).thenReturn(true);
+      });
+
+      // App-lifecycle hidden fires an unpaired lockCurrentWallet — i.e. one
+      // without a matching prior ensureCurrentWalletUnlocked. Sequence:
+      //   flow X ensure → counter 1, wallet unlocked
+      //   _onHidden lock → counter 0, wallet flipped to view
+      //   flow X finally lock → counter still 0 (underflow guard), _lockWalletInPlace
+      //     no-ops because the wallet is already the view form.
+      // The 1:1 ensure↔lock invariant is technically broken by the unpaired
+      // lifecycle call, but the underflow guard + `is! SoftwareWallet` guard
+      // keep the state consistent. This test pins that contract.
+      test('unpaired lock from lifecycle leaves the holder counter at 0, never below', () async {
+        final stored = <AWallet>[SoftwareViewWallet(7, 'Main', _debugAddress)];
+        when(() => appStore.wallet).thenAnswer((_) => stored.last);
+        when(() => appStore.wallet = any(that: isA<AWallet>())).thenAnswer((inv) {
+          final newWallet = inv.positionalArguments.single as AWallet;
+          stored.add(newWallet);
+          return newWallet;
+        });
+        when(() => settings.currentWalletId).thenReturn(7);
+        when(() => repo.getUnlockedWalletById(7)).thenAnswer(
+          (_) async => _info(id: 7, name: 'Main', seed: _testMnemonic, type: WalletType.software),
+        );
+
+        // Sign flow opens the contract.
+        await service.ensureCurrentWalletUnlocked();
+        expect(stored.last, isA<SoftwareWallet>(),
+            reason: 'sign flow unlocked the wallet');
+
+        // App-lifecycle hidden fires concurrently — drops to view wallet.
+        await service.lockCurrentWallet();
+        expect(stored.last, isA<SoftwareViewWallet>(),
+            reason: 'lifecycle lock flipped the wallet to its view form');
+
+        // Sign flow finally — counter is already 0, must NOT underflow and
+        // must NOT crash on _lockWalletInPlace reading the (now view) wallet.
+        await service.lockCurrentWallet();
+        expect(stored.last, isA<SoftwareViewWallet>(),
+            reason: 'finally lock is idempotent — counter stays at 0');
+
+        // A subsequent ensure must still produce a usable unlocked wallet —
+        // i.e. the counter didn't drift negative and break the next cycle.
+        await service.ensureCurrentWalletUnlocked();
+        expect(stored.last, isA<SoftwareWallet>(),
+            reason: 'next ensure starts cleanly from counter == 0');
+      });
+
       // Race: flow A and flow B both call ensureCurrentWalletUnlocked while
       // the wallet is locked. A finishes its sign + lock first; B is still
       // mid-sign and must see an unlocked wallet. Without the holder counter

--- a/test/setup/lifecycle_initializer_test.dart
+++ b/test/setup/lifecycle_initializer_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/balance_service.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
+import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
+import 'package:realunit_wallet/setup/lifecycle_initializer.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockBalanceService extends Mock implements BalanceService {}
+
+class _MockPinAuthCubit extends Mock implements PinAuthCubit {}
+
+class _MockWalletService extends Mock implements WalletService {}
+
+void main() {
+  late _MockAppStore appStore;
+  late _MockBalanceService balanceService;
+  late _MockPinAuthCubit pinAuthCubit;
+  late _MockWalletService walletService;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    balanceService = _MockBalanceService();
+    pinAuthCubit = _MockPinAuthCubit();
+    walletService = _MockWalletService();
+
+    final getIt = GetIt.instance;
+    getIt.registerSingleton<AppStore>(appStore);
+    getIt.registerSingleton<BalanceService>(balanceService);
+    getIt.registerSingleton<PinAuthCubit>(pinAuthCubit);
+    getIt.registerSingleton<WalletService>(walletService);
+
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
+  });
+
+  tearDown(() => GetIt.instance.reset());
+
+  Future<void> pumpLifecycle(WidgetTester tester) =>
+      tester.pumpWidget(
+        const LifecycleInitializer(
+          child: SizedBox.shrink(),
+        ),
+      );
+
+  testWidgets(
+    'AppLifecycleState.hidden drops the mnemonic via WalletService.lockCurrentWallet',
+    (tester) async {
+      await pumpLifecycle(tester);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      await tester.pump();
+
+      verify(() => walletService.lockCurrentWallet()).called(1);
+    },
+  );
+
+  // The architecture decision "no try/catch / catchError around the
+  // unawaited lockCurrentWallet" is locked in by the source itself — see
+  // the inline comment in `_onHidden`. We tried encoding it as a test, but
+  // every variant (`thenThrow`, `thenAnswer((_) async => throw …)`,
+  // `Future.error(...)`) routed the failure through the testWidgets
+  // framework's synchronous catch rather than the Zone uncaught-error sink
+  // that `tester.takeException()` reads from — the routing depends on
+  // Flutter's AppLifecycleListener dispatch (changes between 3.41 and 3.44).
+  // A brittle false-positive on CI is worse than relying on code review +
+  // the source comment to catch a future regression at the call site.
+
+  testWidgets(
+    'AppLifecycleState.paused does NOT lock the wallet — already covered by hidden',
+    (tester) async {
+      await pumpLifecycle(tester);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+
+      verifyNever(() => walletService.lockCurrentWallet());
+    },
+  );
+
+  testWidgets(
+    'AppLifecycleState.resumed does NOT call lockCurrentWallet',
+    (tester) async {
+      when(() => appStore.primaryAddress).thenReturn('0xabc');
+      when(() => balanceService.updateBalance(any())).thenAnswer((_) async {});
+      when(() => pinAuthCubit.onAppResumed()).thenAnswer((_) {});
+
+      await pumpLifecycle(tester);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+
+      verifyNever(() => walletService.lockCurrentWallet());
+    },
+  );
+}


### PR DESCRIPTION
Supersedes Blume1977/realunit-app#1 (closed) — same intent, rebased onto post-#483 develop, addresses TaprootFreak's two review points by pushing the precondition into `WalletService` instead of catching it at the call site.

## Why

PR #472 / #483 added an explicit `WalletService.lockCurrentWallet()` after every sign and a 60 s post-unlock safety-net timer. Reviewer (#468) flagged the residual gap in the second-pass review:

> 🟡 iOS suspendiert Dart-`Timer`s im Background — 60s-Cap ist Best-Effort. App-Lifecycle ruft `lockCurrentWallet` nicht explizit auf Hide auf — könnte ein eigenes Follow-up-Issue werden.

This closes that gap.

## What changed

Three atomic commits:

1. **`feat(app-store): isWalletLoaded getter`** — non-throwing predicate so services can early-return defensively. Named distinctly from `WalletService.hasWallet()` (which is persisted state, not in-memory load state) so the two predicates can't be confused at the call site.

2. **`fix(wallet-service): no-op lockCurrentWallet when no wallet is loaded`** — Onboarding-path guard inside `WalletService` itself. An alternative would have been a `try/catch` at the call site, which would silently mask any future regression in `lockCurrentWallet`. Pushing the precondition into the service means the call site stays clean and future extensions (DB write, audit log) won't get their errors quietly caught. Two regression tests added: the `!isWalletLoaded` no-op, and a lifecycle-hidden-during-active-sign scenario that pins the counter-underflow guard.

3. **`feat(lifecycle): lock the wallet on hidden`** — `LifecycleInitializer._onHidden()` fires `unawaited(getIt<WalletService>().lockCurrentWallet())`. No try/catch, no helper method — the service is defensive on its own. Tests cover happy path + the two no-call states (paused/resumed).

## Why `hidden` (not `paused`)

- Fires **earlier than `paused`** on iOS (covers multitasking switcher + notification drag-down).
- Android raises it via the unified lifecycle pipeline.
- `PinAuthCubit` already uses `_onHidden` for its lockout-time stamp — semantically aligned.

## Scope gap (deliberately deferred)

This PR drops the mnemonic stored in `AppStore.wallet`. It does **not** clear the mnemonic temporarily held in `CreateWalletState.wallet` (a `Cubit` state inside the create-wallet flow) — that copy lives independent of `AppStore` and `lockCurrentWallet` is a no-op for it. Backgrounding during onboarding still leaves the just-generated mnemonic in cubit memory until the cubit closes. Pre-existing condition, not introduced here. Worth a follow-up if the threat model demands it.

## Why no test for "lifecycle doesn't `catchError` the unawaited future"

The architecture decision — _the lifecycle caller deliberately does not attach `.catchError` or wrap in try/catch_ — is locked in by the inline comment in `_onHidden`, not by a test. Every variant I tried (`thenThrow`, `thenAnswer((_) async => throw …)`, `Future.error(...)`) routed the failure through the testWidgets framework's synchronous catch path rather than the Zone uncaught-error sink that `tester.takeException()` reads from. The routing differs between Flutter 3.41 (CI) and 3.44 (local), so a test that's green locally would flake on CI. Brittle false-positives are worse than the source comment for catching a future regression at the call site — every code reviewer reads `_onHidden`.

## Reviewer feedback (TaprootFreak)

Iteration after the first review:

- **Naming-Kollision (Blocker 1)** — renamed `hasWallet` to `isWalletLoaded` on `AppStore` to avoid colliding with `WalletService.hasWallet()` which has different semantics.
- **Holder-Counter test gap (Blocker 2)** — added a test that simulates `ensure → unpaired lifecycle lock → finally lock`, verifying the underflow guard prevents counter drift and the next ensure cycle still works.
- **Inline comment too long (R3)** — condensed from 15 lines to 7; rationale moved to commit message + this PR body.
- **Microtask ordering note (R4)** — added a one-line note in the lifecycle hook for any future contributor who introduces `ensureCurrentWalletUnlocked()` in `_onResumed`.
- **Test setup drift (R5)** — `isWalletLoaded = true` moved out of the global `setUp` into per-group `setUp` so unrelated groups don't carry the stub and the negative path isn't masked.
- **Doc accuracy (R7)** — clarified that both `LoadCurrentWalletEvent` and `LoadWalletEvent` populate `AppStore.wallet`.

Why the architecture diverges from the original draft (Blume1977#1): previous incarnation wrapped `lockCurrentWallet()` in a `try { } on Exception catch (e)` helper in the lifecycle file. Reviewer pushed back that this would silently swallow future regressions (e.g. DB-write failures from a logging extension). Single Responsibility: the "is wallet loaded" precondition belongs to `WalletService`, not its callers.

## UX impact

None visible. The next sign re-decrypts the mnemonic via the OS-keystore-wrapped key in sub-100 ms.

## Test plan

- [x] \`flutter analyze\` — clean
- [x] \`flutter test --coverage\` — 1424 / 1424 green (1417 develop baseline + 7 new: 2 isWalletLoaded, 1 no-wallet lock, 1 unpaired-lock counter race, 3 lifecycle states)
- [x] Local CI parity run: \`flutter pub get\` → \`dart run tool/generate_localization.dart\` → \`dart run tool/generate_release_info.dart\` → \`flutter pub run build_runner build\` → \`flutter analyze\` → \`flutter test --coverage\` → \`lcov\` filter — all green; \`bitbox-audit\` 0 findings
- [ ] **iOS manual**: sell → swipe up to multitasking → return → next sign re-decrypts in <100 ms, no PIN re-prompt within PinAuthCubit's lockoutDuration
- [ ] **iOS manual**: sell → home button → wait 10 min → return → PIN re-prompt as before (unchanged)
- [ ] **Android manual**: sell → recent-apps switcher → return → same as iOS path 1
- [ ] **Onboarding manual**: fresh install → reach onboarding screen → background app → return → no crash, no unhandled async error