### PR TITLE
refactor(kyc): match TFA_REQUIRED on body code, drop status-only fallback

### DIFF
--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -176,9 +176,11 @@ class KycCubit extends Cubit<KycState> {
       emit(const KycCompleted());
     } on ApiException catch (e) {
       if (isClosed || generation != _runGeneration) return;
-      // API returns 403 / code TFA_REQUIRED when 2FA verification is required
-      // before proceeding.
-      if (e.statusCode == 403 || e.code == 'TFA_REQUIRED') {
+      // The body `code` is the authoritative signal — `TfaRequiredException`
+      // on the API sets `{code: 'TFA_REQUIRED', level, message}` and happens
+      // to use HTTP 403 as transport. Matching on status alone would also
+      // capture unrelated forbidden errors and misroute them to 2FA.
+      if (e.code == 'TFA_REQUIRED') {
         emit(const KycSuccess(currentStep: KycStep.twoFa));
       } else {
         rethrow;

--- a/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
+++ b/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
@@ -314,10 +314,26 @@ void main() {
     );
 
     blocTest<KycCubit, KycState>(
-      'routes to twoFa step on ApiException(statusCode: 403)',
+      'does NOT route to twoFa on 403 without TFA_REQUIRED body code',
       setUp: () {
         when(() => kycService.getKycStatus()).thenThrow(
           const ApiException(statusCode: 403, code: 'FORBIDDEN', message: ''),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.checkKyc(),
+      expect: () => [
+        const KycLoading(),
+        isA<KycFailure>(),
+      ],
+    );
+
+    blocTest<KycCubit, KycState>(
+      "routes to twoFa step on ApiException(code: 'TFA_REQUIRED'), regardless of HTTP status",
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenThrow(
+          const ApiException(statusCode: 400, code: 'TFA_REQUIRED', message: ''),
         );
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
@@ -330,10 +346,10 @@ void main() {
     );
 
     blocTest<KycCubit, KycState>(
-      "routes to twoFa step on ApiException(code: 'TFA_REQUIRED')",
+      "routes to twoFa step on ApiException(statusCode: 403, code: 'TFA_REQUIRED')",
       setUp: () {
         when(() => kycService.getKycStatus()).thenThrow(
-          const ApiException(statusCode: 400, code: 'TFA_REQUIRED', message: ''),
+          const ApiException(statusCode: 403, code: 'TFA_REQUIRED', message: ''),
         );
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },


### PR DESCRIPTION
## Summary

The 2FA-required signal is carried by the API response body `{code: 'TFA_REQUIRED', level, message}`, not by the HTTP status. The existing OR-condition (`statusCode == 403 || code == 'TFA_REQUIRED'`) was a defensive over-capture from when only the status was checked: any 403 with a different code (`FORBIDDEN`, future error codes) silently misrouted the user to the 2FA screen.

First app-only quick win from the API-as-Decision-Authority audit ([`docs/api-authority-plan.md`](docs/api-authority-plan.md) Wave 1.5). No API change needed — the body code is already returned by `TfaRequiredException` on the API side.

## Changes

- `lib/screens/kyc/cubits/kyc/kyc_cubit.dart` — keep only `e.code == 'TFA_REQUIRED'`. The HTTP 403 status is incidental; the body code is the authoritative signal. Comment explains the *why* so future readers don't add the status fallback back.
- `test/screens/kyc/cubits/kyc/kyc_cubit_test.dart` — invert the old 403-with-`FORBIDDEN` test to assert the new (correct) behaviour: a generic 403 emits `KycFailure`, not 2FA. Add a second positive test covering the realistic shape (`statusCode: 403` paired with `code: 'TFA_REQUIRED'`) so the status path is still exercised end-to-end.

## Why this is safe

`ApiException.fromJson` (`lib/packages/service/dfx/exceptions/api_exception.dart:14-30`) parses the body's `code` field if present, defaulting to `'UNKNOWN'` only when missing. Since the API's `TfaRequiredException` always populates `code: 'TFA_REQUIRED'` in the body, every legitimate 2FA-required response continues to route correctly. Only the spurious branch (403 without the code) is removed.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — **1418 / 1418 passed**

## Follow-ups

Part of Wave 1 from the API-authority audit. Next items in the queue:
- `refactor(buy/sell): render minVolume from API quote, drop hardcoded \`_minAmountChf\`` (W1.1 + W1.2)
- `refactor(payment): use BankAccountDto.default for auto-selection`
- `refactor(settings): drive currency + language picker from /v1/fiat + /v1/language`

Foundation rule + audit + plan in #491.