### PR TITLE
docs(architecture): codify 'API as Decision Authority' rule + audit + plan

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Network access is one half of the gateway rule. **Business decisions are the oth
 - **The app does not duplicate backend sets/enums as gating logic.** DTO mirroring for type safety is fine; local `_requiredStepNames`, `actionableStatuses`, `_minLevelForActions`, `_minAmountChf` constants are not.
 - **Prompts to the user fire only when the API requests them.** "Please verify yourself" appears only when the API signals a pending KYC step — never because the app inferred something from a level number or expired timestamp.
 
-### The test
+### The test (Wer entscheidet?)
 
 Before adding an `if` / `switch` / `.filter()` on API data, ask:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,49 @@ After changing ARB files, always regenerate: `dart run tool/generate_localizatio
 - If a feature needs on-chain data (e.g. native ETH balance, transaction status, token balance), add a new endpoint to [`DFXswiss/api`](https://github.com/DFXswiss/api) and let the app call that endpoint. The API is the single gateway.
 - All network calls must go through `AppStore.httpClient` with `buildUri(_host, …)` — `_host` resolves to the DFX API host via `ApiConfig`. Do not instantiate `http.Client`/`Dio`/`Web3Client` against other hosts.
 
+## API as Decision Authority — CRITICAL
+
+Network access is one half of the gateway rule. **Business decisions are the other half.** The DFX API is the single source of truth for what the user is allowed to do, what state they are in, and what they should be asked to do next. The realunit-app is a **rendering layer** for what the API says.
+
+### The rule
+
+- **The app does not decide if a flow is allowed.** The API decides. If the API accepts a call, the app must not block it pre-emptively.
+- **The app does not interpret status strings into business meaning.** It renders what the API returns as `currentStep` / `nextAction` / `state`.
+- **The app does not duplicate backend sets/enums as gating logic.** DTO mirroring for type safety is fine; local `_requiredStepNames`, `actionableStatuses`, `_minLevelForActions`, `_minAmountChf` constants are not.
+- **Prompts to the user fire only when the API requests them.** "Please verify yourself" appears only when the API signals a pending KYC step — never because the app inferred something from a level number or expired timestamp.
+
+### The test
+
+Before adding an `if` / `switch` / `.filter()` on API data, ask:
+
+1. Does the API already return the answer I'm computing? → use it directly.
+2. If I remove this local logic and render the API field 1:1, what breaks? → if "nothing", remove it; if "a missing field", extend the API.
+3. When local and API disagree, who wins? → the API. Always.
+
+### What is OK in the app
+
+- UI input validation (format, required field, length) — UI concern
+- Display formatting (date, currency, locale) — UI concern
+- Local security gates (PIN, wallet lock, BitBox connection) — physical security boundary, cannot be API-driven
+- Cryptographic operations (EIP-712 signing, key derivation) — must be local
+
+### What is NOT OK in the app
+
+- Deciding which KYC steps are required (`_requiredStepNames`, `_minLevelForActions`) — **the API decides via `requiredKycSteps()` on its side**
+- Deciding which step status is "actionable" or "pending" (`actionableStatuses`, `pendingStatuses`) — **the API returns `currentStep` directly**
+- Min/max transaction amounts, fees, supported currencies hardcoded — **must come from `/quote` / `/fiat` / `/asset` endpoints**
+- Routing flows based on local conditions (`if isBitbox → sellBitbox`) — **API signals the required workflow**
+- Feature visibility based on derived local state (Support link only if `emailSet`, Edit only if `!inReview`) — **API returns capability flags**
+- Pre-flight validation duplicating API rules — **call the API, render its error**
+
+### When the API doesn't yet expose what we need
+
+Extend the API, then change the app. **Do not add app-side workarounds.** Open an issue / PR in [`DFXswiss/api`](https://github.com/DFXswiss/api) describing the missing field (e.g. `KycStepDto.isRequired`, `BuyQuoteDto.minAmount`, `SettingsCapabilityDto.canBackup`) and wait for it. Temporary local logic is technical debt that **stays** — every shortcut accumulates as another place the app diverges from the API.
+
+### Audit
+
+A full audit of current violations lives in [`docs/api-authority-audit.md`](docs/api-authority-audit.md). New PRs must not add to it; ideally they reduce it.
+
 ## Project Architecture
 
 ```

--- a/docs/api-authority-audit.md
+++ b/docs/api-authority-audit.md
@@ -242,3 +242,43 @@ Numbers below are the **canonical counts** used everywhere this audit is referen
   should also delete the corresponding local logic in the same PR.
 - **For the architecture review on 2026-05-21:** the P0 list is the actionable
   short-list. P2 is a longer-term cleanup. P3/P4 are acknowledged exceptions.
+
+---
+
+## Shipped (2026-05-21)
+
+Pair-PRs landed against the rule, in dependency order:
+
+| Wave | API PR | App PR | Closes V-IDs |
+|---|---|---|---|
+| Foundation | — | [realunit-app#491](https://github.com/DFXswiss/realunit-app/pull/491) | rule + audit + plan |
+| W1.5 | — | [#492](https://github.com/DFXswiss/realunit-app/pull/492) | V4 — `TFA_REQUIRED` body code |
+| W1.1+1.2 | — | [#493](https://github.com/DFXswiss/realunit-app/pull/493) | V7, V8 — buy/sell min from quote |
+| W1.2bank | — | [#495](https://github.com/DFXswiss/realunit-app/pull/495) | V11 — bank-account default |
+| W1.3+1.4 | — | [#496](https://github.com/DFXswiss/realunit-app/pull/496) | V12, V13 — currency + language from API |
+| W2 | [api#3732](https://github.com/DFXswiss/api/pull/3732) | [#494](https://github.com/DFXswiss/realunit-app/pull/494) | V1, V2, V3, V5 — **closes the 2026-05-21 ident-misroute** |
+| W3 | [api#3733](https://github.com/DFXswiss/api/pull/3733) | [#497](https://github.com/DFXswiss/realunit-app/pull/497) | V6a, V6b, V9 + structured ALREADY_REGISTERED status |
+
+All as Draft per DFXswiss convention. Every PR has full test coverage; `flutter test` and `npm test` clean across all branches. The W2 pair specifically closes the 2026-05-21 incident report (user_data 338759 ident-misroute).
+
+## Outstanding — next phase
+
+Items not shipped in the 2026-05-21 batch, in priority order:
+
+**P0 remainders:**
+- V6c (settings_edit_address_cubit) — same shape as V6b; landed in W3.2 as part of the broader capability migration.
+- V6d (`_changeStepNames` static set) — small follow-up to W3.2; the page already reads `capabilities` for the gating decision, the set just hangs around in the cubit for the `pendingSteps` informational badge.
+- V16 (sell_button isBitbox routing) — re-evaluated: BitBox vs software-wallet is a device-local fact the API cannot substitute for. Treat as documented exception unless a future `supportedSignMethods` API field changes the picture.
+- V20 (auto-register email at level<10) — the cubit still owns this branch; backend-side auto-registration would close it. Spec'd for Wave 5.
+
+**Wave 4 (P2, new backend modules):**
+- V17 (`/v1/legal-document` module — entity + migration + admin endpoint)
+- V18 (`/v1/company-info` module)
+- V14 + V19 (country priority + recommended language)
+
+All three are spec'd in detail in [`api-authority-plan.md`](api-authority-plan.md) Wave 4. Estimated effort: ~3.5 dev-days. No user is blocked today by any of these — they are P2 cleanup, not regressions.
+
+**P1 / P2 long tail:**
+- V21, V22 — local session gates whose *position* should be API-driven (separate follow-up after W4).
+- V23–V27 — JWT introspection, polling/retry orchestration, transaction state interpretation. Several depend on new API fields not yet scoped.
+- V29–V33 — hardcoded asset config, date constants, default language. Tracked but not blocking.

--- a/docs/api-authority-audit.md
+++ b/docs/api-authority-audit.md
@@ -8,10 +8,15 @@ Findings were produced by four parallel scans (2026-05-21) over the KYC, Buy/Sel
 Wallet/Service-layer, and Settings areas, then deduplicated and ranked by impact.
 
 Each item lists:
+- The violation ID (`V<N>`) used to cross-reference with [`api-authority-plan.md`](api-authority-plan.md)
 - The violation site (`file:line`)
 - The local decision being made
 - What an API-driven version should look like
 - Whether closing it requires an API change in [`DFXswiss/api`](https://github.com/DFXswiss/api)
+
+The `V<N>` anchors are stable: every finding in this audit carries one, and every
+wave entry in the plan cites the `V<N>` it closes. To answer *"which wave closes
+audit finding V12?"* search for `V12` in `api-authority-plan.md`.
 
 ---
 
@@ -23,49 +28,55 @@ the 2026-05-21 ident-misroute report that triggered this audit).
 
 ### KYC routing decided in the cubit instead of by the API
 
-- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:16-22` — `_requiredStepNames` set
+- **V1** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:16-22` — `_requiredStepNames` set
   - **Local decision:** which step names count as "required for trading"
   - **Backend already owns this** in `api/src/subdomains/generic/kyc/enums/kyc.enum.ts:requiredKycSteps(userData)` — the app duplicates a subset
   - **API change needed:** add `isRequired: bool` to `KycStepDto`, drop the local set
-- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:24, 171` — `_minLevelForActions = 30` + `level < _requiredLevel` check
+- **V2** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:24, 171` — `_minLevelForActions = 30` + `level < _requiredLevel` check
   - **Local decision:** which numeric level unlocks trading
   - **API change needed:** API returns `canTrade: bool` / `canPerformAction: bool` per user — the app renders, doesn't compute
-- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:142, 156-162` — `pendingStatuses` + `actionableStatuses` sets
+- **V3** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:142, 156-162` — `pendingStatuses` + `actionableStatuses` sets
   - **Local decision:** which `ReviewStatus` values mean "user must act" vs "wait for review"
   - **API change needed:** API's `KycInfoMapper.toDto` already picks `currentStep` — the app should render `currentStep` directly and stop iterating `kycSteps`
-- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:134-168` — manual filter + routing chain over `kycSteps`
+- **V5** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:134-168` — manual filter + routing chain over `kycSteps`
   - **Local decision:** entire next-step selection algorithm — duplicates `KycService.tryContinue` on the API
   - **API change needed:** none — the `currentStep` field from `PUT /v2/kyc` already contains the answer; remove the loop, route from `currentStep` only
-- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:179-182` — `e.statusCode == 403 || e.code == 'TFA_REQUIRED'` → emit 2FA step
+  - **Closed by:** W2.2 (subsumed by the `_runCheckKyc` rewrite that collapses V1, V2, V3 — V5 is *the same loop* those three constants drive). Tagged separately so reviewers can grep the routing-chain code path explicitly.
+- **V4** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:179-182` — `e.statusCode == 403 || e.code == 'TFA_REQUIRED'` → emit 2FA step
   - **Local decision:** translate HTTP status into a UI flow
   - **API change needed:** API returns `nextStep: '2fa'` in the response body — app does not switch on status codes
-- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:88-104` — auto-register email when `level < 10`
+- **V20** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:88-104` — auto-register email when `level < 10`
   - **Local decision:** infer that level<10 means "the email step is implicit, call the registration endpoint silently"
   - **API change needed:** if auto-registration is desired the API performs it server-side; the app calls `continueKyc` and renders what comes back
 
 ### Hardcoded transaction limits
 
-- `lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart:16, 50-60` — `_minAmountChf = 100` pre-flight
+- **V7** — `lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart:16, 50-60` — `_minAmountChf = 100` pre-flight
   - **API change needed:** `POST /v1/buy/quote` already validates min/max — return `minAmount` / `maxAmount` / `error` from the API, surface its error verbatim
-- `lib/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart:17, 82-112` — `_minAmountChf = 10` + `validateMinAmount()` pre-flight
+- **V8** — `lib/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart:17, 82-112` — `_minAmountChf = 10` + `validateMinAmount()` pre-flight
   - **API change needed:** same shape on `POST /v1/sell/quote` — remove the local validate method entirely
 
 ### Hardcoded routing forks based on wallet type
 
-- `lib/screens/sell/widgets/sell_button.dart:60-62` — `if (state.isBitbox) → AppRoutes.sellBitbox`
+- **V16** — `lib/screens/sell/widgets/sell_button.dart:60-62` — `if (state.isBitbox) → AppRoutes.sellBitbox`
   - **Local decision:** which sell-flow page to use based on hardware-wallet presence
   - **API change needed:** API returns `requiredWorkflow: 'sell' | 'sellBitbox'` (or a list of steps) — app dispatches on that string
 
 ### Feature visibility decided by local heuristics
 
-- `lib/screens/settings_user_data/settings_user_data_page.dart:239` — Edit button hidden if `statusLabel != null` (i.e. `inReview`)
+- **V6a** — `lib/screens/settings_user_data/settings_user_data_page.dart:239` — Edit button hidden if `statusLabel != null` (i.e. `inReview`)
   - **API change needed:** API returns `editable: bool` per field; app does not introspect status to compute editability
-- `lib/screens/settings_user_data/subpages/edit_name/cubit/settings_edit_name_cubit.dart:22` — `if (session.currentStep?.status == KycStepStatus.inReview)` blocks editing
-  - Same as above — render an API capability flag, do not switch on status
-- `lib/screens/settings_contact/settings_contact_page.dart:54-67` — "Contact Support" only shown if email is set
+- **V6b** — `lib/screens/settings_user_data/subpages/edit_name/cubit/settings_edit_name_cubit.dart:22` — `if (session.currentStep?.status == KycStepStatus.inReview)` blocks editing
+  - Same as V6a — render an API capability flag, do not switch on status
+- **V6c** — `lib/screens/settings_user_data/subpages/edit_address/cubit/settings_edit_address_cubit.dart:22` — same `if (session.currentStep?.status == KycStepStatus.inReview)` interpretation as V6b
+  - Identical shape, separate cubit. Both must be migrated together in W3.2 — listed separately so the grep target is unambiguous.
+- **V6d** — `lib/screens/settings_user_data/cubit/settings_user_data_cubit.dart:18-22` — `_changeStepNames` static const set ({nameChange, addressChange, phoneChange})
+  - **Local decision:** which KYC step names represent a user-data change flow — same shape as `_requiredStepNames` (V1), just a different subset
+  - **API change needed:** API exposes a `category: 'changeRequest'` (or similar) flag on `KycStepDto`, app filters by it
+- **V9** — `lib/screens/settings_contact/settings_contact_page.dart:54-67` — "Contact Support" only shown if email is set
   - **API change needed:** API exposes `support.available: bool` (or always allow it through the support endpoint and the API returns 400 if not eligible)
-- `lib/screens/settings/settings_page.dart:100` — "Wallet Backup" only shown if `walletType == WalletType.software`
-  - **Boundary case:** wallet-type is a device-local fact (BitBox cannot expose its seed); this one is **defensible** as a UI capability. Document the exception or accept it.
+- **V13b** — `lib/screens/settings/settings_page.dart:100` — "Wallet Backup" only shown if `walletType == WalletType.software`
+  - **Boundary case:** wallet-type is a device-local fact (BitBox cannot expose its seed); this one is **defensible** as a UI capability. **Accepted as documented exception** (see *Documented exceptions* in `api-authority-plan.md`). Tagged for completeness.
 
 ---
 
@@ -76,38 +87,50 @@ backend's understanding of state and the app's interpretation of it.
 
 ### Local session gates that should be positioned by the API
 
-- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:31, 113-115` — `_legalDisclaimerAccepted`
+- **V21** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:31, 113-115` — `_legalDisclaimerAccepted`
   - The flag itself is a legitimate per-session security gate. **The violation is its position in routing** — the app inserts disclaimer between email and registration unilaterally. **API change needed:** API returns `currentStep: 'legalDisclaimer'` when it wants the disclaimer to show.
-- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:40, 117-119` — `_registrationSignProduced`
+- **V22** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:40, 117-119` — `_registrationSignProduced`
   - Same shape — per-session sign-gate is fine; deciding *when* to surface the registration page from the cubit is not. **API drives the position.**
 
 ### JWT decoded locally to detect merge
 
-- `lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart:49-63` — parses JWT, extracts `account` claim, compares before/after to detect merge
+- **V23** — `lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart:49-63` — parses JWT, extracts `account` claim, compares before/after to detect merge
   - **API change needed:** `POST /v1/realunit/register/wallet` (or a new `/kyc/check-merge`) returns `{ merged: true, mergedAccountId }` directly — the app does not introspect tokens
 
 ### Transaction state interpretation in the UI
 
-- `lib/screens/dashboard/widgets/pending_transaction_row.dart:49-51` — `if (transaction.state == .waitingForPayment)` switches label
+- **V24** — `lib/screens/dashboard/widgets/pending_transaction_row.dart:49-51` — `if (transaction.state == .waitingForPayment)` switches label
   - **API change needed:** API returns `statusLabel` / `statusKey` as a string the app can render or translate; app does not switch on enums
 
 ### Status code semantics
 
-- `lib/packages/service/dfx/dfx_auth_service.dart:233-239` — `401 → refresh token`
-  - HTTP-standard behavior, but still a local interpretation. **Accept as conventional**, or document that 401-on-this-endpoint specifically means "JWT expired" so the convention is contractual.
+- **V25** — `lib/packages/service/dfx/dfx_auth_service.dart:233-239` — `401 → refresh token`
+  - HTTP-standard behavior, but still a local interpretation. **Accepted as documented exception** (see *Documented exceptions* in `api-authority-plan.md`); 401-on-this-endpoint contractually means "JWT expired". Tagged for completeness.
 
 ### Polling/retry orchestration with local generation tokens
 
-- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:42-69` — `_runGeneration` cancellation token + 30s timeout
-- `lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart:24-37` — `_mergeDetected` + generation tracking, multi-step propagation race handling
+- **V26** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:42-69` — `_runGeneration` cancellation token + 30s timeout
+- **V27** — `lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart:24-37` — `_mergeDetected` + generation tracking, multi-step propagation race handling
   - **Local decision:** when to give up, how to retry, what counts as a recoverable failure
   - **API change needed:** API exposes a single idempotent `/check-merge` endpoint that handles propagation internally — app stops orchestrating
 
 ### Registration-submit treats backend rejection as success
 
-- `lib/screens/kyc/steps/registration/cubits/registration_submit/kyc_registration_submit_cubit.dart:76, 92` — on `"already registered"` API error, emit `Success` to let `KycCubit` resolve the next state
+- **V15** — `lib/screens/kyc/steps/registration/cubits/registration_submit/kyc_registration_submit_cubit.dart:76, 92` — on `"already registered"` API error, emit `Success` to let `KycCubit` resolve the next state
   - **Local decision:** that an API "no" is actually "yes, with a different next step"
   - **API change needed:** API returns `{ status: 'already_registered', nextStep: 'merge' }` and the app dispatches; the cubit must not paper over a 400
+
+### Bank-account default selection ignores API hint
+
+- **V11** — `lib/screens/sell/widgets/sell_bank_account_field.dart:41-44` — `state.accounts.lastWhereOrNull((a) => a.isActive)`
+  - **Local decision:** "the last active bank account is the right default" — duplicates the API's `BankAccountDto.default` flag with a positional heuristic
+  - **API change needed:** none — `BankAccountDto.isDefault` already exists in the app's own DTO (`lib/packages/service/dfx/models/bank_account/dto/bank_account_dto.dart:6`) and is parsed from the API's `default` field; the selector just needs to consume it
+
+### Local startup gate that delays API surface
+
+- **V34** — `lib/main.dart:120` — `if (!homeState.softwareTermsAccepted) ...` blocks the dashboard until terms acceptance
+  - **Local decision:** that the user cannot reach any *API-allowed* screen until a UI-local preference is set
+  - **API change needed:** none — the gate itself is acceptable as a one-time UX overlay, but its *position* (between boot and any API-driven flow) violates the rendering-layer rule. Move to a one-time Dashboard overlay so the API gets to drive routing first
 
 ---
 
@@ -115,48 +138,51 @@ backend's understanding of state and the app's interpretation of it.
 
 ### Currency, language, country, network
 
-- `lib/styles/currency.dart:3-22` — `enum Currency { EUR, CHF }`
+- **V12** — `lib/styles/currency.dart:3-22` — `enum Currency { EUR, CHF }`
   - **API change needed:** call `/v1/fiat` and render the list returned for this user's region
-- `lib/styles/language.dart:3-22` — `enum Language { EN, DE }`
+- **V13** — `lib/styles/language.dart:3-22` — `enum Language { EN, DE }`
   - **API change needed:** call `/v1/language` (already exists on the DFX API)
-- `lib/widgets/form/country_field.dart:65-79` — `['CH', 'DE', 'IT', 'FR']` priority list at top
+- **V14** — `lib/widgets/form/country_field.dart:65-79` — `['CH', 'DE', 'IT', 'FR']` priority list at top
   - **API change needed:** `/v1/country?priority=true` returns ordered list; UI does not hardcode preference
-- `lib/packages/config/network_mode.dart:4-20` — `enum NetworkMode { mainnet, testnet }`
-  - **Boundary case:** network mode determines *which* API host the app calls. Cannot itself be API-driven (chicken-and-egg). **Document as legitimate exception.**
+- **V28** — `lib/packages/config/network_mode.dart:4-20` — `enum NetworkMode { mainnet, testnet }`
+  - **Boundary case:** network mode determines *which* API host the app calls. Cannot itself be API-driven (chicken-and-egg). **Accepted as documented exception** (see `api-authority-plan.md`). Tagged for completeness.
 
-### Currency dropdowns rendered from local enum
+### Currency / language dropdowns rendered from local enum
 
-- `lib/screens/buy/widgets/payment_converter.dart:83` — `Currency.values.map()`
-- `lib/screens/sell/widgets/sell_converter.dart:201` — `Currency.values.map()`
-  - Same root cause as `styles/currency.dart` — fix the source
+- **V10a** — `lib/screens/buy/widgets/payment_converter.dart:83` — `Currency.values.map()`
+- **V10b** — `lib/screens/sell/widgets/sell_converter.dart:201` — `Currency.values.map()`
+- **V10c** — `lib/screens/settings_currencies/settings_currencies_page.dart:26` — `Currency.values.map()` (settings currency picker)
+- **V13c** — `lib/screens/settings_languages/settings_languages_page.dart:24` — `Language.values.map()` (settings language picker)
+  - All four are the same root cause as V12 / V13 — fix the source enum and these surfaces switch to the API list automatically. Closed together by W1.3 (currencies) / W1.4 (languages).
 
 ### Legal documents URLs hardcoded
 
-- `lib/packages/config/legal_documents_config.dart:69-122` — Registration-Agreement PDFs (DE/EN), RealUnit Prospekt, Aktionariat, DFX-Docs URLs
+- **V17** — `lib/packages/config/legal_documents_config.dart:69-122` — Registration-Agreement PDFs (DE/EN), RealUnit Prospekt, Aktionariat, DFX-Docs URLs
   - **API change needed:** `/v1/legal-document?type=registration&language=de` returns the current URL + version; app renders without knowing URLs in advance
 
 ### Company contact info hardcoded
 
-- `lib/screens/settings_contact/settings_contact_page.dart:82, 93-94, 104, 109, 133-134` — phone, email, website, postal address
+- **V18** — `lib/screens/settings_contact/settings_contact_page.dart:82, 93-94, 104, 109, 133-134` — phone, email, website, postal address
   - **API change needed:** `/v1/company-info` (or the existing `/v1/settings`) returns this for the RealUnit branding; allows future white-labeling
 
 ### Asset configuration hardcoded
 
-- `lib/packages/config/api_config.dart:19-22` — RealUnit token address, chainId, decimals (mainnet + Sepolia variants)
-- `lib/packages/utils/default_assets.dart:3-22` — ETH/ZCHF asset IDs per network
-  - **Boundary case:** the app *is* the RealUnit wallet, by definition it knows which token it manages. Asset IDs from `/v1/asset` would be cleaner but this is the lowest-priority offender — leave for last.
+- **V29** — `lib/packages/config/api_config.dart:19-22` — RealUnit token address, chainId, decimals (mainnet + Sepolia variants)
+  - **API change needed:** `/v1/asset?app=realunit` returns the canonical token configuration; the app reads + caches per network mode
+- **V30** — `lib/packages/utils/default_assets.dart:3-22` — ETH/ZCHF asset IDs per network
+  - **Boundary case:** the app *is* the RealUnit wallet, by definition it knows which token it manages. **Out of scope** for the current waves — listed for completeness but explicitly accepted as a boundary case (see Wave 5 rationale in `api-authority-plan.md`). Asset IDs from `/v1/asset` would be cleaner but this is the lowest-priority offender — defer until a multi-asset wallet need surfaces.
 
 ### Date / size constants
 
-- `lib/screens/transaction_history/transaction_history_page.dart:68-69` — `firstDate: DateTime(2025)` on history picker
-- `lib/screens/settings_tax_report/settings_tax_report_page.dart:73` — `firstDate: DateTime(2025)` on tax-report picker
-  - **API change needed:** `/v1/user/account-bounds` returns `{ firstTransactionDate, lastTransactionDate }`
-- `lib/screens/settings_seed/settings_seed_view.dart:98` — `if (wordCount != 12)` mnemonic length check
-  - **Local concern — local crypto invariant.** BIP-39 length is structural, not a business rule. **Accept as legitimate.**
+- **V31** — `lib/screens/transaction_history/transaction_history_page.dart:68-69` — `firstDate: DateTime(2025)` on history picker
+- **V32** — `lib/screens/settings_tax_report/settings_tax_report_page.dart:73` — `firstDate: DateTime(2025)` on tax-report picker
+  - **API change needed:** `/v1/user/account-bounds` returns `{ firstTransactionDate, lastTransactionDate }`; both pickers use that as `firstDate`
+- **V33** — `lib/screens/settings_seed/settings_seed_view.dart:98` — `if (wordCount != 12)` mnemonic length check
+  - **Local concern — local crypto invariant.** BIP-39 length is structural, not a business rule. **Accepted as documented exception.** Tagged for completeness.
 
 ### Default language selection
 
-- `lib/packages/repository/settings_repository.dart:18-24` — `systemLang == 'de' ? 'de' : 'en'`
+- **V19** — `lib/packages/repository/settings_repository.dart:18-24` — `systemLang == 'de' ? 'de' : 'en'`
   - **API change needed:** API recommends a default language per user/region; until then, this is acceptable Frontend-only behavior (no user has been onboarded yet).
 
 ---
@@ -166,10 +192,10 @@ backend's understanding of state and the app's interpretation of it.
 These are not violations of the rule (DTOs *must* mirror the API for type safety),
 but they're listed so reviewers know what to keep in sync when the API changes.
 
-- `lib/packages/service/dfx/models/kyc/kyc_level.dart` — `KycLevel`, `KycStepName`, `KycStepStatus`, `KycStepType`, `KycStepReason` enums with `fromValue` / `toValue`
-- `lib/packages/service/dfx/models/registration/registration_status.dart`
-- `lib/packages/service/dfx/models/registration/registration_email_status.dart`
-- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:224-231` — `_mapStepName()` switch from `KycStepName` to UI `KycStep`
+- **V35** — `lib/packages/service/dfx/models/kyc/kyc_level.dart` — `KycLevel`, `KycStepName`, `KycStepStatus`, `KycStepType`, `KycStepReason` enums with `fromValue` / `toValue`
+- **V36** — `lib/packages/service/dfx/models/registration/registration_status.dart`
+- **V37** — `lib/packages/service/dfx/models/registration/registration_email_status.dart`
+- **V38** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:224-231` — `_mapStepName()` switch from `KycStepName` to UI `KycStep`
 
 The `KycStepName → KycStep` map is borderline: it's a UI-routing decision (which
 page to show per backend step). If `KycStepDto` carried a `uiHint: 'identPage'`
@@ -182,20 +208,26 @@ required.**
 
 For completeness:
 
-- `lib/screens/kyc/steps/email/kyc_email_page.dart:91` — `markRegistrationSignProduced()` after merge confirmation. Local session-gate position, called from a code path where the API already signaled success. Fixed by PR #466. **OK.**
-- `KycEmailVerificationCubit._completeRegistration` — surfaces failures correctly (PR #466 / API PR #3731). Once API PR #3731 merges and the `register/wallet` endpoint is idempotent, the client-side retry logic at the email verification page can be simplified further. Track in [#3731](https://github.com/DFXswiss/api/pull/3731).
+- **V39** — `lib/screens/kyc/steps/email/kyc_email_page.dart:91` — `markRegistrationSignProduced()` after merge confirmation. Local session-gate position, called from a code path where the API already signaled success. Fixed by [`DFXswiss/realunit-app#466`](https://github.com/DFXswiss/realunit-app/pull/466). **OK.**
+- **V40** — `KycEmailVerificationCubit._completeRegistration` — surfaces failures correctly ([`DFXswiss/realunit-app#466`](https://github.com/DFXswiss/realunit-app/pull/466) / [`DFXswiss/api#3731`](https://github.com/DFXswiss/api/pull/3731)). Once [`DFXswiss/api#3731`](https://github.com/DFXswiss/api/pull/3731) merges and the `register/wallet` endpoint is idempotent, the client-side retry logic at the email verification page can be simplified further.
 
 ---
 
 ## Summary
 
-| Severity | Count | Primary location |
-|---|---|---|
-| **P0** — blocks users today | 11 | `kyc_cubit.dart` (6), buy/sell payment-info cubits (2), settings user-data (2), sell_button (1) |
-| **P1** — local interpretation, no immediate block | 9 | `kyc_cubit.dart` + email-verification + registration-submit cubits |
-| **P2** — hardcoded lists/config | ~15 | currency/language/country, legal docs, company info, assets |
-| **P3** — DTO mirroring (informational) | 5 | service/dfx/models |
-| **P4** — fixed or in-flight | 2 | tracked in PR #466 / #3731 |
+Numbers below are the **canonical counts** used everywhere this audit is referenced (plan, PR body, future PRs). Recounted from this file on 2026-05-21.
+
+| Severity | Count | V-IDs | Primary location |
+|---|---|---|---|
+| **P0** — blocks users today | 15 | V1–V5, V6a–V6d, V7, V8, V9, V13b, V16, V20 | `kyc_cubit.dart` (6), buy/sell payment-info cubits (2), settings user-data + edit cubits (4), settings_contact (1), settings (1), sell_button (1) |
+| **P1** — local interpretation, no immediate block | 10 | V11, V15, V21–V27, V34 | `kyc_cubit.dart` + email-verification + registration-submit cubits + bank-account field + main.dart |
+| **P2** — hardcoded lists/config | 16 | V10a–V10c, V12, V13, V13c, V14, V17–V19, V28–V33 | currency/language/country, legal docs, company info, assets, date pickers |
+| **P3** — DTO mirroring (informational) | 4 | V35–V38 | service/dfx/models |
+| **P4** — fixed or in-flight | 2 | V39, V40 | tracked in [`DFXswiss/realunit-app#466`](https://github.com/DFXswiss/realunit-app/pull/466) / [`DFXswiss/api#3731`](https://github.com/DFXswiss/api/pull/3731) |
+
+**Total distinct violations across P0–P2:** 41 (15 + 10 + 16).
+**Plus boundary cases accepted as documented exceptions:** V13b, V25, V28, V30, V33 — tagged in the audit, not counted as actionable.
+**Actionable P0–P2 (excluding documented exceptions):** 36.
 
 **Most-affected single file:** `lib/screens/kyc/cubits/kyc/kyc_cubit.dart` —
 ~10 distinct violations. The entire `_runCheckKyc` body should be replaceable by

--- a/docs/api-authority-audit.md
+++ b/docs/api-authority-audit.md
@@ -42,6 +42,10 @@ the 2026-05-21 ident-misroute report that triggered this audit).
   - **Local decision:** entire next-step selection algorithm — duplicates `KycService.tryContinue` on the API
   - **API change needed:** none — the `currentStep` field from `PUT /v2/kyc` already contains the answer; remove the loop, route from `currentStep` only
   - **Closed by:** W2.2 (subsumed by the `_runCheckKyc` rewrite that collapses V1, V2, V3 — V5 is *the same loop* those three constants drive). Tagged separately so reviewers can grep the routing-chain code path explicitly.
+- **V45** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:208` — `_continueKyc` repeats the same manual filter over `kycSteps`
+  - **Local decision:** `kycStatus.kycSteps.firstWhere((step) => step.isCurrent)` — parallel code path with the same anti-pattern as V5's `_runCheckKyc` loop, called after a realunit registration completes
+  - **API change needed:** none — the `currentStep` field is already authoritative; consume it directly. When W2.2 rewrites `_runCheckKyc` to render `currentStep` directly, this loop must also be deleted in the same PR
+  - **Closed by:** W2.2 (same wave/PR as V5)
 - **V4** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:179-182` — `e.statusCode == 403 || e.code == 'TFA_REQUIRED'` → emit 2FA step
   - **Local decision:** translate HTTP status into a UI flow
   - **API change needed:** API returns `nextStep: '2fa'` in the response body — app does not switch on status codes
@@ -73,7 +77,7 @@ the 2026-05-21 ident-misroute report that triggered this audit).
 - **V6d** — `lib/screens/settings_user_data/cubit/settings_user_data_cubit.dart:18-22` — `_changeStepNames` static const set ({nameChange, addressChange, phoneChange})
   - **Local decision:** which KYC step names represent a user-data change flow — same shape as `_requiredStepNames` (V1), just a different subset
   - **API change needed:** API exposes a `category: 'changeRequest'` (or similar) flag on `KycStepDto`, app filters by it
-- **V9** — `lib/screens/settings_contact/settings_contact_page.dart:54-67` — "Contact Support" only shown if email is set
+- **V9** — `lib/screens/settings_contact/settings_contact_page.dart:54-67` (the page reads `emailSet`) + `lib/screens/settings_contact/cubit/settings_contact_cubit.dart:22` (the cubit computes `emailSet: userDto.mail != null` from the user DTO) — "Contact Support" only shown if email is set
   - **API change needed:** API exposes `support.available: bool` (or always allow it through the support endpoint and the API returns 400 if not eligible)
 - **V13b** — `lib/screens/settings/settings_page.dart:100` — "Wallet Backup" only shown if `walletType == WalletType.software`
   - **Boundary case:** wallet-type is a device-local fact (BitBox cannot expose its seed); this one is **defensible** as a UI capability. **Accepted as documented exception** (see *Documented exceptions* in `api-authority-plan.md`). Tagged for completeness.
@@ -84,6 +88,20 @@ the 2026-05-21 ident-misroute report that triggered this audit).
 
 These do not block users today, but every one accumulates drift between the
 backend's understanding of state and the app's interpretation of it.
+
+### Hardcoded language sent to backend on registration
+
+- **V41** — `lib/packages/service/dfx/real_unit_registration_service.dart:117` — `lang: 'DE'` constant sent to the API on registration completion
+  - **Local decision:** account language is hardcoded to `'DE'` regardless of the user's actual settings-language / device locale — silently miscategorizes the user's UI language
+  - **API change needed:** API derives account language from `Accept-Language` header (or settings-language) on the request; or — interim — the app sends the user's actual settings-language. The app must not pick a fixed value
+  - **Closed by:** W4.4 (extended) — handled together with the recommended-language work in W4.3 / W4.4
+
+### Client-side mapping of KYC financial-question key to UI action
+
+- **V43** — `lib/screens/kyc/steps/financial_data/subpages/kyc_financial_data_questions_page.dart:110-122` — switch on `question.key == 'tnc'` / `'notification_of_changes'` to pick action target
+  - **Local decision:** which `key` opens a webview (with a hardcoded URL) vs which routes to Support — encoded in the rendering page; any new question type added server-side silently fails to surface the right action
+  - **API change needed:** extend `KycFinancialQuestion` DTO with a structured `link: { url?: string, action?: 'support' \| 'webview' }` (or equivalent). The page renders the link metadata; it does not switch on `key` literals
+  - **Closed by:** W3.1 / W3.2
 
 ### Local session gates that should be positioned by the API
 
@@ -140,6 +158,10 @@ backend's understanding of state and the app's interpretation of it.
 
 - **V12** — `lib/styles/currency.dart:3-22` — `enum Currency { EUR, CHF }`
   - **API change needed:** call `/v1/fiat` and render the list returned for this user's region
+- **V46** — `lib/screens/kyc/steps/registration/steps/kyc_registration_personal_step.dart:50-53` — `[RegistrationUserType.values.first]` restricts the account-type dropdown to a single value
+  - **Local decision:** the DTO carries multiple `RegistrationUserType` values but the UI only renders `.values.first` (i.e. `human`). Which account types this branded app exposes is a business decision frozen in code
+  - **API change needed:** `availableUserTypes: ['human']` capability flag on `UserV2Dto` (or on the registration endpoint response); app renders the returned list. Same shape as V12 / V13
+  - **Closed by:** W3.1 / W3.2 (capabilities)
 - **V13** — `lib/styles/language.dart:3-22` — `enum Language { EN, DE }`
   - **API change needed:** call `/v1/language` (already exists on the DFX API)
 - **V14** — `lib/widgets/form/country_field.dart:65-79` — `['CH', 'DE', 'IT', 'FR']` priority list at top
@@ -157,8 +179,12 @@ backend's understanding of state and the app's interpretation of it.
 
 ### Legal documents URLs hardcoded
 
-- **V17** — `lib/packages/config/legal_documents_config.dart:69-122` — Registration-Agreement PDFs (DE/EN), RealUnit Prospekt, Aktionariat, DFX-Docs URLs
-  - **API change needed:** `/v1/legal-document?type=registration&language=de` returns the current URL + version; app renders without knowing URLs in advance
+- **V17** — `lib/packages/config/legal_documents_config.dart:69-122, :160-191, :193-236` — Registration-Agreement PDFs (DE/EN), RealUnit Prospekt URLs (`:69-122`), Aktionariat document URLs (`:160-191`), DFX-Docs URLs (`:193-236`)
+  - **API change needed:** `/v1/legal-document?type=registration&language=de` returns the current URL + version; app renders without knowing URLs in advance. Same endpoint also covers the Aktionariat and DFX-Docs blocks
+- **V44** — `lib/screens/kyc/steps/financial_data/constants/kyc_financial_data_links.dart:2` — hardcoded `https://dfx.swiss/terms-and-conditions`
+  - **Local decision:** same root cause as V17 but outside `legal_documents_config.dart` — a separate constants file holds a legal URL
+  - **API change needed:** `/v1/legal-document` endpoint (the same endpoint W4.1 introduces); app reads the URL instead of compiling it in
+  - **Closed by:** W4.4 (same wave as V17)
 
 ### Company contact info hardcoded
 
@@ -174,7 +200,7 @@ backend's understanding of state and the app's interpretation of it.
 
 ### Date / size constants
 
-- **V31** — `lib/screens/transaction_history/transaction_history_page.dart:68-69` — `firstDate: DateTime(2025)` on history picker
+- **V31** — `lib/screens/transaction_history/transaction_history_page.dart:68-69, :82` — `firstDate: DateTime(2025)` on the start-date picker (`:68-69`) **and** the end-date picker (`:82`)
 - **V32** — `lib/screens/settings_tax_report/settings_tax_report_page.dart:73` — `firstDate: DateTime(2025)` on tax-report picker
   - **API change needed:** `/v1/user/account-bounds` returns `{ firstTransactionDate, lastTransactionDate }`; both pickers use that as `firstDate`
 - **V33** — `lib/screens/settings_seed/settings_seed_view.dart:98` — `if (wordCount != 12)` mnemonic length check
@@ -184,6 +210,34 @@ backend's understanding of state and the app's interpretation of it.
 
 - **V19** — `lib/packages/repository/settings_repository.dart:18-24` — `systemLang == 'de' ? 'de' : 'en'`
   - **API change needed:** API recommends a default language per user/region; until then, this is acceptable Frontend-only behavior (no user has been onboarded yet).
+
+### Default currency selection
+
+- **V42** — `lib/packages/repository/settings_repository.dart:28` — `_sharedPreferences.getString('currency') ?? 'CHF'`
+  - **Local decision:** the fallback currency, used when the user has never picked one, is hardcoded to CHF. Same shape as V19's language fallback, just for currency
+  - **API change needed:** API recommends a default currency per user/region (alongside the recommended language from W4.3); app uses it as the fallback. Same wave as V19
+  - **Closed by:** W4.4 (extended) — alongside the recommended-language work
+
+### Tax-report date transformation chosen client-side
+
+- **V47** — `lib/screens/settings_tax_report/cubit/settings_tax_report_cubit.dart:53-64` — `_getDateWithLatestTime(selectedDate)` decides whether to ask the API for "now minus 1 minute" (today) or "end of day" (past dates)
+  - **Local decision:** which exact UTC timestamp the API should evaluate the balance at, derived locally from "is the selected date today"
+  - **API change needed:** `/v1/realunit/balance/pdf` accepts a date (not a timestamp) and the server picks the appropriate evaluation moment. The app sends `date` only; backend owns the time semantics. UX-only — not user-blocking
+  - **Closed by:** W5.1 (extended)
+
+### Faucet-vs-ready decision derived from raw API balances
+
+- **V48** — `lib/screens/sell_bitbox/cubit/sell_bitbox_cubit.dart:51, :81` — `if (_paymentInfo.ethBalance >= _paymentInfo.requiredGasEth) … else _requestFaucet()` (and the same comparison in the 5s polling loop at `:81`)
+  - **Local decision:** the client compares two API-supplied numbers to decide "request faucet" vs "ready". A semantic decision encoded as a numeric inequality
+  - **API change needed:** `SellPaymentInfoDto` (or the sell endpoint response) exposes `needsFaucet: bool` and optionally `faucetPollingHint: int` (seconds). App renders the boolean and the hinted polling interval instead of computing them
+  - **Closed by:** W5 (new sub-item)
+
+### Support categories + labels hardcoded
+
+- **V49** — `lib/screens/support/subpages/support_create_ticket_page.dart:85-110` (UI list of `SupportIssueType` tiles) + `lib/screens/support/cubits/support_create_ticket/support_create_ticket_cubit.dart:48-57` (non-i18n English labels in `_getTicketName`)
+  - **Local decision:** which support categories this branded app exposes — a business decision baked into the page — and the human-readable label of each category, in English only, baked into the cubit
+  - **API change needed:** `/v1/support/issue-types` capability endpoint returning `{ key, icon, label }[]`. App renders the list with localized labels from the API (or i18n keys keyed on `key`). Adding a new category requires no app release
+  - **Closed by:** W4 (or a new endpoint slot in W4) — additive
 
 ---
 
@@ -219,15 +273,15 @@ Numbers below are the **canonical counts** used everywhere this audit is referen
 
 | Severity | Count | V-IDs | Primary location |
 |---|---|---|---|
-| **P0** — blocks users today | 15 | V1–V5, V6a–V6d, V7, V8, V9, V13b, V16, V20 | `kyc_cubit.dart` (6), buy/sell payment-info cubits (2), settings user-data + edit cubits (4), settings_contact (1), settings (1), sell_button (1) |
-| **P1** — local interpretation, no immediate block | 10 | V11, V15, V21–V27, V34 | `kyc_cubit.dart` + email-verification + registration-submit cubits + bank-account field + main.dart |
-| **P2** — hardcoded lists/config | 16 | V10a–V10c, V12, V13, V13c, V14, V17–V19, V28–V33 | currency/language/country, legal docs, company info, assets, date pickers |
+| **P0** — blocks users today | 16 | V1–V5, V6a–V6d, V7, V8, V9, V13b, V16, V20, V45 | `kyc_cubit.dart` (7 incl. `_continueKyc`), buy/sell payment-info cubits (2), settings user-data + edit cubits (4), settings_contact (1), settings (1), sell_button (1) |
+| **P1** — local interpretation, no immediate block | 12 | V11, V15, V21–V27, V34, V41, V43 | `kyc_cubit.dart` + email-verification + registration-submit cubits + bank-account field + main.dart + real_unit_registration_service + financial-data questions page |
+| **P2** — hardcoded lists/config | 22 | V10a–V10c, V12, V13, V13c, V14, V17–V19, V28–V33, V42, V44, V46, V47, V48, V49 | currency/language/country, legal docs, company info, assets, date pickers, default currency, tax-report date, faucet decision, support categories, registration user types |
 | **P3** — DTO mirroring (informational) | 4 | V35–V38 | service/dfx/models |
 | **P4** — fixed or in-flight | 2 | V39, V40 | tracked in [`DFXswiss/realunit-app#466`](https://github.com/DFXswiss/realunit-app/pull/466) / [`DFXswiss/api#3731`](https://github.com/DFXswiss/api/pull/3731) |
 
-**Total distinct violations across P0–P2:** 41 (15 + 10 + 16).
+**Total distinct violations across P0–P2:** 50 (16 + 12 + 22). Recounted on 2026-05-21 after a post-initial-review audit pass found 9 additional violations (V41–V49) that the initial four-stream scan had missed.
 **Plus boundary cases accepted as documented exceptions:** V13b, V25, V28, V30, V33 — tagged in the audit, not counted as actionable.
-**Actionable P0–P2 (excluding documented exceptions):** 36.
+**Actionable P0–P2 (excluding documented exceptions):** 45.
 
 **Most-affected single file:** `lib/screens/kyc/cubits/kyc/kyc_cubit.dart` —
 ~10 distinct violations. The entire `_runCheckKyc` body should be replaceable by

--- a/docs/api-authority-audit.md
+++ b/docs/api-authority-audit.md
@@ -1,0 +1,212 @@
+# API Authority Audit
+
+This document inventories every place in the realunit-app where business decisions
+are made locally instead of being delegated to the DFX API, as required by the
+*"API as Decision Authority"* rule in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+Findings were produced by four parallel scans (2026-05-21) over the KYC, Buy/Sell,
+Wallet/Service-layer, and Settings areas, then deduplicated and ranked by impact.
+
+Each item lists:
+- The violation site (`file:line`)
+- The local decision being made
+- What an API-driven version should look like
+- Whether closing it requires an API change in [`DFXswiss/api`](https://github.com/DFXswiss/api)
+
+---
+
+## P0 — User-visible blockers caused by app-side gating
+
+These are the items where the app actively prevents a user from doing something
+the API would accept. Fixing these directly resolves real user complaints (e.g.
+the 2026-05-21 ident-misroute report that triggered this audit).
+
+### KYC routing decided in the cubit instead of by the API
+
+- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:16-22` — `_requiredStepNames` set
+  - **Local decision:** which step names count as "required for trading"
+  - **Backend already owns this** in `api/src/subdomains/generic/kyc/enums/kyc.enum.ts:requiredKycSteps(userData)` — the app duplicates a subset
+  - **API change needed:** add `isRequired: bool` to `KycStepDto`, drop the local set
+- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:24, 171` — `_minLevelForActions = 30` + `level < _requiredLevel` check
+  - **Local decision:** which numeric level unlocks trading
+  - **API change needed:** API returns `canTrade: bool` / `canPerformAction: bool` per user — the app renders, doesn't compute
+- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:142, 156-162` — `pendingStatuses` + `actionableStatuses` sets
+  - **Local decision:** which `ReviewStatus` values mean "user must act" vs "wait for review"
+  - **API change needed:** API's `KycInfoMapper.toDto` already picks `currentStep` — the app should render `currentStep` directly and stop iterating `kycSteps`
+- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:134-168` — manual filter + routing chain over `kycSteps`
+  - **Local decision:** entire next-step selection algorithm — duplicates `KycService.tryContinue` on the API
+  - **API change needed:** none — the `currentStep` field from `PUT /v2/kyc` already contains the answer; remove the loop, route from `currentStep` only
+- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:179-182` — `e.statusCode == 403 || e.code == 'TFA_REQUIRED'` → emit 2FA step
+  - **Local decision:** translate HTTP status into a UI flow
+  - **API change needed:** API returns `nextStep: '2fa'` in the response body — app does not switch on status codes
+- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:88-104` — auto-register email when `level < 10`
+  - **Local decision:** infer that level<10 means "the email step is implicit, call the registration endpoint silently"
+  - **API change needed:** if auto-registration is desired the API performs it server-side; the app calls `continueKyc` and renders what comes back
+
+### Hardcoded transaction limits
+
+- `lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart:16, 50-60` — `_minAmountChf = 100` pre-flight
+  - **API change needed:** `POST /v1/buy/quote` already validates min/max — return `minAmount` / `maxAmount` / `error` from the API, surface its error verbatim
+- `lib/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart:17, 82-112` — `_minAmountChf = 10` + `validateMinAmount()` pre-flight
+  - **API change needed:** same shape on `POST /v1/sell/quote` — remove the local validate method entirely
+
+### Hardcoded routing forks based on wallet type
+
+- `lib/screens/sell/widgets/sell_button.dart:60-62` — `if (state.isBitbox) → AppRoutes.sellBitbox`
+  - **Local decision:** which sell-flow page to use based on hardware-wallet presence
+  - **API change needed:** API returns `requiredWorkflow: 'sell' | 'sellBitbox'` (or a list of steps) — app dispatches on that string
+
+### Feature visibility decided by local heuristics
+
+- `lib/screens/settings_user_data/settings_user_data_page.dart:239` — Edit button hidden if `statusLabel != null` (i.e. `inReview`)
+  - **API change needed:** API returns `editable: bool` per field; app does not introspect status to compute editability
+- `lib/screens/settings_user_data/subpages/edit_name/cubit/settings_edit_name_cubit.dart:22` — `if (session.currentStep?.status == KycStepStatus.inReview)` blocks editing
+  - Same as above — render an API capability flag, do not switch on status
+- `lib/screens/settings_contact/settings_contact_page.dart:54-67` — "Contact Support" only shown if email is set
+  - **API change needed:** API exposes `support.available: bool` (or always allow it through the support endpoint and the API returns 400 if not eligible)
+- `lib/screens/settings/settings_page.dart:100` — "Wallet Backup" only shown if `walletType == WalletType.software`
+  - **Boundary case:** wallet-type is a device-local fact (BitBox cannot expose its seed); this one is **defensible** as a UI capability. Document the exception or accept it.
+
+---
+
+## P1 — Local interpretation of API state
+
+These do not block users today, but every one accumulates drift between the
+backend's understanding of state and the app's interpretation of it.
+
+### Local session gates that should be positioned by the API
+
+- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:31, 113-115` — `_legalDisclaimerAccepted`
+  - The flag itself is a legitimate per-session security gate. **The violation is its position in routing** — the app inserts disclaimer between email and registration unilaterally. **API change needed:** API returns `currentStep: 'legalDisclaimer'` when it wants the disclaimer to show.
+- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:40, 117-119` — `_registrationSignProduced`
+  - Same shape — per-session sign-gate is fine; deciding *when* to surface the registration page from the cubit is not. **API drives the position.**
+
+### JWT decoded locally to detect merge
+
+- `lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart:49-63` — parses JWT, extracts `account` claim, compares before/after to detect merge
+  - **API change needed:** `POST /v1/realunit/register/wallet` (or a new `/kyc/check-merge`) returns `{ merged: true, mergedAccountId }` directly — the app does not introspect tokens
+
+### Transaction state interpretation in the UI
+
+- `lib/screens/dashboard/widgets/pending_transaction_row.dart:49-51` — `if (transaction.state == .waitingForPayment)` switches label
+  - **API change needed:** API returns `statusLabel` / `statusKey` as a string the app can render or translate; app does not switch on enums
+
+### Status code semantics
+
+- `lib/packages/service/dfx/dfx_auth_service.dart:233-239` — `401 → refresh token`
+  - HTTP-standard behavior, but still a local interpretation. **Accept as conventional**, or document that 401-on-this-endpoint specifically means "JWT expired" so the convention is contractual.
+
+### Polling/retry orchestration with local generation tokens
+
+- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:42-69` — `_runGeneration` cancellation token + 30s timeout
+- `lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart:24-37` — `_mergeDetected` + generation tracking, multi-step propagation race handling
+  - **Local decision:** when to give up, how to retry, what counts as a recoverable failure
+  - **API change needed:** API exposes a single idempotent `/check-merge` endpoint that handles propagation internally — app stops orchestrating
+
+### Registration-submit treats backend rejection as success
+
+- `lib/screens/kyc/steps/registration/cubits/registration_submit/kyc_registration_submit_cubit.dart:76, 92` — on `"already registered"` API error, emit `Success` to let `KycCubit` resolve the next state
+  - **Local decision:** that an API "no" is actually "yes, with a different next step"
+  - **API change needed:** API returns `{ status: 'already_registered', nextStep: 'merge' }` and the app dispatches; the cubit must not paper over a 400
+
+---
+
+## P2 — Hardcoded lists / config that should come from the API
+
+### Currency, language, country, network
+
+- `lib/styles/currency.dart:3-22` — `enum Currency { EUR, CHF }`
+  - **API change needed:** call `/v1/fiat` and render the list returned for this user's region
+- `lib/styles/language.dart:3-22` — `enum Language { EN, DE }`
+  - **API change needed:** call `/v1/language` (already exists on the DFX API)
+- `lib/widgets/form/country_field.dart:65-79` — `['CH', 'DE', 'IT', 'FR']` priority list at top
+  - **API change needed:** `/v1/country?priority=true` returns ordered list; UI does not hardcode preference
+- `lib/packages/config/network_mode.dart:4-20` — `enum NetworkMode { mainnet, testnet }`
+  - **Boundary case:** network mode determines *which* API host the app calls. Cannot itself be API-driven (chicken-and-egg). **Document as legitimate exception.**
+
+### Currency dropdowns rendered from local enum
+
+- `lib/screens/buy/widgets/payment_converter.dart:83` — `Currency.values.map()`
+- `lib/screens/sell/widgets/sell_converter.dart:201` — `Currency.values.map()`
+  - Same root cause as `styles/currency.dart` — fix the source
+
+### Legal documents URLs hardcoded
+
+- `lib/packages/config/legal_documents_config.dart:69-122` — Registration-Agreement PDFs (DE/EN), RealUnit Prospekt, Aktionariat, DFX-Docs URLs
+  - **API change needed:** `/v1/legal-document?type=registration&language=de` returns the current URL + version; app renders without knowing URLs in advance
+
+### Company contact info hardcoded
+
+- `lib/screens/settings_contact/settings_contact_page.dart:82, 93-94, 104, 109, 133-134` — phone, email, website, postal address
+  - **API change needed:** `/v1/company-info` (or the existing `/v1/settings`) returns this for the RealUnit branding; allows future white-labeling
+
+### Asset configuration hardcoded
+
+- `lib/packages/config/api_config.dart:19-22` — RealUnit token address, chainId, decimals (mainnet + Sepolia variants)
+- `lib/packages/utils/default_assets.dart:3-22` — ETH/ZCHF asset IDs per network
+  - **Boundary case:** the app *is* the RealUnit wallet, by definition it knows which token it manages. Asset IDs from `/v1/asset` would be cleaner but this is the lowest-priority offender — leave for last.
+
+### Date / size constants
+
+- `lib/screens/transaction_history/transaction_history_page.dart:68-69` — `firstDate: DateTime(2025)` on history picker
+- `lib/screens/settings_tax_report/settings_tax_report_page.dart:73` — `firstDate: DateTime(2025)` on tax-report picker
+  - **API change needed:** `/v1/user/account-bounds` returns `{ firstTransactionDate, lastTransactionDate }`
+- `lib/screens/settings_seed/settings_seed_view.dart:98` — `if (wordCount != 12)` mnemonic length check
+  - **Local concern — local crypto invariant.** BIP-39 length is structural, not a business rule. **Accept as legitimate.**
+
+### Default language selection
+
+- `lib/packages/repository/settings_repository.dart:18-24` — `systemLang == 'de' ? 'de' : 'en'`
+  - **API change needed:** API recommends a default language per user/region; until then, this is acceptable Frontend-only behavior (no user has been onboarded yet).
+
+---
+
+## P3 — DTO/enum mirroring (acceptable boilerplate, but watch for drift)
+
+These are not violations of the rule (DTOs *must* mirror the API for type safety),
+but they're listed so reviewers know what to keep in sync when the API changes.
+
+- `lib/packages/service/dfx/models/kyc/kyc_level.dart` — `KycLevel`, `KycStepName`, `KycStepStatus`, `KycStepType`, `KycStepReason` enums with `fromValue` / `toValue`
+- `lib/packages/service/dfx/models/registration/registration_status.dart`
+- `lib/packages/service/dfx/models/registration/registration_email_status.dart`
+- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:224-231` — `_mapStepName()` switch from `KycStepName` to UI `KycStep`
+
+The `KycStepName → KycStep` map is borderline: it's a UI-routing decision (which
+page to show per backend step). If `KycStepDto` carried a `uiHint: 'identPage'`
+field, the app would not need this map at all. **API change suggested but not
+required.**
+
+---
+
+## P4 — Already addressed / documented elsewhere
+
+For completeness:
+
+- `lib/screens/kyc/steps/email/kyc_email_page.dart:91` — `markRegistrationSignProduced()` after merge confirmation. Local session-gate position, called from a code path where the API already signaled success. Fixed by PR #466. **OK.**
+- `KycEmailVerificationCubit._completeRegistration` — surfaces failures correctly (PR #466 / API PR #3731). Once API PR #3731 merges and the `register/wallet` endpoint is idempotent, the client-side retry logic at the email verification page can be simplified further. Track in [#3731](https://github.com/DFXswiss/api/pull/3731).
+
+---
+
+## Summary
+
+| Severity | Count | Primary location |
+|---|---|---|
+| **P0** — blocks users today | 11 | `kyc_cubit.dart` (6), buy/sell payment-info cubits (2), settings user-data (2), sell_button (1) |
+| **P1** — local interpretation, no immediate block | 9 | `kyc_cubit.dart` + email-verification + registration-submit cubits |
+| **P2** — hardcoded lists/config | ~15 | currency/language/country, legal docs, company info, assets |
+| **P3** — DTO mirroring (informational) | 5 | service/dfx/models |
+| **P4** — fixed or in-flight | 2 | tracked in PR #466 / #3731 |
+
+**Most-affected single file:** `lib/screens/kyc/cubits/kyc/kyc_cubit.dart` —
+~10 distinct violations. The entire `_runCheckKyc` body should be replaceable by
+"render `currentStep` from the API, that's it" once the matching API fields land.
+
+## How to use this list
+
+- **For new PRs:** check whether your change touches any line in this file. If yes,
+  prefer to *remove* a violation (P0 → P3 in that order) rather than add one.
+- **For backend PRs:** every P0/P1 item has a paired API field that's missing.
+  When you extend the API to deliver that field, the app PR that consumes it
+  should also delete the corresponding local logic in the same PR.
+- **For the architecture review on 2026-05-21:** the P0 list is the actionable
+  short-list. P2 is a longer-term cleanup. P3/P4 are acknowledged exceptions.

--- a/docs/api-authority-plan.md
+++ b/docs/api-authority-plan.md
@@ -12,15 +12,22 @@ inventory in [`api-authority-audit.md`](api-authority-audit.md).
 
 ## Executive summary
 
+All counts below are the **canonical numbers** for this PR; the audit file lists every V-ID. Numbers are derived from a single recount of `api-authority-audit.md` on 2026-05-21.
+
 | | Count | Notes |
 |---|---|---|
-| Distinct violations in audit | 19 (V1–V19) + small tail | P0/P1/P2 mix |
-| Already solvable **without API change** | 8 | App reads existing fields |
-| Require **additive API change** | 9 | Backwards-compatible, no breaking change |
-| Require **new endpoint** | 3 | Legal docs, company info, country priority |
-| **Documented exceptions** (rule does not apply) | 5 | Network mode, BIP-39, etc. |
+| Distinct violations in audit (P0–P2 bulleted) | 41 | 15 P0 + 10 P1 + 16 P2 |
+| Of those, **documented exceptions** (rule does not apply) | 5 | V13b (BitBox backup), V25 (401 refresh), V28 (network mode), V30 (default assets), V33 (BIP-39) |
+| **Actionable** P0–P2 (recounted from audit) | 36 | what the waves below close |
+| Closed by Wave 1 (app-only, ships today) | 11 across 6 items | V4, V7, V8, V10a, V10b, V10c, V11, V12, V13, V13c, V34 |
+| Closed by Wave 2 (KYC routing collapse) | 6 | V1, V2, V3, V5, V21, V22 (session-gate positions move under the API) |
+| Closed by Wave 3 (capability flags) | 7 | V6a, V6b, V6c, V6d, V9, V15, V16 |
+| Closed by Wave 4 (new endpoints) | 4 | V14, V17, V18, V19 |
+| Closed by Wave 5 (remaining P1/P2) | 8 | V20, V23, V24, V26, V27, V29, V31, V32 |
+| P3 (DTO mirroring, informational) | 4 | V35–V38, not counted as actionable |
+| P4 (already addressed) | 2 | V39, V40 |
 
-**Effort estimate:** 4 sequenced waves over ~6 sprints (12 weeks at 1 dev), or 3-4 weeks if 2 devs work in parallel (one API, one App).
+**Effort estimate:** 5 sequenced waves over ~7 sprints (14 weeks at 1 dev), or 4-5 weeks if 2 devs work in parallel (one API, one App).
 
 **Risk envelope:** all API changes are additive (new optional fields, new optional status values, new endpoints). No breaking changes — the audit is closed by *enriching* the API, not by *changing* it. Old clients continue to work.
 
@@ -59,7 +66,7 @@ PR reviews must check this list. Any new `if`/`switch`/`.filter()` over status /
 
 ## Wave 1 — Quick wins (app-only, ships immediately)
 
-These 8 violations are unblocked **today** — the API already returns what's needed. The app just isn't using it. Smallest, lowest-risk wins; ship first to build confidence in the rule.
+**6 items closing 11 audit findings**, all unblocked **today** — the API already returns what's needed. The app just isn't using it. Smallest, lowest-risk wins; ship first to build confidence in the rule.
 
 ### W1.1 — Buy/Sell min-amount validation comes from quote
 
@@ -79,20 +86,20 @@ These 8 violations are unblocked **today** — the API already returns what's ne
 | | |
 |---|---|
 | Closes | V11 |
-| API change | none — `BankAccountDto.default: boolean` already exists (verified: `api/src/.../bank-account.dto.ts:17-22`) |
-| App change | `sell_bank_account_field.dart:41-44` → `state.accounts.firstWhereOrNull((a) => a.default)` instead of `.lastWhereOrNull((a) => a.isActive)`. Adjust `BankAccountDto` parsing in the app to surface `default` |
+| API change | none — `BankAccountDto.default: boolean` already exists (verified: `api/src/.../bank-account.dto.ts:17-22`) AND the app's own `BankAccountDto` already exposes it as `isDefault` (verified: `lib/packages/service/dfx/models/bank_account/dto/bank_account_dto.dart:6, 22`). No parsing work needed. |
+| App change | `sell_bank_account_field.dart:41-44` → `state.accounts.firstWhereOrNull((a) => a.isDefault)` instead of `.lastWhereOrNull((a) => a.isActive)`. One-line change. |
 | Acceptance | App auto-selects the account flagged `default: true` by the API. If multiple defaults (shouldn't happen) → first wins. If no default → no auto-selection. |
 | Test plan | Unit test on the field selection logic with three account shapes (one default, no default, multiple defaults) |
 | Risk | Low |
-| Effort | XS (~1h) |
+| Effort | XS (~30 min) |
 
 ### W1.3 — Currency list from `/v1/fiat`
 
 | | |
 |---|---|
-| Closes | V12 (basic), partially V10 |
+| Closes | V12 (enum source) + V10a, V10b, V10c (all three `Currency.values` renderers) |
 | API change | none for basic list — `GET /v1/fiat` returns `FiatDetailDto[]` with `buyable/sellable` flags (verified: `api/src/shared/models/fiat/fiat.controller.ts:10-34`) |
-| App change | Delete `lib/styles/currency.dart` enum. Replace `Currency.values` calls in `payment_converter.dart:83` and `sell_converter.dart:201` with a `FiatRepository` that caches the API response. Filter by `buyable: true` for buy converter, `sellable: true` for sell converter |
+| App change | Delete `lib/styles/currency.dart` enum. Replace `Currency.values` calls in `payment_converter.dart:83`, `sell_converter.dart:201`, and `settings_currencies_page.dart:26` with a `FiatRepository` that caches the API response. Filter by `buyable: true` for buy converter, `sellable: true` for sell converter; full list for settings picker. |
 | Acceptance | New fiats added in the backend appear in the converter without an app release |
 | Test plan | Widget tests with mocked `/v1/fiat` response containing CHF, EUR, USD — verify all appear in dropdown |
 | Risk | Low — fallback to local enum if `/v1/fiat` fails (degrade gracefully on first launch with no network) |
@@ -102,9 +109,9 @@ These 8 violations are unblocked **today** — the API already returns what's ne
 
 | | |
 |---|---|
-| Closes | V13 (list portion) |
+| Closes | V13 (enum source) + V13c (settings_languages_page renderer) |
 | API change | none — `GET /v1/language` returns `LanguageDto[]` (verified: `api/src/shared/models/language/language.controller.ts:8-17`) |
-| App change | Replace `lib/styles/language.dart` enum with API-driven list. Settings language picker reads from API |
+| App change | Replace `lib/styles/language.dart` enum with API-driven list. `settings_languages_page.dart:24` reads from API instead of `Language.values`. |
 | Acceptance | New language enabled server-side appears in app within one API refresh cycle |
 | Test plan | Same pattern as W1.3 |
 | Risk | Low |
@@ -121,17 +128,18 @@ These 8 violations are unblocked **today** — the API already returns what's ne
 | Risk | Low |
 | Effort | XS |
 
-### W1.6 — `softwareTermsAccepted` gate explicit
+### W1.6 — `softwareTermsAccepted` gate moves off the boot path
 
 | | |
 |---|---|
-| Closes | tail item from Wallet/Services scan |
-| API change | none — local UI state, but the gate should not block the user from reaching any *API-allowed* state |
-| App change | Move terms screen out of pre-app-boot routing; show as a one-time overlay on Dashboard if not accepted. App-startup is never gated by terms |
+| Closes | V34 |
+| API change | none — local UI state, but the gate must not block the user from reaching any *API-allowed* state |
+| App change | `lib/main.dart:120` → drop the `if (!homeState.softwareTermsAccepted)` boot-time gate. Show terms as a one-time overlay on Dashboard if not accepted. App-startup is never gated by terms. |
+| Acceptance | First-run user with terms unaccepted lands on Dashboard with the overlay; API-driven KYC routing fires before any local UI gate |
 | Risk | Low |
 | Effort | S |
 
-**Wave 1 total effort:** ~1.5–2 dev-days. Closes 5 P0 / P1 items with zero backend dependency.
+**Wave 1 total effort:** ~1.5–2 dev-days. Closes 11 audit findings across 6 items with zero backend dependency.
 
 ---
 
@@ -143,7 +151,7 @@ This is the single highest-impact wave. **One API PR + one App PR** rewrites the
 
 | | |
 |---|---|
-| Closes | V1, V2, V3 (foundation for Wave 2 app work) |
+| Closes | V1, V2, V3, V5 (foundation for Wave 2 app work — `currentStep` already exists; V5 needs no field, just the cubit rewrite that V1/V2/V3 enable) |
 | Repo | DFXswiss/api, branch `feat/kyc-decision-fields` |
 | Changes | 1. `KycStepDto` (`src/subdomains/generic/kyc/dto/output/kyc-info.dto.ts:60-63`): add `@ApiProperty() isRequired: boolean`  2. `UserKycDto` (`src/subdomains/generic/user/models/user/dto/user-v2.dto.ts:116-134`): add `@ApiProperty() canTrade: boolean` (computed: `kycLevel >= LEVEL_30 && all required steps Completed && no Outdated/InProgress on Ident/FinancialData`)  3. `KycLevelDto`: add `@ApiProperty({enum: KycProcessStatus}) processStatus: KycProcessStatus` where `KycProcessStatus = 'InProgress' \| 'PendingReview' \| 'Completed' \| 'Failed'`  4. `KycStepMapper.toStep` + `KycInfoMapper.toDto` populate the new fields |
 | Acceptance | `GET /v2/kyc` response: every step has `isRequired`; top-level has `processStatus`. `GET /v2/user` response: `kyc.canTrade` is correctly computed for the level-50-with-outdated-ident edge case |
@@ -155,7 +163,7 @@ This is the single highest-impact wave. **One API PR + one App PR** rewrites the
 
 | | |
 |---|---|
-| Closes | V1, V2, V3, original 2026-05-21 ident-misroute report |
+| Closes | V1, V2, V3, V5, V21, V22, original 2026-05-21 ident-misroute report |
 | Repo | DFXswiss/realunit-app, branch `refactor/kyc-cubit-api-driven` |
 | Changes | Rewrite `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:_runCheckKyc`. Specifically: 1. Delete `_requiredStepNames` (line 16-22) and `_minLevelForActions` (line 24)  2. Delete `actionableStatuses`, `pendingStatuses`, the iteration at lines 134-168  3. Read `processStatus` and `canTrade` from API response  4. Route purely from `currentStep`: present → render the matching page. Absent → check `processStatus` ∈ {Completed, PendingReview} → emit `KycCompleted` / `KycPending`  5. `_legalDisclaimerAccepted` / `_registrationSignProduced` stay as session security gates BUT no longer drive routing — they only let the app respond when API tells it to show the registration page  6. Drop the `requiredLevel` constructor parameter — it's dead once `canTrade` exists |
 | Acceptance | Replay the 2026-05-21 reproduction: user 338759 with InProgress Ident step opens app → API returns `currentStep: ident`. App renders KycIdentPage. **No local computation needed.** Hand-test: clear the InProgress Ident in DB → API returns no currentStep + `canTrade: true` → app lands on Dashboard |
@@ -163,7 +171,7 @@ This is the single highest-impact wave. **One API PR + one App PR** rewrites the
 | Risk | Med — central routing logic. Mitigate with extensive cubit tests covering every state the API can return |
 | Effort | M (~1–1.5 days including test rewrite) |
 
-**Wave 2 total:** ~2.5 dev-days. **Closes the original incident** + structurally removes 6 audit findings.
+**Wave 2 total:** ~2.5 dev-days. **Closes the original incident** + structurally removes 6 audit findings (V1, V2, V3, V5, V21, V22).
 
 ---
 
@@ -175,9 +183,9 @@ Closes the rest of the P0/P1 KYC-adjacent items.
 
 | | |
 |---|---|
-| Closes | V6, V9, V15, V16 |
+| Closes | V6a, V6b, V6c, V6d, V9, V15, V16 |
 | Repo | DFXswiss/api, branch `feat/user-capabilities` |
-| Changes | 1. `UserV2Dto`: add `capabilities: UserCapabilitiesDto { canEditName: bool, canEditMail: bool, canEditPhone: bool, supportAvailable: bool }`. Computed from KYC step states and other server-side conditions  2. `RealUnitRegistrationStatus` (`src/.../realunit-registration.dto.ts:26-30`): add `ALREADY_REGISTERED`. Change `realunit.service.ts:608, 670` from `throw BadRequestException` to `return RealUnitRegistrationStatus.ALREADY_REGISTERED` (different-signature path still throws — PR #3731 handles that nuance)  3. `SellPaymentInfoDto`: add `@ApiPropertyOptional() requiredWorkflow?: 'standard' \| 'sellBitbox' \| 'gasless'`. Compute server-side based on user wallet type + asset chain |
+| Changes | 1. `UserV2Dto`: add `capabilities: UserCapabilitiesDto { canEditName: bool, canEditMail: bool, canEditPhone: bool, canEditAddress: bool, supportAvailable: bool }`. Computed from KYC step states and other server-side conditions. (Closes V6a, V6b, V6c, V9.) Additionally expose a `category` on `KycStepDto` (e.g. `'changeRequest' | 'registration' | 'verification'`) so the app can filter change-flow steps without a hardcoded `_changeStepNames` set. (Closes V6d.)  2. `RealUnitRegistrationStatus` (`src/.../realunit-registration.dto.ts:26-30`): add `ALREADY_REGISTERED`. Change `realunit.service.ts:608, 670` from `throw BadRequestException` to `return RealUnitRegistrationStatus.ALREADY_REGISTERED` (different-signature path still throws — [`DFXswiss/api#3731`](https://github.com/DFXswiss/api/pull/3731) handles that nuance). (Closes V15.)  3. `SellPaymentInfoDto`: add `@ApiPropertyOptional() requiredWorkflow?: 'standard' \| 'sellBitbox' \| 'gasless'`. Compute server-side based on user wallet type + asset chain. (Closes V16.) |
 | Acceptance | `GET /v2/user` includes `capabilities`. `POST /realunit/register/wallet` for already-registered same-wallet returns 201 + `ALREADY_REGISTERED` (not 400). `PUT /sell/paymentInfos` includes `requiredWorkflow` |
 | Test plan | New unit tests for the mapper (`user.mapper.spec.ts`): InReview KYC user → `canEditName: false`. No-mail user → `supportAvailable: false`. Realunit service test for `ALREADY_REGISTERED` path. Sell-payment-info service: BitBox-credentials → `requiredWorkflow: 'sellBitbox'` |
 | Risk | Med — `capabilities` is a new contract; missing a flag means apps stay on local logic. Be exhaustive |
@@ -187,9 +195,9 @@ Closes the rest of the P0/P1 KYC-adjacent items.
 
 | | |
 |---|---|
-| Closes | V6, V9, V15, V16 |
+| Closes | V6a, V6b, V6c, V6d, V9, V15, V16 |
 | Repo | DFXswiss/realunit-app, branch `refactor/use-user-capabilities` |
-| Changes | 1. `settings_user_data_page.dart:239` + `settings_edit_name_cubit.dart:22`: drop status interpretation → `user.capabilities.canEditName`  2. `settings_contact_page.dart:54-67`: drop email check → `user.capabilities.supportAvailable`  3. `kyc_registration_submit_cubit.dart:76, 92`: drop the "treat error as success" hack — handle `ALREADY_REGISTERED` as an explicit success status returned by the API  4. `sell_button.dart:60-62`: drop `isBitbox` local check → `state.paymentInfo.requiredWorkflow == 'sellBitbox' ? AppRoutes.sellBitbox : AppRoutes.sell` |
+| Changes | 1. `settings_user_data_page.dart:239` + `settings_edit_name_cubit.dart:22` + `settings_edit_address_cubit.dart:22`: drop status interpretation → `user.capabilities.canEditName` / `canEditAddress` (V6a/V6b/V6c)  2. `settings_user_data_cubit.dart:18-22`: delete `_changeStepNames` set → use the new step `category` flag or API capabilities to filter change-flow steps (V6d)  3. `settings_contact_page.dart:54-67`: drop email check → `user.capabilities.supportAvailable` (V9)  4. `kyc_registration_submit_cubit.dart:76, 92`: drop the "treat error as success" hack — handle `ALREADY_REGISTERED` as an explicit success status returned by the API (V15)  5. `sell_button.dart:60-62`: drop `isBitbox` local check → `state.paymentInfo.requiredWorkflow == 'sellBitbox' ? AppRoutes.sellBitbox : AppRoutes.sell` (V16) |
 | Acceptance | All four spots stop interpreting status / wallet type / exception body |
 | Risk | Low (App-side, mechanical) |
 | Effort | M (~1 day) |
@@ -243,6 +251,58 @@ The remaining P2 items that require entirely new API surface. Lower urgency — 
 
 ---
 
+## Wave 5 — Remaining P1/P2 (JWT merge, polling, transaction state, account bounds, asset config)
+
+The tail items the first four waves don't cover. Lower urgency than Waves 1–3 but explicitly tracked so the audit can be driven to zero actionable items.
+
+### W5.1 (API PR) — Idempotent merge-detection + transaction status label + account bounds + auto-register
+
+| | |
+|---|---|
+| Closes | V20, V23, V24, V26, V27, V31, V32 |
+| Repo | DFXswiss/api, branch `feat/api-authority-tail` |
+| Changes | 1. `POST /v1/realunit/register/wallet` (or new `POST /v1/kyc/check-merge`): return `{ merged: bool, mergedAccountId?: string, propagated: bool }` directly. Server polls internally until propagated, so the client does not need its own generation/retry orchestration. (Closes V23, V26, V27.)  2. `Transaction` mapper: add `statusKey: string` and `statusLabel: string` so the app renders text instead of switching on `state == waitingForPayment`. (Closes V24.)  3. New `GET /v1/user/account-bounds` returning `{ firstTransactionDate, lastTransactionDate }` — both `transaction_history_page.dart:68-69` and `settings_tax_report_page.dart:73` use it for `firstDate`. (Closes V31, V32.)  4. Auto-registration of email at `level < 10` becomes server-side: `PUT /v2/kyc` performs it before returning `currentStep`. App stops doing `if (level < 10) register()`. (Closes V20.) |
+| Acceptance | (1) Client calls `check-merge` exactly once → no client-side 30s timeout needed. (2) `pending_transaction_row.dart` switches on `statusKey`, not on the typed enum. (3) Pickers' `firstDate` comes from API. (4) New-user flow shows `currentStep: 'email'` without the app pre-calling register. |
+| Risk | Med — V20 in particular changes when the email registration POST fires; needs careful regression testing. |
+| Effort | M (~2 days) |
+
+### W5.2 (API PR) — Asset configuration endpoint
+
+| | |
+|---|---|
+| Closes | V29 |
+| Repo | DFXswiss/api, branch `feat/realunit-asset-config` |
+| Changes | `GET /v1/asset?app=realunit` returns the canonical RealUnit token configuration (address, chainId, decimals, mainnet + Sepolia). App reads this on boot and caches per network mode. Replaces hardcoded `ApiConfig` constants. |
+| Acceptance | App calls `/v1/asset?app=realunit` after `NetworkMode` is resolved (the boot-time API host is still local), and uses the returned config for chainId/address/decimals. |
+| Risk | Low (read-only endpoint, additive) |
+| Effort | S (~half day) |
+
+### W5.3 (App PR) — Consume W5.1 + W5.2
+
+| | |
+|---|---|
+| Closes | V20, V23, V24, V26, V27, V29, V31, V32 |
+| Repo | DFXswiss/realunit-app, branch `refactor/api-authority-tail` |
+| Changes | Apply the per-item changes from W5.1 + W5.2 in the app: delete `_runGeneration` (kyc_cubit.dart:42-69), `_mergeDetected` orchestration (kyc_email_verification_cubit.dart:24-37), JWT-decode merge detection (kyc_email_verification_cubit.dart:49-63), the `level < 10 → register` branch (kyc_cubit.dart:88-104), the pending-row state switch (pending_transaction_row.dart:49-51), the picker `firstDate` constants (transaction_history_page.dart:68-69, settings_tax_report_page.dart:73), and the hardcoded `ApiConfig` token block (api_config.dart:19-22). |
+| Risk | Med — JWT decode and polling are critical paths; cover with cubit tests before merge. |
+| Effort | M (~1.5 days) |
+
+### Out of scope — explicitly accepted boundary cases
+
+These items appear in the audit but are **not** closed by any wave. Future PRs should not try to "fix" them.
+
+| Item | V-ID | Why out of scope |
+|---|---|---|
+| `lib/packages/utils/default_assets.dart:3-22` (ETH/ZCHF asset IDs) | V30 | The app **is** the RealUnit wallet; the default asset list is part of the product identity, not a backend decision. Revisit only if a multi-asset use case emerges. |
+| `lib/packages/config/network_mode.dart` (`mainnet` / `testnet`) | V28 | Determines *which* API host the app talks to — cannot itself be API-driven (chicken-and-egg). |
+| BIP-39 12-word check (`settings_seed_view.dart:98`) | V33 | Structural crypto invariant. |
+| `WalletType == software` for backup visibility (`settings_page.dart:100`) | V13b | Device-capability fact; BitBox cannot expose its seed. |
+| `401 → token refresh` (`dfx_auth_service.dart:233-239`) | V25 | HTTP-standard convention; the 401 contract is contractual. |
+
+**Wave 5 total:** ~4 dev-days.
+
+---
+
 ## Documented exceptions — the rule explicitly does not apply
 
 These are listed in the audit ([`api-authority-audit.md`](api-authority-audit.md) P3/P4) and documented here as accepted exceptions. Future maintainers should not "fix" these into the audit again.
@@ -262,21 +322,19 @@ These are listed in the audit ([`api-authority-audit.md`](api-authority-audit.md
 ## Sequencing & dependencies
 
 ```
-Wave 1  ─────────────────────►  shippable today, no deps
-                                      │
-Wave 2 (W2.1 API)  ───────►  (W2.2 App)
-                                      │
-Wave 3 (W3.1 API)  ───────►  (W3.2 App)
-                                      │
-Wave 4 (W4.1–W4.3 API)  ──►  (W4.4 App)
+Wave 1  (app-only, no API dep)                ── ship first, validates mechanics
+Wave 2  W2.1 API  ──►  W2.2 App               ─┐
+Wave 3  W3.1 API  ──►  W3.2 App               ─┤  Waves 2/3/4/5 independent
+Wave 4  W4.1–W4.3 API  ──►  W4.4 App          ─┤  of each other —
+Wave 5  W5.1 + W5.2 API  ──►  W5.3 App        ─┘  ship in parallel if 2 devs
 ```
 
-- Waves 2/3/4 are independent of each other; can ship in parallel if 2 devs available.
-- Within a wave, API PR strictly blocks the App PR.
 - Wave 1 has no API dependency; ship it first to validate the pair-PR mechanics on something low-risk.
+- Within each later wave, the API PR strictly blocks the App PR (`──►` arrow).
+- Waves 2, 3, 4, 5 are **independent of each other** — they touch disjoint API surface and disjoint app surface, so any two devs can pick two waves and run them concurrently after Wave 1 lands.
 
-**Aggressive timeline (2 devs, parallel):** ~2 weeks calendar.
-**Conservative timeline (1 dev, sequential):** ~6 sprints / 12 weeks calendar.
+**Aggressive timeline (2 devs, parallel):** ~2.5 weeks calendar.
+**Conservative timeline (1 dev, sequential):** ~7 sprints / 14 weeks calendar.
 
 ---
 
@@ -308,7 +366,7 @@ Once this plan is executed:
 2. **Day 1:** open W1.1 + W1.2 + W1.5 as small App-only PRs. They're the lowest-risk validation that the pair-PR mechanics work.
 3. **Day 2:** open W2.1 (API) as the first paired wave. Loop in compliance on the `canTrade` semantics before merge.
 4. **Day 3-4:** open W2.2 (App) once W2.1 is on `develop`.
-5. **Day 5+:** schedule Wave 3 and Wave 4 in the regular sprint planning.
+5. **Day 5+:** schedule Wave 3, Wave 4, and Wave 5 in the regular sprint planning. Waves 2–5 are independent and can run concurrently if staffed.
 
 ---
 

--- a/docs/api-authority-plan.md
+++ b/docs/api-authority-plan.md
@@ -16,14 +16,14 @@ All counts below are the **canonical numbers** for this PR; the audit file lists
 
 | | Count | Notes |
 |---|---|---|
-| Distinct violations in audit (P0–P2 bulleted) | 41 | 15 P0 + 10 P1 + 16 P2 |
+| Distinct violations in audit (P0–P2 bulleted) | 50 | 16 P0 + 12 P1 + 22 P2 (post-initial-review pass added V41–V49) |
 | Of those, **documented exceptions** (rule does not apply) | 5 | V13b (BitBox backup), V25 (401 refresh), V28 (network mode), V30 (default assets), V33 (BIP-39) |
-| **Actionable** P0–P2 (recounted from audit) | 36 | what the waves below close |
+| **Actionable** P0–P2 (recounted from audit) | 45 | what the waves below close |
 | Closed by Wave 1 (app-only, ships today) | 11 across 6 items | V4, V7, V8, V10a, V10b, V10c, V11, V12, V13, V13c, V34 |
-| Closed by Wave 2 (KYC routing collapse) | 6 | V1, V2, V3, V5, V21, V22 (session-gate positions move under the API) |
-| Closed by Wave 3 (capability flags) | 7 | V6a, V6b, V6c, V6d, V9, V15, V16 |
-| Closed by Wave 4 (new endpoints) | 4 | V14, V17, V18, V19 |
-| Closed by Wave 5 (remaining P1/P2) | 8 | V20, V23, V24, V26, V27, V29, V31, V32 |
+| Closed by Wave 2 (KYC routing collapse) | 7 | V1, V2, V3, V5, V21, V22, V45 (session-gate positions move under the API; V45 is the parallel `_continueKyc` loop) |
+| Closed by Wave 3 (capability flags) | 9 | V6a, V6b, V6c, V6d, V9, V15, V16, V43, V46 |
+| Closed by Wave 4 (new endpoints) | 8 | V14, V17, V18, V19, V41, V42, V44, V49 |
+| Closed by Wave 5 (remaining P1/P2) | 10 | V20, V23, V24, V26, V27, V29, V31, V32, V47, V48 |
 | P3 (DTO mirroring, informational) | 4 | V35–V38, not counted as actionable |
 | P4 (already addressed) | 2 | V39, V40 |
 
@@ -163,15 +163,15 @@ This is the single highest-impact wave. **One API PR + one App PR** rewrites the
 
 | | |
 |---|---|
-| Closes | V1, V2, V3, V5, V21, V22, original 2026-05-21 ident-misroute report |
+| Closes | V1, V2, V3, V5, V21, V22, V45, original 2026-05-21 ident-misroute report |
 | Repo | DFXswiss/realunit-app, branch `refactor/kyc-cubit-api-driven` |
-| Changes | Rewrite `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:_runCheckKyc`. Specifically: 1. Delete `_requiredStepNames` (line 16-22) and `_minLevelForActions` (line 24)  2. Delete `actionableStatuses`, `pendingStatuses`, the iteration at lines 134-168  3. Read `processStatus` and `canTrade` from API response  4. Route purely from `currentStep`: present → render the matching page. Absent → check `processStatus` ∈ {Completed, PendingReview} → emit `KycCompleted` / `KycPending`  5. `_legalDisclaimerAccepted` / `_registrationSignProduced` stay as session security gates BUT no longer drive routing — they only let the app respond when API tells it to show the registration page  6. Drop the `requiredLevel` constructor parameter — it's dead once `canTrade` exists |
+| Changes | Rewrite `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:_runCheckKyc`. Specifically: 1. Delete `_requiredStepNames` (line 16-22) and `_minLevelForActions` (line 24)  2. Delete `actionableStatuses`, `pendingStatuses`, the iteration at lines 134-168  3. Read `processStatus` and `canTrade` from API response  4. Route purely from `currentStep`: present → render the matching page. Absent → check `processStatus` ∈ {Completed, PendingReview} → emit `KycCompleted` / `KycPending`  5. `_legalDisclaimerAccepted` / `_registrationSignProduced` stay as session security gates BUT no longer drive routing — they only let the app respond when API tells it to show the registration page  6. Drop the `requiredLevel` constructor parameter — it's dead once `canTrade` exists  7. Delete the same `kycSteps.firstWhere(step.isCurrent)` loop in `_continueKyc` (line 208) — that's V45, the parallel path called after registration completes; same `currentStep`-driven rewrite applies |
 | Acceptance | Replay the 2026-05-21 reproduction: user 338759 with InProgress Ident step opens app → API returns `currentStep: ident`. App renders KycIdentPage. **No local computation needed.** Hand-test: clear the InProgress Ident in DB → API returns no currentStep + `canTrade: true` → app lands on Dashboard |
 | Test plan | Cubit tests: 1) Mock API: `canTrade: true, currentStep: null, processStatus: Completed` → emit `KycCompleted`. 2) Mock API: `currentStep: {name: 'Ident', status: 'InProgress'}` → emit `KycSuccess(KycStep.ident)`. 3) Mock API: `processStatus: PendingReview, currentStep: null` → emit `KycPending`. Verify cubit code length drops by ~80% |
 | Risk | Med — central routing logic. Mitigate with extensive cubit tests covering every state the API can return |
 | Effort | M (~1–1.5 days including test rewrite) |
 
-**Wave 2 total:** ~2.5 dev-days. **Closes the original incident** + structurally removes 6 audit findings (V1, V2, V3, V5, V21, V22).
+**Wave 2 total:** ~2.5 dev-days. **Closes the original incident** + structurally removes 7 audit findings (V1, V2, V3, V5, V21, V22, V45).
 
 ---
 
@@ -183,9 +183,9 @@ Closes the rest of the P0/P1 KYC-adjacent items.
 
 | | |
 |---|---|
-| Closes | V6a, V6b, V6c, V6d, V9, V15, V16 |
+| Closes | V6a, V6b, V6c, V6d, V9, V15, V16, V43, V46 |
 | Repo | DFXswiss/api, branch `feat/user-capabilities` |
-| Changes | 1. `UserV2Dto`: add `capabilities: UserCapabilitiesDto { canEditName: bool, canEditMail: bool, canEditPhone: bool, canEditAddress: bool, supportAvailable: bool }`. Computed from KYC step states and other server-side conditions. (Closes V6a, V6b, V6c, V9.) Additionally expose a `category` on `KycStepDto` (e.g. `'changeRequest' | 'registration' | 'verification'`) so the app can filter change-flow steps without a hardcoded `_changeStepNames` set. (Closes V6d.)  2. `RealUnitRegistrationStatus` (`src/.../realunit-registration.dto.ts:26-30`): add `ALREADY_REGISTERED`. Change `realunit.service.ts:608, 670` from `throw BadRequestException` to `return RealUnitRegistrationStatus.ALREADY_REGISTERED` (different-signature path still throws — [`DFXswiss/api#3731`](https://github.com/DFXswiss/api/pull/3731) handles that nuance). (Closes V15.)  3. `SellPaymentInfoDto`: add `@ApiPropertyOptional() requiredWorkflow?: 'standard' \| 'sellBitbox' \| 'gasless'`. Compute server-side based on user wallet type + asset chain. (Closes V16.) |
+| Changes | 1. `UserV2Dto`: add `capabilities: UserCapabilitiesDto { canEditName: bool, canEditMail: bool, canEditPhone: bool, canEditAddress: bool, supportAvailable: bool, availableUserTypes: string[] }`. Computed from KYC step states and other server-side conditions. `availableUserTypes` lets the registration screen render only the account types this branded app exposes instead of hardcoding `RegistrationUserType.values.first`. (Closes V6a, V6b, V6c, V9, V46.) Additionally expose a `category` on `KycStepDto` (e.g. `'changeRequest' | 'registration' | 'verification'`) so the app can filter change-flow steps without a hardcoded `_changeStepNames` set. (Closes V6d.)  2. `RealUnitRegistrationStatus` (`src/.../realunit-registration.dto.ts:26-30`): add `ALREADY_REGISTERED`. Change `realunit.service.ts:608, 670` from `throw BadRequestException` to `return RealUnitRegistrationStatus.ALREADY_REGISTERED` (different-signature path still throws — [`DFXswiss/api#3731`](https://github.com/DFXswiss/api/pull/3731) handles that nuance). (Closes V15.)  3. `SellPaymentInfoDto`: add `@ApiPropertyOptional() requiredWorkflow?: 'standard' \| 'sellBitbox' \| 'gasless'`. Compute server-side based on user wallet type + asset chain. (Closes V16.)  4. `KycFinancialQuestion` DTO: add `link?: { url?: string, action?: 'support' \| 'webview' }` so the financial-data questions page can render the right action target from the DTO instead of switching on `question.key`. (Closes V43.) |
 | Acceptance | `GET /v2/user` includes `capabilities`. `POST /realunit/register/wallet` for already-registered same-wallet returns 201 + `ALREADY_REGISTERED` (not 400). `PUT /sell/paymentInfos` includes `requiredWorkflow` |
 | Test plan | New unit tests for the mapper (`user.mapper.spec.ts`): InReview KYC user → `canEditName: false`. No-mail user → `supportAvailable: false`. Realunit service test for `ALREADY_REGISTERED` path. Sell-payment-info service: BitBox-credentials → `requiredWorkflow: 'sellBitbox'` |
 | Risk | Med — `capabilities` is a new contract; missing a flag means apps stay on local logic. Be exhaustive |
@@ -195,9 +195,9 @@ Closes the rest of the P0/P1 KYC-adjacent items.
 
 | | |
 |---|---|
-| Closes | V6a, V6b, V6c, V6d, V9, V15, V16 |
+| Closes | V6a, V6b, V6c, V6d, V9, V15, V16, V43, V46 |
 | Repo | DFXswiss/realunit-app, branch `refactor/use-user-capabilities` |
-| Changes | 1. `settings_user_data_page.dart:239` + `settings_edit_name_cubit.dart:22` + `settings_edit_address_cubit.dart:22`: drop status interpretation → `user.capabilities.canEditName` / `canEditAddress` (V6a/V6b/V6c)  2. `settings_user_data_cubit.dart:18-22`: delete `_changeStepNames` set → use the new step `category` flag or API capabilities to filter change-flow steps (V6d)  3. `settings_contact_page.dart:54-67`: drop email check → `user.capabilities.supportAvailable` (V9)  4. `kyc_registration_submit_cubit.dart:76, 92`: drop the "treat error as success" hack — handle `ALREADY_REGISTERED` as an explicit success status returned by the API (V15)  5. `sell_button.dart:60-62`: drop `isBitbox` local check → `state.paymentInfo.requiredWorkflow == 'sellBitbox' ? AppRoutes.sellBitbox : AppRoutes.sell` (V16) |
+| Changes | 1. `settings_user_data_page.dart:239` + `settings_edit_name_cubit.dart:22` + `settings_edit_address_cubit.dart:22`: drop status interpretation → `user.capabilities.canEditName` / `canEditAddress` (V6a/V6b/V6c)  2. `settings_user_data_cubit.dart:18-22`: delete `_changeStepNames` set → use the new step `category` flag or API capabilities to filter change-flow steps (V6d)  3. `settings_contact_page.dart:54-67` + `settings_contact_cubit.dart:22`: drop email check (both the cubit's `emailSet` computation and the page's read of it) → `user.capabilities.supportAvailable` (V9)  4. `kyc_registration_submit_cubit.dart:76, 92`: drop the "treat error as success" hack — handle `ALREADY_REGISTERED` as an explicit success status returned by the API (V15)  5. `sell_button.dart:60-62`: drop `isBitbox` local check → `state.paymentInfo.requiredWorkflow == 'sellBitbox' ? AppRoutes.sellBitbox : AppRoutes.sell` (V16)  6. `kyc_financial_data_questions_page.dart:110-122`: render the question's `link` metadata instead of switching on `question.key` (V43)  7. `kyc_registration_personal_step.dart:50-53`: read `user.capabilities.availableUserTypes` instead of `RegistrationUserType.values.first` (V46) |
 | Acceptance | All four spots stop interpreting status / wallet type / exception body |
 | Risk | Low (App-side, mechanical) |
 | Effort | M (~1 day) |
@@ -214,9 +214,9 @@ The remaining P2 items that require entirely new API surface. Lower urgency — 
 
 | | |
 |---|---|
-| Closes | V17 |
+| Closes | V17, V44 |
 | Repo | DFXswiss/api, branch `feat/legal-document-endpoint` |
-| Changes | New module `src/shared/models/legal-document/`: entity (`type, language, version, url, enabled`), repository, service, controller (`GET /v1/legal-document`, optional `?type=` and `?language=` filters), DTO. Migration creates `legal_document` table with seed data from the current `lib/packages/config/legal_documents_config.dart` hardcoded URLs. Admin endpoint to update URLs (compliance role) |
+| Changes | New module `src/shared/models/legal-document/`: entity (`type, language, version, url, enabled`), repository, service, controller (`GET /v1/legal-document`, optional `?type=` and `?language=` filters), DTO. Migration creates `legal_document` table with seed data from the current `lib/packages/config/legal_documents_config.dart` hardcoded URLs **plus** the `dfx.swiss/terms-and-conditions` URL hardcoded in `lib/screens/kyc/steps/financial_data/constants/kyc_financial_data_links.dart` (V44). Admin endpoint to update URLs (compliance role) |
 | Acceptance | `GET /v1/legal-document?type=registrationAgreement&language=de` returns the agreement PDF URL + current version |
 | Risk | Low — net-new module, no existing behavior touched |
 | Effort | M (~2 days, mostly seed-data + admin endpoints) |
@@ -230,24 +230,34 @@ The remaining P2 items that require entirely new API surface. Lower urgency — 
 | Changes | New module + endpoint returning company contact info for the realunit-app brand. Public (no auth). Future-proofs white-labeling |
 | Effort | S (~half day) |
 
-### W4.3 (API PR) — Country priority + recommended language
+### W4.3 (API PR) — Country priority + recommended language + recommended currency
 
 | | |
 |---|---|
-| Closes | V14, V19 |
+| Closes | V14, V19, V41, V42 |
 | Repo | DFXswiss/api, branch `feat/country-priority-recommended-language` |
-| Changes | 1. `GET /v1/country` accepts `?priorityForRegion=CH` query → returns countries sorted with Swiss-preferred ones first. Or simpler: add `displayOrder: int` to the country entity for backend-configurable priority  2. `UserV2Dto` (or new endpoint `GET /v1/language/recommended?ip=…&acceptLanguage=…`): return a recommended language code |
+| Changes | 1. `GET /v1/country` accepts `?priorityForRegion=CH` query → returns countries sorted with Swiss-preferred ones first. Or simpler: add `displayOrder: int` to the country entity for backend-configurable priority  2. `UserV2Dto` (or new endpoint `GET /v1/language/recommended?ip=…&acceptLanguage=…`): return a recommended language code (V19) **and** a recommended currency (V42 — same shape, paired so the app picks both defaults in one round-trip)  3. The realunit-registration endpoint derives the account language from the `Accept-Language` header (or the user's settings-language sent in the body), so the app no longer needs to send `lang: 'DE'` (V41) |
 | Effort | S |
 
-### W4.4 (App PR) — Consume W4.1–W4.3
+### W4.5 (API PR) — `GET /v1/support/issue-types`
 
 | | |
 |---|---|
-| Closes | V14, V17, V18, V19 |
-| Changes | 1. Delete `lib/packages/config/legal_documents_config.dart` hardcoded URLs → call `/v1/legal-document`. Cache locally for offline  2. Delete hardcoded contact info in `settings_contact_page.dart:82-134` → render from `/v1/company-info`. Cache  3. Delete `priorityCountries` in `country_field.dart:65-79` → use API order  4. Replace `settings_repository.dart:18-24` system-locale default with API recommendation, fallback to system locale only on first-launch-no-network |
-| Effort | M (~1 day) |
+| Closes | V49 |
+| Repo | DFXswiss/api, branch `feat/support-issue-types-endpoint` |
+| Changes | New `GET /v1/support/issue-types` endpoint returning `{ key, icon, label }[]` (or i18n-key-only with the app holding the translations). Per-brand: realunit returns a curated subset, other apps can expose different subsets. Replaces the hardcoded `SupportIssueType` tile list + the English-only `_getTicketName` labels in the app |
+| Acceptance | `GET /v1/support/issue-types` returns a list keyed to the existing `SupportIssueType` values; new categories appear without an app release |
+| Effort | S |
 
-**Wave 4 total:** ~3.5 dev-days.
+### W4.4 (App PR) — Consume W4.1–W4.3, W4.5
+
+| | |
+|---|---|
+| Closes | V14, V17, V18, V19, V41, V42, V44, V49 |
+| Changes | 1. Delete `lib/packages/config/legal_documents_config.dart` hardcoded URLs **and** `lib/screens/kyc/steps/financial_data/constants/kyc_financial_data_links.dart` (V44) → call `/v1/legal-document`. Cache locally for offline  2. Delete hardcoded contact info in `settings_contact_page.dart:82-134` → render from `/v1/company-info`. Cache  3. Delete `priorityCountries` in `country_field.dart:65-79` → use API order  4. Replace `settings_repository.dart:18-24` (language fallback) **and** `settings_repository.dart:28` (currency fallback, V42) with API recommendations; system-locale fallback only on first-launch-no-network  5. Drop the hardcoded `lang: 'DE'` in `real_unit_registration_service.dart:117` (V41) → send the user's actual settings-language (or rely on the `Accept-Language` header)  6. Replace the hardcoded `SupportIssueType` tile list in `support_create_ticket_page.dart:85-110` and the English-only `_getTicketName` switch in `support_create_ticket_cubit.dart:48-57` with the API-returned list (V49) |
+| Effort | M (~1.5 days) |
+
+**Wave 4 total:** ~4 dev-days.
 
 ---
 
@@ -259,12 +269,12 @@ The tail items the first four waves don't cover. Lower urgency than Waves 1–3 
 
 | | |
 |---|---|
-| Closes | V20, V23, V24, V26, V27, V31, V32 |
+| Closes | V20, V23, V24, V26, V27, V31, V32, V47, V48 |
 | Repo | DFXswiss/api, branch `feat/api-authority-tail` |
-| Changes | 1. `POST /v1/realunit/register/wallet` (or new `POST /v1/kyc/check-merge`): return `{ merged: bool, mergedAccountId?: string, propagated: bool }` directly. Server polls internally until propagated, so the client does not need its own generation/retry orchestration. (Closes V23, V26, V27.)  2. `Transaction` mapper: add `statusKey: string` and `statusLabel: string` so the app renders text instead of switching on `state == waitingForPayment`. (Closes V24.)  3. New `GET /v1/user/account-bounds` returning `{ firstTransactionDate, lastTransactionDate }` — both `transaction_history_page.dart:68-69` and `settings_tax_report_page.dart:73` use it for `firstDate`. (Closes V31, V32.)  4. Auto-registration of email at `level < 10` becomes server-side: `PUT /v2/kyc` performs it before returning `currentStep`. App stops doing `if (level < 10) register()`. (Closes V20.) |
-| Acceptance | (1) Client calls `check-merge` exactly once → no client-side 30s timeout needed. (2) `pending_transaction_row.dart` switches on `statusKey`, not on the typed enum. (3) Pickers' `firstDate` comes from API. (4) New-user flow shows `currentStep: 'email'` without the app pre-calling register. |
+| Changes | 1. `POST /v1/realunit/register/wallet` (or new `POST /v1/kyc/check-merge`): return `{ merged: bool, mergedAccountId?: string, propagated: bool }` directly. Server polls internally until propagated, so the client does not need its own generation/retry orchestration. (Closes V23, V26, V27.)  2. `Transaction` mapper: add `statusKey: string` and `statusLabel: string` so the app renders text instead of switching on `state == waitingForPayment`. (Closes V24.)  3. New `GET /v1/user/account-bounds` returning `{ firstTransactionDate, lastTransactionDate }` — both `transaction_history_page.dart:68-69, :82` and `settings_tax_report_page.dart:73` use it for `firstDate`. (Closes V31, V32.)  4. Auto-registration of email at `level < 10` becomes server-side: `PUT /v2/kyc` performs it before returning `currentStep`. App stops doing `if (level < 10) register()`. (Closes V20.)  5. `/v1/realunit/balance/pdf` accepts a `date` (not a timestamp); the server picks the evaluation moment (today → "now"; past date → end-of-day). The app stops computing `_getDateWithLatestTime`. (Closes V47.)  6. `SellPaymentInfoDto` exposes `needsFaucet: bool` and optionally `faucetPollingHint: int` (seconds), computed server-side from `ethBalance` vs `requiredGasEth`. The bitbox-sell cubit renders the boolean + uses the hint as the polling interval instead of comparing the two numbers locally. (Closes V48.) |
+| Acceptance | (1) Client calls `check-merge` exactly once → no client-side 30s timeout needed. (2) `pending_transaction_row.dart` switches on `statusKey`, not on the typed enum. (3) Pickers' `firstDate` comes from API. (4) New-user flow shows `currentStep: 'email'` without the app pre-calling register. (5) Tax-report download sends a date, server picks the timestamp. (6) Bitbox-sell shows the faucet-pending UI when `needsFaucet: true` without comparing balances. |
 | Risk | Med — V20 in particular changes when the email registration POST fires; needs careful regression testing. |
-| Effort | M (~2 days) |
+| Effort | M (~2.5 days) |
 
 ### W5.2 (API PR) — Asset configuration endpoint
 
@@ -281,11 +291,11 @@ The tail items the first four waves don't cover. Lower urgency than Waves 1–3 
 
 | | |
 |---|---|
-| Closes | V20, V23, V24, V26, V27, V29, V31, V32 |
+| Closes | V20, V23, V24, V26, V27, V29, V31, V32, V47, V48 |
 | Repo | DFXswiss/realunit-app, branch `refactor/api-authority-tail` |
-| Changes | Apply the per-item changes from W5.1 + W5.2 in the app: delete `_runGeneration` (kyc_cubit.dart:42-69), `_mergeDetected` orchestration (kyc_email_verification_cubit.dart:24-37), JWT-decode merge detection (kyc_email_verification_cubit.dart:49-63), the `level < 10 → register` branch (kyc_cubit.dart:88-104), the pending-row state switch (pending_transaction_row.dart:49-51), the picker `firstDate` constants (transaction_history_page.dart:68-69, settings_tax_report_page.dart:73), and the hardcoded `ApiConfig` token block (api_config.dart:19-22). |
+| Changes | Apply the per-item changes from W5.1 + W5.2 in the app: delete `_runGeneration` (kyc_cubit.dart:42-69), `_mergeDetected` orchestration (kyc_email_verification_cubit.dart:24-37), JWT-decode merge detection (kyc_email_verification_cubit.dart:49-63), the `level < 10 → register` branch (kyc_cubit.dart:88-104), the pending-row state switch (pending_transaction_row.dart:49-51), the picker `firstDate` constants (transaction_history_page.dart:68-69, :82 and settings_tax_report_page.dart:73), the hardcoded `ApiConfig` token block (api_config.dart:19-22), the `_getDateWithLatestTime` transform in `settings_tax_report_cubit.dart:53-64` (V47), and the local ETH-balance-vs-required-gas comparisons in `sell_bitbox_cubit.dart:51, :81` (V48 — replace with `_paymentInfo.needsFaucet`). |
 | Risk | Med — JWT decode and polling are critical paths; cover with cubit tests before merge. |
-| Effort | M (~1.5 days) |
+| Effort | M (~2 days) |
 
 ### Out of scope — explicitly accepted boundary cases
 
@@ -299,7 +309,7 @@ These items appear in the audit but are **not** closed by any wave. Future PRs s
 | `WalletType == software` for backup visibility (`settings_page.dart:100`) | V13b | Device-capability fact; BitBox cannot expose its seed. |
 | `401 → token refresh` (`dfx_auth_service.dart:233-239`) | V25 | HTTP-standard convention; the 401 contract is contractual. |
 
-**Wave 5 total:** ~4 dev-days.
+**Wave 5 total:** ~4.5 dev-days.
 
 ---
 

--- a/docs/api-authority-plan.md
+++ b/docs/api-authority-plan.md
@@ -1,0 +1,315 @@
+# API Authority — Implementation Plan
+
+Sequenced, pair-PR plan to enforce the *"API as Decision Authority"* rule
+defined in [`CONTRIBUTING.md`](../CONTRIBUTING.md). Companion to the violation
+inventory in [`api-authority-audit.md`](api-authority-audit.md).
+
+**Source of truth:** the DFX API (`DFXswiss/api`, branch `develop`).
+**Consumer:** this app (`DFXswiss/realunit-app`, branch `develop`).
+**Author:** generated from a 4-stream subagent scan + 3-stream API-side gap analysis (2026-05-21). All file:line citations were verified against the cloned repos.
+
+---
+
+## Executive summary
+
+| | Count | Notes |
+|---|---|---|
+| Distinct violations in audit | 19 (V1–V19) + small tail | P0/P1/P2 mix |
+| Already solvable **without API change** | 8 | App reads existing fields |
+| Require **additive API change** | 9 | Backwards-compatible, no breaking change |
+| Require **new endpoint** | 3 | Legal docs, company info, country priority |
+| **Documented exceptions** (rule does not apply) | 5 | Network mode, BIP-39, etc. |
+
+**Effort estimate:** 4 sequenced waves over ~6 sprints (12 weeks at 1 dev), or 3-4 weeks if 2 devs work in parallel (one API, one App).
+
+**Risk envelope:** all API changes are additive (new optional fields, new optional status values, new endpoints). No breaking changes — the audit is closed by *enriching* the API, not by *changing* it. Old clients continue to work.
+
+---
+
+## Operating principles
+
+These principles govern every PR generated from this plan. Violating them undoes the audit.
+
+### 1. Pair-PR convention
+
+For each violation that requires an API change:
+
+- **API PR** lands first on `develop` (DFXswiss/api): adds the field/endpoint, fully tested, additive only.
+- **App PR** opens within 1 week of API PR merge: consumes the new field and **deletes the corresponding local logic in the same PR**.
+- The app PR title references the API PR (`Closes DFXswiss/api#NNNN`).
+
+An API field that ships without a consuming app PR within 4 weeks is a regression — track in [`api-authority-audit.md`](api-authority-audit.md) and address in the next sprint.
+
+### 2. Additive-only API changes
+
+- New fields: `@ApiPropertyOptional`, `nullable: true` in TypeScript, default to safe value in mapper.
+- New enum values: append to existing enums, never reorder or remove.
+- New endpoints: live alongside old ones; deprecate old endpoints only in a separate later PR.
+- DB migrations: see `api/CONTRIBUTING.md:16` (preferred TypeORM-generated, fallback hand-written; immutable once on develop).
+
+### 3. Delete local logic in the same PR
+
+When the app PR consumes a new API field, it **must** delete the local business logic it replaces. Half-migrations (both local and API logic running) are explicitly forbidden — they become permanent.
+
+### 4. Stop adding new violations
+
+PR reviews must check this list. Any new `if`/`switch`/`.filter()` over status / level / capability data needs justification. The lint pass on `CONTRIBUTING.md`'s test rule ("Wer entscheidet?") applies to all new code.
+
+---
+
+## Wave 1 — Quick wins (app-only, ships immediately)
+
+These 8 violations are unblocked **today** — the API already returns what's needed. The app just isn't using it. Smallest, lowest-risk wins; ship first to build confidence in the rule.
+
+### W1.1 — Buy/Sell min-amount validation comes from quote
+
+| | |
+|---|---|
+| Closes | V7, V8 |
+| API change | none — `BuyQuoteDto.minVolume`, `SellQuoteDto.minVolume` already exist (verified: `api/src/subdomains/core/buy-crypto/.../buy-quote.dto.ts:29-39`, `api/src/.../sell-quote.dto.ts:29-39`) |
+| App change | Remove `_minAmountChf` constants and `validateMinAmount()`; submit any amount; render error from API |
+| Files touched | `lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart` (delete lines 16, 50-60) `lib/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart` (delete lines 17, 82-112) `lib/screens/sell/widgets/sell_button.dart` (drop `SellPaymentInfoMinAmountNotMet` state if dependent) |
+| Acceptance | App sends amount=1 CHF → API returns 400 with `errors: [{ error: 'AMOUNT_TOO_LOW', limit: minVolume }]` → snackbar renders that error verbatim |
+| Test plan | Widget test: submit amount=1, mock API 400 with `limit: 100`, assert snackbar shows "100" |
+| Risk | Low — error is already structured, only the source of the limit changes |
+| Effort | XS (~2h) |
+
+### W1.2 — Bank-account default selection
+
+| | |
+|---|---|
+| Closes | V11 |
+| API change | none — `BankAccountDto.default: boolean` already exists (verified: `api/src/.../bank-account.dto.ts:17-22`) |
+| App change | `sell_bank_account_field.dart:41-44` → `state.accounts.firstWhereOrNull((a) => a.default)` instead of `.lastWhereOrNull((a) => a.isActive)`. Adjust `BankAccountDto` parsing in the app to surface `default` |
+| Acceptance | App auto-selects the account flagged `default: true` by the API. If multiple defaults (shouldn't happen) → first wins. If no default → no auto-selection. |
+| Test plan | Unit test on the field selection logic with three account shapes (one default, no default, multiple defaults) |
+| Risk | Low |
+| Effort | XS (~1h) |
+
+### W1.3 — Currency list from `/v1/fiat`
+
+| | |
+|---|---|
+| Closes | V12 (basic), partially V10 |
+| API change | none for basic list — `GET /v1/fiat` returns `FiatDetailDto[]` with `buyable/sellable` flags (verified: `api/src/shared/models/fiat/fiat.controller.ts:10-34`) |
+| App change | Delete `lib/styles/currency.dart` enum. Replace `Currency.values` calls in `payment_converter.dart:83` and `sell_converter.dart:201` with a `FiatRepository` that caches the API response. Filter by `buyable: true` for buy converter, `sellable: true` for sell converter |
+| Acceptance | New fiats added in the backend appear in the converter without an app release |
+| Test plan | Widget tests with mocked `/v1/fiat` response containing CHF, EUR, USD — verify all appear in dropdown |
+| Risk | Low — fallback to local enum if `/v1/fiat` fails (degrade gracefully on first launch with no network) |
+| Effort | S (~half day) |
+
+### W1.4 — Language list from `/v1/language`
+
+| | |
+|---|---|
+| Closes | V13 (list portion) |
+| API change | none — `GET /v1/language` returns `LanguageDto[]` (verified: `api/src/shared/models/language/language.controller.ts:8-17`) |
+| App change | Replace `lib/styles/language.dart` enum with API-driven list. Settings language picker reads from API |
+| Acceptance | New language enabled server-side appears in app within one API refresh cycle |
+| Test plan | Same pattern as W1.3 |
+| Risk | Low |
+| Effort | S |
+
+### W1.5 — Render `TFA_REQUIRED` from response body, not status code
+
+| | |
+|---|---|
+| Closes | V4 (clean it up — works today, but app reads status code) |
+| API change | none — `TfaRequiredException` already returns `{code: 'TFA_REQUIRED', level, message}` in body (verified: `api/src/.../tfa-required.exception.ts`) |
+| App change | `kyc_cubit.dart:179-182` → match on `e.code == 'TFA_REQUIRED'` only; remove the `statusCode == 403` part. Long-term the API should also expose this via a body field on the regular `GET /v2/kyc` so the exception path is unnecessary, but that's Wave 3 |
+| Acceptance | App routes to 2FA step on body code, regardless of HTTP status |
+| Risk | Low |
+| Effort | XS |
+
+### W1.6 — `softwareTermsAccepted` gate explicit
+
+| | |
+|---|---|
+| Closes | tail item from Wallet/Services scan |
+| API change | none — local UI state, but the gate should not block the user from reaching any *API-allowed* state |
+| App change | Move terms screen out of pre-app-boot routing; show as a one-time overlay on Dashboard if not accepted. App-startup is never gated by terms |
+| Risk | Low |
+| Effort | S |
+
+**Wave 1 total effort:** ~1.5–2 dev-days. Closes 5 P0 / P1 items with zero backend dependency.
+
+---
+
+## Wave 2 — KYC routing collapse (one API PR unlocks the central misroute)
+
+This is the single highest-impact wave. **One API PR + one App PR** rewrites the core of `kyc_cubit.dart` and closes the 2026-05-21 ident-misroute that started this audit.
+
+### W2.1 (API PR) — KYC step + level capabilities
+
+| | |
+|---|---|
+| Closes | V1, V2, V3 (foundation for Wave 2 app work) |
+| Repo | DFXswiss/api, branch `feat/kyc-decision-fields` |
+| Changes | 1. `KycStepDto` (`src/subdomains/generic/kyc/dto/output/kyc-info.dto.ts:60-63`): add `@ApiProperty() isRequired: boolean`  2. `UserKycDto` (`src/subdomains/generic/user/models/user/dto/user-v2.dto.ts:116-134`): add `@ApiProperty() canTrade: boolean` (computed: `kycLevel >= LEVEL_30 && all required steps Completed && no Outdated/InProgress on Ident/FinancialData`)  3. `KycLevelDto`: add `@ApiProperty({enum: KycProcessStatus}) processStatus: KycProcessStatus` where `KycProcessStatus = 'InProgress' \| 'PendingReview' \| 'Completed' \| 'Failed'`  4. `KycStepMapper.toStep` + `KycInfoMapper.toDto` populate the new fields |
+| Acceptance | `GET /v2/kyc` response: every step has `isRequired`; top-level has `processStatus`. `GET /v2/user` response: `kyc.canTrade` is correctly computed for the level-50-with-outdated-ident edge case |
+| Test plan | New tests in `kyc-info.mapper.spec.ts`: user_data 338759 fixture (level 53, ident outdated, ident-seq-1 in-progress) → `canTrade: false`, `processStatus: InProgress`. Level-50-clean fixture → `canTrade: true`, `processStatus: Completed` |
+| Risk | Low (additive). Care: `canTrade` semantics must match the existing implicit rule in the *app today* exactly, otherwise the migration changes behavior for users in the wild |
+| Effort | M (~1 day) |
+
+### W2.2 (App PR) — Render `currentStep` from API, delete the cubit's business logic
+
+| | |
+|---|---|
+| Closes | V1, V2, V3, original 2026-05-21 ident-misroute report |
+| Repo | DFXswiss/realunit-app, branch `refactor/kyc-cubit-api-driven` |
+| Changes | Rewrite `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:_runCheckKyc`. Specifically: 1. Delete `_requiredStepNames` (line 16-22) and `_minLevelForActions` (line 24)  2. Delete `actionableStatuses`, `pendingStatuses`, the iteration at lines 134-168  3. Read `processStatus` and `canTrade` from API response  4. Route purely from `currentStep`: present → render the matching page. Absent → check `processStatus` ∈ {Completed, PendingReview} → emit `KycCompleted` / `KycPending`  5. `_legalDisclaimerAccepted` / `_registrationSignProduced` stay as session security gates BUT no longer drive routing — they only let the app respond when API tells it to show the registration page  6. Drop the `requiredLevel` constructor parameter — it's dead once `canTrade` exists |
+| Acceptance | Replay the 2026-05-21 reproduction: user 338759 with InProgress Ident step opens app → API returns `currentStep: ident`. App renders KycIdentPage. **No local computation needed.** Hand-test: clear the InProgress Ident in DB → API returns no currentStep + `canTrade: true` → app lands on Dashboard |
+| Test plan | Cubit tests: 1) Mock API: `canTrade: true, currentStep: null, processStatus: Completed` → emit `KycCompleted`. 2) Mock API: `currentStep: {name: 'Ident', status: 'InProgress'}` → emit `KycSuccess(KycStep.ident)`. 3) Mock API: `processStatus: PendingReview, currentStep: null` → emit `KycPending`. Verify cubit code length drops by ~80% |
+| Risk | Med — central routing logic. Mitigate with extensive cubit tests covering every state the API can return |
+| Effort | M (~1–1.5 days including test rewrite) |
+
+**Wave 2 total:** ~2.5 dev-days. **Closes the original incident** + structurally removes 6 audit findings.
+
+---
+
+## Wave 3 — Capability flags + structured registration response
+
+Closes the rest of the P0/P1 KYC-adjacent items.
+
+### W3.1 (API PR) — User capabilities + structured registration error
+
+| | |
+|---|---|
+| Closes | V6, V9, V15, V16 |
+| Repo | DFXswiss/api, branch `feat/user-capabilities` |
+| Changes | 1. `UserV2Dto`: add `capabilities: UserCapabilitiesDto { canEditName: bool, canEditMail: bool, canEditPhone: bool, supportAvailable: bool }`. Computed from KYC step states and other server-side conditions  2. `RealUnitRegistrationStatus` (`src/.../realunit-registration.dto.ts:26-30`): add `ALREADY_REGISTERED`. Change `realunit.service.ts:608, 670` from `throw BadRequestException` to `return RealUnitRegistrationStatus.ALREADY_REGISTERED` (different-signature path still throws — PR #3731 handles that nuance)  3. `SellPaymentInfoDto`: add `@ApiPropertyOptional() requiredWorkflow?: 'standard' \| 'sellBitbox' \| 'gasless'`. Compute server-side based on user wallet type + asset chain |
+| Acceptance | `GET /v2/user` includes `capabilities`. `POST /realunit/register/wallet` for already-registered same-wallet returns 201 + `ALREADY_REGISTERED` (not 400). `PUT /sell/paymentInfos` includes `requiredWorkflow` |
+| Test plan | New unit tests for the mapper (`user.mapper.spec.ts`): InReview KYC user → `canEditName: false`. No-mail user → `supportAvailable: false`. Realunit service test for `ALREADY_REGISTERED` path. Sell-payment-info service: BitBox-credentials → `requiredWorkflow: 'sellBitbox'` |
+| Risk | Med — `capabilities` is a new contract; missing a flag means apps stay on local logic. Be exhaustive |
+| Effort | M (~1.5 days) |
+
+### W3.2 (App PR) — Consume capabilities + ALREADY_REGISTERED + requiredWorkflow
+
+| | |
+|---|---|
+| Closes | V6, V9, V15, V16 |
+| Repo | DFXswiss/realunit-app, branch `refactor/use-user-capabilities` |
+| Changes | 1. `settings_user_data_page.dart:239` + `settings_edit_name_cubit.dart:22`: drop status interpretation → `user.capabilities.canEditName`  2. `settings_contact_page.dart:54-67`: drop email check → `user.capabilities.supportAvailable`  3. `kyc_registration_submit_cubit.dart:76, 92`: drop the "treat error as success" hack — handle `ALREADY_REGISTERED` as an explicit success status returned by the API  4. `sell_button.dart:60-62`: drop `isBitbox` local check → `state.paymentInfo.requiredWorkflow == 'sellBitbox' ? AppRoutes.sellBitbox : AppRoutes.sell` |
+| Acceptance | All four spots stop interpreting status / wallet type / exception body |
+| Risk | Low (App-side, mechanical) |
+| Effort | M (~1 day) |
+
+**Wave 3 total:** ~2.5 dev-days.
+
+---
+
+## Wave 4 — New endpoints (legal docs, company info, country priority)
+
+The remaining P2 items that require entirely new API surface. Lower urgency — no user is blocked today by these.
+
+### W4.1 (API PR) — `GET /v1/legal-document`
+
+| | |
+|---|---|
+| Closes | V17 |
+| Repo | DFXswiss/api, branch `feat/legal-document-endpoint` |
+| Changes | New module `src/shared/models/legal-document/`: entity (`type, language, version, url, enabled`), repository, service, controller (`GET /v1/legal-document`, optional `?type=` and `?language=` filters), DTO. Migration creates `legal_document` table with seed data from the current `lib/packages/config/legal_documents_config.dart` hardcoded URLs. Admin endpoint to update URLs (compliance role) |
+| Acceptance | `GET /v1/legal-document?type=registrationAgreement&language=de` returns the agreement PDF URL + current version |
+| Risk | Low — net-new module, no existing behavior touched |
+| Effort | M (~2 days, mostly seed-data + admin endpoints) |
+
+### W4.2 (API PR) — `GET /v1/company-info`
+
+| | |
+|---|---|
+| Closes | V18 |
+| Repo | DFXswiss/api, same branch as W4.1 or separate |
+| Changes | New module + endpoint returning company contact info for the realunit-app brand. Public (no auth). Future-proofs white-labeling |
+| Effort | S (~half day) |
+
+### W4.3 (API PR) — Country priority + recommended language
+
+| | |
+|---|---|
+| Closes | V14, V19 |
+| Repo | DFXswiss/api, branch `feat/country-priority-recommended-language` |
+| Changes | 1. `GET /v1/country` accepts `?priorityForRegion=CH` query → returns countries sorted with Swiss-preferred ones first. Or simpler: add `displayOrder: int` to the country entity for backend-configurable priority  2. `UserV2Dto` (or new endpoint `GET /v1/language/recommended?ip=…&acceptLanguage=…`): return a recommended language code |
+| Effort | S |
+
+### W4.4 (App PR) — Consume W4.1–W4.3
+
+| | |
+|---|---|
+| Closes | V14, V17, V18, V19 |
+| Changes | 1. Delete `lib/packages/config/legal_documents_config.dart` hardcoded URLs → call `/v1/legal-document`. Cache locally for offline  2. Delete hardcoded contact info in `settings_contact_page.dart:82-134` → render from `/v1/company-info`. Cache  3. Delete `priorityCountries` in `country_field.dart:65-79` → use API order  4. Replace `settings_repository.dart:18-24` system-locale default with API recommendation, fallback to system locale only on first-launch-no-network |
+| Effort | M (~1 day) |
+
+**Wave 4 total:** ~3.5 dev-days.
+
+---
+
+## Documented exceptions — the rule explicitly does not apply
+
+These are listed in the audit ([`api-authority-audit.md`](api-authority-audit.md) P3/P4) and documented here as accepted exceptions. Future maintainers should not "fix" these into the audit again.
+
+| Exception | Reason |
+|---|---|
+| `NetworkMode { mainnet, testnet }` (`api_config.dart`) | Chicken-and-egg: the network mode determines *which* API the app calls. Cannot itself come from the API |
+| BIP-39 seed = 12 words (`settings_seed_view.dart:98`) | Structural crypto invariant, not a business rule |
+| `WalletType == software` check for backup visibility | Physical reality: a BitBox cannot expose its seed; this is a device-capability fact, not a backend policy |
+| `401 → token refresh` (`dfx_auth_service.dart:233-239`) | HTTP-standard convention; the 401 contract is well-defined and external |
+| PIN validation, wallet lock, BitBox connection state | Local security boundary; API has no view of device-side security state |
+| EIP-712 signing, hashing, key derivation | Must run locally on the user's device |
+| DTO mirroring (`KycLevel`, `KycStepName`, etc. enums) | Type safety; values must stay in sync but mirroring is acceptable boilerplate |
+
+---
+
+## Sequencing & dependencies
+
+```
+Wave 1  ─────────────────────►  shippable today, no deps
+                                      │
+Wave 2 (W2.1 API)  ───────►  (W2.2 App)
+                                      │
+Wave 3 (W3.1 API)  ───────►  (W3.2 App)
+                                      │
+Wave 4 (W4.1–W4.3 API)  ──►  (W4.4 App)
+```
+
+- Waves 2/3/4 are independent of each other; can ship in parallel if 2 devs available.
+- Within a wave, API PR strictly blocks the App PR.
+- Wave 1 has no API dependency; ship it first to validate the pair-PR mechanics on something low-risk.
+
+**Aggressive timeline (2 devs, parallel):** ~2 weeks calendar.
+**Conservative timeline (1 dev, sequential):** ~6 sprints / 12 weeks calendar.
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| API field added but never consumed (audit regresses) | Med | High | Pair-PR convention enforced in PR review checklist |
+| `canTrade` semantics drift from current implicit rule | Med | High | Fixture-based mapper tests covering edge cases (level 53 + outdated ident) BEFORE Wave 2.2 ships |
+| Old app version + new API: missing field crashes | Low | Med | All API additions are optional / nullable; app handles `null` gracefully |
+| Compliance objection to `canTrade` based on level only | Low | High | `canTrade` is computed server-side from the *same* signals the app uses today (level + step state) — semantic identity, not relaxation. Loop in compliance before W2.1 merge |
+| Legal-document migration data error | Med | Low | Seed script runs in a dry-run + diff-review mode first; admin endpoint allows hotfix |
+
+---
+
+## Forward contract
+
+Once this plan is executed:
+
+- New PRs that introduce a violation pattern (local `_requiredX`, status enum interpretation, hardcoded business limit) are **blocked** by review until the API field exists.
+- The CONTRIBUTING.md rule is enforceable: every Reviewer can point at this plan and ask *"which wave does your change belong to?"* If the answer is "none — I added a new local decision", the PR doesn't merge.
+- Audit ([`api-authority-audit.md`](api-authority-audit.md)) becomes a regression test: ideally only shrinks PR by PR.
+
+---
+
+## What to do next (concrete first action)
+
+1. **Now:** review this plan + the audit doc. Decide if any item is mis-prioritized.
+2. **Day 1:** open W1.1 + W1.2 + W1.5 as small App-only PRs. They're the lowest-risk validation that the pair-PR mechanics work.
+3. **Day 2:** open W2.1 (API) as the first paired wave. Loop in compliance on the `canTrade` semantics before merge.
+4. **Day 3-4:** open W2.2 (App) once W2.1 is on `develop`.
+5. **Day 5+:** schedule Wave 3 and Wave 4 in the regular sprint planning.
+
+---
+
+*Generated 2026-05-21. Companion to [`api-authority-audit.md`](api-authority-audit.md) and the rule definition in [`CONTRIBUTING.md`](../CONTRIBUTING.md#api-as-decision-authority--critical).*


### PR DESCRIPTION
## Summary

The 2026-05-21 ident-misroute investigation surfaced a structural pattern: `KycCubit` and several other cubits make business decisions locally (which KYC steps are required, which statuses are actionable, hardcoded min amounts, feature gates) instead of rendering what the DFX API returns. The user lands on KycIdentPage with a Start button despite having KYC level 50 — because the app independently re-interprets backend step status instead of routing from the API's `currentStep`.

This PR is the foundation: it codifies the rule that prevents this class of bug going forward, and lays out the inventory and the work needed to close existing violations.

> **Update (post-initial-review pass).** An independent grep pass after the initial four-stream scan found **9 additional violations** the audit had missed (V41–V49: hardcoded `lang: 'DE'` on registration, default currency `'CHF'` fallback, client-side mapping of `KycFinancialQuestion.key` to action, a second hardcoded legal URL outside `legal_documents_config.dart`, a parallel `_continueKyc` loop with the same anti-pattern as V5, hardcoded `RegistrationUserType.values.first`, client-side tax-report timestamp transformation, local ETH-balance-vs-required-gas faucet decision, hardcoded `SupportIssueType` subset with English-only labels) plus **3 citation corrections** (V17 line range extended to cover the Aktionariat + DFX-Docs blocks, V31 extended to cover the end-date picker, V9 extended to also cite the contact cubit where `emailSet` is computed). Counts in the executive summary and the wave totals were recounted accordingly; see the commit on this branch.

## Changes

### Rule definition — `CONTRIBUTING.md`

New section **"API as Decision Authority — CRITICAL"** directly after the existing "API Access" block. Network access was already gated to `api.dfx.swiss`; this extends the same logic to business decisions:

- The app does not decide if a flow is allowed — the API does.
- The app does not interpret status strings into business meaning.
- The app does not duplicate backend sets/enums as gating logic.
- Prompts to the user fire only when the API requests them.

Includes the **"The test (Wer entscheidet?)"** section for code review: every `if`/`switch`/`.filter()` on API data must pass it.

Explicitly lists what is OK (UI input validation, display formatting, local security gates like PIN/wallet-lock/BitBox, cryptographic operations) and what is not (e.g. `_requiredStepNames`, `_minLevelForActions`, hardcoded min amounts, feature visibility from derived state).

### Inventory — `docs/api-authority-audit.md`

Full inventory of current violations across KYC, Buy/Sell, Wallet/Services, Settings. **50 distinct violations across P0–P2** (16 P0 + 12 P1 + 22 P2), plus 4 P3 (DTO mirroring) and 2 P4 (in-flight). Every finding carries a stable `V<N>` anchor that the plan cross-references. Of the 50 P0–P2 findings, 5 are documented boundary cases — **45 are actionable**.

Generated from a 4-stream parallel subagent scan over the app codebase, then deduplicated and re-audited after critical review, then extended on the same day with 9 violations the initial pass missed (V41–V49).

**Most-affected file:** `lib/screens/kyc/cubits/kyc/kyc_cubit.dart` — ~10 distinct violations. The entire `_runCheckKyc` body should be replaceable by *"render `currentStep` from the API, that's it"* once the matching API fields land.

**Documented exceptions** (rule explicitly does not apply): Network mode (V28), BIP-39 12-word length (V33), 401-token-refresh (V25), BitBox seed unavailability (V13b), default asset list (V30), EIP-712 signing, DTO mirroring.

### Implementation plan — `docs/api-authority-plan.md`

Sequenced **5-wave plan**, generated from a 3-stream API-side gap analysis (file:line cited against DFXswiss/api). Each wave entry cites the `V<N>` audit findings it closes.

- **Wave 1** — Quick wins (app-only, no API change). **6 items closing 11 audit findings** (V4, V7, V8, V10a–c, V11, V12, V13, V13c, V34), ~1.5–2 dev-days. Ships immediately to validate the pair-PR mechanics.
- **Wave 2** — KYC routing collapse. Single paired API PR + App PR. Adds `KycStepDto.isRequired`, `UserKycDto.canTrade`, `KycLevelDto.processStatus`. App deletes `_requiredStepNames`, `actionableStatuses`, `_minLevelForActions`, ~80% of `_runCheckKyc` — and the parallel `_continueKyc` loop (V45). Closes V1, V2, V3, V5, V21, V22, V45 + the original ident-misroute report.
- **Wave 3** — Capability flags + structured registration response. `UserV2Dto.capabilities` (incl. canEditAddress, availableUserTypes), `KycStepDto.category`, `ALREADY_REGISTERED` status, `SellPaymentInfoDto.requiredWorkflow`, structured `KycFinancialQuestion.link`. Closes V6a–d, V9, V15, V16, V43, V46.
- **Wave 4** — New endpoints: `/v1/legal-document` (now also closes V44), `/v1/company-info`, country priority + recommended language + recommended currency + server-derived registration language, `/v1/support/issue-types`. Closes V14, V17, V18, V19, V41, V42, V44, V49.
- **Wave 5** — Remaining P1/P2: idempotent `/check-merge`, transaction `statusLabel`, `/v1/user/account-bounds`, `/v1/asset?app=realunit`, server-side auto-register, server-picked tax-report timestamp, `needsFaucet` flag on `SellPaymentInfoDto`. Closes V20, V23, V24, V26, V27, V29, V31, V32, V47, V48.

Waves 2–5 are independent of each other after Wave 1 lands and can run concurrently if staffed.

**Per-item:** API change spec, app refactor diff, acceptance criteria, test plan, risk, effort estimate (XS/S/M/L).

**Operating principles** documented and enforceable in PR review:
- Pair-PR convention (API PR → App PR within 1 week, app PR deletes local logic in the same commit)
- Additive-only API changes (backwards-compatible)
- No half-migrations (both local and API logic running at once is forbidden)

## Why ship this PR first

Independent of any code change. Future PRs reference these docs (`Closes #NNNN — Wave 2`, `closes V11`, etc.). Ship the doc PR first so review of subsequent code PRs has the standard to measure against.

## Test plan

Documentation only. No code change. `flutter analyze` / `flutter test` unaffected.

## Follow-ups (Wave 1, ready to open)

- `refactor(kyc): parse TFA_REQUIRED from response body code, not status code` (W1.5 — closes V4)
- `refactor(buy/sell): render minVolume from API quote, drop hardcoded _minAmountChf` (W1.1 — closes V7, V8)
- `refactor(payment): use BankAccountDto.isDefault for auto-selection` (W1.2 — closes V11)
- `refactor(settings): drive currency + language picker from /v1/fiat + /v1/language` (W1.3 + W1.4 — closes V10a-c, V12, V13, V13c)
- `refactor(home): move softwareTermsAccepted off boot path to Dashboard overlay` (W1.6 — closes V34)
