### PR TITLE
refactor(sell): consume BankAccountDto.default for auto-selection, drop active-fallback heuristic

### DIFF
--- a/docs/api-authority-audit.md
+++ b/docs/api-authority-audit.md
@@ -138,12 +138,6 @@ backend's understanding of state and the app's interpretation of it.
   - **Local decision:** that an API "no" is actually "yes, with a different next step"
   - **API change needed:** API returns `{ status: 'already_registered', nextStep: 'merge' }` and the app dispatches; the cubit must not paper over a 400
 
-### Bank-account default selection ignores API hint
-
-- **V11** — `lib/screens/sell/widgets/sell_bank_account_field.dart:41-44` — `state.accounts.lastWhereOrNull((a) => a.isActive)`
-  - **Local decision:** "the last active bank account is the right default" — duplicates the API's `BankAccountDto.default` flag with a positional heuristic
-  - **API change needed:** none — `BankAccountDto.isDefault` already exists in the app's own DTO (`lib/packages/service/dfx/models/bank_account/dto/bank_account_dto.dart:6`) and is parsed from the API's `default` field; the selector just needs to consume it
-
 ### Local startup gate that delays API surface
 
 - **V34** — `lib/main.dart:120` — `if (!homeState.softwareTermsAccepted) ...` blocks the dashboard until terms acceptance
@@ -262,6 +256,7 @@ required.**
 
 For completeness:
 
+- **V11** — `lib/screens/sell/widgets/sell_bank_account_field.dart` + `lib/screens/sell/widgets/sell_bank_account_selection_page.dart` — auto-selection now consumes `BankAccountDto.default` (mapped through to `BankAccount.isDefault`) under a strict `isDefault && isActive` filter on both surfaces; no positional fallback. Multi-default ambiguity is logged via `developer.log` and resolved by picking the first list entry. **Closed by:** W1.2 / [`DFXswiss/realunit-app#495`](https://github.com/DFXswiss/realunit-app/pull/495).
 - **V39** — `lib/screens/kyc/steps/email/kyc_email_page.dart:91` — `markRegistrationSignProduced()` after merge confirmation. Local session-gate position, called from a code path where the API already signaled success. Fixed by [`DFXswiss/realunit-app#466`](https://github.com/DFXswiss/realunit-app/pull/466). **OK.**
 - **V40** — `KycEmailVerificationCubit._completeRegistration` — surfaces failures correctly ([`DFXswiss/realunit-app#466`](https://github.com/DFXswiss/realunit-app/pull/466) / [`DFXswiss/api#3731`](https://github.com/DFXswiss/api/pull/3731)). Once [`DFXswiss/api#3731`](https://github.com/DFXswiss/api/pull/3731) merges and the `register/wallet` endpoint is idempotent, the client-side retry logic at the email verification page can be simplified further.
 
@@ -274,14 +269,14 @@ Numbers below are the **canonical counts** used everywhere this audit is referen
 | Severity | Count | V-IDs | Primary location |
 |---|---|---|---|
 | **P0** — blocks users today | 16 | V1–V5, V6a–V6d, V7, V8, V9, V13b, V16, V20, V45 | `kyc_cubit.dart` (7 incl. `_continueKyc`), buy/sell payment-info cubits (2), settings user-data + edit cubits (4), settings_contact (1), settings (1), sell_button (1) |
-| **P1** — local interpretation, no immediate block | 12 | V11, V15, V21–V27, V34, V41, V43 | `kyc_cubit.dart` + email-verification + registration-submit cubits + bank-account field + main.dart + real_unit_registration_service + financial-data questions page |
+| **P1** — local interpretation, no immediate block | 11 | V15, V21–V27, V34, V41, V43 | `kyc_cubit.dart` + email-verification + registration-submit cubits + main.dart + real_unit_registration_service + financial-data questions page |
 | **P2** — hardcoded lists/config | 22 | V10a–V10c, V12, V13, V13c, V14, V17–V19, V28–V33, V42, V44, V46, V47, V48, V49 | currency/language/country, legal docs, company info, assets, date pickers, default currency, tax-report date, faucet decision, support categories, registration user types |
 | **P3** — DTO mirroring (informational) | 4 | V35–V38 | service/dfx/models |
-| **P4** — fixed or in-flight | 2 | V39, V40 | tracked in [`DFXswiss/realunit-app#466`](https://github.com/DFXswiss/realunit-app/pull/466) / [`DFXswiss/api#3731`](https://github.com/DFXswiss/api/pull/3731) |
+| **P4** — fixed or in-flight | 3 | V11, V39, V40 | tracked in [`DFXswiss/realunit-app#466`](https://github.com/DFXswiss/realunit-app/pull/466) / [`DFXswiss/realunit-app#495`](https://github.com/DFXswiss/realunit-app/pull/495) / [`DFXswiss/api#3731`](https://github.com/DFXswiss/api/pull/3731) |
 
-**Total distinct violations across P0–P2:** 50 (16 + 12 + 22). Recounted on 2026-05-21 after a post-initial-review audit pass found 9 additional violations (V41–V49) that the initial four-stream scan had missed.
+**Total distinct violations across P0–P2:** 49 (16 + 11 + 22). Recounted on 2026-05-21 after a post-initial-review audit pass found 9 additional violations (V41–V49) that the initial four-stream scan had missed; V11 moved to P4 once W1.2 shipped.
 **Plus boundary cases accepted as documented exceptions:** V13b, V25, V28, V30, V33 — tagged in the audit, not counted as actionable.
-**Actionable P0–P2 (excluding documented exceptions):** 45.
+**Actionable P0–P2 (excluding documented exceptions):** 44.
 
 **Most-affected single file:** `lib/screens/kyc/cubits/kyc/kyc_cubit.dart` —
 ~10 distinct violations. The entire `_runCheckKyc` body should be replaceable by

--- a/lib/packages/service/dfx/models/bank_account/bank_account.dart
+++ b/lib/packages/service/dfx/models/bank_account/bank_account.dart
@@ -5,12 +5,17 @@ class BankAccount extends Equatable {
   final String? name;
   final String iban;
   final bool isActive;
+  // Backend-tagged "this is the user's preferred account" flag. Drives
+  // auto-selection in the sell flow without the app having to guess which
+  // active account the user wants.
+  final bool isDefault;
 
   const BankAccount({
     required this.id,
     required this.iban,
     this.name,
     this.isActive = false,
+    this.isDefault = false,
   });
 
   @override

--- a/lib/screens/sell/cubits/sell_bank_accounts/sell_bank_accounts_cubit.dart
+++ b/lib/screens/sell/cubits/sell_bank_accounts/sell_bank_accounts_cubit.dart
@@ -56,6 +56,7 @@ class SellBankAccountsCubit extends Cubit<SellBankAccountsState> {
               iban: bankAccount.iban,
               name: bankAccount.label,
               isActive: bankAccount.isActive,
+              isDefault: bankAccount.isDefault,
             ),
           )
           .toList();

--- a/lib/screens/sell/widgets/sell_bank_account_field.dart
+++ b/lib/screens/sell/widgets/sell_bank_account_field.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -39,12 +41,22 @@ class BankAccountFieldView extends StatelessWidget {
       listenWhen: (previous, current) => previous.accounts.length != current.accounts.length,
       listener: (context, state) {
         if (state.accounts.isNotEmpty) {
-          // Prefer the backend-tagged default account; fall back to the most
-          // recently added active one if no default is set. The API is the
-          // authority on which account is the user's preferred one.
-          final preferred =
-              state.accounts.firstWhereOrNull((a) => a.isDefault) ??
-              state.accounts.lastWhereOrNull((a) => a.isActive);
+          // API as authority: only auto-select the backend-tagged default
+          // account, and only if it is also active. No fallback heuristic —
+          // if the backend doesn't mark a default the picker stays empty and
+          // the user must choose explicitly. See "Keine Fallbacks" rule.
+          final defaults = state.accounts.where((a) => a.isDefault).toList();
+          if (defaults.length > 1) {
+            developer.log(
+              'Backend returned ${defaults.length} default bank accounts; '
+              'expected at most one. Picking the first in list order.',
+              name: 'SellBankAccountField',
+              level: 900,
+            );
+          }
+          final preferred = state.accounts.firstWhereOrNull(
+            (a) => a.isDefault && a.isActive,
+          );
           context.read<SellSelectedBankAccountCubit>().selectBankAccount(preferred);
         }
       },

--- a/lib/screens/sell/widgets/sell_bank_account_field.dart
+++ b/lib/screens/sell/widgets/sell_bank_account_field.dart
@@ -39,9 +39,13 @@ class BankAccountFieldView extends StatelessWidget {
       listenWhen: (previous, current) => previous.accounts.length != current.accounts.length,
       listener: (context, state) {
         if (state.accounts.isNotEmpty) {
-          context.read<SellSelectedBankAccountCubit>().selectBankAccount(
-            state.accounts.lastWhereOrNull((account) => account.isActive),
-          );
+          // Prefer the backend-tagged default account; fall back to the most
+          // recently added active one if no default is set. The API is the
+          // authority on which account is the user's preferred one.
+          final preferred =
+              state.accounts.firstWhereOrNull((a) => a.isDefault) ??
+              state.accounts.lastWhereOrNull((a) => a.isActive);
+          context.read<SellSelectedBankAccountCubit>().selectBankAccount(preferred);
         }
       },
       builder: (context, state) => Column(

--- a/lib/screens/sell/widgets/sell_bank_account_selection_page.dart
+++ b/lib/screens/sell/widgets/sell_bank_account_selection_page.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -32,9 +34,25 @@ class SellBankAccountSelectionPage extends StatelessWidget {
                     BlocListener<SellBankAccountsCubit, SellBankAccountsState>(
                       listener: (context, state) {
                         if (state is SellBankAccountsSuccess) {
+                          // Mirrors the auto-selection in `BankAccountFieldView`:
+                          // API is authority — only the backend-tagged default
+                          // (and only if active) is auto-selected. No active-
+                          // fallback heuristic, otherwise re-opening this page
+                          // would overwrite a correctly chosen default with the
+                          // last-active account.
+                          final defaults = state.accounts.where((a) => a.isDefault).toList();
+                          if (defaults.length > 1) {
+                            developer.log(
+                              'Backend returned ${defaults.length} default '
+                              'bank accounts; expected at most one. Picking '
+                              'the first in list order.',
+                              name: 'SellBankAccountSelectionPage',
+                              level: 900,
+                            );
+                          }
                           context.read<SellSelectedBankAccountCubit>().selectBankAccount(
-                            state.accounts.lastWhereOrNull(
-                              (account) => account.isActive,
+                            state.accounts.firstWhereOrNull(
+                              (account) => account.isDefault && account.isActive,
                             ),
                           );
                         }

--- a/test/screens/sell/widgets/sell_bank_account_field_test.dart
+++ b/test/screens/sell/widgets/sell_bank_account_field_test.dart
@@ -46,6 +46,11 @@ void main() {
     id: 4,
     iban: 'CH0000000000000000004',
   );
+  const accountDefaultButInactive = BankAccount(
+    id: 6,
+    iban: 'CH0000000000000000006',
+    isDefault: true,
+  );
 
   setUpAll(() {
     registerFallbackValue(accountActiveNonDefault1);
@@ -75,7 +80,11 @@ void main() {
         accountsCubit,
         Stream.fromIterable(const [
           SellBankAccountsInitial(),
-          SellBankAccountsSuccess([accountActiveNonDefault1, accountDefault, accountActiveNonDefault2]),
+          SellBankAccountsSuccess([
+            accountActiveNonDefault1,
+            accountDefault,
+            accountActiveNonDefault2,
+          ]),
         ]),
         initialState: const SellBankAccountsInitial(),
       );
@@ -87,8 +96,11 @@ void main() {
     });
 
     testWidgets(
-      'falls back to the last active account when no default is set',
+      'selects null when no default is flagged (no active-fallback heuristic)',
       (tester) async {
+        // Strict mode per "Keine Fallbacks" rule: if the backend doesn't tag a
+        // default we do NOT silently pick "the last active account". The user
+        // has to choose explicitly.
         whenListen(
           accountsCubit,
           Stream.fromIterable(const [
@@ -101,7 +113,7 @@ void main() {
         await pumpView(tester);
         await tester.pump();
 
-        verify(() => selectedCubit.selectBankAccount(accountActiveNonDefault2)).called(1);
+        verify(() => selectedCubit.selectBankAccount(null)).called(1);
       },
     );
 
@@ -125,11 +137,39 @@ void main() {
     );
 
     testWidgets(
+      'selects null when the only default account is inactive',
+      (tester) async {
+        // Threat model: backend bug could ship `default: true, active: false`.
+        // We must not auto-select such an account — `sell_button.dart` only
+        // null-checks the selection, so an inactive default would slip through.
+        whenListen(
+          accountsCubit,
+          Stream.fromIterable(const [
+            SellBankAccountsInitial(),
+            SellBankAccountsSuccess([
+              accountActiveNonDefault1,
+              accountDefaultButInactive,
+            ]),
+          ]),
+          initialState: const SellBankAccountsInitial(),
+        );
+
+        await pumpView(tester);
+        await tester.pump();
+
+        verify(() => selectedCubit.selectBankAccount(null)).called(1);
+      },
+    );
+
+    testWidgets(
       'picks the first default when multiple defaults are flagged',
       (tester) async {
         // Plan W1.2 acceptance: "If multiple defaults (shouldn't happen) →
         // first wins." Pins `firstWhereOrNull` ordering so a future switch to
-        // `lastWhereOrNull` (or any reverse iteration) is caught by CI.
+        // `lastWhereOrNull` (or any reverse iteration) is caught by CI. The
+        // `developer.log` warning emitted in this case is observable in dev
+        // tooling but not asserted here (dart:developer has no mockable
+        // surface).
         whenListen(
           accountsCubit,
           Stream.fromIterable(const [

--- a/test/screens/sell/widgets/sell_bank_account_field_test.dart
+++ b/test/screens/sell/widgets/sell_bank_account_field_test.dart
@@ -1,0 +1,137 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/bank_account/bank_account.dart';
+import 'package:realunit_wallet/screens/sell/cubits/sell_bank_accounts/sell_bank_accounts_cubit.dart';
+import 'package:realunit_wallet/screens/sell/cubits/sell_selected_bank_account/sell_selected_bank_account_cubit.dart';
+import 'package:realunit_wallet/screens/sell/widgets/sell_bank_account_field.dart';
+
+import '../../../helper/helper.dart';
+
+class _MockSellBankAccountsCubit extends MockCubit<SellBankAccountsState>
+    implements SellBankAccountsCubit {}
+
+class _MockSellSelectedBankAccountCubit extends MockCubit<BankAccount?>
+    implements SellSelectedBankAccountCubit {}
+
+void main() {
+  late _MockSellBankAccountsCubit accountsCubit;
+  late _MockSellSelectedBankAccountCubit selectedCubit;
+
+  const accountActiveNonDefault1 = BankAccount(
+    id: 1,
+    iban: 'CH0000000000000000001',
+    isActive: true,
+  );
+  const accountActiveNonDefault2 = BankAccount(
+    id: 2,
+    iban: 'CH0000000000000000002',
+    isActive: true,
+  );
+  const accountDefault = BankAccount(
+    id: 3,
+    iban: 'CH0000000000000000003',
+    isActive: true,
+    isDefault: true,
+  );
+  const accountInactive = BankAccount(
+    id: 4,
+    iban: 'CH0000000000000000004',
+  );
+
+  setUpAll(() {
+    registerFallbackValue(accountActiveNonDefault1);
+  });
+
+  setUp(() {
+    accountsCubit = _MockSellBankAccountsCubit();
+    selectedCubit = _MockSellSelectedBankAccountCubit();
+    when(() => selectedCubit.state).thenReturn(null);
+  });
+
+  Future<void> pumpView(WidgetTester tester) => tester.pumpApp(
+    MultiBlocProvider(
+      providers: [
+        BlocProvider<SellBankAccountsCubit>.value(value: accountsCubit),
+        BlocProvider<SellSelectedBankAccountCubit>.value(value: selectedCubit),
+      ],
+      child: const Scaffold(
+        body: SingleChildScrollView(child: BankAccountFieldView()),
+      ),
+    ),
+  );
+
+  group('$BankAccountFieldView auto-selection precedence', () {
+    testWidgets('prefers the default account when one is flagged', (tester) async {
+      whenListen(
+        accountsCubit,
+        Stream.fromIterable(const [
+          SellBankAccountsInitial(),
+          SellBankAccountsSuccess([accountActiveNonDefault1, accountDefault, accountActiveNonDefault2]),
+        ]),
+        initialState: const SellBankAccountsInitial(),
+      );
+
+      await pumpView(tester);
+      await tester.pump();
+
+      verify(() => selectedCubit.selectBankAccount(accountDefault)).called(1);
+    });
+
+    testWidgets(
+      'falls back to the last active account when no default is set',
+      (tester) async {
+        whenListen(
+          accountsCubit,
+          Stream.fromIterable(const [
+            SellBankAccountsInitial(),
+            SellBankAccountsSuccess([accountActiveNonDefault1, accountActiveNonDefault2]),
+          ]),
+          initialState: const SellBankAccountsInitial(),
+        );
+
+        await pumpView(tester);
+        await tester.pump();
+
+        verify(() => selectedCubit.selectBankAccount(accountActiveNonDefault2)).called(1);
+      },
+    );
+
+    testWidgets(
+      'selects null when accounts exist but none are default or active',
+      (tester) async {
+        whenListen(
+          accountsCubit,
+          Stream.fromIterable(const [
+            SellBankAccountsInitial(),
+            SellBankAccountsSuccess([accountInactive]),
+          ]),
+          initialState: const SellBankAccountsInitial(),
+        );
+
+        await pumpView(tester);
+        await tester.pump();
+
+        verify(() => selectedCubit.selectBankAccount(null)).called(1);
+      },
+    );
+
+    testWidgets('does nothing when accounts list stays empty', (tester) async {
+      whenListen(
+        accountsCubit,
+        Stream.fromIterable(const [
+          SellBankAccountsInitial(),
+          SellBankAccountsLoadFailure(),
+        ]),
+        initialState: const SellBankAccountsInitial(),
+      );
+
+      await pumpView(tester);
+      await tester.pump();
+
+      verifyNever(() => selectedCubit.selectBankAccount(any()));
+    });
+  });
+}

--- a/test/screens/sell/widgets/sell_bank_account_field_test.dart
+++ b/test/screens/sell/widgets/sell_bank_account_field_test.dart
@@ -36,6 +36,12 @@ void main() {
     isActive: true,
     isDefault: true,
   );
+  const accountDefaultSecond = BankAccount(
+    id: 5,
+    iban: 'CH0000000000000000005',
+    isActive: true,
+    isDefault: true,
+  );
   const accountInactive = BankAccount(
     id: 4,
     iban: 'CH0000000000000000004',
@@ -115,6 +121,33 @@ void main() {
         await tester.pump();
 
         verify(() => selectedCubit.selectBankAccount(null)).called(1);
+      },
+    );
+
+    testWidgets(
+      'picks the first default when multiple defaults are flagged',
+      (tester) async {
+        // Plan W1.2 acceptance: "If multiple defaults (shouldn't happen) →
+        // first wins." Pins `firstWhereOrNull` ordering so a future switch to
+        // `lastWhereOrNull` (or any reverse iteration) is caught by CI.
+        whenListen(
+          accountsCubit,
+          Stream.fromIterable(const [
+            SellBankAccountsInitial(),
+            SellBankAccountsSuccess([
+              accountActiveNonDefault1,
+              accountDefault,
+              accountDefaultSecond,
+            ]),
+          ]),
+          initialState: const SellBankAccountsInitial(),
+        );
+
+        await pumpView(tester);
+        await tester.pump();
+
+        verify(() => selectedCubit.selectBankAccount(accountDefault)).called(1);
+        verifyNever(() => selectedCubit.selectBankAccount(accountDefaultSecond));
       },
     );
 

--- a/test/screens/sell/widgets/sell_bank_account_selection_page_test.dart
+++ b/test/screens/sell/widgets/sell_bank_account_selection_page_test.dart
@@ -1,0 +1,207 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/generated/i18n.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/bank_account/bank_account.dart';
+import 'package:realunit_wallet/screens/sell/cubits/sell_bank_accounts/sell_bank_accounts_cubit.dart';
+import 'package:realunit_wallet/screens/sell/cubits/sell_selected_bank_account/sell_selected_bank_account_cubit.dart';
+import 'package:realunit_wallet/screens/sell/widgets/sell_bank_account_selection_page.dart';
+
+class _MockSellBankAccountsCubit extends MockCubit<SellBankAccountsState>
+    implements SellBankAccountsCubit {}
+
+class _MockSellSelectedBankAccountCubit extends MockCubit<BankAccount?>
+    implements SellSelectedBankAccountCubit {}
+
+void main() {
+  late _MockSellBankAccountsCubit accountsCubit;
+  late _MockSellSelectedBankAccountCubit selectedCubit;
+
+  const accountActiveNonDefault1 = BankAccount(
+    id: 1,
+    iban: 'CH0000000000000000001',
+    isActive: true,
+  );
+  const accountActiveNonDefault2 = BankAccount(
+    id: 2,
+    iban: 'CH0000000000000000002',
+    isActive: true,
+  );
+  const accountDefault = BankAccount(
+    id: 3,
+    iban: 'CH0000000000000000003',
+    isActive: true,
+    isDefault: true,
+  );
+  const accountDefaultSecond = BankAccount(
+    id: 5,
+    iban: 'CH0000000000000000005',
+    isActive: true,
+    isDefault: true,
+  );
+  const accountDefaultButInactive = BankAccount(
+    id: 6,
+    iban: 'CH0000000000000000006',
+    isDefault: true,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(accountActiveNonDefault1);
+  });
+
+  setUp(() {
+    accountsCubit = _MockSellBankAccountsCubit();
+    selectedCubit = _MockSellSelectedBankAccountCubit();
+    when(() => selectedCubit.state).thenReturn(null);
+  });
+
+  // The page calls `context.pop()` when the accounts list grows, so we have
+  // to wrap it in a GoRouter for those listeners to resolve. The router is
+  // never actually navigated in these tests because we only assert on the
+  // initial auto-selection listener.
+  Future<void> pumpPage(WidgetTester tester) async {
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => MultiBlocProvider(
+            providers: [
+              BlocProvider<SellBankAccountsCubit>.value(value: accountsCubit),
+              BlocProvider<SellSelectedBankAccountCubit>.value(
+                value: selectedCubit,
+              ),
+            ],
+            child: const SellBankAccountSelectionPage(),
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+    await tester.pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+        localizationsDelegates: [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+        ],
+        supportedLocales: S.delegate.supportedLocales,
+      ),
+    );
+  }
+
+  group('$SellBankAccountSelectionPage auto-selection on re-open', () {
+    testWidgets(
+      'prefers the default account, even after the page is re-opened',
+      (tester) async {
+        // Regression for V11: the previous active-last heuristic on this page
+        // would overwrite the default chosen in BankAccountFieldView the
+        // moment the user opened the selection page. We start from a Loading
+        // state with the same accounts already populated (mirroring the
+        // re-open flow where the cubit already has data) so the SAME length
+        // is emitted afterwards — the `accounts.length` listener guards the
+        // pop, but the selection listener fires unconditionally on Success.
+        whenListen(
+          accountsCubit,
+          Stream.fromIterable(const [
+            SellBankAccountsSuccess([
+              accountActiveNonDefault1,
+              accountDefault,
+              accountActiveNonDefault2,
+            ]),
+          ]),
+          initialState: const SellBankAccountsLoading([
+            accountActiveNonDefault1,
+            accountDefault,
+            accountActiveNonDefault2,
+          ]),
+        );
+
+        await pumpPage(tester);
+        await tester.pump();
+
+        verify(() => selectedCubit.selectBankAccount(accountDefault)).called(1);
+      },
+    );
+
+    testWidgets(
+      'selects null when no default is flagged (no active-fallback)',
+      (tester) async {
+        whenListen(
+          accountsCubit,
+          Stream.fromIterable(const [
+            SellBankAccountsSuccess([
+              accountActiveNonDefault1,
+              accountActiveNonDefault2,
+            ]),
+          ]),
+          initialState: const SellBankAccountsLoading([
+            accountActiveNonDefault1,
+            accountActiveNonDefault2,
+          ]),
+        );
+
+        await pumpPage(tester);
+        await tester.pump();
+
+        verify(() => selectedCubit.selectBankAccount(null)).called(1);
+      },
+    );
+
+    testWidgets(
+      'selects null when the only default account is inactive',
+      (tester) async {
+        whenListen(
+          accountsCubit,
+          Stream.fromIterable(const [
+            SellBankAccountsSuccess([
+              accountActiveNonDefault1,
+              accountDefaultButInactive,
+            ]),
+          ]),
+          initialState: const SellBankAccountsLoading([
+            accountActiveNonDefault1,
+            accountDefaultButInactive,
+          ]),
+        );
+
+        await pumpPage(tester);
+        await tester.pump();
+
+        verify(() => selectedCubit.selectBankAccount(null)).called(1);
+      },
+    );
+
+    testWidgets(
+      'picks the first default when multiple defaults are flagged',
+      (tester) async {
+        whenListen(
+          accountsCubit,
+          Stream.fromIterable(const [
+            SellBankAccountsSuccess([
+              accountActiveNonDefault1,
+              accountDefault,
+              accountDefaultSecond,
+            ]),
+          ]),
+          initialState: const SellBankAccountsLoading([
+            accountActiveNonDefault1,
+            accountDefault,
+            accountDefaultSecond,
+          ]),
+        );
+
+        await pumpPage(tester);
+        await tester.pump();
+
+        verify(() => selectedCubit.selectBankAccount(accountDefault)).called(1);
+        verifyNever(
+          () => selectedCubit.selectBankAccount(accountDefaultSecond),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Wave 1.2 of the API-as-Decision-Authority audit ([`docs/api-authority-plan.md`](docs/api-authority-plan.md), foundation rule in #491). `BankAccountDto.default` already exists in the API response (`/v1/bankAccount` returns `{ ..., active, default }`); the app was ignoring it and falling back to a "last active" heuristic for auto-selection in the sell flow.

## Changes

- `BankAccount` domain model gains `isDefault: bool` (defaults to `false`); `SellBankAccountsCubit._loadBankAccounts` maps `bankAccount.isDefault` from the DTO through to the model.
- **Strict default-only auto-selection on both sell-flow surfaces:**
  - `sell_bank_account_field.dart` (auto-select listener after `_loadBankAccounts`).
  - `sell_bank_account_selection_page.dart` (auto-select listener on the selection-page modal).
  Both sites use the same filter: `firstWhereOrNull((a) => a.isDefault && a.isActive)`.
- **No positional fallback.** If the API does not flag any account as default, the picker stays empty and the user must choose explicitly. Aligns with the "Keine Fallbacks" rule and matches plan W1.2's strict acceptance.
- **Multi-default ambiguity** (more than one `isDefault == true` in the list) is logged via `developer.log(level: 900, name: 'SellBankAccountField' | 'SellBankAccountSelectionPage')` and resolved by picking the first list entry. Backend constraint is "at most one default"; the warning surfaces a violation without dropping the user into a stuck UI.
- Five focused widget tests pin the precedence across `(one default, no default, multiple defaults)` plus the empty- and all-inactive-list edges, on **both** surfaces (field + selection page).

## Why this is safe

- Zero API changes; new domain field is additive with a safe `false` default.
- Old "last active" heuristic is gone, but the previous behaviour was already an audit finding (V11, P1) — the UX change is the intended fix, not a regression.
- Strict semantics match the API contract: the backend is the authority on which account is the default.

## Audit

- **Closes V11** — `lib/screens/sell/widgets/sell_bank_account_field.dart` + `lib/screens/sell/widgets/sell_bank_account_selection_page.dart` auto-selection now consumes `BankAccountDto.default`. Moved from P1 → P4 in [`docs/api-authority-audit.md`](docs/api-authority-audit.md) (P1 12 → 11, P4 2 → 3, Total P0–P2 50 → 49).

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — **1445 / 1445 passing** (incl. 5 new cases across `test/screens/sell/widgets/sell_bank_account_field_test.dart` + `sell_bank_account_selection_page_test.dart`)
