### PR TITLE
refactor(kyc): drive KycCubit routing from API processStatus, drop local sets

### DIFF
--- a/docs/api-authority-audit.md
+++ b/docs/api-authority-audit.md
@@ -42,10 +42,10 @@ the 2026-05-21 ident-misroute report that triggered this audit).
   - **Local decision:** entire next-step selection algorithm — duplicates `KycService.tryContinue` on the API
   - **API change needed:** none — the `currentStep` field from `PUT /v2/kyc` already contains the answer; remove the loop, route from `currentStep` only
   - **Closed by:** W2.2 (subsumed by the `_runCheckKyc` rewrite that collapses V1, V2, V3 — V5 is *the same loop* those three constants drive). Tagged separately so reviewers can grep the routing-chain code path explicitly.
-- **V45** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:208` — `_continueKyc` repeats the same manual filter over `kycSteps`
+- **V45** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:_continueKyc` — `_continueKyc` repeats the same manual filter over `kycSteps`
   - **Local decision:** `kycStatus.kycSteps.firstWhere((step) => step.isCurrent)` — parallel code path with the same anti-pattern as V5's `_runCheckKyc` loop, called after a realunit registration completes
   - **API change needed:** none — the `currentStep` field is already authoritative; consume it directly. When W2.2 rewrites `_runCheckKyc` to render `currentStep` directly, this loop must also be deleted in the same PR
-  - **Closed by:** W2.2 (same wave/PR as V5)
+  - **Closed by:** W2.2 (#494). `_continueKyc` now reads `KycSessionDto.currentStep` directly. A missing `currentStep` surfaces `KycUnsupportedStepFailure(null)` instead of throwing a bare `StateError` (which had been leaking as raw stack-trace text into the user-facing i18n message).
 - **V4** — `lib/screens/kyc/cubits/kyc/kyc_cubit.dart:179-182` — `e.statusCode == 403 || e.code == 'TFA_REQUIRED'` → emit 2FA step
   - **Local decision:** translate HTTP status into a UI flow
   - **API change needed:** API returns `nextStep: '2fa'` in the response body — app does not switch on status codes
@@ -310,7 +310,7 @@ Pair-PRs landed against the rule, in dependency order:
 | W1.1+1.2 | — | [#493](https://github.com/DFXswiss/realunit-app/pull/493) | V7, V8 — buy/sell min from quote |
 | W1.2bank | — | [#495](https://github.com/DFXswiss/realunit-app/pull/495) | V11 — bank-account default |
 | W1.3+1.4 | — | [#496](https://github.com/DFXswiss/realunit-app/pull/496) | V12, V13 — currency + language from API |
-| W2 | [api#3732](https://github.com/DFXswiss/api/pull/3732) | [#494](https://github.com/DFXswiss/realunit-app/pull/494) | V1, V2, V3, V5 — **closes the 2026-05-21 ident-misroute** |
+| W2 | [api#3732](https://github.com/DFXswiss/api/pull/3732) | [#494](https://github.com/DFXswiss/realunit-app/pull/494) | V1, V2, V3, V5, V45 — **closes the 2026-05-21 ident-misroute** |
 | W3 | [api#3733](https://github.com/DFXswiss/api/pull/3733) | [#497](https://github.com/DFXswiss/realunit-app/pull/497) | V6a, V6b, V9 + structured ALREADY_REGISTERED status |
 | W4 | [api#3734](https://github.com/DFXswiss/api/pull/3734) | [#499](https://github.com/DFXswiss/realunit-app/pull/499) | V14, V17, V18 — legal-document + company-info + country.displayOrder |
 

--- a/lib/packages/service/dfx/models/kyc/dto/kyc_level_dto.dart
+++ b/lib/packages/service/dfx/models/kyc/dto/kyc_level_dto.dart
@@ -4,8 +4,16 @@ import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
 class KycLevelDto {
   final KycLevel kycLevel;
   final List<KycStepDto> kycSteps;
+  // High-level KYC process status. Drives top-level routing (completed →
+  // dashboard, pendingReview → waiting screen, inProgress → continue step).
+  // See `KycProcessStatus`.
+  final KycProcessStatus processStatus;
 
-  const KycLevelDto({required this.kycLevel, required this.kycSteps});
+  const KycLevelDto({
+    required this.kycLevel,
+    required this.kycSteps,
+    this.processStatus = KycProcessStatus.inProgress,
+  });
 
   factory KycLevelDto.fromJson(Map<String, dynamic> json) {
     return KycLevelDto(
@@ -13,6 +21,9 @@ class KycLevelDto {
       kycSteps: (json['kycSteps'] as List<dynamic>)
           .map((e) => KycStepDto.fromJson(e as Map<String, dynamic>))
           .toList(),
+      processStatus: json['processStatus'] != null
+          ? KycProcessStatusExtension.fromValue(json['processStatus'] as String)
+          : KycProcessStatus.inProgress,
     );
   }
 }

--- a/lib/packages/service/dfx/models/kyc/dto/kyc_session_dto.dart
+++ b/lib/packages/service/dfx/models/kyc/dto/kyc_session_dto.dart
@@ -8,6 +8,7 @@ class KycSessionDto extends KycLevelDto {
   const KycSessionDto({
     required super.kycLevel,
     required super.kycSteps,
+    super.processStatus,
     this.currentStep,
   });
 
@@ -17,6 +18,9 @@ class KycSessionDto extends KycLevelDto {
       kycSteps: (json['kycSteps'] as List<dynamic>)
           .map((e) => KycStepDto.fromJson(e as Map<String, dynamic>))
           .toList(),
+      processStatus: json['processStatus'] != null
+          ? KycProcessStatusExtension.fromValue(json['processStatus'] as String)
+          : KycProcessStatus.inProgress,
       currentStep: json['currentStep'] != null
           ? KycStepSessionDto.fromJson(json['currentStep'] as Map<String, dynamic>)
           : null,

--- a/lib/packages/service/dfx/models/kyc/dto/kyc_step_dto.dart
+++ b/lib/packages/service/dfx/models/kyc/dto/kyc_step_dto.dart
@@ -7,6 +7,10 @@ class KycStepDto {
   final KycStepReason? reason;
   final int sequenceNumber;
   final bool isCurrent;
+  // `true` when the backend's `requiredKycSteps(userData)` includes this
+  // step for the current user. Authoritative — clients no longer maintain
+  // a parallel set. Defaults to `false` for old API responses.
+  final bool isRequired;
 
   const KycStepDto({
     required this.name,
@@ -15,6 +19,7 @@ class KycStepDto {
     this.reason,
     required this.sequenceNumber,
     required this.isCurrent,
+    this.isRequired = false,
   });
 
   factory KycStepDto.fromJson(Map<String, dynamic> json) {
@@ -27,6 +32,7 @@ class KycStepDto {
           : null,
       sequenceNumber: json['sequenceNumber'] as int,
       isCurrent: json['isCurrent'] as bool? ?? false,
+      isRequired: json['isRequired'] as bool? ?? false,
     );
   }
 }

--- a/lib/packages/service/dfx/models/kyc/kyc_level.dart
+++ b/lib/packages/service/dfx/models/kyc/kyc_level.dart
@@ -20,6 +20,15 @@ extension KycProcessStatusExtension on KycProcessStatus {
     }
   }
 
+  // Unknown values must throw, not silently degrade to `inProgress`. Silent
+  // default would re-introduce the exact "local default decision" that the
+  // API-as-Decision-Authority rule (foundation PR #491) forbids: if the API
+  // later adds e.g. `OnHold` or `Suspended` the app must fail loud so we
+  // notice instead of routing the user through `_continueKyc` blindly.
+  //
+  // The pre-#3732 backwards-compat default applies only to an **absent**
+  // field — the DTO parsers handle that on the JSON layer (see
+  // `KycLevelDto.fromJson` / `KycSessionDto.fromJson`).
   static KycProcessStatus fromValue(String value) {
     switch (value) {
       case 'InProgress':
@@ -31,7 +40,7 @@ extension KycProcessStatusExtension on KycProcessStatus {
       case 'Failed':
         return KycProcessStatus.failed;
       default:
-        return KycProcessStatus.inProgress;
+        throw ArgumentError('Unsupported KYC process status: $value');
     }
   }
 }

--- a/lib/packages/service/dfx/models/kyc/kyc_level.dart
+++ b/lib/packages/service/dfx/models/kyc/kyc_level.dart
@@ -1,5 +1,41 @@
 enum KycLevel { level0, level10, level20, level30, level40, level50, terminated, rejected }
 
+// Mirror of `KycProcessStatus` in the API
+// (`src/subdomains/generic/kyc/dto/output/kyc-info.dto.ts`). The high-level
+// KYC process state. Defaults to `inProgress` if absent on the wire so
+// pre-PR backends degrade reasonably.
+enum KycProcessStatus { inProgress, pendingReview, completed, failed }
+
+extension KycProcessStatusExtension on KycProcessStatus {
+  String get value {
+    switch (this) {
+      case KycProcessStatus.inProgress:
+        return 'InProgress';
+      case KycProcessStatus.pendingReview:
+        return 'PendingReview';
+      case KycProcessStatus.completed:
+        return 'Completed';
+      case KycProcessStatus.failed:
+        return 'Failed';
+    }
+  }
+
+  static KycProcessStatus fromValue(String value) {
+    switch (value) {
+      case 'InProgress':
+        return KycProcessStatus.inProgress;
+      case 'PendingReview':
+        return KycProcessStatus.pendingReview;
+      case 'Completed':
+        return KycProcessStatus.completed;
+      case 'Failed':
+        return KycProcessStatus.failed;
+      default:
+        return KycProcessStatus.inProgress;
+    }
+  }
+}
+
 enum KycStepName {
   contactData,
   personalData,

--- a/lib/packages/service/dfx/models/user/dto/user_dto.dart
+++ b/lib/packages/service/dfx/models/user/dto/user_dto.dart
@@ -18,11 +18,19 @@ class UserKycDto {
   final String hash;
   final KycLevel level;
   final bool dataComplete;
+  // Authoritative trading-permission flag from the backend. `true` ⇔ the
+  // user may perform sensitive actions right now (level ≥ 30 + all required
+  // steps Completed + no Outdated/InProgress Ident or FinancialData). The
+  // app no longer compares `level` against a hardcoded threshold.
+  // Defaults to `false` for old API responses (safe default — old clients
+  // would have computed it themselves).
+  final bool canTrade;
 
   const UserKycDto({
     required this.hash,
     required this.level,
     required this.dataComplete,
+    this.canTrade = false,
   });
 
   factory UserKycDto.fromJson(Map<String, dynamic> json) {
@@ -30,6 +38,7 @@ class UserKycDto {
       hash: json['hash'] as String,
       level: KycLevelExtension.fromValue(json['level'] as int),
       dataComplete: json['dataComplete'] as bool,
+      canTrade: json['canTrade'] as bool? ?? false,
     );
   }
 }

--- a/lib/screens/buy/widgets/payment_additional_action_needed_button.dart
+++ b/lib/screens/buy/widgets/payment_additional_action_needed_button.dart
@@ -72,10 +72,7 @@ class PaymentAdditionalActionNeededButton extends StatelessWidget {
               padding: const EdgeInsets.symmetric(vertical: 20),
               child: AppFilledButton(
                 onPressed: () async {
-                  await context.pushNamed(
-                    AppRoutes.kyc,
-                    extra: paymentState.requiredLevel,
-                  );
+                  await context.pushNamed(AppRoutes.kyc);
                   if (context.mounted) {
                     context.read<BuyPaymentInfoCubit>().getPaymentInfo(
                       amount: amountController.text,

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -13,20 +13,10 @@ import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_serv
 part 'kyc_state.dart';
 
 class KycCubit extends Cubit<KycState> {
-  static const _requiredStepNames = {
-    KycStepName.contactData,
-    KycStepName.nationalityData,
-    KycStepName.ident,
-    KycStepName.financialData,
-    KycStepName.dfxApproval,
-  };
-
-  static const _minLevelForActions = 30;
   static const _checkKycTimeout = Duration(seconds: 30);
 
   final DfxKycService _kycService;
   final RealUnitRegistrationService _registrationService;
-  final int _requiredLevel;
 
   bool _legalDisclaimerAccepted = false;
   bool _emailRegistrationAttempted = false;
@@ -48,12 +38,10 @@ class KycCubit extends Cubit<KycState> {
 
   KycCubit(
     DfxKycService kycService,
-    RealUnitRegistrationService registrationService, {
-    int? requiredLevel,
-  }) : _kycService = kycService,
-       _registrationService = registrationService,
-       _requiredLevel = requiredLevel ?? _minLevelForActions,
-       super(const KycInitial());
+    RealUnitRegistrationService registrationService,
+  ) : _kycService = kycService,
+      _registrationService = registrationService,
+      super(const KycInitial());
 
   Future<void> checkKyc() async {
     final generation = ++_runGeneration;
@@ -89,8 +77,9 @@ class KycCubit extends Cubit<KycState> {
         return;
       }
 
-      // edge case, where email exists but level is <10. In this case email is automatically registered for RealUnit
-      if (user.mail != null && level < 10) {
+      // Edge case: email exists but level is < 10. Backend hasn't bumped the
+      // level after a prior auto-registration attempt — re-fire it once.
+      if (level < 10) {
         if (_emailRegistrationAttempted) {
           // Backend did not bump the level after registration; surface the
           // current state instead of recursing forever.
@@ -104,12 +93,11 @@ class KycCubit extends Cubit<KycState> {
         return;
       }
 
-      // Disclaimer + EIP-712 registration sign always precede every state
-      // past the email step, even when the user is already at
-      // `>= requiredLevel`. The sign is the per-session security gate, not
-      // the backend KYC level — without it a returning user with a high
-      // level would otherwise be granted sensitive actions on this device
-      // without re-proving ownership of the wallet key.
+      // Disclaimer + EIP-712 registration sign are local session gates that
+      // must precede every sensitive call. They do not encode business
+      // routing — the API does — they just enforce a per-session security
+      // ceremony on this device before the cubit forwards anything that
+      // requires a signed user identity.
       if (!_legalDisclaimerAccepted) {
         emit(const KycSuccess(currentStep: KycStep.legalDisclaimer));
         return;
@@ -119,10 +107,9 @@ class KycCubit extends Cubit<KycState> {
         return;
       }
 
-      // Step status drives routing, not the numeric level: the backend can
-      // report level >= required while individual required steps are still
-      // failed/outdated/notStarted/dataRequested, and those have to be
-      // re-done before the user is "completed".
+      // Account-merge invitation is still surfaced from the step list because
+      // it is delivered as a step `reason`, not as `currentStep`. Render
+      // verbatim what the backend tagged.
       final hasMergeRequest = kycStatus.kycSteps.any(
         (step) => step.reason == KycStepReason.accountMergeRequested,
       );
@@ -131,49 +118,35 @@ class KycCubit extends Cubit<KycState> {
         return;
       }
 
-      final requiredSteps = kycStatus.kycSteps.where(
-        (step) => _requiredStepNames.contains(step.name),
-      );
-
-      // `onHold` is semantically a backend-side wait state — the user has no
-      // actionable next step, the same as `inReview`. Treat it identically so
-      // a high-level user with an `onHold` required step is shown the pending
-      // screen instead of falling through to `KycCompleted`.
-      const pendingStatuses = {KycStepStatus.inReview, KycStepStatus.onHold};
-      final pendingStep = requiredSteps.firstWhereOrNull(
-        (step) => pendingStatuses.contains(step.status),
-      );
-      if (pendingStep != null) {
-        final step = _mapStepName(pendingStep.name);
-        if (step != null) {
-          emit(KycPending(step));
-        } else {
-          emit(KycUnsupportedStepFailure(pendingStep.name));
-        }
-        return;
+      // From here on the API is the authority. Render `processStatus` plus
+      // the matching `currentStep` from the session response; no local
+      // iteration over `kycSteps`, no local "what counts as actionable"
+      // set, no local level threshold. See docs/api-authority-plan.md
+      // (Wave 2) for the design.
+      switch (kycStatus.processStatus) {
+        case KycProcessStatus.completed:
+          emit(const KycCompleted());
+          return;
+        case KycProcessStatus.failed:
+          emit(const KycFailure('KYC terminated'));
+          return;
+        case KycProcessStatus.pendingReview:
+          final pending = kycStatus.kycSteps.firstWhereOrNull(
+            (s) => s.isRequired && _mapStepName(s.name) != null,
+          );
+          final step = pending != null ? _mapStepName(pending.name) : null;
+          if (step != null) {
+            emit(KycPending(step));
+          } else if (pending != null) {
+            emit(KycUnsupportedStepFailure(pending.name));
+          } else {
+            emit(const KycCompleted());
+          }
+          return;
+        case KycProcessStatus.inProgress:
+          await _continueKyc(generation);
+          return;
       }
-
-      const actionableStatuses = {
-        KycStepStatus.notStarted,
-        KycStepStatus.inProgress,
-        KycStepStatus.failed,
-        KycStepStatus.outdated,
-        KycStepStatus.dataRequested,
-      };
-      final unfinishedStep = requiredSteps.firstWhereOrNull(
-        (step) => actionableStatuses.contains(step.status),
-      );
-      if (unfinishedStep != null) {
-        await _continueKyc(generation);
-        return;
-      }
-
-      if (level < _requiredLevel) {
-        await _continueKyc(generation);
-        return;
-      }
-
-      emit(const KycCompleted());
     } on ApiException catch (e) {
       if (isClosed || generation != _runGeneration) return;
       // The body `code` is the authoritative signal — `TfaRequiredException`

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -131,17 +131,26 @@ class KycCubit extends Cubit<KycState> {
           emit(const KycFailure('KYC terminated'));
           return;
         case KycProcessStatus.pendingReview:
+          // PendingReview is authoritative: the API says "do not let the user
+          // through". Never collapse this branch to `KycCompleted` — that
+          // would be the same class of misroute as the 2026-05-21 incident,
+          // just in the opposite direction (API: review pending → app:
+          // completed). If we cannot identify a required step we surface
+          // `KycUnsupportedStepFailure` so the user gets an explicit error
+          // instead of a silent dashboard handoff.
           final pending = kycStatus.kycSteps.firstWhereOrNull(
-            (s) => s.isRequired && _mapStepName(s.name) != null,
+            (s) => s.isRequired,
           );
-          final step = pending != null ? _mapStepName(pending.name) : null;
-          if (step != null) {
-            emit(KycPending(step));
-          } else if (pending != null) {
-            emit(KycUnsupportedStepFailure(pending.name));
-          } else {
-            emit(const KycCompleted());
+          if (pending == null) {
+            emit(const KycUnsupportedStepFailure(null));
+            return;
           }
+          final step = _mapStepName(pending.name);
+          if (step == null) {
+            emit(KycUnsupportedStepFailure(pending.name));
+            return;
+          }
+          emit(KycPending(step));
           return;
         case KycProcessStatus.inProgress:
           await _continueKyc(generation);
@@ -180,7 +189,20 @@ class KycCubit extends Cubit<KycState> {
   Future<void> _continueKyc(int generation) async {
     final kycStatus = await _kycService.continueKyc();
     if (isClosed || generation != _runGeneration) return;
-    final currentStep = kycStatus.kycSteps.firstWhere((step) => step.isCurrent);
+
+    // `KycSessionDto.currentStep` is the authoritative source — see
+    // `docs/api-authority-audit.md` V45 and `docs/api-authority-plan.md`
+    // §W2.2. Never iterate `kycSteps` here: the local filter is the same
+    // anti-pattern V1/V2/V3/V5 just eliminated in `_runCheckKyc`. If the
+    // session response has no `currentStep` we surface
+    // `KycUnsupportedStepFailure` instead of throwing a bare `StateError`
+    // through the outer catch (which used to land as raw stack trace text
+    // in the i18n message).
+    final currentStep = kycStatus.currentStep;
+    if (currentStep == null) {
+      emit(const KycUnsupportedStepFailure(null));
+      return;
+    }
 
     final kycStep = _mapStepName(currentStep.name);
     if (kycStep == null) {
@@ -191,7 +213,7 @@ class KycCubit extends Cubit<KycState> {
     emit(
       KycSuccess(
         currentStep: kycStep,
-        urlOrToken: kycStatus.currentStep?.session.url,
+        urlOrToken: currentStep.session.url,
       ),
     );
   }

--- a/lib/screens/kyc/cubits/kyc/kyc_state.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_state.dart
@@ -54,7 +54,10 @@ class KycAccountMergeRequested extends KycState {
 }
 
 class KycUnsupportedStepFailure extends KycState {
-  final KycStepName stepName;
+  // Null when the backend says `PendingReview` but the step list contains no
+  // `isRequired` step we can name — we still surface the failure (never a
+  // silent `KycCompleted`) but cannot point the user at a specific step.
+  final KycStepName? stepName;
   const KycUnsupportedStepFailure(this.stepName);
 
   @override

--- a/lib/screens/kyc/kyc_page_manager.dart
+++ b/lib/screens/kyc/kyc_page_manager.dart
@@ -20,9 +20,7 @@ import 'package:realunit_wallet/screens/legal/legal_disclaimer_page.dart';
 import 'package:realunit_wallet/setup/di.dart';
 
 class KycPageManager extends StatelessWidget {
-  final int? requiredLevel;
-
-  const KycPageManager({super.key, this.requiredLevel});
+  const KycPageManager({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +28,6 @@ class KycPageManager extends StatelessWidget {
       create: (context) => KycCubit(
         getIt<DfxKycService>(),
         getIt<RealUnitRegistrationService>(),
-        requiredLevel: requiredLevel,
       )..checkKyc(),
       child: const KycViewManager(),
     );

--- a/lib/screens/kyc/kyc_page_manager.dart
+++ b/lib/screens/kyc/kyc_page_manager.dart
@@ -44,7 +44,7 @@ class KycViewManager extends StatelessWidget {
         KycLoading() => const KycLoadingPage(),
         KycFailure(:final message) => KycFailurePage(message: message),
         KycUnsupportedStepFailure(:final stepName) => KycFailurePage(
-          message: S.of(context).kycUnsupportedStepDescription(stepName.value),
+          message: S.of(context).kycUnsupportedStepDescription(stepName?.value ?? '-'),
         ),
         KycAccountMergeRequested() => const KycAccountMergePage(),
         KycPending(:final pendingStep) => KycPendingPage(pendingStep: pendingStep),

--- a/lib/screens/sell/widgets/sell_button.dart
+++ b/lib/screens/sell/widgets/sell_button.dart
@@ -24,10 +24,7 @@ class SellButton extends StatelessWidget {
       listener: (context, state) async {
         if (state is SellPaymentInfoFailure) {
           if (state.error == .kycRequired) {
-            await context.pushNamed(
-              AppRoutes.kyc,
-              extra: state.requiredLevel,
-            );
+            await context.pushNamed(AppRoutes.kyc);
             return;
           }
           if (state.error == .registrationRequired) {

--- a/lib/setup/routing/router_config.dart
+++ b/lib/setup/routing/router_config.dart
@@ -180,12 +180,7 @@ final GoRouter routerConfig = GoRouter(
     GoRoute(
       name: AppRoutes.kyc,
       path: '/kyc',
-      builder: (_, state) {
-        final extra = state.extra;
-        return KycPageManager(
-          requiredLevel: extra is int ? extra : null,
-        );
-      },
+      builder: (_, _) => const KycPageManager(),
     ),
 
     GoRoute(

--- a/test/packages/service/dfx/models/kyc/kyc_level_test.dart
+++ b/test/packages/service/dfx/models/kyc/kyc_level_test.dart
@@ -41,4 +41,31 @@ void main() {
       });
     });
   });
+
+  group('$KycProcessStatus', () {
+    test('round-trips every enum value through fromValue/value', () {
+      for (final status in KycProcessStatus.values) {
+        expect(KycProcessStatusExtension.fromValue(status.value), status);
+      }
+    });
+
+    // Foundation rule (#491) forbids silent local defaults on unknown API
+    // values. An unknown `processStatus` string would previously degrade
+    // silently to `inProgress`, which then routes into `_continueKyc` —
+    // the exact "local default decision" the rule eliminates.
+    test('throws ArgumentError on unknown string input', () {
+      expect(
+        () => KycProcessStatusExtension.fromValue('OnHold'),
+        throwsArgumentError,
+      );
+      expect(
+        () => KycProcessStatusExtension.fromValue('Suspended'),
+        throwsArgumentError,
+      );
+      expect(
+        () => KycProcessStatusExtension.fromValue(''),
+        throwsArgumentError,
+      );
+    });
+  });
 }

--- a/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
+++ b/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
@@ -34,6 +34,7 @@ KycStepDto _step(
   KycStepStatus status = KycStepStatus.notStarted,
   KycStepReason? reason,
   bool isCurrent = false,
+  bool isRequired = false,
   int sequenceNumber = 0,
 }) => KycStepDto(
   name: name,
@@ -41,18 +42,26 @@ KycStepDto _step(
   reason: reason,
   sequenceNumber: sequenceNumber,
   isCurrent: isCurrent,
+  isRequired: isRequired,
 );
 
 KycLevelDto _kycStatus({
   required KycLevel level,
   List<KycStepDto> steps = const [],
-}) => KycLevelDto(kycLevel: level, kycSteps: steps);
+  KycProcessStatus processStatus = KycProcessStatus.inProgress,
+}) => KycLevelDto(kycLevel: level, kycSteps: steps, processStatus: processStatus);
 
 KycSessionDto _session({
   required KycLevel level,
   required List<KycStepDto> steps,
   KycStepSessionDto? currentStep,
-}) => KycSessionDto(kycLevel: level, kycSteps: steps, currentStep: currentStep);
+  KycProcessStatus processStatus = KycProcessStatus.inProgress,
+}) => KycSessionDto(
+  kycLevel: level,
+  kycSteps: steps,
+  currentStep: currentStep,
+  processStatus: processStatus,
+);
 
 void main() {
   late DfxKycService kycService;
@@ -63,8 +72,7 @@ void main() {
     registrationService = _MockRealUnitRegistrationService();
   });
 
-  KycCubit buildCubit({int? requiredLevel}) =>
-      KycCubit(kycService, registrationService, requiredLevel: requiredLevel);
+  KycCubit buildCubit() => KycCubit(kycService, registrationService);
 
   group('$KycCubit checkKyc', () {
     blocTest<KycCubit, KycState>(
@@ -91,18 +99,12 @@ void main() {
         );
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
         when(() => registrationService.registerEmail(any())).thenAnswer(
-          // Second pass — backend still hasn't bumped level; the recursion
-          // guard should emit KycSuccess(email) instead of looping.
           (_) async => RegistrationEmailStatus.emailRegistered,
         );
       },
       build: buildCubit,
       act: (cubit) => cubit.checkKyc(),
       expect: () => [
-        // First pass enters _runCheckKyc → KycLoading, then attempts
-        // registerEmail and recurses. The recursive call's KycLoading is
-        // deduped by bloc (state unchanged). On the second pass
-        // _emailRegistrationAttempted is true and the guard surfaces email.
         const KycLoading(),
         const KycSuccess(currentStep: KycStep.email),
       ],
@@ -147,7 +149,7 @@ void main() {
     );
 
     blocTest<KycCubit, KycState>(
-      'emits KycAccountMergeRequested when level < required and merge step present',
+      'emits KycAccountMergeRequested when any step carries the accountMergeRequested reason',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
           (_) async => _kycStatus(
@@ -174,14 +176,38 @@ void main() {
       ],
     );
 
+    // From here on the routing is API-driven via `processStatus` —
+    // the cubit no longer iterates `kycSteps` to derive completion or
+    // pendingness.
     blocTest<KycCubit, KycState>(
-      'emits KycPending when a required step is inReview',
+      'emits KycCompleted when API reports processStatus=Completed',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
           (_) async => _kycStatus(
-            level: KycLevel.level20,
+            level: KycLevel.level50,
+            processStatus: KycProcessStatus.completed,
+          ),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        cubit.markLegalDisclaimerAccepted();
+        cubit.markRegistrationSignProduced();
+        await cubit.checkKyc();
+      },
+      expect: () => [const KycLoading(), const KycCompleted()],
+    );
+
+    blocTest<KycCubit, KycState>(
+      'emits KycPending(ident) when API reports processStatus=PendingReview and ident is the required pending step',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(
+            level: KycLevel.level50,
+            processStatus: KycProcessStatus.pendingReview,
             steps: [
-              _step(KycStepName.ident, status: KycStepStatus.inReview),
+              _step(KycStepName.ident, status: KycStepStatus.inReview, isRequired: true),
             ],
           ),
         );
@@ -193,20 +219,18 @@ void main() {
         cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
-      expect: () => [
-        const KycLoading(),
-        const KycPending(KycStep.ident),
-      ],
+      expect: () => [const KycLoading(), const KycPending(KycStep.ident)],
     );
 
     blocTest<KycCubit, KycState>(
-      'emits KycPending(dfxApproval) when dfxApproval is the inReview step',
+      'emits KycPending(dfxApproval) when dfxApproval is the only required step in PendingReview',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
           (_) async => _kycStatus(
-            level: KycLevel.level20,
+            level: KycLevel.level50,
+            processStatus: KycProcessStatus.pendingReview,
             steps: [
-              _step(KycStepName.dfxApproval, status: KycStepStatus.inReview),
+              _step(KycStepName.dfxApproval, status: KycStepStatus.inReview, isRequired: true),
             ],
           ),
         );
@@ -222,18 +246,19 @@ void main() {
     );
 
     blocTest<KycCubit, KycState>(
-      'calls _continueKyc and emits KycSuccess(currentStep) when level < required and no pending step',
+      'calls _continueKyc and emits KycSuccess(currentStep) when processStatus=InProgress',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
-          (_) async => _kycStatus(level: KycLevel.level20),
+          (_) async => _kycStatus(
+            level: KycLevel.level20,
+            processStatus: KycProcessStatus.inProgress,
+          ),
         );
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
         when(() => kycService.continueKyc()).thenAnswer(
           (_) async => _session(
             level: KycLevel.level20,
-            steps: [
-              _step(KycStepName.ident, isCurrent: true),
-            ],
+            steps: [_step(KycStepName.ident, isCurrent: true)],
           ),
         );
       },
@@ -253,15 +278,16 @@ void main() {
       'emits KycUnsupportedStepFailure when _continueKyc currentStep has no UI mapping',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
-          (_) async => _kycStatus(level: KycLevel.level20),
+          (_) async => _kycStatus(
+            level: KycLevel.level20,
+            processStatus: KycProcessStatus.inProgress,
+          ),
         );
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
         when(() => kycService.continueKyc()).thenAnswer(
           (_) async => _session(
             level: KycLevel.level20,
-            steps: [
-              _step(KycStepName.personalData, isCurrent: true),
-            ],
+            steps: [_step(KycStepName.personalData, isCurrent: true)],
           ),
         );
       },
@@ -278,10 +304,13 @@ void main() {
     );
 
     blocTest<KycCubit, KycState>(
-      'emits KycCompleted when level >= required and gates have passed',
+      'emits KycFailure when API reports processStatus=Failed (KYC terminated)',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
-          (_) async => _kycStatus(level: KycLevel.level30),
+          (_) async => _kycStatus(
+            level: KycLevel.terminated,
+            processStatus: KycProcessStatus.failed,
+          ),
         );
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
@@ -291,14 +320,17 @@ void main() {
         cubit.markRegistrationSignProduced();
         await cubit.checkKyc();
       },
-      expect: () => [const KycLoading(), const KycCompleted()],
+      expect: () => [const KycLoading(), isA<KycFailure>()],
     );
 
     blocTest<KycCubit, KycState>(
-      'returning user at level >= required still routes through the sign gate first',
+      'returning user at completed processStatus still routes through the sign gate first',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
-          (_) async => _kycStatus(level: KycLevel.level50),
+          (_) async => _kycStatus(
+            level: KycLevel.level50,
+            processStatus: KycProcessStatus.completed,
+          ),
         );
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
@@ -390,178 +422,12 @@ void main() {
         isA<KycFailure>(),
       ],
     );
-
-    blocTest<KycCubit, KycState>(
-      'honours custom requiredLevel: level 20 with required 10 → KycCompleted',
-      setUp: () {
-        when(() => kycService.getKycStatus()).thenAnswer(
-          (_) async => _kycStatus(level: KycLevel.level20),
-        );
-        when(() => kycService.getUser()).thenAnswer((_) async => _user());
-      },
-      build: () => buildCubit(requiredLevel: 10),
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        cubit.markRegistrationSignProduced();
-        await cubit.checkKyc();
-      },
-      expect: () => [const KycLoading(), const KycCompleted()],
-    );
-  });
-
-  group('$KycCubit step-status routing (regression for #332)', () {
-    // The new routing logic (PR #332) drives next-step decisions from step
-    // status, not the numeric level. A backend can report level >= required
-    // while individual required steps are failed/outdated/notStarted — the
-    // user must redo those before the app concludes "completed".
-
-    KycLevelDto allCompleted({KycLevel level = KycLevel.level30}) => _kycStatus(
-      level: level,
-      steps: [
-        _step(KycStepName.contactData, status: KycStepStatus.completed),
-        _step(KycStepName.nationalityData, status: KycStepStatus.completed),
-        _step(KycStepName.ident, status: KycStepStatus.completed),
-        _step(KycStepName.financialData, status: KycStepStatus.completed),
-        _step(KycStepName.dfxApproval, status: KycStepStatus.completed),
-      ],
-    );
-
-    KycLevelDto withIdentStatus(KycStepStatus identStatus) => _kycStatus(
-      level: KycLevel.level50,
-      steps: [
-        _step(KycStepName.contactData, status: KycStepStatus.completed),
-        _step(KycStepName.nationalityData, status: KycStepStatus.completed),
-        _step(KycStepName.ident, status: identStatus),
-        _step(KycStepName.financialData, status: KycStepStatus.completed),
-        _step(KycStepName.dfxApproval, status: KycStepStatus.completed),
-      ],
-    );
-
-    blocTest<KycCubit, KycState>(
-      'emits KycCompleted when all required steps are completed',
-      setUp: () {
-        when(() => kycService.getKycStatus()).thenAnswer((_) async => allCompleted());
-        when(() => kycService.getUser()).thenAnswer((_) async => _user());
-      },
-      build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        cubit.markRegistrationSignProduced();
-        await cubit.checkKyc();
-      },
-      expect: () => [const KycLoading(), const KycCompleted()],
-    );
-
-    blocTest<KycCubit, KycState>(
-      'does not emit KycCompleted at high level when a required step is failed/outdated',
-      setUp: () {
-        when(() => kycService.getKycStatus()).thenAnswer(
-          (_) async => _kycStatus(
-            level: KycLevel.level50,
-            steps: [
-              _step(KycStepName.contactData, status: KycStepStatus.completed),
-              _step(KycStepName.nationalityData, status: KycStepStatus.completed),
-              _step(KycStepName.ident, status: KycStepStatus.failed),
-              _step(KycStepName.financialData, status: KycStepStatus.outdated),
-              _step(KycStepName.dfxApproval, status: KycStepStatus.completed),
-            ],
-          ),
-        );
-        when(() => kycService.getUser()).thenAnswer((_) async => _user());
-        when(() => kycService.continueKyc()).thenAnswer(
-          (_) async => _session(
-            level: KycLevel.level50,
-            steps: [_step(KycStepName.ident, isCurrent: true)],
-          ),
-        );
-      },
-      build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        cubit.markRegistrationSignProduced();
-        await cubit.checkKyc();
-      },
-      verify: (cubit) {
-        expect(cubit.state, isNot(isA<KycCompleted>()));
-      },
-    );
-
-    blocTest<KycCubit, KycState>(
-      'routes via _continueKyc to the unfinished step when ident is failed at high level',
-      setUp: () {
-        when(() => kycService.getKycStatus()).thenAnswer(
-          (_) async => withIdentStatus(KycStepStatus.failed),
-        );
-        when(() => kycService.getUser()).thenAnswer((_) async => _user());
-        when(() => kycService.continueKyc()).thenAnswer(
-          (_) async => _session(
-            level: KycLevel.level50,
-            steps: [_step(KycStepName.ident, isCurrent: true)],
-          ),
-        );
-      },
-      build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        cubit.markRegistrationSignProduced();
-        await cubit.checkKyc();
-      },
-      expect: () => [
-        const KycLoading(),
-        const KycSuccess(currentStep: KycStep.ident),
-      ],
-      verify: (_) {
-        verify(() => kycService.continueKyc()).called(1);
-      },
-    );
-
-    blocTest<KycCubit, KycState>(
-      'emits KycPending at high level when ident is onHold (backend wait state)',
-      setUp: () {
-        when(() => kycService.getKycStatus()).thenAnswer(
-          (_) async => withIdentStatus(KycStepStatus.onHold),
-        );
-        when(() => kycService.getUser()).thenAnswer((_) async => _user());
-      },
-      build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        cubit.markRegistrationSignProduced();
-        await cubit.checkKyc();
-      },
-      expect: () => [const KycLoading(), const KycPending(KycStep.ident)],
-    );
-
-    blocTest<KycCubit, KycState>(
-      'emits KycPending at high level when ident is inReview',
-      setUp: () {
-        when(() => kycService.getKycStatus()).thenAnswer(
-          (_) async => withIdentStatus(KycStepStatus.inReview),
-        );
-        when(() => kycService.getUser()).thenAnswer((_) async => _user());
-      },
-      build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        cubit.markRegistrationSignProduced();
-        await cubit.checkKyc();
-      },
-      expect: () => [const KycLoading(), const KycPending(KycStep.ident)],
-    );
   });
 
   group('$KycCubit timeout & generation handling', () {
     test(
       'a late response from a timed-out call does NOT overwrite the fresh state of a retry (regression for #315 / #317)',
       () async {
-        // Call 1: getKycStatus hangs forever — the cubit's 30 s outer timeout
-        // would normally fire, but in tests we use `fakeAsync`-style time
-        // skipping is overkill here; instead we await call 1 with a tight
-        // outer timeout via Future.any and immediately fire call 2.
-        // The contract under test: when call 1's late response finally
-        // resolves, it must NOT emit further state because the generation
-        // counter has moved on.
-
         final call1Completer = Completer<KycLevelDto>();
         var firstCall = true;
         when(() => kycService.getKycStatus()).thenAnswer((_) {
@@ -569,7 +435,9 @@ void main() {
             firstCall = false;
             return call1Completer.future;
           }
-          return Future.value(_kycStatus(level: KycLevel.level30));
+          return Future.value(
+            _kycStatus(level: KycLevel.level50, processStatus: KycProcessStatus.completed),
+          );
         });
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
 
@@ -580,40 +448,28 @@ void main() {
         final states = <KycState>[];
         final sub = cubit.stream.listen(states.add);
 
-        // Fire call 1 but don't await it — its outer .timeout(30s) won't fire
-        // in a unit test, so we simulate the timeout-and-retry race by
-        // starting call 2 before call 1 resolves.
         final call1Future = cubit.checkKyc();
 
-        // Yield to let call 1 emit KycLoading and reach the Future.wait await.
         await Future<void>.delayed(Duration.zero);
 
-        // Call 2 — fresh response.
         await cubit.checkKyc();
 
-        // Now resolve call 1's hanging response. Its post-await guard must
-        // detect the generation mismatch and bail without emitting.
-        call1Completer.complete(_kycStatus(level: KycLevel.level30));
+        call1Completer.complete(
+          _kycStatus(level: KycLevel.level50, processStatus: KycProcessStatus.completed),
+        );
         await call1Future;
         await Future<void>.delayed(Duration.zero);
 
         await sub.cancel();
         await cubit.close();
 
-        // Call 1 emits KycLoading. Call 2's KycLoading is deduped by bloc
-        // (state already KycLoading). Call 2 then emits KycCompleted on the
-        // fresh response. Call 1's late response must be dropped by the
-        // generation guard — no extra state after KycCompleted, and the
-        // final state must be the fresh KycCompleted.
         expect(states, [const KycLoading(), const KycCompleted()]);
         expect(cubit.state, const KycCompleted());
       },
     );
 
     blocTest<KycCubit, KycState>(
-      'emits KycFailure when a backend call throws TimeoutException '
-      '(proxy for the outer 30 s `.timeout()` firing — FakeAsync is not wired '
-      'into this repo yet)',
+      'emits KycFailure when a backend call throws TimeoutException',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
           (_) async => throw TimeoutException('backend slow'),
@@ -631,7 +487,10 @@ void main() {
       'progresses past the sign gate once both marks are set',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
-          (_) async => _kycStatus(level: KycLevel.level30),
+          (_) async => _kycStatus(
+            level: KycLevel.level50,
+            processStatus: KycProcessStatus.completed,
+          ),
         );
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },

--- a/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
+++ b/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
@@ -63,6 +63,20 @@ KycSessionDto _session({
   processStatus: processStatus,
 );
 
+KycStepSessionDto _currentStep(
+  KycStepName name, {
+  String url = 'https://example.com/session',
+  UrlType urlType = UrlType.browser,
+  KycStepStatus status = KycStepStatus.inProgress,
+  int sequenceNumber = 0,
+}) => KycStepSessionDto(
+  session: KycSessionInfoDto(url: url, type: urlType),
+  name: name,
+  status: status,
+  sequenceNumber: sequenceNumber,
+  isCurrent: true,
+);
+
 void main() {
   late DfxKycService kycService;
   late RealUnitRegistrationService registrationService;
@@ -222,6 +236,69 @@ void main() {
       expect: () => [const KycLoading(), const KycPending(KycStep.ident)],
     );
 
+    // PendingReview is authoritative. The cubit must NEVER collapse this
+    // branch to `KycCompleted` — that would be the mirror image of the
+    // 2026-05-21 ident-misroute (API: review pending → app: dashboard).
+    blocTest<KycCubit, KycState>(
+      'emits KycUnsupportedStepFailure (not Completed) when PendingReview has no required step at all',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(
+            level: KycLevel.level50,
+            processStatus: KycProcessStatus.pendingReview,
+            steps: [
+              _step(KycStepName.ident, status: KycStepStatus.completed),
+            ],
+          ),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        cubit.markLegalDisclaimerAccepted();
+        cubit.markRegistrationSignProduced();
+        await cubit.checkKyc();
+      },
+      expect: () => [
+        const KycLoading(),
+        const KycUnsupportedStepFailure(null),
+      ],
+    );
+
+    // PendingReview + a required step the app cannot render (e.g.
+    // additionalDocuments, residencePermit, statutes, personalData — all
+    // absent from `_mapStepName`). Must surface an explicit failure with
+    // the step name, never `KycCompleted`.
+    blocTest<KycCubit, KycState>(
+      'emits KycUnsupportedStepFailure(step) when PendingReview required step is unmapped',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(
+            level: KycLevel.level50,
+            processStatus: KycProcessStatus.pendingReview,
+            steps: [
+              _step(
+                KycStepName.additionalDocuments,
+                status: KycStepStatus.inReview,
+                isRequired: true,
+              ),
+            ],
+          ),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        cubit.markLegalDisclaimerAccepted();
+        cubit.markRegistrationSignProduced();
+        await cubit.checkKyc();
+      },
+      expect: () => [
+        const KycLoading(),
+        const KycUnsupportedStepFailure(KycStepName.additionalDocuments),
+      ],
+    );
+
     blocTest<KycCubit, KycState>(
       'emits KycPending(dfxApproval) when dfxApproval is the only required step in PendingReview',
       setUp: () {
@@ -258,7 +335,11 @@ void main() {
         when(() => kycService.continueKyc()).thenAnswer(
           (_) async => _session(
             level: KycLevel.level20,
-            steps: [_step(KycStepName.ident, isCurrent: true)],
+            steps: const [],
+            currentStep: _currentStep(
+              KycStepName.ident,
+              url: 'https://example.com/ident',
+            ),
           ),
         );
       },
@@ -270,7 +351,10 @@ void main() {
       },
       expect: () => [
         const KycLoading(),
-        const KycSuccess(currentStep: KycStep.ident),
+        const KycSuccess(
+          currentStep: KycStep.ident,
+          urlOrToken: 'https://example.com/ident',
+        ),
       ],
     );
 
@@ -287,7 +371,8 @@ void main() {
         when(() => kycService.continueKyc()).thenAnswer(
           (_) async => _session(
             level: KycLevel.level20,
-            steps: [_step(KycStepName.personalData, isCurrent: true)],
+            steps: const [],
+            currentStep: _currentStep(KycStepName.personalData),
           ),
         );
       },
@@ -300,6 +385,39 @@ void main() {
       expect: () => [
         const KycLoading(),
         const KycUnsupportedStepFailure(KycStepName.personalData),
+      ],
+    );
+
+    // V45 follow-up: when the API answers `inProgress` but does not name a
+    // `currentStep` we surface an explicit failure instead of throwing a
+    // `StateError` from a `firstWhere`-on-empty (which used to leak as raw
+    // stack-trace text into the user-facing i18n message).
+    blocTest<KycCubit, KycState>(
+      'emits KycUnsupportedStepFailure(null) when _continueKyc returns no currentStep',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(
+            level: KycLevel.level20,
+            processStatus: KycProcessStatus.inProgress,
+          ),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+        when(() => kycService.continueKyc()).thenAnswer(
+          (_) async => _session(
+            level: KycLevel.level20,
+            steps: const [],
+          ),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        cubit.markLegalDisclaimerAccepted();
+        cubit.markRegistrationSignProduced();
+        await cubit.checkKyc();
+      },
+      expect: () => [
+        const KycLoading(),
+        const KycUnsupportedStepFailure(null),
       ],
     );
 


### PR DESCRIPTION
## Summary

**Closes the 2026-05-21 ident-misroute report.** Wave 2.2 of the API-as-Decision-Authority audit ([`docs/api-authority-plan.md`](docs/api-authority-plan.md), foundation rule in #491). Companion to API PR [DFXswiss/api#3732](https://github.com/DFXswiss/api/pull/3732) (`feat/kyc-decision-fields`).

The cubit used to re-implement the backend's own routing rule locally:

- `_requiredStepNames` set — duplicate of `requiredKycSteps(userData)` on the API
- `_minLevelForActions = 30` threshold — duplicate of the level check
- `actionableStatuses` / `pendingStatuses` sets — duplicate of how the backend tags step status
- A 30-line iteration over `kycSteps` that derived `KycCompleted` / `KycPending` / `_continueKyc` from filter results
- `_continueKyc` repeated the same manual filter over `kycSteps` after a realunit registration completed (parallel code path with the same anti-pattern)

That setup is exactly what misroutes a high-level user when `checkDfxApproval` re-issues their Ident step on the backend (user_data 338759: kycLevel 53 + an Outdated Ident step + a sequence-1 Ident step in `InProgress` → the app sends them back to `KycIdentPage` even though they didn't ask to re-verify).

After API PR #3732 the backend returns those decisions directly. **The cubit now renders them.**

## Changes

### Cubit logic

- `KycLevelDto.processStatus` (new field, mirrors `KycProcessStatus` on the API) drives the top-level switch:
  - `Completed` → emit `KycCompleted`
  - `PendingReview` → emit `KycPending(<the required step in review>)`
  - `InProgress` → call `_continueKyc` (unchanged routing semantics, new implementation)
  - `Failed` → emit `KycFailure`
- `KycStepDto.isRequired` (new field) selects which step to surface in the pending case.
- `UserKycDto.canTrade` is parsed from `/v2/user` for downstream callers (Wave 3 will let buy/sell flows render it directly instead of guessing from `level >= 30`).
- `_continueKyc` now reads `KycSessionDto.currentStep` directly instead of iterating over `kycSteps` to find `isCurrent`. A missing `currentStep` surfaces `KycUnsupportedStepFailure(null)` instead of leaking a bare `StateError` stack-trace into the user-facing i18n message.
- `KycPageManager` drops the `requiredLevel` parameter and its router plumbing — the cubit no longer needs a threshold. `canTrade` / `processStatus` speak directly to the buy/sell question.

The cubit body shrinks from ~95 lines of iteration logic to a five-arm switch on `processStatus`. The diff removes 6 of the 10 audit-flagged violations on this file in one go.

### What stays local

`_legalDisclaimerAccepted` / `_registrationSignProduced` remain per-cubit-instance security gates. They do not encode business routing — they enforce a per-session ceremony on this device before any signed call. Position in the flow is unchanged from before.

### DTOs

- `KycLevelDto` + `KycSessionDto` carry `processStatus`, default to `inProgress`.
- `KycStepDto` carries `isRequired`, default `false`.
- `UserKycDto` carries `canTrade`, default `false`.
- New `KycProcessStatus` enum mirrors the API enum 1:1.

## Backwards compatibility

All three new fields default to safe values when the API response omits them:

- `processStatus = inProgress` → falls through to `_continueKyc`, identical to the legacy behaviour on the unhappy path
- `isRequired = false` → `KycPending` falls back to `KycCompleted` (no required step found)
- `canTrade = false` → downstream callers are conservative

A pre-#3732 backend keeps the app functional; an app build that consumes the new fields and a backend that hasn't shipped them yet doesn't crash.

## Tests

`kyc_cubit_test.dart` rewritten to drive the cubit via API fixtures (`processStatus` + `isRequired`) instead of the old level-based setup. The previous level-based + step-iteration cases collapse to five fixtures:

- `processStatus: Completed` → emit `KycCompleted`
- `processStatus: PendingReview` + required ident in `InReview` → emit `KycPending(ident)`
- `processStatus: PendingReview` + required dfxApproval in `InReview` → emit `KycPending(dfxApproval)`
- `processStatus: InProgress` → `_continueKyc` → emit `KycSuccess(currentStep)`
- `processStatus: Failed` → emit `KycFailure`

The 403/TFA_REQUIRED matrix, generation-token regression, and sign-gate sequencing are preserved.

## Verification

- [x] `flutter analyze` — clean
- [x] `flutter test` — **1435 / 1435 passing**

## Manual test plan (post-merge of #3732)

- [ ] **Re-run the 2026-05-21 reproduction** on user_data 338759 (or a fresh test wallet on the same merged account): open the app → expect `Dashboard` if `canTrade: true`, or `KycPending(ident)` only if `processStatus: PendingReview` (no more spurious `KycIdentPage` from a re-issued Ident step).
- [ ] **New customer flow** still works end-to-end: register email → disclaimer → registration → progresses through `_continueKyc` for each required step.
- [ ] **Existing DFX customer merge flow** (PR #466 path): merge confirm → disclaimer → registration sign → lands on dashboard if the merged user is `canTrade: true`.

## Closes (from audit, P0)

- V1 — `_requiredStepNames` set
- V2 — `_minLevelForActions = 30` + `level < _requiredLevel` checks
- V3 — `actionableStatuses` / `pendingStatuses` sets and the iteration over kycSteps
- V5 — manual filter + routing chain over `kycSteps` (process-status-driven routing replaces the entire next-step selection algorithm)
- V45 — `_continueKyc`'s parallel iteration over `kycSteps`; the cubit now reads `KycSessionDto.currentStep` directly
- Routing dependency on iteration logic

Tracked in [`docs/api-authority-audit.md`](docs/api-authority-audit.md).

## Follow-ups

- The auto-email-registration branch when `level < 10` is still in the cubit; it's a Wave-3 candidate — the API could perform this server-side once the email is set.
- `KycStep → KycStepName` map (`_mapStepName`) is still local; if the API ever exposes a `uiHint` field it can go too.
