### PR TITLE
ci(handbook): make PIN-entry flows resilient to lost taps

### DIFF
--- a/.github/workflows/tier3-handbook.yaml
+++ b/.github/workflows/tier3-handbook.yaml
@@ -113,11 +113,12 @@ jobs:
       github.event_name != 'pull_request'
       || contains(github.event.pull_request.labels.*.name, 'tier3:full')
     runs-on: macos-latest
-    # 30 min envelope: ~5 min Flutter + tooling setup, ~3 min sim boot/erase,
-    # ~12 min for the 19 handbook flows running back-to-back, plus headroom.
-    # `pull-request.yaml` uses 30 too — keep them aligned for predictable
-    # runner-pool sizing.
-    timeout-minutes: 30
+    # ~12 min setup (Flutter + tooling, build, sim erase/boot/install) plus
+    # ~20-25 min for the 19 handbook flows — each flow restarts the XCUITest
+    # driver (~40-60 s). A full run lands around 32-37 min, so the former
+    # 30 min envelope was too tight and flaked into the job timeout; 45 min
+    # gives headroom for runner-speed variance and the per-flow retry budget.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 

--- a/.maestro/handbook/09-pin-confirm.yaml
+++ b/.maestro/handbook/09-pin-confirm.yaml
@@ -1,12 +1,23 @@
 # Captures docs/handbook/screenshots/09-pin-confirm.png
 # After entering six 1s, the same screen flips to confirm mode with the title
 # "Bestätigen Sie Ihre PIN" (single SetupPinPage with create/confirm states).
+#
+# Each tap is gated on the confirm screen not yet showing and re-tapped if a
+# digit was silently dropped (Maestro/XCUITest tap-loss on Apple Silicon +
+# iOS 26, mobile-dev-inc/maestro#3137). The gate also stops the loop the
+# instant the screen flips, so no surplus tap bleeds into the confirm PIN.
 appId: swiss.realunit.app
 ---
 - repeat:
-    times: 6
+    times: 12
     commands:
-      - tapOn: '1'
+      - runFlow:
+          when:
+            notVisible: 'Bestätigen Sie Ihre PIN'
+          commands:
+            - tapOn:
+                text: '1'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible: 'Bestätigen Sie Ihre PIN'

--- a/.maestro/handbook/10-biometric-prompt.yaml
+++ b/.maestro/handbook/10-biometric-prompt.yaml
@@ -7,22 +7,34 @@
 # around Xcode 26 (verified locally: `simctl ui --help` lists only
 # `appearance`, `increase_contrast`, `content_size`), so we cannot force
 # enrollment on CI. The flow handles both paths: with enrollment the
-# bottom sheet appears and we wait for "Überspringen"; without enrollment
-# the app proceeds straight to the dashboard and we skip the wait. The
-# captured screenshot will then show the dashboard instead of the
-# biometric prompt — local re-captures on a developer's machine with
-# Face ID enrolled produce the documented screenshot.
+# bottom sheet appears ("Überspringen"); without enrollment the app
+# proceeds straight to the dashboard ("RealUnit kaufen"). The captured
+# screenshot will then show the dashboard instead of the biometric
+# prompt — local re-captures on a developer's machine with Face ID
+# enrolled produce the documented screenshot.
+#
+# Each tap is gated on neither post-confirm state being reached yet and
+# re-tapped if a digit was silently dropped (Maestro/XCUITest tap-loss on
+# Apple Silicon + iOS 26, mobile-dev-inc/maestro#3137). The gate also
+# keeps surplus iterations from tapping through the biometric bottom
+# sheet on a local re-capture. The closing extendedWaitUntil fails here,
+# in this flow, if the PIN never completed — instead of one flow later
+# in 11-dashboard with a misleading "RealUnit kaufen not visible".
 appId: swiss.realunit.app
 ---
 - repeat:
-    times: 6
+    times: 12
     commands:
-      - tapOn: '1'
+      - runFlow:
+          when:
+            notVisible:
+              text: '.*Überspringen.*|.*RealUnit kaufen.*'
+          commands:
+            - tapOn:
+                text: '1'
+                optional: true
 - waitForAnimationToEnd
-- runFlow:
-    when:
-      visible: 'Überspringen'
-    commands:
-      - extendedWaitUntil:
-          visible: 'Überspringen'
-          timeout: 5000
+- extendedWaitUntil:
+    visible:
+      text: '.*Überspringen.*|.*RealUnit kaufen.*'
+    timeout: 30000

--- a/.maestro/handbook/18-settings-seed-hidden.yaml
+++ b/.maestro/handbook/18-settings-seed-hidden.yaml
@@ -1,12 +1,23 @@
 # Captures docs/handbook/screenshots/18-settings-seed-hidden.png
 # After entering the PIN, the settings seed page renders the same SeedBlurCard
 # used during onboarding (BackdropFilter — only xcrun can capture it).
+#
+# Each tap is gated on the seed page not yet showing and re-tapped if a
+# digit was silently dropped (Maestro/XCUITest tap-loss on Apple Silicon +
+# iOS 26, mobile-dev-inc/maestro#3137).
 appId: swiss.realunit.app
 ---
 - repeat:
-    times: 6
+    times: 12
     commands:
-      - tapOn: '1'
+      - runFlow:
+          when:
+            notVisible:
+              text: '.*Wiederherstellungs.*'
+          commands:
+            - tapOn:
+                text: '1'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible:


### PR DESCRIPTION
## Problem

Tier 3 handbook run [26233905441](https://github.com/DFXswiss/realunit-app/actions/runs/26233905441) (on the develop→main release PR #325) failed at `11-dashboard`:

```
Assertion '"RealUnit kaufen" is visible' failed
```

That is only the symptom. The Maestro `--debug-output` screenshot shows the real cause: the app sat on **"Bestätigen Sie Ihre PIN"** with **5 of 6 dots filled** — a keypad tap was silently dropped during the flow 10 PIN re-entry (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26, `mobile-dev-inc/maestro#3137`, documented in `tier3-handbook.yaml` itself).

Three flows enter a 6-digit PIN with a blind `repeat: times: 6 / tapOn '1'` and no per-tap check: `09-pin-confirm`, `10-biometric-prompt`, `18-settings-seed-hidden`. Flow 10 had **no assertion at all**, so a lost tap passed silently and surfaced one flow later as a misleading symptom.

## Change

`.maestro/handbook/{09,10,18}.yaml` — replace the blind repeat with a gated, self-healing loop:

```yaml
- repeat:
    times: 12                       # 6 digits + 6 tap-loss headroom
    commands:
      - runFlow:
          when:
            notVisible: <post-entry state>
          commands:
            - tapOn: { text: '1', optional: true }
- waitForAnimationToEnd
- extendedWaitUntil:
    visible: <post-entry state>     # hard gate, clear failure in-flow
    timeout: 30000
```

- A dropped tap → post-entry state not reached → next iteration re-taps. Self-heals.
- PIN complete → post-entry state visible → remaining iterations are no-ops (`addDigit` ignores taps past 6).
- The `notVisible` gate stops the loop the instant the PIN lands, so it never taps through the biometric bottom sheet on a local re-capture, and never bleeds a surplus tap into the confirm PIN.
- `optional: true` covers the brief CI window where the keypad is gone but the next screen has not painted yet.
- Bounded to 12 iterations; `extendedWaitUntil` hard-fails **in the flow that caused it** if the PIN never completes.

Post-entry state per flow: `09` → `Bestätigen Sie Ihre PIN`; `10` → `Überspringen` (biometric prompt) **or** `RealUnit kaufen` (dashboard, unenrolled CI runners); `18` → `Wiederherstellungs…`.

## Scope / deliberately untouched

- `scripts/run-handbook-flows.sh` retry logic — the "assertion failure = real regression, never retry" design is kept; this pattern heals before the assertion.
- `.maestro-version` (2.0.10) — only proven-on-2.0.10 primitives are used; no Maestro upgrade.

## Limitations

A green Tier 3 run proves the happy path is not broken. It cannot prove the self-heal catches a real tap-loss — that is non-deterministic and cannot be forced; correctness follows from the `SetupPinCubit` logic + Maestro semantics. Tier 3 only runs on a PR with the `tier3:full` label.