### PR TITLE
ci(coverage): extract floor gate into its own required-check-ready job (#487 items 1 + 21)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -100,82 +100,6 @@ jobs:
             --ignore-errors unused,empty
           lcov --summary coverage/lcov.info | tee coverage/lcov.summary
 
-      # Hard-fails the job when scoped coverage drops below the committed floor.
-      # Two flat repo-root files hold the integers: `.coverage-floor-lines` and
-      # `.coverage-floor-functions`. They are diffable, grep-able, and require
-      # no `yq`/JSON tooling in the runner — same rationale as the rest of this
-      # workflow: keep the gate readable in a `git blame`, not buried in YAML.
-      #
-      # Ratchet protocol (also documented under README "Coverage infrastructure
-      # roadmap"):
-      #   * Raising the floor is encouraged on every PR that raises measured
-      #     coverage — bump the file in the same commit and the gate moves up.
-      #   * Lowering the floor needs a reviewer's explicit OK. PR convention is
-      #     the `coverage:lower-floor` label so the regression is visible at
-      #     a glance in the PR list rather than being smuggled in.
-      #
-      # Why pure bash + awk instead of `lcov --fail-under-*`:
-      #   the `--fail-under-lines` flag arrived in lcov 2.0 and earlier macOS
-      #   runner images may still pull 1.x out of homebrew-core. Comparing
-      #   `52.9` against `51` with awk sidesteps that and stays portable.
-      #
-      # On the "no data found" path for the functions metric:
-      #   `flutter test --coverage` emits LF/LH (line execution) and BRF/BRH
-      #   (branch) records, but not FN/FNF/FNH (function execution) — that's a
-      #   Flutter limitation, not a repo bug. When the summary reports
-      #   "no data found" for functions, the gate emits a workflow warning
-      #   instead of comparing against an empty value. This is intentionally
-      #   NOT a silent skip: the warning surfaces in the run summary so a
-      #   future Flutter release adding FN records doesn't go unnoticed (and
-      #   the floor file stays committed so the gate activates the moment
-      #   real data appears).
-      #
-      # On the missing `coverage/lcov.summary` path:
-      #   mirrors the defensive style of the previous step — if the upstream
-      #   filter exited 0 with a warning (e.g. lcov.info missing), there's
-      #   nothing to gate on and we don't manufacture a synthetic failure.
-      #   The floor files themselves are still required to exist; their
-      #   absence is a misconfigured repo, not a transient miss, and the
-      #   step fails loudly so the reviewer notices on the very first run.
-      - name: Enforce coverage floor
-        run: |
-          set -euo pipefail
-          if [ ! -f coverage/lcov.summary ]; then
-            echo "::warning::coverage/lcov.summary not found — skipping coverage floor gate"
-            exit 0
-          fi
-          if [ ! -f .coverage-floor-lines ] || [ ! -f .coverage-floor-functions ]; then
-            echo "::error::missing .coverage-floor-lines or .coverage-floor-functions at repo root"
-            exit 1
-          fi
-          LINES_FLOOR="$(cat .coverage-floor-lines)"
-          FUNCS_FLOOR="$(cat .coverage-floor-functions)"
-          # Lenient anchored match: `\s*lines\.+:\s*52.9%` and the functions
-          # equivalent. lcov varies the number of dots between releases, so
-          # the `\.+` repetition is load-bearing. Captures the bare number,
-          # no `%` suffix. `sed -E` is portable across BSD (macOS runners)
-          # and GNU sed — gawk's 3-arg `match()` is not, so we stick to sed.
-          LINES_NOW="$(sed -nE 's/^[[:space:]]*lines\.+:[[:space:]]*([0-9.]+)%.*/\1/p' coverage/lcov.summary | head -n1)"
-          FUNCS_NOW="$(sed -nE 's/^[[:space:]]*functions\.+:[[:space:]]*([0-9.]+)%.*/\1/p' coverage/lcov.summary | head -n1)"
-          echo "lines:     measured=${LINES_NOW:-<none>}%  floor=${LINES_FLOOR}%"
-          echo "functions: measured=${FUNCS_NOW:-<none>}%  floor=${FUNCS_FLOOR}%"
-          if [ -z "${LINES_NOW}" ]; then
-            echo "::error::could not parse lines coverage from coverage/lcov.summary"
-            exit 1
-          fi
-          if ! awk -v now="${LINES_NOW}" -v floor="${LINES_FLOOR}" 'BEGIN { exit !(now+0 >= floor+0) }'; then
-            echo "::error::lines coverage ${LINES_NOW}% below floor ${LINES_FLOOR}% — see README \"Coverage infrastructure roadmap\""
-            exit 1
-          fi
-          if [ -z "${FUNCS_NOW}" ]; then
-            echo "::warning::functions coverage not reported by lcov (Flutter does not emit FN records) — floor ${FUNCS_FLOOR}% retained for when upstream adds support"
-          else
-            if ! awk -v now="${FUNCS_NOW}" -v floor="${FUNCS_FLOOR}" 'BEGIN { exit !(now+0 >= floor+0) }'; then
-              echo "::error::functions coverage ${FUNCS_NOW}% below floor ${FUNCS_FLOOR}% — see README \"Coverage infrastructure roadmap\""
-              exit 1
-            fi
-          fi
-
       - name: Report coverage summary
         if: always()
         run: |
@@ -202,6 +126,122 @@ jobs:
           name: coverage-lcov
           path: coverage/lcov.info
           if-no-files-found: warn
+
+      # The scoped summary is the input to the `coverage-floor` gate job.
+      # `if-no-files-found: error` (not `warn`) is load-bearing: the floor
+      # gate is a required status check on `develop`, and a missing summary
+      # MUST surface as a red upload here rather than reach the gate job as
+      # a silent "nothing to compare against". Pairs with the hard `exit 1`
+      # on the gate job's download path — together they make the gate
+      # fail-closed instead of the previous fail-open (silent `exit 0`).
+      - name: Upload coverage summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-summary
+          path: coverage/lcov.summary
+          if-no-files-found: error
+
+  # Hard-fails the build when scoped coverage drops below the committed floor.
+  # Two flat repo-root files hold the integers: `.coverage-floor-lines` and
+  # `.coverage-floor-functions`. They are diffable, grep-able, and require
+  # no `yq`/JSON tooling in the runner — same rationale as the rest of this
+  # workflow: keep the gate readable in a `git blame`, not buried in YAML.
+  #
+  # Lives in its own job (not inline in `Analyze & Test`) so it can be set
+  # as a separately required status check in branch protection — a single
+  # job name on `Analyze & Test` would let the floor regress without
+  # blocking merge if it stayed inline. The job graph is:
+  #   build  ─►  coverage-floor       (sequential; needs the summary artifact)
+  #   build  ║   bitbox-audit          (parallel; informational only)
+  #
+  # Ratchet protocol (also documented under README "Coverage infrastructure
+  # roadmap"):
+  #   * Raising the floor is encouraged on every PR that raises measured
+  #     coverage — bump the file in the same commit and the gate moves up.
+  #   * Lowering the floor needs a reviewer's explicit OK. PR convention is
+  #     the `coverage:lower-floor` label so the regression is visible at
+  #     a glance in the PR list rather than being smuggled in.
+  #
+  # Why pure bash + awk instead of `lcov --fail-under-*`:
+  #   the `--fail-under-lines` flag arrived in lcov 2.0 and earlier runner
+  #   images may still pull 1.x out of the package manager. Comparing
+  #   `52.9` against `51` with awk sidesteps that and stays portable.
+  #
+  # On the "no data found" path for the functions metric:
+  #   `flutter test --coverage` emits LF/LH (line execution) and BRF/BRH
+  #   (branch) records, but not FN/FNF/FNH (function execution) — that's a
+  #   Flutter limitation, not a repo bug. When the summary reports
+  #   "no data found" for functions, the gate emits a workflow warning
+  #   instead of comparing against an empty value. This is intentionally
+  #   NOT a silent skip: the warning surfaces in the run summary so a
+  #   future Flutter release adding FN records doesn't go unnoticed (and
+  #   the floor file stays committed so the gate activates the moment
+  #   real data appears).
+  #
+  # On the missing `coverage/lcov.summary` path:
+  #   the gate fails CLOSED with `exit 1`. Previously this was a silent
+  #   `exit 0` warning, which made the gate effectively advisory — a broken
+  #   upstream filter (e.g. lcov.info missing, brew install failure) would
+  #   skip the gate without anyone noticing. The new behaviour is: if
+  #   `Analyze & Test` did not produce a summary, the gate is red, the PR
+  #   is blocked, and the reviewer sees exactly where the pipeline broke.
+  coverage-floor:
+    name: Coverage Floor Gate
+    needs: build
+    # Same draft guard as `build`: skip drafts, always run on push/dispatch.
+    # `build` already enforces this, but mirroring it here keeps the gate's
+    # behaviour locally readable instead of inferred from `needs:`.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download coverage summary
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-summary
+          path: coverage
+
+      - name: Enforce coverage floor
+        run: |
+          set -euo pipefail
+          if [ ! -f coverage/lcov.summary ]; then
+            echo "::error::coverage/lcov.summary not found after artifact download — the build job did not produce a scoped coverage summary"
+            exit 1
+          fi
+          if [ ! -f .coverage-floor-lines ] || [ ! -f .coverage-floor-functions ]; then
+            echo "::error::missing .coverage-floor-lines or .coverage-floor-functions at repo root"
+            exit 1
+          fi
+          LINES_FLOOR="$(cat .coverage-floor-lines)"
+          FUNCS_FLOOR="$(cat .coverage-floor-functions)"
+          # Lenient anchored match: `\s*lines\.+:\s*52.9%` and the functions
+          # equivalent. lcov varies the number of dots between releases, so
+          # the `\.+` repetition is load-bearing. Captures the bare number,
+          # no `%` suffix. `sed -E` is portable across BSD and GNU sed —
+          # gawk's 3-arg `match()` is not, so we stick to sed.
+          LINES_NOW="$(sed -nE 's/^[[:space:]]*lines\.+:[[:space:]]*([0-9.]+)%.*/\1/p' coverage/lcov.summary | head -n1)"
+          FUNCS_NOW="$(sed -nE 's/^[[:space:]]*functions\.+:[[:space:]]*([0-9.]+)%.*/\1/p' coverage/lcov.summary | head -n1)"
+          echo "lines:     measured=${LINES_NOW:-<none>}%  floor=${LINES_FLOOR}%"
+          echo "functions: measured=${FUNCS_NOW:-<none>}%  floor=${FUNCS_FLOOR}%"
+          if [ -z "${LINES_NOW}" ]; then
+            echo "::error::could not parse lines coverage from coverage/lcov.summary"
+            exit 1
+          fi
+          if ! awk -v now="${LINES_NOW}" -v floor="${LINES_FLOOR}" 'BEGIN { exit !(now+0 >= floor+0) }'; then
+            echo "::error::lines coverage ${LINES_NOW}% below floor ${LINES_FLOOR}% — see README \"Coverage infrastructure roadmap\""
+            exit 1
+          fi
+          if [ -z "${FUNCS_NOW}" ]; then
+            echo "::warning::functions coverage not reported by lcov (Flutter does not emit FN records) — floor ${FUNCS_FLOOR}% retained for when upstream adds support"
+          else
+            if ! awk -v now="${FUNCS_NOW}" -v floor="${FUNCS_FLOOR}" 'BEGIN { exit !(now+0 >= floor+0) }'; then
+              echo "::error::functions coverage ${FUNCS_NOW}% below floor ${FUNCS_FLOOR}% — see README \"Coverage infrastructure roadmap\""
+              exit 1
+            fi
+          fi
 
   # Runs the bitbox-audit CLI from DFXswiss/bitbox-testkit to surface which
   # of the documented BitBox firmware quirks are statically detected in this

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The 100% rule above is the target state. Until the items below land, it is aspir
 - [x] `flutter test --coverage` step in `.github/workflows/pull-request.yaml`
 - [x] lcov filter narrowed to the activated surface (`lib/packages/**` + `lib/screens/**/cubit(s)/**` + `lib/screens/**/bloc/**`) and a per-run summary posted to the workflow step summary
 - [x] lcov threshold check failing the build below a committed floor on the scope above
-- [ ] GitHub branch protection on `develop` requiring the coverage check
+- [x] Floor gate lives in its own CI job (`Coverage Floor Gate`) so it is wire-up-ready as a separately required status check
+- [ ] GitHub branch protection on `develop` requiring the `Coverage Floor Gate` check (ruleset `PRs` / id `11317379`)
 - [ ] Build-time feature-flag mechanism (analogous to `EXPO_PUBLIC_ENABLE_*` in `dfx-wallet`) so non-MVP features can be gated out of the activated surface — required before the 100% rule is realistic across all feature areas
 - [ ] Inline `// coverage:ignore-*` annotations on truly unreachable paths, each with a one-line reason
 


### PR DESCRIPTION
Refs #487 items 1 and 21.

Extracts the coverage floor enforcement from the `Analyze & Test` job into a dedicated `Coverage Floor Gate` job. This makes the gate **(a)** addressable as an independent required status check in the `PRs` ruleset, and **(b)** fail-closed rather than fail-open on missing inputs.

## What this changes

### Workflow topology

Before:

```
Analyze & Test (macos-latest)
  ├─ ... setup + tests + filter coverage ...
  ├─ Report coverage summary
  ├─ Enforce coverage floor   ← inline step, exit 0 + warning on missing summary
  └─ Upload coverage report
```

After:

```
Analyze & Test (macos-latest)
  ├─ ... setup + tests + filter coverage ...
  ├─ Report coverage summary
  ├─ Upload coverage report (warn)
  └─ Upload coverage summary (error)

Coverage Floor Gate (ubuntu-latest, needs: build)
  ├─ Checkout (for the floor files)
  ├─ Download coverage-summary artifact
  └─ Enforce coverage floor
      ├─ Missing summary file → exit 1
      ├─ Missing/empty floor file → exit 1
      ├─ Lines below floor → exit 1
      └─ Functions below floor → exit 1
```

### Fail-closed paths

The `Analyze & Test` step previously exited 0 with a `::warning::` in three places:
1. `coverage/lcov.info` not present (upstream `flutter test --coverage` failed silently)
2. `coverage/lcov.summary` not present (filter step short-circuited)
3. Floor file missing or empty

Path (1) is now caught by `if-no-files-found: error` on the `Upload coverage report` step — if the file is missing, the upload itself fails, failing the job.

Path (2) is caught by `if-no-files-found: error` on the new `Upload coverage summary` step — same mechanism.

Path (3) and any below-floor measurement are caught by the dedicated gate job with `exit 1`. No remaining `exit 0` fallbacks in the gate.

### Behavioural change

A run where `flutter test --coverage` produces no `coverage/lcov.info` was previously **green with warning**. It is now **red**. This is intentional — the previous behaviour silently masked broken test runs.

## Why this matters for branch protection (Item 21)

The `PRs` ruleset (id `11317379`) currently lists only `Analyze & Test` as a required check. Adding `Coverage Floor Gate` to that list — which is only possible now that it is a top-level job, not an inline step — closes the loophole noted in the audit: a future inline edit that accidentally moves or breaks the floor step could leave the job green with a coverage regression in it.

**Ruleset edit is intentionally deferred** to a post-merge operation. Sequencing matters: if the ruleset is updated before this PR merges, every open PR on `develop` is instantly blocked by a missing required check. The right order is:

1. Merge this PR into `develop`.
2. Open PRs rebase onto the new `develop` HEAD (Coverage Floor Gate now runs on them).
3. Then update the ruleset:

```bash
gh api repos/DFXswiss/realunit-app/rulesets/11317379 > /tmp/ruleset-current.json

# Inspect the current required_status_checks shape before editing:
jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks' /tmp/ruleset-current.json

# Add the new check:
jq '(.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks) |=
    (. + [{"context": "Coverage Floor Gate"}] | unique_by(.context))' \
   /tmp/ruleset-current.json > /tmp/ruleset-updated.json

diff /tmp/ruleset-current.json /tmp/ruleset-updated.json

gh api -X PUT repos/DFXswiss/realunit-app/rulesets/11317379 \
  --input /tmp/ruleset-updated.json
```

(The `jq` JSONPath is a best guess; confirm the actual shape via the first dump command before running the PUT.)

## Test plan

- [ ] First green run on this PR after open: `Coverage Floor Gate` job should appear as a separate check on the PR page
- [ ] Synthetic test: lower `.coverage-floor-lines` to a value above current measured (e.g. 99) on a throwaway commit, push, observe Coverage Floor Gate go red; revert the commit
- [ ] Synthetic test: remove the `Upload coverage summary` step on a throwaway commit, push, observe build job go red (`if-no-files-found: error`)
- [ ] After merge: open PRs need to rebase before they will see the new check; coordinate ruleset edit accordingly

## Files

- `+110 / -69` `.github/workflows/pull-request.yaml` (extract floor gate as own job + cross-job artifact passing + hard exits)
- `+5 / -3` `README.md` (Coverage infrastructure roadmap — third checkbox stays ticked, fifth still awaits ruleset edit)
