### PR TITLE
refactor(app): consume UserCapabilities + ALREADY_REGISTERED registration status

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -209,6 +209,7 @@
   "registerPhoneNumberOnlyDigits": "Nur Zahlen sind erlaubt",
   "registerPhoneNumberTooShort": "Telefonnummer ist zu kurz",
   "registrationFailed": "Registrierung fehlgeschlagen:\n${message}",
+  "registrationForwardingFailed": "Registrierung angenommen, aber die Weiterleitung an die Gesellschaft ist verzögert. Wir versuchen es automatisch erneut.",
   "registrationRequired": "Registrierung erforderlich",
   "registrationRequiredDescription": "Um RealUnit Token kaufen zu können, müssen Sie sich einmalig registrieren.",
   "reset": "Zurücksetzen",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -209,6 +209,7 @@
   "registerPhoneNumberOnlyDigits": "Only numbers are allowed",
   "registerPhoneNumberTooShort": "Phone number is too short",
   "registrationFailed": "Registration failed:\n${message}",
+  "registrationForwardingFailed": "Registration accepted, but forwarding to the company is delayed. We will retry automatically.",
   "registrationRequired": "Registration required",
   "registrationRequiredDescription": "To purchase RealUnit tokens, you must register once.",
   "reset": "Reset",

--- a/docs/api-authority-audit.md
+++ b/docs/api-authority-audit.md
@@ -161,7 +161,7 @@ backend's understanding of state and the app's interpretation of it.
 - **V46** — `lib/screens/kyc/steps/registration/steps/kyc_registration_personal_step.dart:50-53` — `[RegistrationUserType.values.first]` restricts the account-type dropdown to a single value
   - **Local decision:** the DTO carries multiple `RegistrationUserType` values but the UI only renders `.values.first` (i.e. `human`). Which account types this branded app exposes is a business decision frozen in code
   - **API change needed:** `availableUserTypes: ['human']` capability flag on `UserV2Dto` (or on the registration endpoint response); app renders the returned list. Same shape as V12 / V13
-  - **Closed by:** W3.1 / W3.2 (capabilities)
+  - **Deferred:** not in W3.1 / W3.2 scope — the dropdown source is `RegistrationUserType.values` (a local enum), not a capability list from `UserCapabilitiesDto`. Surfacing the available account types requires a separate API change (own capability field or endpoint extension) and a UI migration; tracked for a follow-up wave.
 - **V13** — `lib/styles/language.dart:3-22` — `enum Language { EN, DE }`
   - **API change needed:** call `/v1/language` (already exists on the DFX API)
 - **V14** — `lib/widgets/form/country_field.dart:65-79` — `['CH', 'DE', 'IT', 'FR']` priority list at top

--- a/lib/packages/service/dfx/models/registration/registration_status.dart
+++ b/lib/packages/service/dfx/models/registration/registration_status.dart
@@ -1,7 +1,13 @@
 enum RegistrationStatus {
   completed,
   pendingReview,
-  forwardingFailed;
+  forwardingFailed,
+  // Backend status when the wallet is already registered for the user.
+  // The realunit-app used to handle this as a 400 BadRequestException
+  // ("registration already exists") — PR DFXswiss/api#3733 makes the API
+  // return this structured value instead, and the merge-confirmation /
+  // retry code paths now branch on it as a soft success.
+  alreadyRegistered;
 
   static RegistrationStatus fromString(String status) {
     switch (status) {
@@ -11,6 +17,8 @@ enum RegistrationStatus {
         return RegistrationStatus.pendingReview;
       case 'forwarding_failed':
         return RegistrationStatus.forwardingFailed;
+      case 'already_registered':
+        return RegistrationStatus.alreadyRegistered;
       default:
         throw Exception('Unknown registration status: $status');
     }

--- a/lib/packages/service/dfx/models/user/dto/user_dto.dart
+++ b/lib/packages/service/dfx/models/user/dto/user_dto.dart
@@ -3,13 +3,21 @@ import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
 class UserDto {
   final String? mail;
   final UserKycDto kyc;
+  final UserCapabilitiesDto capabilities;
 
-  const UserDto({this.mail, required this.kyc});
+  const UserDto({
+    this.mail,
+    required this.kyc,
+    this.capabilities = const UserCapabilitiesDto(),
+  });
 
   factory UserDto.fromJson(Map<String, dynamic> json) {
     return UserDto(
       mail: json['mail'] as String?,
       kyc: UserKycDto.fromJson(json['kyc'] as Map<String, dynamic>),
+      capabilities: json['capabilities'] != null
+          ? UserCapabilitiesDto.fromJson(json['capabilities'] as Map<String, dynamic>)
+          : const UserCapabilitiesDto(),
     );
   }
 }
@@ -30,6 +38,37 @@ class UserKycDto {
       hash: json['hash'] as String,
       level: KycLevelExtension.fromValue(json['level'] as int),
       dataComplete: json['dataComplete'] as bool,
+    );
+  }
+}
+
+// Mirror of `UserCapabilitiesDto` on the API. Authoritative per-action
+// gating — the app renders Edit / Support affordances from these flags
+// instead of inferring them from KYC step status. Defaults are
+// conservative (everything `false`) so pre-PR backends do not silently
+// expose actions the API isn't yet ready to handle.
+class UserCapabilitiesDto {
+  final bool canEditName;
+  final bool canEditMail;
+  final bool canEditPhone;
+  final bool canEditAddress;
+  final bool supportAvailable;
+
+  const UserCapabilitiesDto({
+    this.canEditName = false,
+    this.canEditMail = false,
+    this.canEditPhone = false,
+    this.canEditAddress = false,
+    this.supportAvailable = false,
+  });
+
+  factory UserCapabilitiesDto.fromJson(Map<String, dynamic> json) {
+    return UserCapabilitiesDto(
+      canEditName: json['canEditName'] as bool? ?? false,
+      canEditMail: json['canEditMail'] as bool? ?? false,
+      canEditPhone: json['canEditPhone'] as bool? ?? false,
+      canEditAddress: json['canEditAddress'] as bool? ?? false,
+      supportAvailable: json['supportAvailable'] as bool? ?? false,
     );
   }
 }

--- a/lib/screens/kyc/steps/registration/cubits/registration_submit/kyc_registration_submit_cubit.dart
+++ b/lib/screens/kyc/steps/registration/cubits/registration_submit/kyc_registration_submit_cubit.dart
@@ -3,7 +3,6 @@ import 'dart:developer' as developer;
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
-import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/country/country.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/registration.dart';
@@ -74,22 +73,16 @@ class KycRegistrationSubmitCubit extends Cubit<KycRegistrationSubmitState> {
   Future<void> _doCompleteRegistration(Registration registration) async {
     try {
       final status = await _registrationService.completeRegistration(registration);
+      // The API returns a structured `RegistrationStatus` in every
+      // success case — including `alreadyRegistered`
+      // (DFXswiss/api#3733). We forward whatever the backend says and
+      // let `KycCubit.checkKyc()` resolve the next step on the listener
+      // side; no more swallowing of generic ApiExceptions as success.
       emit(KycRegistrationSubmitSuccess(status));
     } on BitboxNotConnectedException {
       emit(
         KycRegistrationSubmitBitboxRequired(registration: registration),
       );
-    } on ApiException catch (e) {
-      // The EIP-712 13-step sign already succeeded on the device — the user
-      // has proven hardware-wallet control. The backend's logical rejection
-      // (already registered / wallet linked to another account / merge
-      // required) is informational, not a signal that the ceremony failed.
-      // Treat the sign as completed and let `KycCubit.checkKyc()` resolve
-      // the next step from the refreshed KYC status (merge page, ident,
-      // ...). Network / parse errors throw a different exception type and
-      // still surface as a failure below.
-      developer.log('completeRegistration backend rejected after sign: $e');
-      emit(const KycRegistrationSubmitSuccess(RegistrationStatus.completed));
     } catch (e) {
       developer.log(e.toString());
       emit(KycRegistrationSubmitFailure(e.toString(), cause: e));

--- a/lib/screens/kyc/steps/registration/kyc_registration_page.dart
+++ b/lib/screens/kyc/steps/registration/kyc_registration_page.dart
@@ -103,11 +103,22 @@ class _KycRegistrationViewState extends State<KycRegistrationView> {
       body: BlocListener<KycRegistrationSubmitCubit, KycRegistrationSubmitState>(
         listener: (context, state) async {
           if (state is KycRegistrationSubmitSuccess) {
-            if (state.status == RegistrationStatus.completed) {
-              // completeRegistration already produced the EIP-712 registration
-              // signature, so the sign gate is satisfied for this session.
-              context.read<KycCubit>().markRegistrationSignProduced();
-              context.read<KycCubit>().checkKyc();
+            // The submit cubit only emits Success after a successful EIP-712
+            // sign through `_signEip712`, regardless of the resulting backend
+            // status (completed, pendingReview, forwardingFailed,
+            // alreadyRegistered). The sign gate is therefore satisfied for
+            // every Success branch — mark it produced and let `checkKyc`
+            // resolve the next KYC step from the API.
+            context.read<KycCubit>().markRegistrationSignProduced();
+            context.read<KycCubit>().checkKyc();
+
+            if (state.status == RegistrationStatus.forwardingFailed) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(S.of(context).registrationForwardingFailed),
+                  backgroundColor: RealUnitColors.status.red600,
+                ),
+              );
             }
           }
           if (state is KycRegistrationSubmitFailure) {

--- a/lib/screens/settings_contact/cubit/settings_contact_cubit.dart
+++ b/lib/screens/settings_contact/cubit/settings_contact_cubit.dart
@@ -19,7 +19,11 @@ class SettingsContactCubit extends Cubit<SettingsContactState> {
     try {
       emit(const SettingsContactLoading());
       final userDto = await _kycService.getUser();
-      emit(SettingsContactSuccess(emailSet: userDto.mail != null));
+      // Render Support directly from the backend's capability flag
+      // (`UserCapabilitiesDto.supportAvailable`) instead of inferring
+      // it from `mail != null`. The flag and the mail check happen to
+      // coincide today, but the API is the authority.
+      emit(SettingsContactSuccess(supportAvailable: userDto.capabilities.supportAvailable));
     } catch (e) {
       developer.log(e.toString(), name: '$SettingsContactCubit');
       emit(SettingsContactFailure(message: e.toString()));

--- a/lib/screens/settings_contact/cubit/settings_contact_state.dart
+++ b/lib/screens/settings_contact/cubit/settings_contact_state.dart
@@ -16,18 +16,18 @@ class SettingsContactLoading extends SettingsContactState {
 }
 
 class SettingsContactSuccess extends SettingsContactState {
-  final bool emailSet;
+  final bool supportAvailable;
 
-  const SettingsContactSuccess({this.emailSet = false});
+  const SettingsContactSuccess({this.supportAvailable = false});
 
-  SettingsContactSuccess copyWith({bool? emailSet}) {
+  SettingsContactSuccess copyWith({bool? supportAvailable}) {
     return SettingsContactSuccess(
-      emailSet: emailSet ?? this.emailSet,
+      supportAvailable: supportAvailable ?? this.supportAvailable,
     );
   }
 
   @override
-  List<Object?> get props => [emailSet];
+  List<Object?> get props => [supportAvailable];
 }
 
 class SettingsContactFailure extends SettingsContactState {

--- a/lib/screens/settings_contact/settings_contact_page.dart
+++ b/lib/screens/settings_contact/settings_contact_page.dart
@@ -51,8 +51,8 @@ class SettingsContactView extends StatelessWidget {
                 children: [
                   BlocBuilder<SettingsContactCubit, SettingsContactState>(
                     builder: (context, state) => switch (state) {
-                      SettingsContactSuccess(:final emailSet) =>
-                        emailSet
+                      SettingsContactSuccess(:final supportAvailable) =>
+                        supportAvailable
                             ? OutlinedTile(
                                 leading: const Icon(
                                   Icons.support_agent_outlined,

--- a/lib/screens/settings_user_data/cubit/settings_user_data_cubit.dart
+++ b/lib/screens/settings_user_data/cubit/settings_user_data_cubit.dart
@@ -8,6 +8,7 @@ import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_level_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/registration_user_type.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/user/dto/user_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/user/user_data.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_wallet_status_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
@@ -43,19 +44,16 @@ class SettingsUserDataCubit extends Cubit<SettingsUserDataState> {
       final results = await Future.wait([
         _walletService.getWalletStatus(),
         _kycService.getKycStatus(),
+        _kycService.getUser(),
       ]);
 
       final result = results.elementAt(0) as RealUnitWalletStatusDto;
       final kycStatus = results.elementAt(1) as KycLevelDto;
+      final user = results.elementAt(2) as UserDto;
       final userDataDto = result.realUnitUserDataDto;
 
       if (userDataDto == null) {
-        try {
-          final user = await _kycService.getUser();
-          emit(SettingsUserDataSuccess(email: user.mail));
-        } catch (_) {
-          emit(const SettingsUserDataSuccess());
-        }
+        emit(SettingsUserDataSuccess(email: user.mail, capabilities: user.capabilities));
         return;
       }
 
@@ -91,6 +89,7 @@ class SettingsUserDataCubit extends Cubit<SettingsUserDataState> {
             lang: userDataDto.lang,
           ),
           pendingSteps: pendingSteps,
+          capabilities: user.capabilities,
         ),
       );
     } on BitboxNotConnectedException {

--- a/lib/screens/settings_user_data/cubit/settings_user_data_state.dart
+++ b/lib/screens/settings_user_data/cubit/settings_user_data_state.dart
@@ -27,9 +27,18 @@ class SettingsUserDataSuccess extends SettingsUserDataState {
   final UserData? userData;
   final String? email;
   final Set<KycStepName> pendingSteps;
+  // API-driven per-action gates from `/v2/user.capabilities`. The page
+  // uses these to decide whether to render Edit buttons — replacing the
+  // local `pendingSteps == inReview` interpretation.
+  final UserCapabilitiesDto capabilities;
 
-  const SettingsUserDataSuccess({this.userData, this.email, this.pendingSteps = const {}});
+  const SettingsUserDataSuccess({
+    this.userData,
+    this.email,
+    this.pendingSteps = const {},
+    this.capabilities = const UserCapabilitiesDto(),
+  });
 
   @override
-  List<Object?> get props => [userData, email, pendingSteps];
+  List<Object?> get props => [userData, email, pendingSteps, capabilities];
 }

--- a/lib/screens/settings_user_data/settings_user_data_page.dart
+++ b/lib/screens/settings_user_data/settings_user_data_page.dart
@@ -44,7 +44,7 @@ class SettingsUserDataView extends StatelessWidget {
         padding: const .symmetric(horizontal: 20.0, vertical: 12.0),
         child: BlocBuilder<SettingsUserDataCubit, SettingsUserDataState>(
           builder: (context, state) => switch (state) {
-            SettingsUserDataSuccess(:final userData, :final email, :final pendingSteps) =>
+            SettingsUserDataSuccess(:final userData, :final email, :final pendingSteps, :final capabilities) =>
               userData != null
                   ? SingleChildScrollView(
                       child: Padding(
@@ -64,14 +64,16 @@ class SettingsUserDataView extends StatelessWidget {
                                 statusLabel: pendingSteps.contains(KycStepName.nameChange)
                                     ? S.of(context).changeInReview
                                     : null,
-                                onEdit: () async {
-                                  final isEdited = await context.pushNamed<bool>(
-                                    SettingsRoutes.editName,
-                                  );
-                                  if (isEdited == true && context.mounted) {
-                                    context.read<SettingsUserDataCubit>().getUserData();
-                                  }
-                                },
+                                onEdit: capabilities.canEditName
+                                    ? () async {
+                                        final isEdited = await context.pushNamed<bool>(
+                                          SettingsRoutes.editName,
+                                        );
+                                        if (isEdited == true && context.mounted) {
+                                          context.read<SettingsUserDataCubit>().getUserData();
+                                        }
+                                      }
+                                    : null,
                               ),
                               _UserDataRow(
                                 label: S.of(context).birthday,
@@ -85,14 +87,16 @@ class SettingsUserDataView extends StatelessWidget {
                               _UserDataRow(
                                 label: S.of(context).phoneNumber,
                                 value: userData.phoneNumber,
-                                onEdit: () async {
-                                  final isEdited = await context.pushNamed<bool>(
-                                    SettingsRoutes.editPhone,
-                                  );
-                                  if (isEdited == true && context.mounted) {
-                                    context.read<SettingsUserDataCubit>().getUserData();
-                                  }
-                                },
+                                onEdit: capabilities.canEditPhone
+                                    ? () async {
+                                        final isEdited = await context.pushNamed<bool>(
+                                          SettingsRoutes.editPhone,
+                                        );
+                                        if (isEdited == true && context.mounted) {
+                                          context.read<SettingsUserDataCubit>().getUserData();
+                                        }
+                                      }
+                                    : null,
                               ),
                               _UserDataRow(
                                 label: S.of(context).residence,
@@ -101,14 +105,16 @@ class SettingsUserDataView extends StatelessWidget {
                                 statusLabel: pendingSteps.contains(KycStepName.addressChange)
                                     ? S.of(context).changeInReview
                                     : null,
-                                onEdit: () async {
-                                  final isEdited = await context.pushNamed<bool>(
-                                    SettingsRoutes.editAddress,
-                                  );
-                                  if (isEdited == true && context.mounted) {
-                                    context.read<SettingsUserDataCubit>().getUserData();
-                                  }
-                                },
+                                onEdit: capabilities.canEditAddress
+                                    ? () async {
+                                        final isEdited = await context.pushNamed<bool>(
+                                          SettingsRoutes.editAddress,
+                                        );
+                                        if (isEdited == true && context.mounted) {
+                                          context.read<SettingsUserDataCubit>().getUserData();
+                                        }
+                                      }
+                                    : null,
                               ),
                             ],
                           ),
@@ -236,7 +242,11 @@ class _UserDataRow extends StatelessWidget {
             ),
           ],
         ),
-        if (onEdit != null && statusLabel == null)
+        // `onEdit == null` is now the authoritative signal: the cubit only
+        // wires it up when `UserCapabilitiesDto.canEdit*` is true. The
+        // status label (e.g. "Change in review") stays as an informational
+        // badge alongside the Edit button — no extra gating here.
+        if (onEdit != null)
           IconButton.filledTonal(
             onPressed: onEdit,
             icon: const Icon(Icons.edit_outlined),

--- a/lib/screens/settings_user_data/subpages/edit_address/cubit/settings_edit_address_cubit.dart
+++ b/lib/screens/settings_user_data/subpages/edit_address/cubit/settings_edit_address_cubit.dart
@@ -19,13 +19,16 @@ class SettingsEditAddressCubit extends Cubit<SettingsEditAddressState> {
       emit(const SettingsEditAddressLoading());
       final session = await _kycService.startStep(KycStepName.addressChange);
 
-      if (session.currentStep?.status == KycStepStatus.inReview) {
+      // Per W3.2: the parent page only invokes this cubit when
+      // `UserCapabilitiesDto.canEditAddress` is true, so an in-review state
+      // is no longer reachable here. The pending branch is kept defensive
+      // (race between the capability check and the start-step call) but
+      // it is no longer the primary gating mechanism.
+      final url = session.currentStep?.session.url;
+      if (url == null) {
         emit(const SettingsEditAddressPending());
         return;
       }
-
-      final url = session.currentStep?.session.url;
-      if (url == null) throw Exception('No session URL returned');
       emit(SettingsEditAddressReady(url));
     } catch (e) {
       emit(SettingsEditAddressFailure(e.toString()));

--- a/lib/screens/settings_user_data/subpages/edit_name/cubit/settings_edit_name_cubit.dart
+++ b/lib/screens/settings_user_data/subpages/edit_name/cubit/settings_edit_name_cubit.dart
@@ -19,13 +19,16 @@ class SettingsEditNameCubit extends Cubit<SettingsEditNameState> {
       emit(const SettingsEditNameLoading());
       final session = await _kycService.startStep(KycStepName.nameChange);
 
-      if (session.currentStep?.status == KycStepStatus.inReview) {
+      // Per W3.2: the parent page only invokes this cubit when
+      // `UserCapabilitiesDto.canEditName` is true, so an in-review state
+      // is no longer reachable here. The pending branch is kept defensive
+      // (race between the capability check and the start-step call) but
+      // it is no longer the primary gating mechanism.
+      final url = session.currentStep?.session.url;
+      if (url == null) {
         emit(const SettingsEditNamePending());
         return;
       }
-
-      final url = session.currentStep?.session.url;
-      if (url == null) throw Exception('No session URL returned');
       emit(SettingsEditNameReady(url));
     } catch (e) {
       emit(SettingsEditNameFailure(e.toString()));

--- a/test/screens/kyc/steps/kyc_registration_page_test.dart
+++ b/test/screens/kyc/steps/kyc_registration_page_test.dart
@@ -53,6 +53,7 @@ void main() {
     when(() => registrationSubmitCubit.state).thenReturn(KycRegistrationSubmitInitial());
     when(() => kycCubit.state).thenReturn(const KycInitial());
     when(() => kycCubit.checkKyc()).thenAnswer((_) => Future.value());
+    when(() => kycCubit.markRegistrationSignProduced()).thenReturn(null);
   });
 
   void setupDependencyInjection() {
@@ -138,8 +139,72 @@ void main() {
       await tester.pumpApp(buildSubject(const KycRegistrationView()));
       await tester.pump();
 
+      verify(() => kycCubit.markRegistrationSignProduced()).called(1);
       verify(() => kycCubit.checkKyc()).called(1);
     });
+
+    testWidgets(
+      'marks sign produced + triggers checkKyc on Success(alreadyRegistered)',
+      (tester) async {
+        // Wave 3.2 regression guard: the API now emits a structured
+        // `Success(alreadyRegistered)` instead of a swallowed
+        // ApiException, and the listener must treat it identically to
+        // `completed` — the EIP-712 sign has already happened, so the
+        // sign gate must be lifted and the KYC step refreshed.
+        whenListen(
+          registrationSubmitCubit,
+          Stream.fromIterable([
+            const KycRegistrationSubmitSuccess(RegistrationStatus.alreadyRegistered),
+          ]),
+          initialState: KycRegistrationSubmitInitial(),
+        );
+
+        await tester.pumpApp(buildSubject(const KycRegistrationView()));
+        await tester.pump();
+
+        verify(() => kycCubit.markRegistrationSignProduced()).called(1);
+        verify(() => kycCubit.checkKyc()).called(1);
+      },
+    );
+
+    testWidgets(
+      'marks sign produced + triggers checkKyc on Success(pendingReview)',
+      (tester) async {
+        whenListen(
+          registrationSubmitCubit,
+          Stream.fromIterable([
+            const KycRegistrationSubmitSuccess(RegistrationStatus.pendingReview),
+          ]),
+          initialState: KycRegistrationSubmitInitial(),
+        );
+
+        await tester.pumpApp(buildSubject(const KycRegistrationView()));
+        await tester.pump();
+
+        verify(() => kycCubit.markRegistrationSignProduced()).called(1);
+        verify(() => kycCubit.checkKyc()).called(1);
+      },
+    );
+
+    testWidgets(
+      'shows SnackBar AND lifts the sign gate on Success(forwardingFailed)',
+      (tester) async {
+        whenListen(
+          registrationSubmitCubit,
+          Stream.fromIterable([
+            const KycRegistrationSubmitSuccess(RegistrationStatus.forwardingFailed),
+          ]),
+          initialState: KycRegistrationSubmitInitial(),
+        );
+
+        await tester.pumpApp(buildSubject(const KycRegistrationView()));
+        await tester.pump();
+
+        verify(() => kycCubit.markRegistrationSignProduced()).called(1);
+        verify(() => kycCubit.checkKyc()).called(1);
+        expect(find.byType(SnackBar), findsOne);
+      },
+    );
 
     testWidgets('shows SnackBar if submitting fails', (tester) async {
       whenListen(

--- a/test/screens/kyc/steps/registration/cubits/registration_submit/kyc_registration_submit_cubit_test.dart
+++ b/test/screens/kyc/steps/registration/cubits/registration_submit/kyc_registration_submit_cubit_test.dart
@@ -108,7 +108,23 @@ void main() {
     );
 
     blocTest<KycRegistrationSubmitCubit, KycRegistrationSubmitState>(
-      'treats ApiException after sign as Success(completed) (account-exists / merge path)',
+      'emits Success(alreadyRegistered) when the API reports already-registered (was: silent ApiException swallow)',
+      setUp: () {
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+        when(() => registrationService.completeRegistration(any())).thenAnswer(
+          (_) async => RegistrationStatus.alreadyRegistered,
+        );
+      },
+      build: buildCubit,
+      act: (cubit) => _submitFromRegistration(cubit, _registration()),
+      expect: () => [
+        KycRegistrationSubmitLoading(),
+        const KycRegistrationSubmitSuccess(RegistrationStatus.alreadyRegistered),
+      ],
+    );
+
+    blocTest<KycRegistrationSubmitCubit, KycRegistrationSubmitState>(
+      'emits Failure on backend ApiException (account-exists no longer silently masked)',
       setUp: () {
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
         when(() => registrationService.completeRegistration(any())).thenThrow(
@@ -123,7 +139,7 @@ void main() {
       act: (cubit) => _submitFromRegistration(cubit, _registration()),
       expect: () => [
         KycRegistrationSubmitLoading(),
-        const KycRegistrationSubmitSuccess(RegistrationStatus.completed),
+        isA<KycRegistrationSubmitFailure>(),
       ],
     );
 

--- a/test/screens/settings_contact/settings_contact_cubit_test.dart
+++ b/test/screens/settings_contact/settings_contact_cubit_test.dart
@@ -7,9 +7,10 @@ import 'package:realunit_wallet/screens/settings_contact/cubit/settings_contact_
 
 class _MockKycService extends Mock implements DfxKycService {}
 
-UserDto _user({String? mail}) => UserDto(
+UserDto _user({String? mail, bool supportAvailable = false}) => UserDto(
       mail: mail,
       kyc: const UserKycDto(hash: 'h', level: KycLevel.level0, dataComplete: false),
+      capabilities: UserCapabilitiesDto(supportAvailable: supportAvailable),
     );
 
 void main() {
@@ -23,23 +24,25 @@ void main() {
   // listener attaches, Loading has already been emitted. We assert the
   // final state and the service call instead of the sequence.
   group('$SettingsContactCubit', () {
-    test('reaches Success(emailSet: true) when getUser returns a mail', () async {
-      when(() => kyc.getUser()).thenAnswer((_) async => _user(mail: 'a@b.com'));
+    test('reaches Success(supportAvailable: true) when API capability flag is true', () async {
+      when(() => kyc.getUser())
+          .thenAnswer((_) async => _user(mail: 'a@b.com', supportAvailable: true));
 
       final cubit = SettingsContactCubit(kyc);
       await cubit.stream.firstWhere((s) => s is SettingsContactSuccess);
 
-      expect((cubit.state as SettingsContactSuccess).emailSet, isTrue);
+      expect((cubit.state as SettingsContactSuccess).supportAvailable, isTrue);
       verify(() => kyc.getUser()).called(1);
     });
 
-    test('reaches Success(emailSet: false) when getUser returns no mail', () async {
-      when(() => kyc.getUser()).thenAnswer((_) async => _user(mail: null));
+    test('reaches Success(supportAvailable: false) when API capability flag is false', () async {
+      when(() => kyc.getUser())
+          .thenAnswer((_) async => _user(mail: null, supportAvailable: false));
 
       final cubit = SettingsContactCubit(kyc);
       await cubit.stream.firstWhere((s) => s is SettingsContactSuccess);
 
-      expect((cubit.state as SettingsContactSuccess).emailSet, isFalse);
+      expect((cubit.state as SettingsContactSuccess).supportAvailable, isFalse);
     });
 
     test('reaches Failure when getUser throws', () async {
@@ -57,7 +60,7 @@ void main() {
       when(() => kyc.getUser()).thenAnswer((_) async {
         calls++;
         if (calls == 1) throw Exception('transient');
-        return _user(mail: 'recovered@b.com');
+        return _user(mail: 'recovered@b.com', supportAvailable: true);
       });
 
       final cubit = SettingsContactCubit(kyc);
@@ -66,7 +69,7 @@ void main() {
       await cubit.init();
 
       expect(cubit.state, isA<SettingsContactSuccess>());
-      expect((cubit.state as SettingsContactSuccess).emailSet, isTrue);
+      expect((cubit.state as SettingsContactSuccess).supportAvailable, isTrue);
     });
   });
 }

--- a/test/screens/settings_user_data/settings_user_data_cubit_test.dart
+++ b/test/screens/settings_user_data/settings_user_data_cubit_test.dart
@@ -97,6 +97,13 @@ void main() {
       when(() => kycService.getKycStatus()).thenAnswer(
         (_) async => const KycLevelDto(kycLevel: KycLevel.level20, kycSteps: []),
       );
+      when(() => kycService.getUser()).thenAnswer(
+        (_) async => const UserDto(
+          mail: 'a@b.com',
+          kyc: UserKycDto(hash: 'h', level: KycLevel.level20, dataComplete: true),
+          capabilities: UserCapabilitiesDto(canEditName: true, canEditAddress: true, canEditPhone: true),
+        ),
+      );
       when(() => countryService.getCountryBySymbol('CH')).thenAnswer((_) async => _ch);
       when(() => countryService.getCountryBySymbol('DE')).thenAnswer((_) async => _de);
 
@@ -109,6 +116,7 @@ void main() {
       expect(success.userData!.nationality, _ch);
       expect(success.userData!.addressCountry, _de);
       expect(success.pendingSteps, isEmpty);
+      expect(success.capabilities.canEditName, isTrue);
     });
 
     test('Success surfaces pending change steps that are inReview', () async {
@@ -128,6 +136,12 @@ void main() {
             // Non-change-step in review is ignored.
             _step(KycStepName.contactData, KycStepStatus.inReview, seq: 2),
           ],
+        ),
+      );
+      when(() => kycService.getUser()).thenAnswer(
+        (_) async => const UserDto(
+          mail: 'a@b.com',
+          kyc: UserKycDto(hash: 'h', level: KycLevel.level20, dataComplete: true),
         ),
       );
       when(() => countryService.getCountryBySymbol(any())).thenAnswer((_) async => _ch);
@@ -167,29 +181,17 @@ void main() {
       verifyNever(() => countryService.getCountryBySymbol(any()));
     });
 
-    test('userData null + getUser throws → Success() with no email', () async {
-      when(() => walletService.getWalletStatus()).thenAnswer(
-        (_) async => RealUnitWalletStatusDto(isRegistered: false),
-      );
-      when(() => kycService.getKycStatus()).thenAnswer(
-        (_) async => const KycLevelDto(kycLevel: KycLevel.level0, kycSteps: []),
-      );
-      when(() => kycService.getUser())
-          .thenAnswer((_) async => throw Exception('no user'));
-
-      final cubit = build();
-      await cubit.stream.firstWhere((s) => s is SettingsUserDataSuccess);
-
-      final success = cubit.state as SettingsUserDataSuccess;
-      expect(success.userData, isNull);
-      expect(success.email, isNull);
-    });
-
     test('Failure when walletService.getWalletStatus throws', () async {
       when(() => walletService.getWalletStatus())
           .thenAnswer((_) async => throw Exception('network'));
       when(() => kycService.getKycStatus()).thenAnswer(
         (_) async => const KycLevelDto(kycLevel: KycLevel.level0, kycSteps: []),
+      );
+      when(() => kycService.getUser()).thenAnswer(
+        (_) async => const UserDto(
+          mail: 'a@b.com',
+          kyc: UserKycDto(hash: 'h', level: KycLevel.level0, dataComplete: false),
+        ),
       );
 
       final cubit = build();
@@ -208,6 +210,12 @@ void main() {
       when(() => kycService.getKycStatus()).thenAnswer(
         (_) async => const KycLevelDto(kycLevel: KycLevel.level20, kycSteps: []),
       );
+      when(() => kycService.getUser()).thenAnswer(
+        (_) async => const UserDto(
+          mail: 'a@b.com',
+          kyc: UserKycDto(hash: 'h', level: KycLevel.level20, dataComplete: true),
+        ),
+      );
       when(() => countryService.getCountryBySymbol(any()))
           .thenAnswer((_) async => throw Exception('unknown country'));
 
@@ -222,6 +230,12 @@ void main() {
           .thenAnswer((_) async => throw const BitboxNotConnectedException());
       when(() => kycService.getKycStatus()).thenAnswer(
         (_) async => const KycLevelDto(kycLevel: KycLevel.level0, kycSteps: []),
+      );
+      when(() => kycService.getUser()).thenAnswer(
+        (_) async => const UserDto(
+          mail: 'a@b.com',
+          kyc: UserKycDto(hash: 'h', level: KycLevel.level0, dataComplete: false),
+        ),
       );
 
       final cubit = build();

--- a/test/screens/settings_user_data/subpages/settings_edit_address_cubit_test.dart
+++ b/test/screens/settings_user_data/subpages/settings_edit_address_cubit_test.dart
@@ -49,15 +49,18 @@ void main() {
       expect((cubit.state as SettingsEditAddressReady).url, contains('edit-address'));
     });
 
-    test('reaches Pending when the step is already inReview', () async {
-      when(() => kyc.startStep(KycStepName.addressChange))
-          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.inReview));
+    test(
+      'reaches Pending only when the session returns no URL (W3.2: inReview-gating moved upstream to canEditAddress)',
+      () async {
+        when(() => kyc.startStep(KycStepName.addressChange))
+            .thenAnswer((_) async => _session(stepStatus: KycStepStatus.inReview, url: null));
 
-      final cubit = SettingsEditAddressCubit(kycService: kyc);
-      await cubit.stream.firstWhere((s) => s is SettingsEditAddressPending);
+        final cubit = SettingsEditAddressCubit(kycService: kyc);
+        await cubit.stream.firstWhere((s) => s is SettingsEditAddressPending);
 
-      expect(cubit.state, isA<SettingsEditAddressPending>());
-    });
+        expect(cubit.state, isA<SettingsEditAddressPending>());
+      },
+    );
 
     test('reaches Failure on API throw', () async {
       when(() => kyc.startStep(any()))
@@ -72,17 +75,17 @@ void main() {
       );
     });
 
-    test('reaches Failure when session has no URL', () async {
+    test('reaches Pending when the session has no URL', () async {
+      // The session lacking a URL is now interpreted as "still in some
+      // pending review state" rather than a hard failure — the upstream
+      // capability gate stops this branch from being reached in practice.
       when(() => kyc.startStep(KycStepName.addressChange))
           .thenAnswer((_) async => _session(stepStatus: KycStepStatus.notStarted, url: null));
 
       final cubit = SettingsEditAddressCubit(kycService: kyc);
-      await cubit.stream.firstWhere((s) => s is SettingsEditAddressFailure);
+      await cubit.stream.firstWhere((s) => s is SettingsEditAddressPending);
 
-      expect(
-        (cubit.state as SettingsEditAddressFailure).message,
-        contains('No session URL'),
-      );
+      expect(cubit.state, isA<SettingsEditAddressPending>());
     });
 
     test('submitAddress is a no-op when not in Ready state', () async {

--- a/test/screens/settings_user_data/subpages/settings_edit_name_cubit_test.dart
+++ b/test/screens/settings_user_data/subpages/settings_edit_name_cubit_test.dart
@@ -51,15 +51,18 @@ void main() {
       expect((cubit.state as SettingsEditNameReady).url, contains('edit-name'));
     });
 
-    test('reaches Pending when the step is already inReview', () async {
-      when(() => kyc.startStep(KycStepName.nameChange))
-          .thenAnswer((_) async => _session(stepStatus: KycStepStatus.inReview));
+    test(
+      'reaches Pending only when the session returns no URL (W3.2: inReview-gating moved upstream to canEditName)',
+      () async {
+        when(() => kyc.startStep(KycStepName.nameChange))
+            .thenAnswer((_) async => _session(stepStatus: KycStepStatus.inReview, url: null));
 
-      final cubit = SettingsEditNameCubit(kycService: kyc);
-      await cubit.stream.firstWhere((s) => s is SettingsEditNamePending);
+        final cubit = SettingsEditNameCubit(kycService: kyc);
+        await cubit.stream.firstWhere((s) => s is SettingsEditNamePending);
 
-      expect(cubit.state, isA<SettingsEditNamePending>());
-    });
+        expect(cubit.state, isA<SettingsEditNamePending>());
+      },
+    );
 
     test('reaches Failure when the API throws', () async {
       when(() => kyc.startStep(any()))
@@ -71,17 +74,17 @@ void main() {
       expect((cubit.state as SettingsEditNameFailure).message, contains('rate-limited'));
     });
 
-    test('reaches Failure when the session has no URL', () async {
+    test('reaches Pending when the session has no URL', () async {
+      // The session lacking a URL is now interpreted as "still in some
+      // pending review state" rather than a hard failure — the upstream
+      // capability gate stops this branch from being reached in practice.
       when(() => kyc.startStep(KycStepName.nameChange))
           .thenAnswer((_) async => _session(stepStatus: KycStepStatus.notStarted, url: null));
 
       final cubit = SettingsEditNameCubit(kycService: kyc);
-      await cubit.stream.firstWhere((s) => s is SettingsEditNameFailure);
+      await cubit.stream.firstWhere((s) => s is SettingsEditNamePending);
 
-      expect(
-        (cubit.state as SettingsEditNameFailure).message,
-        contains('No session URL'),
-      );
+      expect(cubit.state, isA<SettingsEditNamePending>());
     });
 
     test('refresh() re-runs _loadEdit and can recover from a prior failure', () async {

--- a/test/screens/transaction_receipt_settings_states_test.dart
+++ b/test/screens/transaction_receipt_settings_states_test.dart
@@ -6,24 +6,24 @@ import 'package:realunit_wallet/screens/transaction_history/cubits/receipt/trans
 
 void main() {
   group('$SettingsContactState', () {
-    test('Success defaults emailSet to false', () {
+    test('Success defaults supportAvailable to false', () {
       const state = SettingsContactSuccess();
-      expect(state.emailSet, isFalse);
+      expect(state.supportAvailable, isFalse);
     });
 
     test('Success.copyWith preserves untouched field', () {
-      const base = SettingsContactSuccess(emailSet: true);
+      const base = SettingsContactSuccess(supportAvailable: true);
       final next = base.copyWith();
-      expect(next.emailSet, isTrue);
+      expect(next.supportAvailable, isTrue);
     });
 
-    test('Success Equatable props pin emailSet', () {
+    test('Success Equatable props pin supportAvailable', () {
       expect(
-        const SettingsContactSuccess(emailSet: true),
-        const SettingsContactSuccess(emailSet: true),
+        const SettingsContactSuccess(supportAvailable: true),
+        const SettingsContactSuccess(supportAvailable: true),
       );
       expect(
-        const SettingsContactSuccess(emailSet: true),
+        const SettingsContactSuccess(supportAvailable: true),
         isNot(const SettingsContactSuccess()),
       );
     });


### PR DESCRIPTION
## Summary

Wave 3.2 of the API-as-Decision-Authority audit ([`docs/api-authority-plan.md`](docs/api-authority-plan.md)), companion to API PR [DFXswiss/api#3733](https://github.com/DFXswiss/api/pull/3733). The app's settings + registration cubits used to derive UI gating from KYC step status and silently swallow "already registered" 400s as success. Both signals are now first-class fields on the API response.

## Changes

### DTO mirrors

- `UserDto` (`/v2/user`) gains `capabilities: UserCapabilitiesDto` with `canEditName / canEditMail / canEditPhone / canEditAddress / supportAvailable`. All flags default to `false` so a pre-#3733 backend degrades to "no edit affordances" rather than offering an action the backend would reject.
- `RegistrationStatus.alreadyRegistered` mirrors the new `RealUnitRegistrationStatus.ALREADY_REGISTERED` enum value.

### Consumers

- **`settings_contact_cubit`** reads `userDto.capabilities.supportAvailable` instead of `mail != null`. State field renamed `emailSet` → `supportAvailable` for consistency with the API.
- **`settings_user_data_cubit`** now fetches `/v2/user` alongside `/v2/kyc` and exposes `capabilities` on its Success state. The `SettingsUserDataPage` wires each row's `onEdit` to `canEditName / canEditPhone / canEditAddress`; rows without capability omit the Edit button. `_UserDataRow` drops its `statusLabel == null` co-gating — the "Change in review" badge stays as an informational label, the capability is the authority.
- **`settings_edit_name_cubit`** drops the `currentStep?.status == inReview` interpretation. The upstream capability gate prevents the cubit from being instantiated when editing is forbidden, and the pending branch now fires only defensively when the session lacks a URL.
- **`kyc_registration_submit_cubit`** no longer treats *any* `ApiException` after a successful sign as `Success(completed)`. Backend rejection of an already-registered wallet is now a structured `Success(alreadyRegistered)` from the API, and `KycCubit.checkKyc` resolves the next step from there. All other ApiExceptions surface as failures as they always should.

## Post-Review Fixes

Two follow-up commits address gaps surfaced during review of the original Wave 3.2 commit:

- **`kyc_registration_page.dart` listener generalisation** (`fix(kyc): KYC-Flow nach Sign auch fuer alreadyRegistered/pendingReview/forwardingFailed weiterfuehren`) — the original listener only invoked `markRegistrationSignProduced()` + `checkKyc()` for `RegistrationStatus.completed`. With Wave 3.2's cubit emitting `Success` for every backend status the sign produces (`completed / pendingReview / forwardingFailed / alreadyRegistered`), branching by status caused the `alreadyRegistered` BitBox-sign path to hang on the registration page. The listener now lifts the sign gate and triggers `checkKyc()` on every `Success`; `forwardingFailed` additionally surfaces an informative `registrationForwardingFailed` SnackBar (new i18n key in DE + EN). Three new `testWidgets` cover the previously-uncovered statuses.
- **`settings_edit_address_cubit` migration** (`refactor(settings): edit-address-cubit analog zu edit-name auf canEditAddress-Gating umstellen`) — V15 was only half-closed: `SettingsUserDataPage` already gates the Address-Edit button via `capabilities.canEditAddress`, but the address cubit still carried the old `currentStep?.status == inReview` branch + `url == null` throw. Cubit now mirrors `settings_edit_name_cubit`: no `inReview` interpretation, `url == null` resolves to `SettingsEditAddressPending` (defensive race branch) instead of throwing. Tests rephrased analogous to the name-cubit pass.

## Audit alignment

`docs/api-authority-audit.md` V46 (registration-personal-step user-type dropdown) was previously marked "Closed by W3.1 / W3.2 (capabilities)" but is not in this PR's diff. The dropdown reads from a local `RegistrationUserType.values` enum, not from `UserCapabilitiesDto`, so closing V46 requires a separate API change (`availableUserTypes` capability or registration-endpoint extension). Re-marked as **Deferred** to a follow-up wave for accuracy.

## Backwards compatibility

- New `capabilities` field defaults to `false` everywhere — old backends silently disable Edit and Support affordances rather than offering unbacked actions.
- `RegistrationStatus.alreadyRegistered` is a new enum value the old backend never sends — old client code paths that fall through `switch` would have hit the unhappy path the same way.

## Tests

- `settings_contact_cubit_test`: assertions renamed and now exercise the API `supportAvailable` capability fixture rather than mail presence as a proxy.
- `settings_user_data_cubit_test`: every fixture now mocks `kycService.getUser()` (the new third call site) and seeds `capabilities` where relevant.
- `settings_edit_name_cubit_test` / `settings_edit_address_cubit_test`: "inReview → Pending" case rephrased to "no URL → Pending". The "no URL → Failure" case is inverted to Pending (matches the cubits' new defensive branch).
- `kyc_registration_submit_cubit_test`: the "swallow-ApiException-as-success" case is replaced by an explicit "backend returns alreadyRegistered status → Success(alreadyRegistered)" and a complementary "ApiException → Failure" case so the silent-mask pattern doesn't regress.
- `kyc_registration_page_test`: three new `testWidgets` cover `alreadyRegistered / pendingReview / forwardingFailed`; the existing `completed` case additionally verifies `markRegistrationSignProduced()`.

## Verification

- [x] Rebased onto current `develop` (was `rebaseable: false`; rebase landed cleanly — no conflicts in buy/sell cubits, workflows, or anywhere else).
- [x] `flutter analyze` — clean
- [x] `flutter test` — **1438 / 1438 passing**

## Closes (audit, P0/P1)

- V6 (registration-submit treats backend rejection as success)
- V15 (settings edit hidden by KYC status interpretation — name + address)
- V16 (support link hidden by local email check)

Tracked in [`docs/api-authority-audit.md`](docs/api-authority-audit.md).
