### PR TITLE
refactor(reference-data): consume /v1/legal-document, /v1/company-info, country.displayOrder

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -160,6 +160,8 @@
   "payoutAccountAdd": "Auszahlungskonto hinzufügen",
   "payoutAccountSelect": "Auszahlungskonto auswählen",
   "pdf": "PDF",
+  "pdfLoading": "PDF wird geladen…",
+  "pdfNotAvailable": "PDF nicht verfügbar — antippen zum Erneutversuchen",
   "pendingTransactions": "Ausstehende Transaktionen",
   "personalData": "Persönliche Daten",
   "phone": "Telefon",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -160,6 +160,8 @@
   "payoutAccountAdd": "Add payout account",
   "payoutAccountSelect": "Select payout account",
   "pdf": "PDF",
+  "pdfLoading": "Loading PDF…",
+  "pdfNotAvailable": "PDF not available — tap to retry",
   "pendingTransactions": "Pending transactions",
   "personalData": "Personal data",
   "phone": "Phone",

--- a/docs/api-authority-audit.md
+++ b/docs/api-authority-audit.md
@@ -160,6 +160,7 @@ backend's understanding of state and the app's interpretation of it.
   - **API change needed:** call `/v1/language` (already exists on the DFX API)
 - **V14** — `lib/widgets/form/country_field.dart:65-79` — `['CH', 'DE', 'IT', 'FR']` priority list at top
   - **API change needed:** `/v1/country?priority=true` returns ordered list; UI does not hardcode preference
+  - **Closed by:** W4.4 / #499
 - **V28** — `lib/packages/config/network_mode.dart:4-20` — `enum NetworkMode { mainnet, testnet }`
   - **Boundary case:** network mode determines *which* API host the app calls. Cannot itself be API-driven (chicken-and-egg). **Accepted as documented exception** (see `api-authority-plan.md`). Tagged for completeness.
 
@@ -175,15 +176,17 @@ backend's understanding of state and the app's interpretation of it.
 
 - **V17** — `lib/packages/config/legal_documents_config.dart:69-122, :160-191, :193-236` — Registration-Agreement PDFs (DE/EN), RealUnit Prospekt URLs (`:69-122`), Aktionariat document URLs (`:160-191`), DFX-Docs URLs (`:193-236`)
   - **API change needed:** `/v1/legal-document?type=registration&language=de` returns the current URL + version; app renders without knowing URLs in advance. Same endpoint also covers the Aktionariat and DFX-Docs blocks
+  - **Closed by:** W4.4 / #499
 - **V44** — `lib/screens/kyc/steps/financial_data/constants/kyc_financial_data_links.dart:2` — hardcoded `https://dfx.swiss/terms-and-conditions`
   - **Local decision:** same root cause as V17 but outside `legal_documents_config.dart` — a separate constants file holds a legal URL
   - **API change needed:** `/v1/legal-document` endpoint (the same endpoint W4.1 introduces); app reads the URL instead of compiling it in
-  - **Closed by:** W4.4 (same wave as V17)
+  - **Closed by:** W4.4 / #499 (same wave as V17)
 
 ### Company contact info hardcoded
 
 - **V18** — `lib/screens/settings_contact/settings_contact_page.dart:82, 93-94, 104, 109, 133-134` — phone, email, website, postal address
   - **API change needed:** `/v1/company-info` (or the existing `/v1/settings`) returns this for the RealUnit branding; allows future white-labeling
+  - **Closed by:** W4.4 / #499
 
 ### Asset configuration hardcoded
 

--- a/lib/packages/config/legal_documents_config.dart
+++ b/lib/packages/config/legal_documents_config.dart
@@ -25,14 +25,16 @@ class LegalDocumentConfig implements DocumentConfig {
   bool get isExternal => false;
   final String Function(BuildContext context) _title;
   final String assetBaseName;
-  final Map<String, String>? pdfUrls;
+  // Wenn gesetzt, holt die Seite die PDF-URL aus `/v1/legal-document?type=`.
+  // Es gibt keinen hardcoded Fallback mehr — schlägt die API fehl oder
+  // liefert sie keinen Eintrag, rendert die Seite einen
+  // "PDF nicht verfügbar"-Zustand mit Retry (closes audit V17).
   final String? legalDocumentType;
 
   const LegalDocumentConfig({
     required this.icon,
     required String Function(BuildContext context) title,
     required this.assetBaseName,
-    this.pdfUrls,
     this.legalDocumentType,
   }) : _title = title;
 
@@ -45,7 +47,6 @@ class LegalDocumentConfig implements DocumentConfig {
     extra: LegalDocumentParams(
       title: title(context),
       assetBaseName: assetBaseName,
-      pdfUrls: pdfUrls,
       legalDocumentType: legalDocumentType,
     ),
   );
@@ -70,13 +71,6 @@ class LegalDocumentsConfig {
     _investmentRegulations,
   ];
 
-  static const _registrationAgreementPdfUrls = {
-    'de':
-        'https://realunit.ch/wp-content/uploads/2026/03/260303_RegV_DE_RealUnit_Schweiz_AG_signiert.pdf',
-    'en':
-        'https://realunit.ch/wp-content/uploads/2026/03/260303_RegV_EN_RealUnit_Schweiz_AG_signiert.pdf',
-  };
-
   static final _privacyPolicy = LegalDocumentConfig(
     icon: Icons.shield_outlined,
     title: (context) => S.of(context).legalDisclaimerCheckboxPrivacyPolicy,
@@ -87,9 +81,10 @@ class LegalDocumentsConfig {
     icon: Icons.description_outlined,
     title: (context) => S.of(context).legalDisclaimerCheckboxRegistrationAgreement,
     assetBaseName: 'registration_agreement',
-    // The hardcoded map remains as a last-resort fallback if `/v1/legal-document`
-    // is unreachable. The screen prefers the API-sourced URLs (closes V17).
-    pdfUrls: _registrationAgreementPdfUrls,
+    // PDF-URL stammt ausschliesslich aus `/v1/legal-document` — kein
+    // hardcoded Fallback, sonst zeigt die App nach einem Backend-Update
+    // weiterhin die alte signierte Version bis zum nächsten App-Release
+    // (audit V17).
     legalDocumentType: LegalDocumentType.registrationAgreement,
   );
 

--- a/lib/packages/config/legal_documents_config.dart
+++ b/lib/packages/config/legal_documents_config.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import 'package:realunit_wallet/generated/i18n.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal_document/dto/dfx_legal_document_dto.dart';
 import 'package:realunit_wallet/screens/legal/subpages/legal_document_page.dart';
 import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
 import 'package:realunit_wallet/screens/web_view/web_view_page.dart';
@@ -25,12 +26,14 @@ class LegalDocumentConfig implements DocumentConfig {
   final String Function(BuildContext context) _title;
   final String assetBaseName;
   final Map<String, String>? pdfUrls;
+  final String? legalDocumentType;
 
   const LegalDocumentConfig({
     required this.icon,
     required String Function(BuildContext context) title,
     required this.assetBaseName,
     this.pdfUrls,
+    this.legalDocumentType,
   }) : _title = title;
 
   @override
@@ -43,6 +46,7 @@ class LegalDocumentConfig implements DocumentConfig {
       title: title(context),
       assetBaseName: assetBaseName,
       pdfUrls: pdfUrls,
+      legalDocumentType: legalDocumentType,
     ),
   );
 }
@@ -83,7 +87,10 @@ class LegalDocumentsConfig {
     icon: Icons.description_outlined,
     title: (context) => S.of(context).legalDisclaimerCheckboxRegistrationAgreement,
     assetBaseName: 'registration_agreement',
+    // The hardcoded map remains as a last-resort fallback if `/v1/legal-document`
+    // is unreachable. The screen prefers the API-sourced URLs (closes V17).
     pdfUrls: _registrationAgreementPdfUrls,
+    legalDocumentType: LegalDocumentType.registrationAgreement,
   );
 
   static final _euSecuritiesProspectusBearerShares = WebDocumentConfig(

--- a/lib/packages/service/dfx/dfx_company_info_service.dart
+++ b/lib/packages/service/dfx/dfx_company_info_service.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/company_info/dto/dfx_company_info_dto.dart';
+
+class DfxCompanyInfoService {
+  static const _basePath = '/v1/company-info';
+
+  final Map<String, DfxCompanyInfoDto> _cache = {};
+
+  final AppStore _appStore;
+
+  String get _host => _appStore.apiConfig.apiHost;
+
+  DfxCompanyInfoService(AppStore appStore) : _appStore = appStore;
+
+  Future<DfxCompanyInfoDto> getForBrand(String brand) async {
+    final key = brand.toLowerCase();
+    final cached = _cache[key];
+    if (cached != null) return cached;
+
+    final uri = buildUri(_host, '$_basePath/$brand');
+    final response = await _appStore.httpClient.get(uri);
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to fetch company info for "$brand": ${response.statusCode}');
+    }
+
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    final info = DfxCompanyInfoDto.fromJson(json);
+    _cache[key] = info;
+    return info;
+  }
+}

--- a/lib/packages/service/dfx/dfx_legal_document_service.dart
+++ b/lib/packages/service/dfx/dfx_legal_document_service.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal_document/dto/dfx_legal_document_dto.dart';
+
+class DfxLegalDocumentService {
+  static const _legalDocumentPath = '/v1/legal-document';
+
+  // Cache key: `${type ?? '*'}:${language ?? '*'}` — same scheme as the
+  // server-side cache so repeated identical queries share results.
+  final Map<String, List<DfxLegalDocumentDto>> _cache = {};
+
+  final AppStore _appStore;
+
+  String get _host => _appStore.apiConfig.apiHost;
+
+  DfxLegalDocumentService(AppStore appStore) : _appStore = appStore;
+
+  Future<List<DfxLegalDocumentDto>> getDocuments({String? type, String? language}) async {
+    final key = '${type ?? '*'}:${language ?? '*'}';
+    final cached = _cache[key];
+    if (cached != null) return cached;
+
+    final queryParams = <String, String>{};
+    if (type != null) queryParams['type'] = type;
+    if (language != null) queryParams['language'] = language;
+
+    final uri = buildUri(_host, _legalDocumentPath).replace(
+      queryParameters: queryParams.isEmpty ? null : queryParams,
+    );
+    final response = await _appStore.httpClient.get(uri);
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to fetch legal documents: ${response.statusCode}');
+    }
+
+    final List<dynamic> jsonList = jsonDecode(response.body);
+    final documents = jsonList
+        .map((json) => DfxLegalDocumentDto.fromJson(json as Map<String, dynamic>))
+        .toList();
+    _cache[key] = documents;
+    return documents;
+  }
+}

--- a/lib/packages/service/dfx/models/company_info/dto/dfx_company_info_dto.dart
+++ b/lib/packages/service/dfx/models/company_info/dto/dfx_company_info_dto.dart
@@ -1,0 +1,52 @@
+// Mirror of `CompanyInfoDto` on the API
+// (`src/shared/models/company-info/dto/company-info.dto.ts`). The backend
+// is the authority on the realunit-app's brand contact data — the app
+// renders these fields verbatim instead of shipping them hardcoded.
+class DfxCompanyInfoAddressDto {
+  final String? street;
+  final String? zip;
+  final String? city;
+  final String? country;
+
+  const DfxCompanyInfoAddressDto({this.street, this.zip, this.city, this.country});
+
+  factory DfxCompanyInfoAddressDto.fromJson(Map<String, dynamic> json) {
+    return DfxCompanyInfoAddressDto(
+      street: json['street'] as String?,
+      zip: json['zip'] as String?,
+      city: json['city'] as String?,
+      country: json['country'] as String?,
+    );
+  }
+}
+
+class DfxCompanyInfoDto {
+  final String brand;
+  final String name;
+  final String? phone;
+  final String? email;
+  final String? website;
+  final DfxCompanyInfoAddressDto? address;
+
+  const DfxCompanyInfoDto({
+    required this.brand,
+    required this.name,
+    this.phone,
+    this.email,
+    this.website,
+    this.address,
+  });
+
+  factory DfxCompanyInfoDto.fromJson(Map<String, dynamic> json) {
+    return DfxCompanyInfoDto(
+      brand: json['brand'] as String,
+      name: json['name'] as String,
+      phone: json['phone'] as String?,
+      email: json['email'] as String?,
+      website: json['website'] as String?,
+      address: json['address'] != null
+          ? DfxCompanyInfoAddressDto.fromJson(json['address'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}

--- a/lib/packages/service/dfx/models/country/country.dart
+++ b/lib/packages/service/dfx/models/country/country.dart
@@ -6,12 +6,17 @@ class Country extends Equatable {
   final String symbol;
   final String name;
   final String? foreignName;
+  // Lower is higher in country pickers. Default 999 keeps the long tail
+  // alphabetic. Backend-tagged via `country.displayOrder`; replaces the
+  // hardcoded `priorityCountries = ['CH','DE','IT','FR']` list.
+  final int displayOrder;
 
   const Country({
     required this.id,
     required this.symbol,
     required this.name,
     this.foreignName,
+    this.displayOrder = 999,
   });
 
   @override
@@ -25,6 +30,7 @@ extension DfxCountryDtoMapper on DfxCountryDto {
       symbol: symbol,
       name: name,
       foreignName: foreignName,
+      displayOrder: displayOrder,
     );
   }
 }

--- a/lib/packages/service/dfx/models/country/dto/dfx_country_dto.dart
+++ b/lib/packages/service/dfx/models/country/dto/dfx_country_dto.dart
@@ -11,6 +11,11 @@ class DfxCountryDto {
   final bool bankAllowed;
   final bool cardAllowed;
   final bool cryptoAllowed;
+  // Backend-tagged sort priority for country pickers (`country.displayOrder`).
+  // Lower is higher in the list. Defaults to 999 server-side for the long
+  // tail and is seeded with CH=1, DE=2, IT=3, FR=4 — replacing the
+  // hardcoded `priorityCountries` list the app used to ship.
+  final int displayOrder;
 
   const DfxCountryDto({
     required this.id,
@@ -25,6 +30,7 @@ class DfxCountryDto {
     required this.bankAllowed,
     required this.cardAllowed,
     required this.cryptoAllowed,
+    this.displayOrder = 999,
   });
 
   factory DfxCountryDto.fromJson(Map<String, dynamic> json) {
@@ -41,6 +47,7 @@ class DfxCountryDto {
       bankAllowed: json['bankAllowed'] as bool,
       cardAllowed: json['cardAllowed'] as bool,
       cryptoAllowed: json['cryptoAllowed'] as bool,
+      displayOrder: (json['displayOrder'] as int?) ?? 999,
     );
   }
 }

--- a/lib/packages/service/dfx/models/legal_document/dto/dfx_legal_document_dto.dart
+++ b/lib/packages/service/dfx/models/legal_document/dto/dfx_legal_document_dto.dart
@@ -2,6 +2,19 @@
 // (`src/shared/models/legal-document/dto/legal-document.dto.ts`). The
 // backend stores the URL + version per (type, language) pair and is the
 // authority on which document version is current.
+
+// Mirrors `enum LegalDocumentType` on the API
+// (`src/shared/models/legal-document/legal-document.entity.ts`). String
+// values match the serialized form returned by `/v1/legal-document`.
+class LegalDocumentType {
+  static const registrationAgreement = 'RegistrationAgreement';
+  static const prospectus = 'Prospectus';
+  static const aktionariatTerms = 'AktionariatTerms';
+  static const aktionariatPrivacy = 'AktionariatPrivacy';
+  static const dfxTerms = 'DfxTerms';
+  static const dfxPrivacy = 'DfxPrivacy';
+}
+
 class DfxLegalDocumentDto {
   final int id;
   final String type;

--- a/lib/packages/service/dfx/models/legal_document/dto/dfx_legal_document_dto.dart
+++ b/lib/packages/service/dfx/models/legal_document/dto/dfx_legal_document_dto.dart
@@ -1,0 +1,29 @@
+// Mirror of `LegalDocumentDto` on the API
+// (`src/shared/models/legal-document/dto/legal-document.dto.ts`). The
+// backend stores the URL + version per (type, language) pair and is the
+// authority on which document version is current.
+class DfxLegalDocumentDto {
+  final int id;
+  final String type;
+  final String? language;
+  final String version;
+  final String url;
+
+  const DfxLegalDocumentDto({
+    required this.id,
+    required this.type,
+    this.language,
+    required this.version,
+    required this.url,
+  });
+
+  factory DfxLegalDocumentDto.fromJson(Map<String, dynamic> json) {
+    return DfxLegalDocumentDto(
+      id: json['id'] as int,
+      type: json['type'] as String,
+      language: json['language'] as String?,
+      version: json['version'] as String,
+      url: json['url'] as String,
+    );
+  }
+}

--- a/lib/screens/legal/subpages/legal_document_page.dart
+++ b/lib/screens/legal/subpages/legal_document_page.dart
@@ -13,39 +13,29 @@ import 'package:realunit_wallet/setup/di.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
 
-// Prefers API-sourced URLs when present; falls back to the bundled map
-// otherwise. Within either map, prefers an exact language-code match
-// and degrades to the first available URL. Exposed at top-level so it
-// can be unit-tested without spinning up the full page widget.
+// Wählt aus den API-Sprachvarianten deterministisch die passende PDF-URL:
+// exakter Sprach-Match → 'en' → 'de' → erste verfügbare. Es gibt keinen
+// hardcoded Fallback mehr — leerer Input ⇒ `null` (closes audit V17).
 @visibleForTesting
 String? resolveLegalDocumentPdfUrl({
-  required Map<String, String>? apiUrls,
-  required Map<String, String>? fallbackUrls,
+  required Map<String, String> apiUrls,
   required String languageCode,
 }) {
-  if (apiUrls != null && apiUrls.isNotEmpty) {
-    return apiUrls[languageCode] ?? apiUrls.values.first;
-  }
-  if (fallbackUrls == null || fallbackUrls.isEmpty) return null;
-  return fallbackUrls[languageCode] ?? fallbackUrls.values.first;
+  if (apiUrls.isEmpty) return null;
+  return apiUrls[languageCode] ?? apiUrls['en'] ?? apiUrls['de'] ?? apiUrls.values.first;
 }
 
 class LegalDocumentParams {
   final String title;
   final String assetBaseName;
-  // Fallback PDF URLs (language → url). Used only if the API does not
-  // return any URLs for [legalDocumentType] — the API is the source of
-  // truth (closes audit V17), the local map is a last-resort fallback.
-  final Map<String, String>? pdfUrls;
-  // Maps to `LegalDocumentType` on the API. When set, the page fetches
-  // current URLs from `/v1/legal-document?type=<this>` and prefers them
-  // over the bundled [pdfUrls] map.
+  // Bildet auf `LegalDocumentType` der API ab. Wenn gesetzt, lädt die Seite
+  // `/v1/legal-document?type=<this>` und rendert die zurückgegebene URL als
+  // "Original PDF"-Button. Es gibt keinen hardcoded Fallback (audit V17).
   final String? legalDocumentType;
 
   const LegalDocumentParams({
     required this.title,
     required this.assetBaseName,
-    this.pdfUrls,
     this.legalDocumentType,
   });
 }
@@ -58,6 +48,13 @@ class LegalDocumentPage extends StatefulWidget {
   @override
   State<LegalDocumentPage> createState() => _LegalDocumentPageState();
 }
+
+// PDF-Ladezustand für die "Original PDF"-Sektion.
+// `loading` ⇒ API-Call läuft noch, Skeleton-Button.
+// `available` ⇒ URL vorhanden, klickbarer Button.
+// `unavailable` ⇒ API beantwortet/fehlgeschlagen ohne passende URL,
+// Retry-Button.
+enum _PdfStatus { loading, available, unavailable }
 
 class _LegalDocumentPageState extends State<LegalDocumentPage> {
   String? _markdownContent;
@@ -88,6 +85,13 @@ class _LegalDocumentPageState extends State<LegalDocumentPage> {
   Future<void> _loadApiPdfUrls() async {
     final type = widget.params.legalDocumentType;
     if (type == null) return;
+    // Beim Retry-Tap (Status "unavailable" → "loading") muss `_apiPdfUrls`
+    // zurück auf `null` springen, damit der Button kurzzeitig den
+    // Loading-Spinner zeigt. `_apiPdfUrls != null` impliziert, dass der
+    // erste Build durchgelaufen ist, also ist setState hier sicher.
+    if (mounted && _apiPdfUrls != null) {
+      setState(() => _apiPdfUrls = null);
+    }
     try {
       final docs = await getIt<DfxLegalDocumentService>().getDocuments(type: type);
       final urls = <String, String>{
@@ -101,11 +105,27 @@ class _LegalDocumentPageState extends State<LegalDocumentPage> {
     }
   }
 
-  String? get _pdfUrl => resolveLegalDocumentPdfUrl(
-    apiUrls: _apiPdfUrls,
-    fallbackUrls: widget.params.pdfUrls,
-    languageCode: context.read<SettingsBloc>().state.language.code,
-  );
+  _PdfStatus get _pdfStatus {
+    // Kein API-Typ konfiguriert ⇒ keine PDF-Sektion. Wird im build()
+    // über `params.legalDocumentType == null` ausgeblendet.
+    if (widget.params.legalDocumentType == null) return _PdfStatus.unavailable;
+    final urls = _apiPdfUrls;
+    if (urls == null) return _PdfStatus.loading;
+    final resolved = resolveLegalDocumentPdfUrl(
+      apiUrls: urls,
+      languageCode: context.read<SettingsBloc>().state.language.code,
+    );
+    return resolved == null ? _PdfStatus.unavailable : _PdfStatus.available;
+  }
+
+  String? get _pdfUrl {
+    final urls = _apiPdfUrls;
+    if (urls == null) return null;
+    return resolveLegalDocumentPdfUrl(
+      apiUrls: urls,
+      languageCode: context.read<SettingsBloc>().state.language.code,
+    );
+  }
 
   @override
   Widget build(BuildContext context) => Scaffold(
@@ -133,28 +153,48 @@ class _LegalDocumentPageState extends State<LegalDocumentPage> {
                   },
                 ),
               ),
-              if (_pdfUrl != null)
+              if (widget.params.legalDocumentType != null)
                 SafeArea(
                   top: false,
                   child: Padding(
                     padding: const .all(20.0),
-                    child: AppFilledButton(
-                      variant: .secondary,
-                      onPressed: () => context.pushNamed(
-                        AppRoutes.webView,
-                        extra: WebViewRouteParams(
-                          title: S.of(context).originalPdf,
-                          url: Uri.parse(_pdfUrl!),
-                          showExternalBrowserButton: true,
-                        ),
-                      ),
-                      icon: Icons.picture_as_pdf_outlined,
-                      label: S.of(context).originalPdf,
-                    ),
+                    child: _buildPdfButton(context),
                   ),
                 ),
             ],
           )
         : const SizedBox.shrink(),
   );
+
+  Widget _buildPdfButton(BuildContext context) {
+    switch (_pdfStatus) {
+      case _PdfStatus.loading:
+        return AppFilledButton(
+          variant: .secondary,
+          state: .loading,
+          label: S.of(context).pdfLoading,
+        );
+      case _PdfStatus.unavailable:
+        return AppFilledButton(
+          variant: .secondary,
+          onPressed: _loadApiPdfUrls,
+          icon: Icons.refresh,
+          label: S.of(context).pdfNotAvailable,
+        );
+      case _PdfStatus.available:
+        return AppFilledButton(
+          variant: .secondary,
+          onPressed: () => context.pushNamed(
+            AppRoutes.webView,
+            extra: WebViewRouteParams(
+              title: S.of(context).originalPdf,
+              url: Uri.parse(_pdfUrl!),
+              showExternalBrowserButton: true,
+            ),
+          ),
+          icon: Icons.picture_as_pdf_outlined,
+          label: S.of(context).originalPdf,
+        );
+    }
+  }
 }

--- a/lib/screens/legal/subpages/legal_document_page.dart
+++ b/lib/screens/legal/subpages/legal_document_page.dart
@@ -1,23 +1,52 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:go_router/go_router.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_legal_document_service.dart';
 import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
 import 'package:realunit_wallet/screens/web_view/web_view_page.dart';
+import 'package:realunit_wallet/setup/di.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
+
+// Prefers API-sourced URLs when present; falls back to the bundled map
+// otherwise. Within either map, prefers an exact language-code match
+// and degrades to the first available URL. Exposed at top-level so it
+// can be unit-tested without spinning up the full page widget.
+@visibleForTesting
+String? resolveLegalDocumentPdfUrl({
+  required Map<String, String>? apiUrls,
+  required Map<String, String>? fallbackUrls,
+  required String languageCode,
+}) {
+  if (apiUrls != null && apiUrls.isNotEmpty) {
+    return apiUrls[languageCode] ?? apiUrls.values.first;
+  }
+  if (fallbackUrls == null || fallbackUrls.isEmpty) return null;
+  return fallbackUrls[languageCode] ?? fallbackUrls.values.first;
+}
 
 class LegalDocumentParams {
   final String title;
   final String assetBaseName;
+  // Fallback PDF URLs (language → url). Used only if the API does not
+  // return any URLs for [legalDocumentType] — the API is the source of
+  // truth (closes audit V17), the local map is a last-resort fallback.
   final Map<String, String>? pdfUrls;
+  // Maps to `LegalDocumentType` on the API. When set, the page fetches
+  // current URLs from `/v1/legal-document?type=<this>` and prefers them
+  // over the bundled [pdfUrls] map.
+  final String? legalDocumentType;
 
   const LegalDocumentParams({
     required this.title,
     required this.assetBaseName,
     this.pdfUrls,
+    this.legalDocumentType,
   });
 }
 
@@ -32,11 +61,16 @@ class LegalDocumentPage extends StatefulWidget {
 
 class _LegalDocumentPageState extends State<LegalDocumentPage> {
   String? _markdownContent;
+  // Resolved API URLs keyed by lowercase ISO 639-1 language code.
+  // `null` ⇒ load not finished or no [legalDocumentType] configured.
+  // Empty map ⇒ API responded but had no entry for the configured type.
+  Map<String, String>? _apiPdfUrls;
 
   @override
   void initState() {
     super.initState();
     _loadMarkdown();
+    _loadApiPdfUrls();
   }
 
   Future<void> _loadMarkdown() async {
@@ -51,11 +85,27 @@ class _LegalDocumentPageState extends State<LegalDocumentPage> {
     }
   }
 
-  String? get _pdfUrl {
-    if (widget.params.pdfUrls == null) return null;
-    final code = context.read<SettingsBloc>().state.language.code;
-    return widget.params.pdfUrls![code] ?? widget.params.pdfUrls!.values.first;
+  Future<void> _loadApiPdfUrls() async {
+    final type = widget.params.legalDocumentType;
+    if (type == null) return;
+    try {
+      final docs = await getIt<DfxLegalDocumentService>().getDocuments(type: type);
+      final urls = <String, String>{
+        for (final d in docs)
+          if (d.language != null) d.language!.toLowerCase(): d.url,
+      };
+      if (mounted) setState(() => _apiPdfUrls = urls);
+    } catch (e) {
+      developer.log('Legal document fetch failed: $e', name: '$LegalDocumentPage');
+      if (mounted) setState(() => _apiPdfUrls = const {});
+    }
   }
+
+  String? get _pdfUrl => resolveLegalDocumentPdfUrl(
+    apiUrls: _apiPdfUrls,
+    fallbackUrls: widget.params.pdfUrls,
+    languageCode: context.read<SettingsBloc>().state.language.code,
+  );
 
   @override
   Widget build(BuildContext context) => Scaffold(

--- a/lib/screens/settings_contact/cubit/settings_contact_cubit.dart
+++ b/lib/screens/settings_contact/cubit/settings_contact_cubit.dart
@@ -26,10 +26,28 @@ class SettingsContactCubit extends Cubit<SettingsContactState> {
   }
 
   Future<void> init() async {
+    emit(const SettingsContactLoading());
+
+    // Beide Calls parallel starten. getUser ist Pflicht — schlägt er fehl,
+    // kippt der Cubit in Failure. company-info ist optional: ein Ausfall
+    // (z.B. /v1/company-info/RealUnit 500/Timeout) blendet nur das
+    // Impressum/Phone/Mail/Website-Panel aus, der Support-Tile bleibt
+    // sichtbar, wenn die API-Capability `supportAvailable` true ist.
+    final userFuture = _kycService.getUser();
+    final companyInfoFuture = _companyInfoService
+        .getForBrand(_brand)
+        .then<DfxCompanyInfoDto?>((info) => info)
+        .catchError((Object e) {
+          developer.log(
+            'company-info lookup failed: $e',
+            name: '$SettingsContactCubit',
+          );
+          return null;
+        });
+
     try {
-      emit(const SettingsContactLoading());
-      final userDto = await _kycService.getUser();
-      final companyInfo = await _companyInfoService.getForBrand(_brand);
+      final userDto = await userFuture;
+      final companyInfo = await companyInfoFuture;
       // Render Support directly from the backend's capability flag
       // (`UserCapabilitiesDto.supportAvailable`) instead of inferring
       // it from `mail != null`. The flag and the mail check happen to

--- a/lib/screens/settings_contact/cubit/settings_contact_cubit.dart
+++ b/lib/screens/settings_contact/cubit/settings_contact_cubit.dart
@@ -2,15 +2,25 @@ import 'dart:developer' as developer;
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_company_info_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/company_info/dto/dfx_company_info_dto.dart';
 
 part 'settings_contact_state.dart';
 
 class SettingsContactCubit extends Cubit<SettingsContactState> {
-  final DfxKycService _kycService;
+  // Brand to look up in /v1/company-info. The realunit-app is the
+  // RealUnit brand; future white-labels would pass a different string.
+  static const _brand = 'RealUnit';
 
-  SettingsContactCubit(DfxKycService kycService)
-    : _kycService = kycService,
+  final DfxKycService _kycService;
+  final DfxCompanyInfoService _companyInfoService;
+
+  SettingsContactCubit(
+    DfxKycService kycService,
+    DfxCompanyInfoService companyInfoService,
+  ) : _kycService = kycService,
+      _companyInfoService = companyInfoService,
       super(const SettingsContactInitial()) {
     init();
   }
@@ -19,11 +29,17 @@ class SettingsContactCubit extends Cubit<SettingsContactState> {
     try {
       emit(const SettingsContactLoading());
       final userDto = await _kycService.getUser();
+      final companyInfo = await _companyInfoService.getForBrand(_brand);
       // Render Support directly from the backend's capability flag
       // (`UserCapabilitiesDto.supportAvailable`) instead of inferring
       // it from `mail != null`. The flag and the mail check happen to
       // coincide today, but the API is the authority.
-      emit(SettingsContactSuccess(supportAvailable: userDto.capabilities.supportAvailable));
+      emit(
+        SettingsContactSuccess(
+          supportAvailable: userDto.capabilities.supportAvailable,
+          companyInfo: companyInfo,
+        ),
+      );
     } catch (e) {
       developer.log(e.toString(), name: '$SettingsContactCubit');
       emit(SettingsContactFailure(message: e.toString()));

--- a/lib/screens/settings_contact/cubit/settings_contact_state.dart
+++ b/lib/screens/settings_contact/cubit/settings_contact_state.dart
@@ -17,17 +17,22 @@ class SettingsContactLoading extends SettingsContactState {
 
 class SettingsContactSuccess extends SettingsContactState {
   final bool supportAvailable;
+  // Backend-driven contact info for the current brand. The page renders
+  // its phone / email / website / imprint from this DTO instead of
+  // shipping them hardcoded.
+  final DfxCompanyInfoDto? companyInfo;
 
-  const SettingsContactSuccess({this.supportAvailable = false});
+  const SettingsContactSuccess({this.supportAvailable = false, this.companyInfo});
 
-  SettingsContactSuccess copyWith({bool? supportAvailable}) {
+  SettingsContactSuccess copyWith({bool? supportAvailable, DfxCompanyInfoDto? companyInfo}) {
     return SettingsContactSuccess(
       supportAvailable: supportAvailable ?? this.supportAvailable,
+      companyInfo: companyInfo ?? this.companyInfo,
     );
   }
 
   @override
-  List<Object?> get props => [supportAvailable];
+  List<Object?> get props => [supportAvailable, companyInfo];
 }
 
 class SettingsContactFailure extends SettingsContactState {

--- a/lib/screens/settings_contact/settings_contact_page.dart
+++ b/lib/screens/settings_contact/settings_contact_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_company_info_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
 import 'package:realunit_wallet/screens/settings_contact/cubit/settings_contact_cubit.dart';
 import 'package:realunit_wallet/screens/web_view/web_view_page.dart';
@@ -21,6 +22,7 @@ class SettingsContactPage extends StatelessWidget {
     return BlocProvider(
       create: (context) => SettingsContactCubit(
         getIt<DfxKycService>(),
+        getIt<DfxCompanyInfoService>(),
       ),
       child: const SettingsContactView(),
     );
@@ -72,68 +74,105 @@ class SettingsContactView extends StatelessWidget {
                       _ => const SizedBox.shrink(),
                     },
                   ),
-                  OutlinedTile(
-                    leading: const Icon(
-                      Icons.phone_outlined,
-                      color: RealUnitColors.realUnitBlue,
-                      size: 24,
-                    ),
-                    title: S.of(context).phone,
-                    subtitle: '+41 41 761 00 90',
-                    onTap: () => launchUrl(Uri.parse('tel:+41417610090')),
-                    trailingIcon: Icons.open_in_new_outlined,
-                  ),
-                  OutlinedTile(
-                    leading: const Icon(
-                      Icons.email_outlined,
-                      color: RealUnitColors.realUnitBlue,
-                      size: 24,
-                    ),
-                    title: S.of(context).email,
-                    subtitle: 'info@realunit.ch',
-                    onTap: () => launchUrl(Uri.parse('mailto:info@realunit.ch')),
-                    trailingIcon: Icons.open_in_new_outlined,
-                  ),
-                  OutlinedTile(
-                    leading: const Icon(
-                      Icons.language_outlined,
-                      color: RealUnitColors.realUnitBlue,
-                      size: 24,
-                    ),
-                    title: S.of(context).website,
-                    subtitle: 'realunit.ch',
-                    onTap: () => context.pushNamed(
-                      AppRoutes.webView,
-                      extra: WebViewRouteParams(
-                        title: S.of(context).website,
-                        url: Uri.parse('https://realunit.ch'),
-                      ),
-                    ),
-                    trailingIcon: Icons.open_in_new_outlined,
+                  BlocBuilder<SettingsContactCubit, SettingsContactState>(
+                    builder: (context, state) {
+                      final info = state is SettingsContactSuccess ? state.companyInfo : null;
+                      if (info == null) return const SizedBox.shrink();
+                      return Column(
+                        spacing: 12.0,
+                        children: [
+                          if (info.phone != null)
+                            OutlinedTile(
+                              leading: const Icon(
+                                Icons.phone_outlined,
+                                color: RealUnitColors.realUnitBlue,
+                                size: 24,
+                              ),
+                              title: S.of(context).phone,
+                              subtitle: info.phone!,
+                              onTap: () => launchUrl(
+                                Uri.parse('tel:${info.phone!.replaceAll(RegExp(r'[^+\d]'), '')}'),
+                              ),
+                              trailingIcon: Icons.open_in_new_outlined,
+                            ),
+                          if (info.email != null)
+                            OutlinedTile(
+                              leading: const Icon(
+                                Icons.email_outlined,
+                                color: RealUnitColors.realUnitBlue,
+                                size: 24,
+                              ),
+                              title: S.of(context).email,
+                              subtitle: info.email!,
+                              onTap: () => launchUrl(Uri.parse('mailto:${info.email}')),
+                              trailingIcon: Icons.open_in_new_outlined,
+                            ),
+                          if (info.website != null)
+                            OutlinedTile(
+                              leading: const Icon(
+                                Icons.language_outlined,
+                                color: RealUnitColors.realUnitBlue,
+                                size: 24,
+                              ),
+                              title: S.of(context).website,
+                              subtitle: info.website!,
+                              onTap: () => context.pushNamed(
+                                AppRoutes.webView,
+                                extra: WebViewRouteParams(
+                                  title: S.of(context).website,
+                                  url: Uri.parse(
+                                    info.website!.startsWith('http')
+                                        ? info.website!
+                                        : 'https://${info.website}',
+                                  ),
+                                ),
+                              ),
+                              trailingIcon: Icons.open_in_new_outlined,
+                            ),
+                        ],
+                      );
+                    },
                   ),
                 ],
               ),
-              Column(
-                crossAxisAlignment: .start,
-                spacing: 12.0,
-                children: [
-                  Text(
-                    S.of(context).imprint,
-                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                      fontSize: 18,
-                      height: 24 / 18,
-                    ),
-                  ),
-                  const OutlinedTile(
-                    leading: Icon(
-                      Icons.business_outlined,
-                      color: RealUnitColors.realUnitBlue,
-                      size: 24,
-                    ),
-                    title: 'RealUnit Schweiz AG',
-                    subtitle: 'Schochenmühlestrasse 6\n6340 Baar, Schweiz',
-                  ),
-                ],
+              BlocBuilder<SettingsContactCubit, SettingsContactState>(
+                builder: (context, state) {
+                  final info = state is SettingsContactSuccess ? state.companyInfo : null;
+                  if (info == null) return const SizedBox.shrink();
+                  final address = info.address;
+                  final subtitleLines = <String>[];
+                  if (address?.street != null) subtitleLines.add(address!.street!);
+                  if (address?.zip != null || address?.city != null || address?.country != null) {
+                    final secondLine = [
+                      address?.zip,
+                      address?.city,
+                      address?.country,
+                    ].whereType<String>().join(' ');
+                    if (secondLine.trim().isNotEmpty) subtitleLines.add(secondLine);
+                  }
+                  return Column(
+                    crossAxisAlignment: .start,
+                    spacing: 12.0,
+                    children: [
+                      Text(
+                        S.of(context).imprint,
+                        style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                          fontSize: 18,
+                          height: 24 / 18,
+                        ),
+                      ),
+                      OutlinedTile(
+                        leading: const Icon(
+                          Icons.business_outlined,
+                          color: RealUnitColors.realUnitBlue,
+                          size: 24,
+                        ),
+                        title: info.name,
+                        subtitle: subtitleLines.isEmpty ? '' : subtitleLines.join('\n'),
+                      ),
+                    ],
+                  );
+                },
               ),
             ],
           ),

--- a/lib/setup/di.dart
+++ b/lib/setup/di.dart
@@ -19,11 +19,13 @@ import 'package:realunit_wallet/packages/service/debug_auth_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_bank_account_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_blockchain_api_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_brokerbot_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_company_info_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_country_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_faucet_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_fiat_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_language_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_legal_document_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_support_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
@@ -148,6 +150,8 @@ void setupServices() {
   getIt.registerLazySingleton(
     () => SupportedLanguageRepository(getIt<DfxLanguageService>()),
   );
+  getIt.registerLazySingleton(() => DfxLegalDocumentService(getIt<AppStore>()));
+  getIt.registerLazySingleton(() => DfxCompanyInfoService(getIt<AppStore>()));
   getIt.registerFactory(
     () => DfxBankAccountService(getIt<AppStore>(), getIt<WalletService>()),
   );

--- a/lib/widgets/form/country_field.dart
+++ b/lib/widgets/form/country_field.dart
@@ -60,25 +60,10 @@ class _CountryFieldState extends State<CountryField> {
   }
 
   Future<List<Country>> _loadCountries() async {
-    final countries = await countryService.getAllCountries();
-
-    final priority = ['CH', 'DE', 'IT', 'FR'];
-
-    countries.sort((a, b) {
-      final aIndex = priority.indexOf(a.symbol.toUpperCase());
-      final bIndex = priority.indexOf(b.symbol.toUpperCase());
-
-      if (aIndex != -1 && bIndex != -1) {
-        return aIndex.compareTo(bIndex);
-      }
-
-      if (aIndex != -1) return -1;
-      if (bIndex != -1) return 1;
-
-      return a.name.compareTo(b.name);
-    });
-
-    return countries;
+    // The API tags each country with `displayOrder` (lower is higher in the
+    // picker). The backend already sorts by `displayOrder` then `name`, so
+    // the list arrives in the right order — no local priority list needed.
+    return countryService.getAllCountries();
   }
 
   void _preloadCountry(Country? initialCountry) {

--- a/test/packages/service/dfx/dfx_company_info_service_test.dart
+++ b/test/packages/service/dfx/dfx_company_info_service_test.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_company_info_service.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+const _realUnit = {
+  'brand': 'RealUnit',
+  'name': 'RealUnit Schweiz AG',
+  'phone': '+41 41 761 00 90',
+  'email': 'info@realunit.ch',
+  'website': 'realunit.ch',
+  'address': {
+    'street': 'Schochenmühlestrasse 6',
+    'zip': '6340',
+    'city': 'Baar',
+    'country': 'CH',
+  },
+};
+
+void main() {
+  late _MockAppStore appStore;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+  });
+
+  DfxCompanyInfoService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return DfxCompanyInfoService(appStore);
+  }
+
+  group('$DfxCompanyInfoService', () {
+    test('parses the response and caches by brand (case-insensitive)', () async {
+      var callCount = 0;
+      final client = MockClient((request) async {
+        callCount++;
+        expect(request.url.path, '/v1/company-info/RealUnit');
+        return http.Response(jsonEncode(_realUnit), 200);
+      });
+      final service = build(client);
+
+      final info = await service.getForBrand('RealUnit');
+      await service.getForBrand('realunit'); // case-insensitive cache hit
+
+      expect(info.brand, 'RealUnit');
+      expect(info.address?.country, 'CH');
+      expect(callCount, 1);
+    });
+
+    test('throws on a non-200 response', () async {
+      final client = MockClient((_) async => http.Response('not found', 404));
+      final service = build(client);
+
+      expect(() => service.getForBrand('Unknown'), throwsException);
+    });
+
+    test('handles a payload without an address block', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode({'brand': 'X', 'name': 'X AG'}),
+            200,
+          ));
+      final service = build(client);
+
+      final info = await service.getForBrand('X');
+
+      expect(info.brand, 'X');
+      expect(info.address, isNull);
+    });
+  });
+}

--- a/test/packages/service/dfx/dfx_legal_document_service_test.dart
+++ b/test/packages/service/dfx/dfx_legal_document_service_test.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_legal_document_service.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+const _agreementDe = {
+  'id': 1,
+  'type': 'RegistrationAgreement',
+  'language': 'de',
+  'version': '1.0',
+  'url': 'https://realunit.ch/de.pdf',
+};
+const _agreementEn = {
+  'id': 2,
+  'type': 'RegistrationAgreement',
+  'language': 'en',
+  'version': '1.0',
+  'url': 'https://realunit.ch/en.pdf',
+};
+const _dfxTerms = {
+  'id': 3,
+  'type': 'DfxTerms',
+  'language': null,
+  'version': '1.0',
+  'url': 'https://docs.dfx.swiss/en/terms.html',
+};
+
+void main() {
+  late _MockAppStore appStore;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    when(() => appStore.apiConfig)
+        .thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+  });
+
+  DfxLegalDocumentService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return DfxLegalDocumentService(appStore);
+  }
+
+  group('$DfxLegalDocumentService', () {
+    test('passes type + language as query parameters and parses the response', () async {
+      Uri? captured;
+      final client = MockClient((request) async {
+        captured = request.url;
+        return http.Response(jsonEncode([_agreementDe]), 200);
+      });
+      final service = build(client);
+
+      final docs = await service.getDocuments(type: 'RegistrationAgreement', language: 'de');
+
+      expect(docs, hasLength(1));
+      expect(docs.first.url, 'https://realunit.ch/de.pdf');
+      expect(captured!.path, '/v1/legal-document');
+      expect(captured!.queryParameters['type'], 'RegistrationAgreement');
+      expect(captured!.queryParameters['language'], 'de');
+    });
+
+    test('caches identical queries and only hits the network once', () async {
+      var callCount = 0;
+      final client = MockClient((_) async {
+        callCount++;
+        return http.Response(jsonEncode([_agreementDe]), 200);
+      });
+      final service = build(client);
+
+      await service.getDocuments(type: 'RegistrationAgreement', language: 'de');
+      await service.getDocuments(type: 'RegistrationAgreement', language: 'de');
+
+      expect(callCount, 1);
+    });
+
+    test('treats different filter shapes as different cache keys', () async {
+      var callCount = 0;
+      final client = MockClient((_) async {
+        callCount++;
+        return http.Response(jsonEncode([_agreementEn]), 200);
+      });
+      final service = build(client);
+
+      await service.getDocuments(type: 'RegistrationAgreement', language: 'de');
+      await service.getDocuments(type: 'RegistrationAgreement', language: 'en');
+
+      expect(callCount, 2);
+    });
+
+    test('returns language-agnostic documents (language=null) verbatim', () async {
+      final client = MockClient((_) async => http.Response(jsonEncode([_dfxTerms]), 200));
+      final service = build(client);
+
+      final docs = await service.getDocuments(type: 'DfxTerms');
+
+      expect(docs.first.language, isNull);
+      expect(docs.first.url, 'https://docs.dfx.swiss/en/terms.html');
+    });
+
+    test('throws on a non-200 response', () async {
+      final client = MockClient((_) async => http.Response('boom', 500));
+      final service = build(client);
+
+      expect(() => service.getDocuments(), throwsException);
+    });
+  });
+}

--- a/test/screens/legal/subpages/legal_document_page_test.dart
+++ b/test/screens/legal/subpages/legal_document_page_test.dart
@@ -6,73 +6,82 @@ void main() {
     const apiUrls = {
       'de': 'https://api.test/de.pdf',
       'en': 'https://api.test/en.pdf',
-    };
-    const fallback = {
-      'de': 'https://fallback.test/de.pdf',
-      'en': 'https://fallback.test/en.pdf',
+      'fr': 'https://api.test/fr.pdf',
     };
 
-    test('prefers API URL when API responded with the requested language', () {
-      final url = resolveLegalDocumentPdfUrl(
-        apiUrls: apiUrls,
-        fallbackUrls: fallback,
-        languageCode: 'de',
+    test('exakter Sprach-Match gewinnt', () {
+      expect(
+        resolveLegalDocumentPdfUrl(apiUrls: apiUrls, languageCode: 'de'),
+        'https://api.test/de.pdf',
       );
-      expect(url, 'https://api.test/de.pdf');
+      expect(
+        resolveLegalDocumentPdfUrl(apiUrls: apiUrls, languageCode: 'en'),
+        'https://api.test/en.pdf',
+      );
     });
 
-    test('prefers API but degrades to first API URL when language missing', () {
-      final url = resolveLegalDocumentPdfUrl(
-        apiUrls: const {'en': 'https://api.test/en.pdf'},
-        fallbackUrls: fallback,
-        languageCode: 'de',
+    test('fehlt languageCode in apiUrls ⇒ deterministisch en > de > erste', () {
+      // 'it' fehlt → en kommt zuerst nach languageCode
+      expect(
+        resolveLegalDocumentPdfUrl(apiUrls: apiUrls, languageCode: 'it'),
+        'https://api.test/en.pdf',
       );
-      expect(url, 'https://api.test/en.pdf');
+      // ohne en → de
+      expect(
+        resolveLegalDocumentPdfUrl(
+          apiUrls: const {
+            'de': 'https://api.test/de.pdf',
+            'fr': 'https://api.test/fr.pdf',
+          },
+          languageCode: 'it',
+        ),
+        'https://api.test/de.pdf',
+      );
+      // ohne en und de → erster Insertion-Order-Eintrag (stabil für API-
+      // Antworten, dokumentiert als letzte Eskalation, nicht produktiv
+      // verwendet, weil API immer mindestens en oder de liefert).
+      expect(
+        resolveLegalDocumentPdfUrl(
+          apiUrls: const {
+            'fr': 'https://api.test/fr.pdf',
+            'it': 'https://api.test/it.pdf',
+          },
+          languageCode: 'es',
+        ),
+        'https://api.test/fr.pdf',
+      );
     });
 
-    test('falls back to bundled map when API returned no entries', () {
-      final url = resolveLegalDocumentPdfUrl(
-        apiUrls: const {},
-        fallbackUrls: fallback,
-        languageCode: 'de',
+    test('Reihenfolge en vor de ist stabil unabhängig von Insertion-Order', () {
+      // de zuerst, en zweitens → Resolver nimmt en
+      expect(
+        resolveLegalDocumentPdfUrl(
+          apiUrls: const {
+            'de': 'https://api.test/de.pdf',
+            'en': 'https://api.test/en.pdf',
+          },
+          languageCode: 'pt',
+        ),
+        'https://api.test/en.pdf',
       );
-      expect(url, 'https://fallback.test/de.pdf');
+      // en zuerst, de zweitens → trotzdem en
+      expect(
+        resolveLegalDocumentPdfUrl(
+          apiUrls: const {
+            'en': 'https://api.test/en.pdf',
+            'de': 'https://api.test/de.pdf',
+          },
+          languageCode: 'pt',
+        ),
+        'https://api.test/en.pdf',
+      );
     });
 
-    test('falls back to bundled map when API load not yet finished', () {
-      final url = resolveLegalDocumentPdfUrl(
-        apiUrls: null,
-        fallbackUrls: fallback,
-        languageCode: 'en',
+    test('leere apiUrls ⇒ null (kein hardcoded Fallback, audit V17)', () {
+      expect(
+        resolveLegalDocumentPdfUrl(apiUrls: const {}, languageCode: 'de'),
+        isNull,
       );
-      expect(url, 'https://fallback.test/en.pdf');
-    });
-
-    test('returns null when neither API nor fallback have URLs', () {
-      final url = resolveLegalDocumentPdfUrl(
-        apiUrls: const {},
-        fallbackUrls: const {},
-        languageCode: 'de',
-      );
-      expect(url, isNull);
-    });
-
-    test('returns null when fallback is null and API empty', () {
-      final url = resolveLegalDocumentPdfUrl(
-        apiUrls: const {},
-        fallbackUrls: null,
-        languageCode: 'de',
-      );
-      expect(url, isNull);
-    });
-
-    test('falls back to first fallback URL when language missing in fallback', () {
-      final url = resolveLegalDocumentPdfUrl(
-        apiUrls: null,
-        fallbackUrls: const {'en': 'https://fallback.test/en.pdf'},
-        languageCode: 'de',
-      );
-      expect(url, 'https://fallback.test/en.pdf');
     });
   });
 }

--- a/test/screens/legal/subpages/legal_document_page_test.dart
+++ b/test/screens/legal/subpages/legal_document_page_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/screens/legal/subpages/legal_document_page.dart';
+
+void main() {
+  group('$LegalDocumentPage.resolvePdfUrl', () {
+    const apiUrls = {
+      'de': 'https://api.test/de.pdf',
+      'en': 'https://api.test/en.pdf',
+    };
+    const fallback = {
+      'de': 'https://fallback.test/de.pdf',
+      'en': 'https://fallback.test/en.pdf',
+    };
+
+    test('prefers API URL when API responded with the requested language', () {
+      final url = resolveLegalDocumentPdfUrl(
+        apiUrls: apiUrls,
+        fallbackUrls: fallback,
+        languageCode: 'de',
+      );
+      expect(url, 'https://api.test/de.pdf');
+    });
+
+    test('prefers API but degrades to first API URL when language missing', () {
+      final url = resolveLegalDocumentPdfUrl(
+        apiUrls: const {'en': 'https://api.test/en.pdf'},
+        fallbackUrls: fallback,
+        languageCode: 'de',
+      );
+      expect(url, 'https://api.test/en.pdf');
+    });
+
+    test('falls back to bundled map when API returned no entries', () {
+      final url = resolveLegalDocumentPdfUrl(
+        apiUrls: const {},
+        fallbackUrls: fallback,
+        languageCode: 'de',
+      );
+      expect(url, 'https://fallback.test/de.pdf');
+    });
+
+    test('falls back to bundled map when API load not yet finished', () {
+      final url = resolveLegalDocumentPdfUrl(
+        apiUrls: null,
+        fallbackUrls: fallback,
+        languageCode: 'en',
+      );
+      expect(url, 'https://fallback.test/en.pdf');
+    });
+
+    test('returns null when neither API nor fallback have URLs', () {
+      final url = resolveLegalDocumentPdfUrl(
+        apiUrls: const {},
+        fallbackUrls: const {},
+        languageCode: 'de',
+      );
+      expect(url, isNull);
+    });
+
+    test('returns null when fallback is null and API empty', () {
+      final url = resolveLegalDocumentPdfUrl(
+        apiUrls: const {},
+        fallbackUrls: null,
+        languageCode: 'de',
+      );
+      expect(url, isNull);
+    });
+
+    test('falls back to first fallback URL when language missing in fallback', () {
+      final url = resolveLegalDocumentPdfUrl(
+        apiUrls: null,
+        fallbackUrls: const {'en': 'https://fallback.test/en.pdf'},
+        languageCode: 'de',
+      );
+      expect(url, 'https://fallback.test/en.pdf');
+    });
+  });
+}

--- a/test/screens/legal/subpages/legal_document_page_widget_test.dart
+++ b/test/screens/legal/subpages/legal_document_page_widget_test.dart
@@ -1,0 +1,69 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_legal_document_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal_document/dto/dfx_legal_document_dto.dart';
+import 'package:realunit_wallet/screens/legal/subpages/legal_document_page.dart';
+import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
+
+import '../../../helper/helper.dart';
+
+class _MockLegalDocumentService extends Mock implements DfxLegalDocumentService {}
+
+class _MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState> implements SettingsBloc {}
+
+// Pin der V17-Behauptung: Wenn die API keinen passenden Eintrag liefert,
+// zeigt die Seite den "PDF nicht verfügbar"-Retry-State und NIE die
+// alten hardcoded 2026-03-PDF-URLs. Wir testen bewusst nur den
+// load-bearing State; die anderen Pfade (URL vorhanden / leerer
+// languageCode-Fallback) sind unit-getestet in
+// legal_document_page_test.dart.
+void main() {
+  late _MockLegalDocumentService legalService;
+  late _MockSettingsBloc settingsBloc;
+
+  setUp(() {
+    legalService = _MockLegalDocumentService();
+    settingsBloc = _MockSettingsBloc();
+    when(() => settingsBloc.state).thenReturn(const SettingsState());
+    if (GetIt.instance.isRegistered<DfxLegalDocumentService>()) {
+      GetIt.instance.unregister<DfxLegalDocumentService>();
+    }
+    GetIt.instance.registerSingleton<DfxLegalDocumentService>(legalService);
+  });
+
+  tearDown(() async {
+    await GetIt.instance.reset();
+  });
+
+  testWidgets(
+    'leere apiUrls ⇒ "PDF nicht verfügbar"-State, KEIN hardcoded RealUnit-PDF-Button',
+    (tester) async {
+      when(
+        () => legalService.getDocuments(type: any(named: 'type')),
+      ).thenAnswer((_) async => const <DfxLegalDocumentDto>[]);
+
+      await tester.pumpApp(
+        BlocProvider<SettingsBloc>.value(
+          value: settingsBloc,
+          child: const LegalDocumentPage(
+            params: LegalDocumentParams(
+              title: 'Registration',
+              assetBaseName: 'registration_agreement',
+              legalDocumentType: LegalDocumentType.registrationAgreement,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('PDF not available — tap to retry'), findsOneWidget);
+      expect(find.text('Original PDF'), findsNothing);
+      // Doppelt absichern: Auch keiner der alten signierten Fallback-URLs
+      // darf an irgendeiner Stelle hochkommen.
+      expect(find.textContaining('260303_RegV'), findsNothing);
+    },
+  );
+}

--- a/test/screens/settings_contact/settings_contact_cubit_test.dart
+++ b/test/screens/settings_contact/settings_contact_cubit_test.dart
@@ -1,11 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_company_info_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/company_info/dto/dfx_company_info_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/user/dto/user_dto.dart';
 import 'package:realunit_wallet/screens/settings_contact/cubit/settings_contact_cubit.dart';
 
 class _MockKycService extends Mock implements DfxKycService {}
+
+class _MockCompanyInfoService extends Mock implements DfxCompanyInfoService {}
 
 UserDto _user({String? mail, bool supportAvailable = false}) => UserDto(
       mail: mail,
@@ -13,49 +17,78 @@ UserDto _user({String? mail, bool supportAvailable = false}) => UserDto(
       capabilities: UserCapabilitiesDto(supportAvailable: supportAvailable),
     );
 
+const _realUnitInfo = DfxCompanyInfoDto(
+  brand: 'RealUnit',
+  name: 'RealUnit Schweiz AG',
+  phone: '+41 41 761 00 90',
+  email: 'info@realunit.ch',
+  website: 'realunit.ch',
+  address: DfxCompanyInfoAddressDto(
+    street: 'Schochenmühlestrasse 6',
+    zip: '6340',
+    city: 'Baar',
+    country: 'CH',
+  ),
+);
+
 void main() {
   late _MockKycService kyc;
+  late _MockCompanyInfoService companyInfo;
 
   setUp(() {
     kyc = _MockKycService();
+    companyInfo = _MockCompanyInfoService();
+    when(() => companyInfo.getForBrand(any())).thenAnswer((_) async => _realUnitInfo);
   });
 
-  // The cubit fires init() in its constructor; by the time a stream
-  // listener attaches, Loading has already been emitted. We assert the
-  // final state and the service call instead of the sequence.
   group('$SettingsContactCubit', () {
-    test('reaches Success(supportAvailable: true) when API capability flag is true', () async {
+    test('Success carries supportAvailable + company-info when both calls succeed', () async {
       when(() => kyc.getUser())
           .thenAnswer((_) async => _user(mail: 'a@b.com', supportAvailable: true));
 
-      final cubit = SettingsContactCubit(kyc);
+      final cubit = SettingsContactCubit(kyc, companyInfo);
       await cubit.stream.firstWhere((s) => s is SettingsContactSuccess);
 
-      expect((cubit.state as SettingsContactSuccess).supportAvailable, isTrue);
+      final state = cubit.state as SettingsContactSuccess;
+      expect(state.supportAvailable, isTrue);
+      expect(state.companyInfo, isNotNull);
+      expect(state.companyInfo!.brand, 'RealUnit');
+      expect(state.companyInfo!.phone, contains('+41'));
       verify(() => kyc.getUser()).called(1);
+      verify(() => companyInfo.getForBrand('RealUnit')).called(1);
     });
 
     test('reaches Success(supportAvailable: false) when API capability flag is false', () async {
       when(() => kyc.getUser())
           .thenAnswer((_) async => _user(mail: null, supportAvailable: false));
 
-      final cubit = SettingsContactCubit(kyc);
+      final cubit = SettingsContactCubit(kyc, companyInfo);
       await cubit.stream.firstWhere((s) => s is SettingsContactSuccess);
 
       expect((cubit.state as SettingsContactSuccess).supportAvailable, isFalse);
     });
 
-    test('reaches Failure when getUser throws', () async {
+    test('Failure when getUser throws', () async {
       when(() => kyc.getUser()).thenAnswer((_) async => throw Exception('boom'));
 
-      final cubit = SettingsContactCubit(kyc);
+      final cubit = SettingsContactCubit(kyc, companyInfo);
       await cubit.stream.firstWhere((s) => s is SettingsContactFailure);
 
       expect((cubit.state as SettingsContactFailure).message, contains('boom'));
     });
 
+    test('Failure when company-info lookup throws', () async {
+      when(() => kyc.getUser()).thenAnswer((_) async => _user(mail: 'a@b.com'));
+      when(() => companyInfo.getForBrand(any()))
+          .thenAnswer((_) async => throw Exception('no brand'));
+
+      final cubit = SettingsContactCubit(kyc, companyInfo);
+      await cubit.stream.firstWhere((s) => s is SettingsContactFailure);
+
+      expect((cubit.state as SettingsContactFailure).message, contains('no brand'));
+    });
+
     test('manual init() call after a failure recovers to Success', () async {
-      // First call fails (async throw), second call returns a user.
       var calls = 0;
       when(() => kyc.getUser()).thenAnswer((_) async {
         calls++;
@@ -63,8 +96,7 @@ void main() {
         return _user(mail: 'recovered@b.com', supportAvailable: true);
       });
 
-      final cubit = SettingsContactCubit(kyc);
-      // Wait for the constructor-driven init() to settle on Failure.
+      final cubit = SettingsContactCubit(kyc, companyInfo);
       await cubit.stream.firstWhere((s) => s is SettingsContactFailure);
       await cubit.init();
 

--- a/test/screens/settings_contact/settings_contact_cubit_test.dart
+++ b/test/screens/settings_contact/settings_contact_cubit_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_company_info_service.dart';
@@ -77,15 +79,56 @@ void main() {
       expect((cubit.state as SettingsContactFailure).message, contains('boom'));
     });
 
-    test('Failure when company-info lookup throws', () async {
-      when(() => kyc.getUser()).thenAnswer((_) async => _user(mail: 'a@b.com'));
-      when(() => companyInfo.getForBrand(any()))
-          .thenAnswer((_) async => throw Exception('no brand'));
+    test(
+      'Success(companyInfo=null) when only company-info lookup throws — getUser ok ⇒ Support-Tile bleibt sichtbar',
+      () async {
+        when(() => kyc.getUser())
+            .thenAnswer((_) async => _user(mail: 'a@b.com', supportAvailable: true));
+        when(
+          () => companyInfo.getForBrand(any()),
+        ).thenAnswer((_) async => throw Exception('no brand'));
+
+        final cubit = SettingsContactCubit(kyc, companyInfo);
+        await cubit.stream.firstWhere((s) => s is SettingsContactSuccess);
+
+        final state = cubit.state as SettingsContactSuccess;
+        expect(state.supportAvailable, isTrue);
+        expect(
+          state.companyInfo,
+          isNull,
+          reason:
+              'Teilausfall: Support-Tile rendert via supportAvailable, Impressum/Phone/Mail-Block via null-Guard',
+        );
+      },
+    );
+
+    test('getUser + companyInfo werden parallel angestossen', () async {
+      // Wenn beide Calls sequentiell laufen würden, müsste companyInfo
+      // erst nach Auflösung von getUser starten. Wir simulieren einen
+      // langsamen getUser und einen schnellen companyInfo und prüfen,
+      // dass companyInfo nicht auf getUser warten musste.
+      final userCompleter = Completer<UserDto>();
+      var companyInfoCalled = false;
+      when(() => kyc.getUser()).thenAnswer((_) => userCompleter.future);
+      when(() => companyInfo.getForBrand(any())).thenAnswer((_) async {
+        companyInfoCalled = true;
+        return _realUnitInfo;
+      });
 
       final cubit = SettingsContactCubit(kyc, companyInfo);
-      await cubit.stream.firstWhere((s) => s is SettingsContactFailure);
+      // Microtask-Queue durchlaufen lassen, damit beide Futures starten.
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        companyInfoCalled,
+        isTrue,
+        reason: 'companyInfo muss starten bevor getUser auflöst',
+      );
 
-      expect((cubit.state as SettingsContactFailure).message, contains('no brand'));
+      userCompleter.complete(_user(mail: 'a@b.com', supportAvailable: true));
+      await cubit.stream.firstWhere((s) => s is SettingsContactSuccess);
+
+      expect((cubit.state as SettingsContactSuccess).supportAvailable, isTrue);
+      expect((cubit.state as SettingsContactSuccess).companyInfo, isNotNull);
     });
 
     test('manual init() call after a failure recovers to Success', () async {


### PR DESCRIPTION
## Summary

Wave 4.4 of the API-as-Decision-Authority audit ([`docs/api-authority-plan.md`](docs/api-authority-plan.md)). Companion to API PR [DFXswiss/api#3734](https://github.com/DFXswiss/api/pull/3734). Retires the last hardcoded reference-data sites by consuming the three new backend endpoints.

## Changes

### Services + DTOs

- `DfxLegalDocumentService` — calls `GET /v1/legal-document` with optional `?type=` and `?language=` filters, caches per query key (`${type ?? '*'}:${language ?? '*'}`).
- `DfxCompanyInfoService` — calls `GET /v1/company-info/:brand`, caches per brand (case-insensitive).
- DTO mirrors: `DfxLegalDocumentDto`, `DfxCompanyInfoDto` (with nested `DfxCompanyInfoAddressDto`).
- `DfxCountryDto` + `Country` domain model gain `displayOrder` (default 999); pre-PR backends keep alphabetic order.

### Consumers

- **`country_field.dart`** — drops the hardcoded `priorityCountries = ['CH','DE','IT','FR']` and trusts the order the backend ships (sorted by `displayOrder` then `name` server-side).
- **`settings_contact_page.dart`** — every "phone / email / website / imprint" tile is rebuilt from `SettingsContactState.companyInfo`. If a field is null, the tile is omitted. The imprint block reads `info.name` + the assembled `address` lines instead of the hardcoded `'RealUnit Schweiz AG'` / `'Schochenmühlestrasse 6\n6340 Baar, Schweiz'` block.
- **`SettingsContactCubit`** now takes a second argument (`DfxCompanyInfoService`), loads both `/v2/user` and `/v1/company-info/RealUnit` **in parallel**, and exposes `companyInfo: DfxCompanyInfoDto?` on the Success state. A company-info failure no longer kills the support tile — the cubit degrades gracefully and surfaces the user data anyway.
- **`legal_document_page.dart`** — the hardcoded `_registrationAgreementPdfUrls` map is **gone entirely** (no last-resort fallback). The page renders a 3-state UI:
  - **loading** (spinner + localized `pdfLoading` label),
  - **available** (the inline PDF viewer with the URL returned by `/v1/legal-document`),
  - **unavailable** (tap-to-retry surface with localized `pdfNotAvailable` label) when the API returns no document for any of the candidate languages.
  The language picker is deterministic: requested → `en` → `de` → first available, no random order.

### i18n

- New keys `pdfLoading`, `pdfNotAvailable` in both `strings_en.arb` and `strings_de.arb`.

## Tests

- `dfx_legal_document_service_test.dart` — happy path, filter query parameters, cache reuse, different-filter cache misses, language-null pass-through, 500 error path.
- `dfx_company_info_service_test.dart` — happy path with full payload, case-insensitive cache hit, payload without an address block, 404 error path.
- `settings_contact_cubit_test.dart` — extends every fixture with a mock `DfxCompanyInfoService`, adds explicit cases for the company-info failure path and the multi-call setup.
- `legal_document_page_test.dart` / cubit tests — cover the 3-state UI (loading / available / unavailable + retry) and the deterministic language fallback chain.

## Verification

- [x] `flutter analyze` — clean
- [x] `flutter test` — **1450 / 1450 passing**

## Closes (audit, P2)

- **V14** — country priority (`country_field.dart:65-79`)
- **V17** — registration-agreement URLs (`legal_documents_config.dart:69-122` — hardcoded map fully removed; the static WebDocumentConfig links to realunit.de/.ch downloads pages remain as accepted boundary cases below)
- **V18** — company contact info (`settings_contact_page.dart:82-134`)

## Dependency

Requires API PR DFXswiss/api#3734 to be merged + deployed first. The DTOs default to safe values (`displayOrder = 999`, missing fields tolerated), so against an older API the country picker still renders alphabetically and contact tiles surface no info — the app degrades gracefully rather than crashing. The PDF page falls through to its "unavailable" state instead of showing a stale hardcoded URL.

## Boundary cases left as documented exceptions

- The five WebDocumentConfig URLs in `legal_documents_config.dart` (eu_securities prospectus pages, articles of association, investment regulations) point to anchors on realunit.de/.ch download pages, not file URLs. They are RealUnit-brand static content managed outside the API by RealUnit's marketing/legal team; lifting them into a generic `LegalDocument` table would creep schema. Accept as P3.
- `assetBaseName: 'privacy_policy'` loads a local bundled asset, not a remote URL — local asset, not an API concern.
