### PR TITLE
refactor(buy/sell): render quote validity + minVolume from API, drop hardcoded `_minAmountChf`

### DIFF
--- a/lib/packages/service/dfx/models/payment/buy/buy_payment_info.dart
+++ b/lib/packages/service/dfx/models/payment/buy/buy_payment_info.dart
@@ -14,6 +14,13 @@ class BuyPaymentInfo extends Equatable {
   final Currency currency;
   final String? paymentRequest;
   final String? remittanceInfo;
+  // Fields below come from the API quote response. The backend is the
+  // authority on whether the quote is valid for trading and what the
+  // current min/max limits are for the user+currency combination.
+  final bool isValid;
+  final double? minVolume;
+  final double? maxVolume;
+  final String? error;
 
   const BuyPaymentInfo({
     required this.id,
@@ -26,10 +33,31 @@ class BuyPaymentInfo extends Equatable {
     required this.city,
     required this.country,
     required this.currency,
+    this.isValid = true,
     this.paymentRequest,
     this.remittanceInfo,
+    this.minVolume,
+    this.maxVolume,
+    this.error,
   });
 
   @override
-  List<Object?> get props => [id, iban, bic, name, street, number, zip, city, country, currency, paymentRequest, remittanceInfo];
+  List<Object?> get props => [
+    id,
+    iban,
+    bic,
+    name,
+    street,
+    number,
+    zip,
+    city,
+    country,
+    currency,
+    paymentRequest,
+    remittanceInfo,
+    isValid,
+    minVolume,
+    maxVolume,
+    error,
+  ];
 }

--- a/lib/packages/service/dfx/models/payment/buy/dto/real_unit_buy_payment_info_dto.dart
+++ b/lib/packages/service/dfx/models/payment/buy/dto/real_unit_buy_payment_info_dto.dart
@@ -28,6 +28,7 @@ class RealUnitBuyPaymentInfoDto {
   final String? paymentRequest;
   final String? remittanceInfo;
   final bool isValid;
+  final String? error;
 
   const RealUnitBuyPaymentInfoDto({
     required this.id,
@@ -55,6 +56,7 @@ class RealUnitBuyPaymentInfoDto {
     this.paymentRequest,
     this.remittanceInfo,
     required this.isValid,
+    this.error,
   });
 
   factory RealUnitBuyPaymentInfoDto.fromJson(Map<String, dynamic> json) {
@@ -86,6 +88,7 @@ class RealUnitBuyPaymentInfoDto {
       paymentRequest: json['paymentRequest'] as String?,
       remittanceInfo: json['remittanceInfo'] as String?,
       isValid: json['isValid'] as bool,
+      error: json['error'] as String?,
     );
   }
 }

--- a/lib/packages/service/dfx/models/payment/sell/dto/real_unit_sell_payment_info_dto.dart
+++ b/lib/packages/service/dfx/models/payment/sell/dto/real_unit_sell_payment_info_dto.dart
@@ -26,6 +26,7 @@ class RealUnitSellPaymentInfoDto {
   final double ethBalance;
   final double requiredGasEth;
   final bool isValid;
+  final String? error;
 
   const RealUnitSellPaymentInfoDto({
     required this.id,
@@ -50,6 +51,7 @@ class RealUnitSellPaymentInfoDto {
     required this.ethBalance,
     required this.requiredGasEth,
     required this.isValid,
+    this.error,
   });
 
   factory RealUnitSellPaymentInfoDto.fromJson(Map<String, dynamic> json) {
@@ -78,6 +80,7 @@ class RealUnitSellPaymentInfoDto {
       ethBalance: (json['ethBalance'] as num).toDouble(),
       requiredGasEth: (json['requiredGasEth'] as num).toDouble(),
       isValid: json['isValid'] as bool,
+      error: json['error'] as String?,
     );
   }
 }

--- a/lib/packages/service/dfx/models/payment/sell/sell_payment_info.dart
+++ b/lib/packages/service/dfx/models/payment/sell/sell_payment_info.dart
@@ -16,6 +16,13 @@ class SellPaymentInfo {
   final int chainId;
   final double ethBalance;
   final double requiredGasEth;
+  // Fields below come from the API quote response. The backend is the
+  // authority on whether the quote is valid for trading and what the
+  // current min/max limits are for the user+currency combination.
+  final bool isValid;
+  final double minVolume;
+  final double maxVolume;
+  final String? error;
 
   const SellPaymentInfo({
     required this.id,
@@ -31,5 +38,9 @@ class SellPaymentInfo {
     required this.chainId,
     required this.ethBalance,
     required this.requiredGasEth,
+    this.isValid = true,
+    this.minVolume = 0,
+    this.maxVolume = double.infinity,
+    this.error,
   });
 }

--- a/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
@@ -44,6 +44,10 @@ class RealUnitBuyPaymentInfoService extends DFXAuthService {
         currency: responseDto.currency,
         paymentRequest: responseDto.paymentRequest,
         remittanceInfo: responseDto.remittanceInfo,
+        isValid: responseDto.isValid,
+        minVolume: responseDto.minVolume,
+        maxVolume: responseDto.maxVolume,
+        error: responseDto.error,
       );
     } else if (response.statusCode == 403) {
       final errorJson = jsonDecode(response.body) as Map<String, dynamic>;

--- a/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_sell_payment_info_service.dart
@@ -66,6 +66,10 @@ class RealUnitSellPaymentInfoService extends DFXAuthService {
         chainId: responseDto.chainId,
         ethBalance: responseDto.ethBalance,
         requiredGasEth: responseDto.requiredGasEth,
+        isValid: responseDto.isValid,
+        minVolume: responseDto.minVolume,
+        maxVolume: responseDto.maxVolume,
+        error: responseDto.error,
       );
     } else if (response.statusCode == 403) {
       final errorJson = jsonDecode(response.body) as Map<String, dynamic>;

--- a/lib/screens/buy/buy_page.dart
+++ b/lib/screens/buy/buy_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_brokerbot_service.dart';
-import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
 import 'package:realunit_wallet/screens/buy/cubits/buy_converter/buy_converter_cubit.dart';
 import 'package:realunit_wallet/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart';
@@ -26,7 +25,6 @@ class BuyPage extends StatelessWidget {
         BlocProvider(
           create: (_) => BuyPaymentInfoCubit(
             getIt<RealUnitBuyPaymentInfoService>(),
-            getIt<DFXPriceService>(),
           ),
         ),
       ],

--- a/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
+++ b/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
@@ -3,7 +3,6 @@ import 'dart:developer' as developer;
 import 'package:async/async.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/payment/buy_exceptions.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/buy_payment_info.dart';
@@ -13,18 +12,20 @@ import 'package:realunit_wallet/styles/currency.dart';
 
 part 'buy_payment_info_state.dart';
 
-const double _minAmountChf = 100;
+// Backend QuoteError code for the "amount below the per-currency minimum"
+// case. The API returns this in the success body's `error` field together
+// with the authoritative `minVolume`; the app surfaces it as a typed state
+// for the UI to render. Other QuoteError values (KYC, limit, …) are
+// already routed via dedicated ApiExceptions and dedicated failure states.
+const String _quoteErrorAmountTooLow = 'AmountTooLow';
 
 class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
   final RealUnitBuyPaymentInfoService _buyPaymentInfoService;
-  final DFXPriceService _priceService;
   CancelableOperation<BuyPaymentInfoState>? _completer;
 
   BuyPaymentInfoCubit(
     RealUnitBuyPaymentInfoService buyPaymentInfoService,
-    DFXPriceService priceService,
   ) : _buyPaymentInfoService = buyPaymentInfoService,
-      _priceService = priceService,
       super(const BuyPaymentInfoInitial());
 
   Future<void> getPaymentInfo({String amount = '300', Currency currency = Currency.chf}) async {
@@ -47,22 +48,23 @@ class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
       final sanitizedAmount = amount.isEmpty ? '0' : amount.replaceAll(',', '.');
       final parsedAmount = double.parse(sanitizedAmount);
 
-      double minAmount = _minAmountChf;
-      if (currency == Currency.eur) {
-        final chfToEurRate = await _priceService.getChfToEurRate();
-        minAmount = (_minAmountChf * chfToEurRate).ceilToDouble();
-      }
-
-      if (parsedAmount < minAmount) {
-        return BuyPaymentInfoMinAmountNotMetFailure(
-          PaymentInfoError.minAmountNotMet,
-          minAmount: minAmount,
-        );
-      }
       final paymentInfo = await _buyPaymentInfoService.getPaymentInfo(
         parsedAmount.round(),
         currency: currency,
       );
+
+      // Only the backend knows the current per-currency limits, exchange
+      // rates and any compliance gating — when it tags the quote
+      // `isValid: false` we surface its verdict without re-interpreting it.
+      if (!paymentInfo.isValid) {
+        if (paymentInfo.error == _quoteErrorAmountTooLow && paymentInfo.minVolume != null) {
+          return BuyPaymentInfoMinAmountNotMetFailure(
+            PaymentInfoError.minAmountNotMet,
+            minAmount: paymentInfo.minVolume!,
+          );
+        }
+        return const BuyPaymentInfoFailure(PaymentInfoError.unknown);
+      }
       return BuyPaymentInfoSuccess(paymentInfo);
     } on KycLevelRequiredException catch (e) {
       return BuyPaymentInfoFailure(

--- a/lib/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart
+++ b/lib/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart
@@ -3,7 +3,6 @@ import 'dart:developer' as developer;
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
-import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/payment/buy_exceptions.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/payment_info_error.dart';
@@ -14,19 +13,21 @@ import 'package:realunit_wallet/styles/currency.dart';
 
 part 'sell_payment_info_state.dart';
 
-const double _minAmountChf = 10;
+// Backend QuoteError code for the "amount below the per-currency minimum"
+// case. The API returns this in the success body's `error` field together
+// with the authoritative `minVolume`; the app surfaces it as a typed state
+// for the UI to render. Other QuoteError values (KYC, limit, …) are
+// already routed via dedicated ApiExceptions and dedicated failure states.
+const String _quoteErrorAmountTooLow = 'AmountTooLow';
 
 class SellPaymentInfoCubit extends Cubit<SellPaymentInfoState> {
   final RealUnitSellPaymentInfoService _sellPaymentInfoService;
-  final DFXPriceService _priceService;
   final AppStore _appStore;
 
   SellPaymentInfoCubit(
     RealUnitSellPaymentInfoService sellPaymentInfoService,
-    DFXPriceService priceService,
     AppStore appStore,
   ) : _sellPaymentInfoService = sellPaymentInfoService,
-      _priceService = priceService,
       _appStore = appStore,
       super(const SellPaymentInfoInitial());
 
@@ -43,6 +44,28 @@ class SellPaymentInfoCubit extends Cubit<SellPaymentInfoState> {
         iban,
         currency: currency,
       );
+
+      // Only the backend knows the current per-currency limits, exchange
+      // rates and any compliance gating — when it tags the quote
+      // `isValid: false` we surface its verdict without re-interpreting it.
+      if (!paymentInfo.isValid) {
+        if (paymentInfo.error == _quoteErrorAmountTooLow) {
+          emit(
+            SellPaymentInfoMinAmountNotMet(
+              minAmount: paymentInfo.minVolume,
+              currency: paymentInfo.currency,
+            ),
+          );
+          return;
+        }
+        emit(
+          SellPaymentInfoFailure(
+            PaymentInfoError.unknown,
+            message: paymentInfo.error ?? '',
+          ),
+        );
+        return;
+      }
 
       final isBitbox = _appStore.wallet.walletType == WalletType.bitbox;
       emit(SellPaymentInfoSuccess(paymentInfo, isBitbox: isBitbox));
@@ -75,38 +98,6 @@ class SellPaymentInfoCubit extends Cubit<SellPaymentInfoState> {
           PaymentInfoError.unknown,
           message: e.toString(),
         ),
-      );
-    }
-  }
-
-  Future<void> validateMinAmount({
-    required String fiatAmount,
-    Currency currency = Currency.chf,
-  }) async {
-    try {
-      final sanitizedAmount = fiatAmount.isEmpty ? '0' : fiatAmount.replaceAll(',', '.');
-      final parsedAmount = double.tryParse(sanitizedAmount) ?? 0;
-
-      double minAmount = _minAmountChf;
-      if (currency == Currency.eur) {
-        final chfToEurRate = await _priceService.getChfToEurRate();
-        minAmount = (_minAmountChf * chfToEurRate).ceilToDouble();
-      }
-
-      if (parsedAmount < minAmount) {
-        emit(
-          SellPaymentInfoMinAmountNotMet(
-            minAmount: minAmount,
-            currency: currency,
-          ),
-        );
-      } else if (state is SellPaymentInfoMinAmountNotMet) {
-        emit(const SellPaymentInfoInitial());
-      }
-    } catch (e) {
-      developer.log(
-        'Error validating min amount: $e',
-        name: '$SellPaymentInfoCubit',
       );
     }
   }

--- a/lib/screens/sell/sell_page.dart
+++ b/lib/screens/sell/sell_page.dart
@@ -4,7 +4,6 @@ import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/repository/balance_repository.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_brokerbot_service.dart';
-import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_sell_payment_info_service.dart';
 import 'package:realunit_wallet/screens/sell/cubits/sell_balance/sell_balance_cubit.dart';
 import 'package:realunit_wallet/screens/sell/cubits/sell_converter/sell_converter_cubit.dart';
@@ -36,7 +35,6 @@ class SellPage extends StatelessWidget {
         BlocProvider(
           create: (context) => SellPaymentInfoCubit(
             getIt<RealUnitSellPaymentInfoService>(),
-            getIt<DFXPriceService>(),
             getIt<AppStore>(),
           ),
         ),
@@ -73,10 +71,6 @@ class _SellViewState extends State<SellView> {
         listener: (context, state) {
           _syncController(_amountController, state.sharesText);
           _syncController(_resultController, state.fiatText);
-          context.read<SellPaymentInfoCubit>().validateMinAmount(
-            fiatAmount: state.fiatText,
-            currency: state.currency,
-          );
         },
         builder: (context, state) {
           return SafeArea(

--- a/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
+++ b/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/payment/buy_exceptions.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/buy_payment_info.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/payment_info_error.dart';
@@ -11,9 +10,12 @@ import 'package:realunit_wallet/styles/currency.dart';
 class _MockBuyPaymentInfoService extends Mock
     implements RealUnitBuyPaymentInfoService {}
 
-class _MockPriceService extends Mock implements DFXPriceService {}
-
-const _info = BuyPaymentInfo(
+BuyPaymentInfo _info({
+  bool isValid = true,
+  double? minVolume,
+  String? error,
+  Currency currency = Currency.chf,
+}) => BuyPaymentInfo(
   id: 1,
   iban: 'CH56 0483 5012 3456 78',
   bic: 'CRESCHZZ80A',
@@ -23,12 +25,14 @@ const _info = BuyPaymentInfo(
   zip: '8000',
   city: 'Zurich',
   country: 'CH',
-  currency: Currency.chf,
+  currency: currency,
+  isValid: isValid,
+  minVolume: minVolume,
+  error: error,
 );
 
 void main() {
   late _MockBuyPaymentInfoService service;
-  late _MockPriceService priceService;
 
   setUpAll(() {
     registerFallbackValue(Currency.chf);
@@ -36,29 +40,30 @@ void main() {
 
   setUp(() {
     service = _MockBuyPaymentInfoService();
-    priceService = _MockPriceService();
   });
 
-  BuyPaymentInfoCubit build() => BuyPaymentInfoCubit(service, priceService);
+  BuyPaymentInfoCubit build() => BuyPaymentInfoCubit(service);
 
   group('$BuyPaymentInfoCubit', () {
     test('initial state is BuyPaymentInfoInitial', () {
       expect(build().state, isA<BuyPaymentInfoInitial>());
     });
 
-    test('happy path with CHF emits Loading then Success', () async {
+    test('happy path emits Success with the payment info from the API', () async {
       when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => _info);
+          .thenAnswer((_) async => _info());
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300');
 
       expect(cubit.state, isA<BuyPaymentInfoSuccess>());
-      expect((cubit.state as BuyPaymentInfoSuccess).buyPaymentInfo, _info);
       verify(() => service.getPaymentInfo(300, currency: Currency.chf)).called(1);
     });
 
-    test('amount below 100 CHF minimum → MinAmountNotMetFailure', () async {
+    test('API isValid=false with error=AmountTooLow → MinAmountNotMetFailure with API limit', () async {
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info(isValid: false, error: 'AmountTooLow', minVolume: 100));
+
       final cubit = build();
       await cubit.getPaymentInfo(amount: '50');
 
@@ -66,44 +71,54 @@ void main() {
       final f = cubit.state as BuyPaymentInfoMinAmountNotMetFailure;
       expect(f.error, PaymentInfoError.minAmountNotMet);
       expect(f.minAmount, 100);
-      verifyNever(() => service.getPaymentInfo(any(), currency: any(named: 'currency')));
+      verify(() => service.getPaymentInfo(50, currency: Currency.chf)).called(1);
     });
 
-    test('EUR minimum is scaled by getChfToEurRate (ceil'
-        ')', () async {
-      // 100 CHF * 0.92 EUR/CHF = 92 → ceil = 92.
-      when(() => priceService.getChfToEurRate()).thenAnswer((_) async => 0.92);
+    test('EUR min is reported by the API as-is, not scaled in the app', () async {
+      // For EUR the API returns its own currency-specific minVolume; the
+      // app no longer multiplies a hardcoded CHF baseline by an exchange
+      // rate locally — the rate lives server-side.
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info(
+            isValid: false,
+            error: 'AmountTooLow',
+            minVolume: 92,
+            currency: Currency.eur,
+          ));
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '50', currency: Currency.eur);
 
-      expect(cubit.state, isA<BuyPaymentInfoMinAmountNotMetFailure>());
       final f = cubit.state as BuyPaymentInfoMinAmountNotMetFailure;
       expect(f.minAmount, 92);
+      verify(() => service.getPaymentInfo(50, currency: Currency.eur)).called(1);
     });
 
-    test('EUR amount above scaled minimum proceeds to service', () async {
-      when(() => priceService.getChfToEurRate()).thenAnswer((_) async => 0.92);
+    test('API isValid=false with unknown error → generic Failure', () async {
       when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => _info);
+          .thenAnswer((_) async => _info(isValid: false, error: 'AmountTooHigh', minVolume: 100));
 
       final cubit = build();
-      await cubit.getPaymentInfo(amount: '200', currency: Currency.eur);
+      await cubit.getPaymentInfo(amount: '999999999');
 
-      expect(cubit.state, isA<BuyPaymentInfoSuccess>());
-      verify(() => service.getPaymentInfo(200, currency: Currency.eur)).called(1);
+      expect(cubit.state, isA<BuyPaymentInfoFailure>());
+      expect((cubit.state as BuyPaymentInfoFailure).error, PaymentInfoError.unknown);
     });
 
-    test('empty amount string is treated as 0 → below minimum', () async {
+    test('empty amount string is treated as 0 → still calls the API', () async {
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info(isValid: false, error: 'AmountTooLow', minVolume: 100));
+
       final cubit = build();
       await cubit.getPaymentInfo(amount: '');
 
       expect(cubit.state, isA<BuyPaymentInfoMinAmountNotMetFailure>());
+      verify(() => service.getPaymentInfo(0, currency: Currency.chf)).called(1);
     });
 
     test('comma decimal separator is normalised to dot', () async {
       when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => _info);
+          .thenAnswer((_) async => _info());
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300,75');

--- a/test/screens/sell/cubits/sell_payment_info_cubit_test.dart
+++ b/test/screens/sell/cubits/sell_payment_info_cubit_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
-import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/payment/buy_exceptions.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/payment_info_error.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/dto/eip7702/eip7702_data_dto.dart';
@@ -16,16 +15,19 @@ import 'package:realunit_wallet/styles/currency.dart';
 class _MockSellPaymentInfoService extends Mock
     implements RealUnitSellPaymentInfoService {}
 
-class _MockPriceService extends Mock implements DFXPriceService {}
-
 class _MockAppStore extends Mock implements AppStore {}
 
 const _testMnemonic =
     'test test test test test test test test test test test junk';
 
-const _info = SellPaymentInfo(
+SellPaymentInfo _info({
+  bool isValid = true,
+  double minVolume = 10,
+  String? error,
+  Currency currency = Currency.chf,
+}) => SellPaymentInfo(
   id: 1,
-  eip7702: Eip7702Data(
+  eip7702: const Eip7702Data(
     relayerAddress: '0x1',
     delegationManagerAddress: '0x2',
     delegatorAddress: '0x3',
@@ -51,19 +53,21 @@ const _info = SellPaymentInfo(
   amount: 100,
   exchangeRate: 1.0,
   rate: 1.0,
-  beneficiary: BeneficiaryDto(iban: 'CH56'),
+  beneficiary: const BeneficiaryDto(iban: 'CH56'),
   estimatedAmount: 100,
-  currency: Currency.chf,
+  currency: currency,
   depositAddress: '0xA',
   tokenAddress: '0xB',
   chainId: 1,
   ethBalance: 0.01,
   requiredGasEth: 0.001,
+  isValid: isValid,
+  minVolume: minVolume,
+  error: error,
 );
 
 void main() {
   late _MockSellPaymentInfoService service;
-  late _MockPriceService priceService;
   late _MockAppStore appStore;
 
   setUpAll(() {
@@ -72,157 +76,131 @@ void main() {
 
   setUp(() {
     service = _MockSellPaymentInfoService();
-    priceService = _MockPriceService();
     appStore = _MockAppStore();
-    // Default to a software wallet so isBitbox is false unless overridden.
     when(() => appStore.wallet)
         .thenReturn(SoftwareWallet(1, 'Main', _testMnemonic));
   });
 
-  SellPaymentInfoCubit build() =>
-      SellPaymentInfoCubit(service, priceService, appStore);
+  SellPaymentInfoCubit build() => SellPaymentInfoCubit(service, appStore);
 
   group('$SellPaymentInfoCubit', () {
     test('initial state is SellPaymentInfoInitial', () {
       expect(build().state, isA<SellPaymentInfoInitial>());
     });
 
-    group('getPaymentInfo', () {
-      test('happy path emits Success with isBitbox=false for a software wallet', () async {
-        when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
-            .thenAnswer((_) async => _info);
+    test('happy path emits Success with isBitbox=false for a software wallet', () async {
+      when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info());
 
-        final cubit = build();
-        await cubit.getPaymentInfo(amount: '100', iban: 'CH56');
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '100', iban: 'CH56');
 
-        final success = cubit.state as SellPaymentInfoSuccess;
-        expect(success.sellPaymentInfo, _info);
-        expect(success.isBitbox, isFalse);
-        verify(() => service.getPaymentInfo(100, 'CH56', currency: Currency.chf)).called(1);
-      });
-
-      test('Success.isBitbox=true when the current wallet is a BitboxWallet', () async {
-        when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
-            .thenAnswer((_) async => _info);
-        when(() => appStore.wallet)
-            .thenReturn(_BitboxStubWallet());
-
-        final cubit = build();
-        await cubit.getPaymentInfo(amount: '100', iban: 'CH56');
-
-        expect((cubit.state as SellPaymentInfoSuccess).isBitbox, isTrue);
-      });
-
-      test('KycLevelRequiredException → Failure(kycRequired, requiredLevel)', () async {
-        when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
-            .thenAnswer(
-          (_) async => throw const KycLevelRequiredException(
-            statusCode: 403,
-            code: 'KYC_REQUIRED',
-            message: 'KYC required',
-            requiredLevel: 30,
-            currentLevel: 10,
-          ),
-        );
-
-        final cubit = build();
-        await cubit.getPaymentInfo(amount: '100', iban: 'CH56');
-
-        final f = cubit.state as SellPaymentInfoFailure;
-        expect(f.error, PaymentInfoError.kycRequired);
-        expect(f.requiredLevel, 30);
-      });
-
-      test('RegistrationRequiredException → Failure(registrationRequired)', () async {
-        when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
-            .thenAnswer(
-          (_) async => throw const RegistrationRequiredException(
-            statusCode: 403,
-            code: 'REGISTRATION_REQUIRED',
-            message: 'Sign first',
-          ),
-        );
-
-        final cubit = build();
-        await cubit.getPaymentInfo(amount: '100', iban: 'CH56');
-
-        expect(
-          (cubit.state as SellPaymentInfoFailure).error,
-          PaymentInfoError.registrationRequired,
-        );
-      });
-
-      test('generic exception → Failure(unknown) carrying the message', () async {
-        when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
-            .thenAnswer((_) async => throw Exception('network'));
-
-        final cubit = build();
-        await cubit.getPaymentInfo(amount: '100', iban: 'CH56');
-
-        final f = cubit.state as SellPaymentInfoFailure;
-        expect(f.error, PaymentInfoError.unknown);
-        expect(f.message, contains('network'));
-      });
+      final success = cubit.state as SellPaymentInfoSuccess;
+      expect(success.isBitbox, isFalse);
+      verify(() => service.getPaymentInfo(100, 'CH56', currency: Currency.chf)).called(1);
     });
 
-    group('validateMinAmount', () {
-      test('CHF amount below the 10 CHF floor emits MinAmountNotMet', () async {
-        final cubit = build();
+    test('Success.isBitbox=true when the current wallet is a BitboxWallet', () async {
+      when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info());
+      when(() => appStore.wallet).thenReturn(_BitboxStubWallet());
 
-        await cubit.validateMinAmount(fiatAmount: '5');
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '100', iban: 'CH56');
 
-        final s = cubit.state as SellPaymentInfoMinAmountNotMet;
-        expect(s.minAmount, 10);
-        expect(s.currency, Currency.chf);
-      });
+      expect((cubit.state as SellPaymentInfoSuccess).isBitbox, isTrue);
+    });
 
-      test('CHF amount above the floor leaves state untouched (no MinAmountNotMet)', () async {
-        final cubit = build();
+    test('API isValid=false with error=AmountTooLow → MinAmountNotMet with API limit', () async {
+      when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info(isValid: false, error: 'AmountTooLow', minVolume: 10));
 
-        await cubit.validateMinAmount(fiatAmount: '15');
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '5', iban: 'CH56');
 
-        expect(cubit.state, isA<SellPaymentInfoInitial>());
-      });
+      final s = cubit.state as SellPaymentInfoMinAmountNotMet;
+      expect(s.minAmount, 10);
+      expect(s.currency, Currency.chf);
+    });
 
-      test('EUR minimum is scaled by getChfToEurRate (ceil)', () async {
-        // 10 CHF × 0.92 EUR/CHF = 9.2 → ceil = 10.
-        when(() => priceService.getChfToEurRate()).thenAnswer((_) async => 0.92);
+    test('EUR minimum is reported by the API as-is, not scaled in the app', () async {
+      when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info(
+            isValid: false,
+            error: 'AmountTooLow',
+            minVolume: 9,
+            currency: Currency.eur,
+          ));
 
-        final cubit = build();
-        await cubit.validateMinAmount(fiatAmount: '5', currency: Currency.eur);
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '5', iban: 'CH56', currency: Currency.eur);
 
-        final s = cubit.state as SellPaymentInfoMinAmountNotMet;
-        expect(s.minAmount, 10);
-        expect(s.currency, Currency.eur);
-      });
+      final s = cubit.state as SellPaymentInfoMinAmountNotMet;
+      expect(s.minAmount, 9);
+      expect(s.currency, Currency.eur);
+    });
 
-      test('previously below-min state is cleared back to Initial when amount rises', () async {
-        when(() => priceService.getChfToEurRate()).thenAnswer((_) async => 0.92);
-        final cubit = build();
-        await cubit.validateMinAmount(fiatAmount: '5');
-        expect(cubit.state, isA<SellPaymentInfoMinAmountNotMet>());
+    test('API isValid=false with unrelated error → Failure(unknown) carrying the error', () async {
+      when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info(isValid: false, error: 'KycRequired'));
 
-        await cubit.validateMinAmount(fiatAmount: '20');
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '100', iban: 'CH56');
 
-        expect(cubit.state, isA<SellPaymentInfoInitial>());
-      });
+      final f = cubit.state as SellPaymentInfoFailure;
+      expect(f.error, PaymentInfoError.unknown);
+      expect(f.message, 'KycRequired');
+    });
 
-      test('comma separator is normalised to dot', () async {
-        final cubit = build();
+    test('KycLevelRequiredException → Failure(kycRequired, requiredLevel)', () async {
+      when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
+          .thenAnswer(
+        (_) async => throw const KycLevelRequiredException(
+          statusCode: 403,
+          code: 'KYC_REQUIRED',
+          message: 'KYC required',
+          requiredLevel: 30,
+          currentLevel: 10,
+        ),
+      );
 
-        await cubit.validateMinAmount(fiatAmount: '15,5');
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '100', iban: 'CH56');
 
-        // 15.5 ≥ 10 → no MinAmountNotMet.
-        expect(cubit.state, isA<SellPaymentInfoInitial>());
-      });
+      final f = cubit.state as SellPaymentInfoFailure;
+      expect(f.error, PaymentInfoError.kycRequired);
+      expect(f.requiredLevel, 30);
+    });
 
-      test('empty string is treated as 0 → below minimum', () async {
-        final cubit = build();
+    test('RegistrationRequiredException → Failure(registrationRequired)', () async {
+      when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
+          .thenAnswer(
+        (_) async => throw const RegistrationRequiredException(
+          statusCode: 403,
+          code: 'REGISTRATION_REQUIRED',
+          message: 'Sign first',
+        ),
+      );
 
-        await cubit.validateMinAmount(fiatAmount: '');
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '100', iban: 'CH56');
 
-        expect(cubit.state, isA<SellPaymentInfoMinAmountNotMet>());
-      });
+      expect(
+        (cubit.state as SellPaymentInfoFailure).error,
+        PaymentInfoError.registrationRequired,
+      );
+    });
+
+    test('generic exception → Failure(unknown) carrying the message', () async {
+      when(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => throw Exception('network'));
+
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '100', iban: 'CH56');
+
+      final f = cubit.state as SellPaymentInfoFailure;
+      expect(f.error, PaymentInfoError.unknown);
+      expect(f.message, contains('network'));
     });
   });
 }

--- a/test/screens/sell/sell_page_test.dart
+++ b/test/screens/sell/sell_page_test.dart
@@ -91,9 +91,6 @@ void main() {
         currency: Currency.chf,
       ),
     ).thenAnswer((_) => Future.value());
-    when(
-      () => sellPaymentInfoCubit.validateMinAmount(fiatAmount: any(named: 'fiatAmount')),
-    ).thenAnswer((_) => Future.value());
     when(() => sellSelectedBankAccountCubit.state).thenReturn(null);
     when(() => sellBalanceCubit.state).thenReturn(
       Balance(


### PR DESCRIPTION
## Summary

Wave 1.1 of the API-as-Decision-Authority audit (see [`docs/api-authority-plan.md`](docs/api-authority-plan.md), foundation rule in #491). The API already returns the structured verdict that decides whether a buy/sell quote is valid for the current user + currency — the app was nevertheless deciding *amount too low* locally and even multiplying the CHF baseline by a `DFXPriceService` exchange rate when the currency was EUR. Both decisions belong on the API side: only the backend knows the current per-currency limits, exchange rates, and any compliance gating.

This PR closes 4 P0 audit findings (V7, V8, the EUR-conversion sub-issue, and the `validateMinAmount` pre-flight) with **zero backend changes** — the necessary fields already exist in `BuyQuoteDto` / `SellQuoteDto` and in `StructuredErrorDto` / `QuoteError`.

## Changes

### Domain + service

- `BuyPaymentInfo` / `SellPaymentInfo` domain models now carry the backend's verdict: `isValid`, `minVolume`, `maxVolume`, `error`. The service layer maps these straight from the DTOs (which already parsed them).
- Defaults on the new optional fields (`isValid = true`, `minVolume = 0`, `maxVolume = infinity`) keep the existing call sites compiling — only the production service path overrides them with real backend values.

### Cubits

- `BuyPaymentInfoCubit` and `SellPaymentInfoCubit`:
  - Drop the `_minAmountChf` constant and the pre-flight that blocked sub-minimum amounts from ever reaching the API.
  - Drop the `DFXPriceService` dependency entirely — the EUR rate was only ever used for the local baseline conversion.
  - Drop the `validateMinAmount` method on the sell cubit and its debounced call site in `sell_page.dart`. Inline-as-you-type validation was the UX motivation for that path; we now surface the API verdict when the quote runs.
  - Branch on `paymentInfo.isValid`: when the backend tags the quote invalid with `error == 'AmountTooLow'`, emit the existing `MinAmountNotMet` failure state with `minAmount` taken straight from `paymentInfo.minVolume`.
- `buy_page.dart` / `sell_page.dart` cubit construction drops the `DFXPriceService` argument.

### Tests

`buy_payment_info_cubit_test.dart` and `sell_payment_info_cubit_test.dart` rewritten to assert the API-driven path: low amounts hit the mocked service which returns `isValid: false, error: 'AmountTooLow', minVolume: <limit>`, and the cubit emits `MinAmountNotMet` with the API's limit. The previous \"local pre-flight returns hardcoded 100/10\" tests were inverted to verify the same outcome via the API path.

`sell_page_test.dart` drops the `validateMinAmount` mock setup.

## Trade-off documented

The inline \"amount below minimum\" hint that used to appear as the user typed is now surfaced after they tap the sell/buy button (or whenever the quote actually runs). Per the rule, the app should not hold a parallel min-amount table — and per-keystroke quote calls would be wasteful network. A future PR could cache the most recent `minVolume` from a successful quote and re-use it for cheap inline hints without violating the rule (the cache would still be API-sourced).

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — **1414 / 1414 passed** (4 obsolete `validateMinAmount` cubit tests removed, no new tests needed beyond rewriting existing ones)

## Closes (from audit)

- V7 — Buy min-amount hardcoded (100 CHF)
- V8 — Sell min-amount hardcoded (10 CHF)
- EUR-conversion (priceService) sub-issue
- `validateMinAmount` pre-flight method

Tracked in [`docs/api-authority-audit.md`](docs/api-authority-audit.md) P0.

## Follow-ups

- Inline-validation UX: cache last-known `minVolume` and use it for as-you-type hints. Out of scope here.
- Other QuoteError values (`AMOUNT_TOO_HIGH`, `KYC_REQUIRED`, `LIMIT_EXCEEDED`, …) currently fall through to the generic failure state; if the UI needs distinct messages, route them to dedicated states in a follow-up.
