### PR TITLE
ci: quick-wins bundle for #487 (cache, timeouts, consistency, hardening)

### DIFF
--- a/.github/workflows/auto-release-pr.yaml
+++ b/.github/workflows/auto-release-pr.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Check for existing PR
         id: check-pr
         run: |
+          set -euo pipefail
           PR_COUNT=$(gh pr list --base main --head develop --state open --json number --jq 'length')
           echo "pr_exists=$([[ $PR_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "::notice::Open PRs from develop to main: $PR_COUNT"
@@ -40,6 +41,7 @@ jobs:
         id: check-diff
         if: steps.check-pr.outputs.pr_exists == 'false'
         run: |
+          set -euo pipefail
           DIFF_COUNT=$(git rev-list --count origin/main..origin/develop)
           echo "has_changes=$([[ $DIFF_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
           echo "commit_count=$DIFF_COUNT" >> $GITHUB_OUTPUT
@@ -51,6 +53,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_COUNT: ${{ steps.check-diff.outputs.commit_count }}
         run: |
+          set -euo pipefail
           printf '%s\n' \
             "## Automatic Release PR" \
             "" \

--- a/.github/workflows/auto-release-pr.yaml
+++ b/.github/workflows/auto-release-pr.yaml
@@ -17,6 +17,7 @@ jobs:
   create-release-pr:
     name: Create Release PR
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -34,10 +34,14 @@ jobs:
       - name: Get latest tag
         id: get-tag
         run: |
+          set -euo pipefail
           # Only consider clean semver tags (vX.Y.Z). Legacy beta tags
           # (vX.Y.Z-beta.N) are ignored — they were superseded by the
-          # plain-SemVer schema.
-          LATEST_TAG=$(git tag -l --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
+          # plain-SemVer schema. The trailing `|| true` keeps the
+          # pipeline tolerant of an empty grep under `pipefail`: a
+          # fresh repo with zero matching tags is a legitimate state
+          # that the next `[ -z ... ]` branch handles explicitly.
+          LATEST_TAG=$(git tag -l --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
 
           if [ -z "$LATEST_TAG" ]; then
             echo "No existing tags found, starting with v0.0.0"
@@ -50,6 +54,7 @@ jobs:
       - name: Calculate next version
         id: next-version
         run: |
+          set -euo pipefail
           LATEST_TAG="${{ steps.get-tag.outputs.latest_tag }}"
 
           # Remove 'v' prefix and split into parts
@@ -65,8 +70,11 @@ jobs:
           # Floor for major/minor jumps: when pubspec.yaml is ahead of the
           # patch-bumped tag, use pubspec instead. Patch increments still come
           # from the tag history; pubspec is only consulted to trigger jumps.
+          # `|| true` keeps the pipeline tolerant of an empty grep under
+          # `pipefail`: a pubspec without a `version:` line is a legitimate
+          # state that the next `[ -n ... ]` branch handles explicitly.
           PUBSPEC_VERSION=$(grep -E '^version:[[:space:]]+[0-9]+\.[0-9]+\.[0-9]+' pubspec.yaml \
-            | awk '{print $2}' | cut -d+ -f1)
+            | awk '{print $2}' | cut -d+ -f1 || true)
           if [ -n "$PUBSPEC_VERSION" ]; then
             HIGHEST=$(printf '%s\n%s\n' "${NEXT_VERSION#v}" "$PUBSPEC_VERSION" | sort -V | tail -n 1)
             NEXT_VERSION="v${HIGHEST}"
@@ -81,6 +89,7 @@ jobs:
       - name: Check if tag exists
         id: check-tag
         run: |
+          set -euo pipefail
           NEW_TAG="${{ steps.next-version.outputs.new_tag }}"
           if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
             echo "::error::Tag $NEW_TAG already exists!"
@@ -92,6 +101,7 @@ jobs:
       - name: Create and push tag
         if: steps.check-tag.outputs.exists == 'false'
         run: |
+          set -euo pipefail
           NEW_TAG="${{ steps.next-version.outputs.new_tag }}"
 
           git config user.name "github-actions[bot]"

--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -15,6 +15,7 @@ jobs:
   create-tag:
     name: Create Release Tag
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/beta-release-android.yaml
+++ b/.github/workflows/beta-release-android.yaml
@@ -61,6 +61,7 @@ jobs:
           PLAY_STORE_JSON: ${{ secrets.PLAY_STORE_JSON_BASE64 }}
           ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
+          set -euo pipefail
           echo "$PLAY_STORE_JSON" | base64 --decode > android/credentials.json
           echo "$ANDROID_KEYSTORE" | base64 --decode > android/app/upload-keystore.jks
 

--- a/.github/workflows/beta-release-android.yaml
+++ b/.github/workflows/beta-release-android.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/.github/workflows/beta-release-android.yaml
+++ b/.github/workflows/beta-release-android.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   android-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Check out code

--- a/.github/workflows/beta-release-ios.yaml
+++ b/.github/workflows/beta-release-ios.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   build_ios:
     runs-on: macos-26
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/beta-release-ios.yaml
+++ b/.github/workflows/beta-release-ios.yaml
@@ -96,3 +96,13 @@ jobs:
         working-directory: ios
         env:
           NEW_VERSION: ${{ github.ref_name }}
+
+      # Remove the App Store Connect .p8 private key from the runner
+      # workspace once Fastlane has finished. Hosted runners are
+      # ephemeral so the file would be discarded anyway when the VM
+      # is recycled, but keeping the secret on disk one second
+      # longer than needed is the kind of thing that bites in a
+      # post-mortem. Defence-in-depth — costs nothing.
+      - name: Clean up App Store Connect key
+        if: always()
+        run: rm -f "${FASTLANE_APPLE_API_KEY_PATH:-${{ github.workspace }}/AuthKey.p8}" || true

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -25,6 +25,7 @@ jobs:
     # store backends.
     name: Decide whether this is a production-candidate tag
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       proceed: ${{ steps.check.outputs.proceed }}
     steps:
@@ -51,6 +52,7 @@ jobs:
     needs: guard
     if: needs.guard.outputs.proceed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Check out code
@@ -150,6 +152,7 @@ jobs:
     needs: guard
     if: needs.guard.outputs.proceed == 'true'
     runs-on: macos-26
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -246,6 +249,7 @@ jobs:
     needs: [guard, android-deploy, ios-deploy]
     if: needs.guard.outputs.proceed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       # -------------------
       # Setup Environment

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -245,6 +245,17 @@ jobs:
           name: ios-ipa
           path: ios/realunit-*.ipa
 
+      # Remove the App Store Connect .p8 private key from the runner
+      # workspace once Fastlane has finished. Hosted runners are
+      # ephemeral so the file would be discarded anyway when the VM
+      # is recycled, but `actions/upload-artifact` above globs from
+      # the workspace and a stray `AuthKey.p8` would otherwise be
+      # eligible for inclusion in any future artifact whose `path`
+      # widened. Defence-in-depth — costs nothing.
+      - name: Clean up App Store Connect key
+        if: always()
+        run: rm -f "${FASTLANE_APPLE_API_KEY_PATH:-${{ github.workspace }}/AuthKey.p8}" || true
+
   github-release:
     needs: [guard, android-deploy, ios-deploy]
     if: needs.guard.outputs.proceed == 'true'

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Inspect tag
         id: check
         run: |
+          set -euo pipefail
           TAG="${{ github.ref_name }}"
           # Strict shape: vX.Y.Z with all parts numeric, no suffix.
           if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
@@ -108,6 +109,7 @@ jobs:
           PLAY_STORE_JSON: ${{ secrets.PLAY_STORE_JSON_BASE64 }}
           ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
+          set -euo pipefail
           echo "$PLAY_STORE_JSON" | base64 --decode > android/credentials.json
           echo "$ANDROID_KEYSTORE" | base64 --decode > android/app/upload-keystore.jks
 

--- a/.github/workflows/bitbox-simulator-slash.yml
+++ b/.github/workflows/bitbox-simulator-slash.yml
@@ -28,6 +28,7 @@ jobs:
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '/bitbox-simulator')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       authorized: ${{ steps.authz.outputs.authorized }}
       sha: ${{ steps.parse.outputs.sha }}

--- a/.github/workflows/bitbox-simulator-slash.yml
+++ b/.github/workflows/bitbox-simulator-slash.yml
@@ -42,7 +42,14 @@ jobs:
           ACTOR: ${{ github.event.comment.user.login }}
         with:
           script: |
-            const allowed = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            // OWNER + MEMBER only. `COLLABORATOR` is excluded on purpose:
+            // it includes outside collaborators (people invited per-repo
+            // who are NOT in the DFXswiss org). The slash command accepts
+            // a `ref=` token that resolves into `actions/checkout@v4` with
+            // `ref:`, and an attacker-controlled ref can run arbitrary
+            // code on the runner — only trusted org identities are
+            // allowed to trigger that path.
+            const allowed = ['OWNER', 'MEMBER'];
             const ok = allowed.includes(process.env.ASSOC);
             core.setOutput('authorized', ok ? 'true' : 'false');
             if (!ok) {

--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -29,6 +29,11 @@ name: bitbox-simulator
 
 on:
   pull_request:
+    # Match the rest of the repo: pull_request workflows only listen to
+    # PRs targeting `develop`. The release lane (develop → main) is
+    # produced by `auto-release-pr.yaml` and doesn't need a second
+    # firmware simulator run on the same SHA.
+    branches: [develop]
     paths:
       - 'lib/packages/hardware_wallet/**'
       - 'lib/packages/wallet/**'
@@ -40,9 +45,13 @@ on:
       - '.github/workflows/bitbox-simulator.yml'
   workflow_dispatch:
 
+# `read` only — this workflow does not comment back on the PR, so the
+# default-elevated `write` was unused and granted more authority than
+# needed (the slash-command sibling keeps `write` because it DOES
+# create comments to report authz/parse state).
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   group: bitbox-simulator-${{ github.ref }}
@@ -51,6 +60,11 @@ concurrency:
 jobs:
   simulator:
     name: BitBox02 simulator (real firmware)
+    # Skip on draft PRs (matches `pull-request.yaml` + `tier3-handbook.yaml`).
+    # `workflow_dispatch` falls through because there's no `pull_request`
+    # context — the condition is "anything that isn't a PR, or a PR
+    # that isn't a draft".
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/develop-release.yaml
+++ b/.github/workflows/develop-release.yaml
@@ -241,6 +241,17 @@ jobs:
           name: ios-ipa
           path: ios/realunit-*.ipa
 
+      # Remove the App Store Connect .p8 private key from the runner
+      # workspace once Fastlane has finished. Hosted runners are
+      # ephemeral so the file would be discarded anyway when the VM
+      # is recycled, but `actions/upload-artifact` above globs from
+      # the workspace and a stray `AuthKey.p8` would otherwise be
+      # eligible for inclusion in any future artifact whose `path`
+      # widened. Defence-in-depth — costs nothing.
+      - name: Clean up App Store Connect key
+        if: always()
+        run: rm -f "${FASTLANE_APPLE_API_KEY_PATH:-${{ github.workspace }}/AuthKey.p8}" || true
+
   github-release:
     needs: [guard, android-deploy, ios-deploy]
     if: needs.guard.outputs.proceed == 'true'

--- a/.github/workflows/develop-release.yaml
+++ b/.github/workflows/develop-release.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Inspect tag
         id: check
         run: |
+          set -euo pipefail
           TAG="${{ github.ref_name }}"
           # Strict shape: vX.Y.Z with all parts numeric, no suffix.
           if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
@@ -104,6 +105,7 @@ jobs:
           PLAY_STORE_JSON: ${{ secrets.PLAY_STORE_JSON_BASE64 }}
           ANDROID_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
+          set -euo pipefail
           echo "$PLAY_STORE_JSON" | base64 --decode > android/credentials.json
           echo "$ANDROID_KEYSTORE" | base64 --decode > android/app/upload-keystore.jks
 

--- a/.github/workflows/develop-release.yaml
+++ b/.github/workflows/develop-release.yaml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       # -------------------
       # Setup Environment

--- a/.github/workflows/develop-release.yaml
+++ b/.github/workflows/develop-release.yaml
@@ -21,6 +21,7 @@ jobs:
     # human-pushed MAJOR/MINOR tag (App-Store-update marker).
     name: Decide whether this is an internal-patch tag
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       proceed: ${{ steps.check.outputs.proceed }}
     steps:
@@ -47,6 +48,7 @@ jobs:
     needs: guard
     if: needs.guard.outputs.proceed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Check out code
@@ -146,6 +148,7 @@ jobs:
     needs: guard
     if: needs.guard.outputs.proceed == 'true'
     runs-on: macos-26
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -242,6 +245,7 @@ jobs:
     needs: [guard, android-deploy, ios-deploy]
     if: needs.guard.outputs.proceed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/handbook-dev.yaml
+++ b/.github/workflows/handbook-dev.yaml
@@ -56,6 +56,7 @@ jobs:
           CLOUDFLARED_VERSION: "2025.4.0"
           CLOUDFLARED_SHA256: "2561391ee9abdc828afcc52f5ac314b6551a9a6a31ff59cbc64efc63aec04615"
         run: |
+          set -euo pipefail
           curl -fsSL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-arm64" -o /usr/local/bin/cloudflared
           echo "${CLOUDFLARED_SHA256}  /usr/local/bin/cloudflared" | sha256sum -c -
           chmod +x /usr/local/bin/cloudflared
@@ -70,6 +71,7 @@ jobs:
       # for the apparent smoke-test flakiness tracked in #487 Item 4).
       - name: Deploy to server
         run: |
+          set -euo pipefail
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key

--- a/.github/workflows/handbook-dev.yaml
+++ b/.github/workflows/handbook-dev.yaml
@@ -26,6 +26,7 @@ jobs:
   build-and-deploy:
     name: Build and deploy to DEV
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/handbook-dev.yaml
+++ b/.github/workflows/handbook-dev.yaml
@@ -47,6 +47,8 @@ jobs:
           push: true
           tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Install cloudflared
         env:

--- a/.github/workflows/handbook-prd.yaml
+++ b/.github/workflows/handbook-prd.yaml
@@ -56,6 +56,7 @@ jobs:
           CLOUDFLARED_VERSION: "2025.4.0"
           CLOUDFLARED_SHA256: "2561391ee9abdc828afcc52f5ac314b6551a9a6a31ff59cbc64efc63aec04615"
         run: |
+          set -euo pipefail
           curl -fsSL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-arm64" -o /usr/local/bin/cloudflared
           echo "${CLOUDFLARED_SHA256}  /usr/local/bin/cloudflared" | sha256sum -c -
           chmod +x /usr/local/bin/cloudflared
@@ -70,6 +71,7 @@ jobs:
       # for the apparent smoke-test flakiness tracked in #487 Item 4).
       - name: Deploy to server
         run: |
+          set -euo pipefail
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key

--- a/.github/workflows/handbook-prd.yaml
+++ b/.github/workflows/handbook-prd.yaml
@@ -26,6 +26,7 @@ jobs:
   build-and-deploy:
     name: Build and deploy to PRD
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/handbook-prd.yaml
+++ b/.github/workflows/handbook-prd.yaml
@@ -47,6 +47,8 @@ jobs:
           push: true
           tags: ${{ env.DOCKER_TAGS }}
           platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Install cloudflared
         env:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           flutter-version: "3.41.6"
           channel: "stable"
+          cache: true
       - run: flutter pub get
       - run: dart run tool/generate_localization.dart
       - run: dart run tool/generate_release_info.dart

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -218,7 +218,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25.5"
 
       - name: Install bitbox-audit
         continue-on-error: true

--- a/.github/workflows/tier3-handbook.yaml
+++ b/.github/workflows/tier3-handbook.yaml
@@ -125,6 +125,7 @@ jobs:
         with:
           flutter-version: "3.41.6"
           channel: "stable"
+          cache: true
 
       - run: flutter pub get
       - run: dart run tool/generate_localization.dart


### PR DESCRIPTION
Refs #487.

Quick-wins bundle for the CI/workflow tracking issue. Each commit is one logical fix per item cluster — safe to review and revert independently. No item touches application code; all changes are workflow YAML.

## Items addressed (9 of 22 in #487)

| Item | Commit | What |
| --- | --- | --- |
| 5 | `23d5429` | `cache: true` on `subosito/flutter-action@v2` in `pull-request.yaml` + `tier3-handbook.yaml` |
| 10 | `23d5429` | Docker GHA layer cache (`cache-from`/`cache-to: type=gha,mode=max`) in `handbook-{dev,prd}.yaml` |
| 11 | `f7d91c2` | `actions/checkout@v5` → `@v4` (3 occurrences in release workflows; repo now uniformly `@v4`) |
| 12 | `f7d91c2` | `go-version: "1.24"` → `"1.25.5"` in `pull-request.yaml::bitbox-audit` (all workflows now consistent) |
| 13 | `35dcbc9` | `timeout-minutes` added to 15 jobs that lacked one (envelopes: 5/10/20/45 min by job class) |
| 14 | `2ba4434` | `set -euo pipefail` added to multi-line `run: |` blocks with real `cut`/`grep`/`awk`/`base64` pipefail risk |
| 16 | `045f673` | App Store Connect `.p8` key cleanup via `if: always()` post-step in 3 iOS-uploading workflows |
| 17 | `766d698` | `bitbox-simulator.yml` hardening: `branches: [develop]`, draft-skip, `pull-requests: write → read` |
| 18 | `766d698` | `bitbox-simulator-slash.yml`: drop `COLLABORATOR` from authz allow-list (only `OWNER` + `MEMBER`) |

## Why these specific items

These 8 items have three properties in common:
- **Pure workflow YAML.** No application-code change, no test-coverage interaction.
- **Independent.** Reverting one does not break the others.
- **Low risk.** No item changes deploy semantics; cache misses gracefully (the workflow still runs), timeout-minutes only bites on actual hangs, `set -euo pipefail` only changes behaviour on already-broken inputs that were previously silenced.

Other #487 items either need a product decision (3 — keep or delete platform-specific release workflows; 1+21 — required status checks and branch protection) or are larger refactors (7, 8, 9, 15 — composite actions and workflow consolidation) and stay separately tracked.

## Item 14 scope note

The wording in #487 Item 14 reads as "every multi-line `run: \|`". This bundle implements that **defensively scoped**: blocks with `cut`/`grep`/`awk`/`base64` or other pipe-failure risk get `set -euo pipefail`, while trivially-linear blocks (`flutter pub get`, single `echo` heredocs, sequential `xcrun` commands) are left alone — `pipefail` adds no value there and `nounset` would have to be paired with a manual variable-existence audit for every env-var the block reads. A future strict pass can extend the convention if desired.

## Test plan

- [ ] `pull-request.yaml` workflow run on this branch must pass with the new `cache: true` flag (subosito/flutter-action picks up the cache on second run)
- [ ] `bitbox-audit` job must build with `go-version: "1.25.5"`
- [ ] No job in the test plan should hit a `timeout-minutes` (all values are above observed historical runtimes)
- [ ] After merge: first `handbook-dev` build is cold (no prior GHA cache); follow-up build should log `importing cache manifest from gha:...`
- [ ] After merge: a PR opened against `main` (rare; release PRs only) should **not** trigger `bitbox-simulator.yml` (the `branches: [develop]` change is intentional — Issue #487 Item 17 rationale)
- [ ] `/bitbox-simulator` slash command from a `COLLABORATOR`-but-not-`MEMBER` account should now be denied (Item 18 rationale)

## Out of scope

Everything else in #487 stays tracked there. The next reasonable follow-up PRs:
- Item 6 — DerivedData cache in `tier3-handbook.yaml` (~1 h, needs a cold-vs-warm run comparison to validate)
- Items 1 + 21 — extract floor-gate as own job + extend required status checks on the `PRs` ruleset (operational + small refactor)
- Items 8 + 9 — workflow consolidations (`handbook-{dev,prd}` reusable, `beta-release`+`develop-release` merge)
