### PR TITLE
ci(handbook): pin SSH to deploy_key only — fix intermittent auth failures

### DIFF
--- a/.github/workflows/handbook-dev.yaml
+++ b/.github/workflows/handbook-dev.yaml
@@ -57,6 +57,14 @@ jobs:
           echo "${CLOUDFLARED_SHA256}  /usr/local/bin/cloudflared" | sha256sum -c -
           chmod +x /usr/local/bin/cloudflared
 
+      # Deploy via SSH through Cloudflare Tunnel. The `IdentitiesOnly=yes`
+      # and `IdentityAgent=none` options pin SSH to ONLY the explicit
+      # `deploy_key` and disable ssh-agent lookup — without them,
+      # OpenSSH probes default keys + agent identities first and may
+      # exhaust the server's MaxAuthTries before reaching deploy_key,
+      # producing intermittent "Permission denied … Too many
+      # authentication failures" on otherwise-healthy runs (root cause
+      # for the apparent smoke-test flakiness tracked in #487 Item 4).
       - name: Deploy to server
         run: |
           mkdir -p ~/.ssh
@@ -64,6 +72,8 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key \
+            -o IdentitiesOnly=yes \
+            -o IdentityAgent=none \
             -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
             ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
             "${{ env.DEPLOY_SERVICE }}"

--- a/.github/workflows/handbook-prd.yaml
+++ b/.github/workflows/handbook-prd.yaml
@@ -57,6 +57,14 @@ jobs:
           echo "${CLOUDFLARED_SHA256}  /usr/local/bin/cloudflared" | sha256sum -c -
           chmod +x /usr/local/bin/cloudflared
 
+      # Deploy via SSH through Cloudflare Tunnel. The `IdentitiesOnly=yes`
+      # and `IdentityAgent=none` options pin SSH to ONLY the explicit
+      # `deploy_key` and disable ssh-agent lookup — without them,
+      # OpenSSH probes default keys + agent identities first and may
+      # exhaust the server's MaxAuthTries before reaching deploy_key,
+      # producing intermittent "Permission denied … Too many
+      # authentication failures" on otherwise-healthy runs (root cause
+      # for the apparent smoke-test flakiness tracked in #487 Item 4).
       - name: Deploy to server
         run: |
           mkdir -p ~/.ssh
@@ -64,6 +72,8 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key \
+            -o IdentitiesOnly=yes \
+            -o IdentityAgent=none \
             -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
             ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
             "${{ env.DEPLOY_SERVICE }}"


### PR DESCRIPTION
Refs #487 Item 4.

## Root cause

Issue #487 Item 4 flagged `handbook-dev.yaml` as having ~30 % failure rate. A deep root-cause analysis of the last 10 runs found **three distinct failure classes**, not one:

| Failed run | Failed step | Cause |
|---|---|---|
| [26153613923](https://github.com/DFXswiss/realunit-app/actions/runs/26153613923) | Smoke test | DNS race — `dev-handbook.realunit.app` NS-swap not yet propagated (PR #451 cutover). Self-healed in 19 min. |
| [26126437801](https://github.com/DFXswiss/realunit-app/actions/runs/26126437801) + [26126347453](https://github.com/DFXswiss/realunit-app/actions/runs/26126347453) | **Deploy to server** | **SSH `Permission denied … Too many authentication failures` after 2 s** — the recurring class this PR fixes |
| [26055611218](https://github.com/DFXswiss/realunit-app/actions/runs/26055611218) | Docker Hub login | Missing repo secrets during initial workflow rollout. Self-healed when secrets were added. |

The original hypothesis ("nginx not ready / smoke test gives up too early") is **not supported by evidence**: every successful run answers with HTTP 200 on the **first** attempt (~0.8 s). The 30 × 10 s retry window is already over-dimensioned for any realistic container-startup latency.

## Why the SSH step intermittently fails

OpenSSH may offer multiple public keys to the server before honouring `-i deploy_key`: every identity advertised by the ssh-agent at `$SSH_AUTH_SOCK`, plus any explicit additional `IdentityFile` entries. When the count of offered keys exceeds the server's `MaxAuthTries` (default 6), the server aborts with `Too many authentication failures` before `deploy_key` is ever attempted.

GitHub-hosted runners sometimes inherit a non-empty `SSH_AUTH_SOCK` from the preceding `actions/checkout` step or carry over default keys from the runner image. Runs 26126437801 + 26126347453 (both on SHA `3eecab0`, 110 s apart) demonstrate this exact mode.

## Fix

Two SSH options added to the `ssh -i ~/.ssh/deploy_key` invocation in both `handbook-dev.yaml` and `handbook-prd.yaml`:

- `-o IdentitiesOnly=yes` — SSH may only authenticate with identities passed via `-i`, never via agent or `~/.ssh/id_*`.
- `-o IdentityAgent=none` — explicitly disable ssh-agent lookup even if `$SSH_AUTH_SOCK` is set.

`IdentitiesOnly=yes` alone would suffice in practice (it filters out any agent-advertised identity that is not in the explicit `IdentityFile` set). `IdentityAgent=none` is defensive belt-and-suspenders: it short-circuits the ssh-agent socket roundtrip entirely and removes any chance of agent-identity offers surviving edge-case interactions with `IdentityFile`. Both options are cheap, both make the intent explicit.

Behavior unchanged for healthy auth (`deploy_key` is the only identity offered, same as before); strict only when the previously-silent identity probing would have masked a successful auth.

## Other failure classes are not addressed here

- **DNS race:** one-off cutover effect, self-healed. A defensive `getent hosts` pre-check before the smoke-test loop is sketched in the audit findings as a *nice-to-have* but not implemented in this PR — it would only help future similar cutovers, none of which are currently planned.
- **Missing Docker Hub credentials:** a setup artefact at workflow rollout. Cannot recur unless the secrets are explicitly removed.

## Test plan

- [x] YAML parse both files
- [x] `ssh -G -o IdentitiesOnly=yes -o IdentityAgent=none` verifies both options are accepted by the local OpenSSH (10.2p1) — GitHub Actions runners ship 9.6+, both options are available since OpenSSH 7.3 (Aug 2016)
- [ ] Next `develop` push touching `docs/handbook/**` (or manual `workflow_dispatch`) — DEV deploy must reach the smoke test without `Permission denied`
- [ ] 5 consecutive green runs on the dev workflow → check off Item 4 in #487

## Out of scope (separate follow-ups, tracked in #487)

- Item 14: `webfactory/ssh-agent@v0.9.0` migration for both handbook workflows. Would eliminate the manual `echo > ~/.ssh/deploy_key` pattern entirely and replace it with the same `ssh-agent`-managed pattern already used by all release workflows. Larger surface change; this PR is the targeted minimum fix.
- Identical SSH-pattern fix in the upstream template `infrastructure/templates/ssh-deploy-{dev,prd}.yaml` in `DFXswiss/server` — the comment in `handbook-dev.yaml` already states the workflows "Mirror" that template, so the drift should be reconciled there in a separate small commit.
