### PR TITLE
ci(handbook): extract reusable workflow, replace dev/prd with thin callers (#487 item 8)

### DIFF
--- a/.github/workflows/handbook-dev.yaml
+++ b/.github/workflows/handbook-dev.yaml
@@ -1,9 +1,8 @@
 name: Handbook DEV CI/CD
 
-# Builds the handbook nginx image, publishes dfxswiss/realunit-app-handbook:beta
-# to Docker Hub, and tells the dev server to pull + recreate the container.
-#
-# Mirrors infrastructure/templates/ssh-deploy-dev.yaml from DFXServer/server.
+# Thin caller for the reusable handbook workflow.
+# All deploy logic lives in .github/workflows/handbook.yaml — this file
+# only wires the DEV-specific tag, smoke URL, and DEPLOY_DEV_* secrets.
 
 on:
   push:
@@ -13,101 +12,23 @@ on:
       - "Dockerfile.handbook"
       - "handbook.nginx.conf"
       - ".github/workflows/handbook-dev.yaml"
+      - ".github/workflows/handbook.yaml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
-env:
-  DOCKER_TAGS: dfxswiss/realunit-app-handbook:beta
-  DEPLOY_SERVICE: realunit-app-handbook
-
 jobs:
-  build-and-deploy:
-    name: Build and deploy to DEV
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 20
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push handbook image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.handbook
-          push: true
-          tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Install cloudflared
-        env:
-          CLOUDFLARED_VERSION: "2025.4.0"
-          CLOUDFLARED_SHA256: "2561391ee9abdc828afcc52f5ac314b6551a9a6a31ff59cbc64efc63aec04615"
-        run: |
-          set -euo pipefail
-          curl -fsSL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-arm64" -o /usr/local/bin/cloudflared
-          echo "${CLOUDFLARED_SHA256}  /usr/local/bin/cloudflared" | sha256sum -c -
-          chmod +x /usr/local/bin/cloudflared
-
-      # Deploy via SSH through Cloudflare Tunnel. The `IdentitiesOnly=yes`
-      # and `IdentityAgent=none` options pin SSH to ONLY the explicit
-      # `deploy_key` and disable ssh-agent lookup — without them,
-      # OpenSSH probes default keys + agent identities first and may
-      # exhaust the server's MaxAuthTries before reaching deploy_key,
-      # producing intermittent "Permission denied … Too many
-      # authentication failures" on otherwise-healthy runs (root cause
-      # for the apparent smoke-test flakiness tracked in #487 Item 4).
-      - name: Deploy to server
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-          ssh -i ~/.ssh/deploy_key \
-            -o IdentitiesOnly=yes \
-            -o IdentityAgent=none \
-            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
-            ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
-            "${{ env.DEPLOY_SERVICE }}"
-
-      # Post-deploy smoke test: poll the public endpoint until the nginx
-      # container answers 200, or give up. Without this step a "green"
-      # deploy can lie — a misconfigured nginx leaves the container
-      # Up-but-unresponsive while the workflow reports success. Failing
-      # this step blocks the auto-release PR from collecting a green
-      # check and surfaces the regression in CI. Mirrors the pattern
-      # from zkcoins/server `deploy-dev.yaml`.
-      #
-      # Probes the canonical root URL with `curl -L` so the default-locale
-      # redirect (`/` → `/de/`) is followed end to end: nginx up, root
-      # routing intact, locale `index.html` served. Pinning a specific
-      # locale path would re-rot if the locale layout ever changes.
-      - name: Smoke test public endpoint
-        env:
-          SMOKE_URL: https://dev-handbook.realunit.app/
-        run: |
-          set -euo pipefail
-          for i in $(seq 1 30); do
-            code=$(curl -sS -L --max-redirs 3 -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE_URL" || echo "000")
-            if [ "$code" = "200" ]; then
-              echo "DEV handbook responded 200 after ${i} attempt(s)"
-              exit 0
-            fi
-            echo "[$i/30] $SMOKE_URL -> ${code} (waiting 10 s)"
-            sleep 10
-          done
-          echo "::error::DEV handbook never returned 200 within ~5 min after deploy"
-          exit 1
+  deploy:
+    uses: ./.github/workflows/handbook.yaml
+    with:
+      environment: DEV
+      docker_tag: dfxswiss/realunit-app-handbook:beta
+      smoke_url: https://dev-handbook.realunit.app/
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_DEV_SSH_KEY }}
+      DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_DEV_USER }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_DEV_HOST }}

--- a/.github/workflows/handbook-prd.yaml
+++ b/.github/workflows/handbook-prd.yaml
@@ -1,9 +1,8 @@
 name: Handbook PRD CI/CD
 
-# Builds the handbook nginx image, publishes dfxswiss/realunit-app-handbook:latest
-# to Docker Hub, and tells the prd server to pull + recreate the container.
-#
-# Mirrors infrastructure/templates/ssh-deploy-prd.yaml from DFXServer/server.
+# Thin caller for the reusable handbook workflow.
+# All deploy logic lives in .github/workflows/handbook.yaml — this file
+# only wires the PRD-specific tag, smoke URL, and DEPLOY_PRD_* secrets.
 
 on:
   push:
@@ -13,99 +12,23 @@ on:
       - "Dockerfile.handbook"
       - "handbook.nginx.conf"
       - ".github/workflows/handbook-prd.yaml"
+      - ".github/workflows/handbook.yaml"
   workflow_dispatch:
 
 permissions:
   contents: read
 
-env:
-  DOCKER_TAGS: dfxswiss/realunit-app-handbook:latest
-  DEPLOY_SERVICE: realunit-app-handbook
-
 jobs:
-  build-and-deploy:
-    name: Build and deploy to PRD
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 20
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push handbook image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile.handbook
-          push: true
-          tags: ${{ env.DOCKER_TAGS }}
-          platforms: linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Install cloudflared
-        env:
-          CLOUDFLARED_VERSION: "2025.4.0"
-          CLOUDFLARED_SHA256: "2561391ee9abdc828afcc52f5ac314b6551a9a6a31ff59cbc64efc63aec04615"
-        run: |
-          set -euo pipefail
-          curl -fsSL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-arm64" -o /usr/local/bin/cloudflared
-          echo "${CLOUDFLARED_SHA256}  /usr/local/bin/cloudflared" | sha256sum -c -
-          chmod +x /usr/local/bin/cloudflared
-
-      # Deploy via SSH through Cloudflare Tunnel. The `IdentitiesOnly=yes`
-      # and `IdentityAgent=none` options pin SSH to ONLY the explicit
-      # `deploy_key` and disable ssh-agent lookup — without them,
-      # OpenSSH probes default keys + agent identities first and may
-      # exhaust the server's MaxAuthTries before reaching deploy_key,
-      # producing intermittent "Permission denied … Too many
-      # authentication failures" on otherwise-healthy runs (root cause
-      # for the apparent smoke-test flakiness tracked in #487 Item 4).
-      - name: Deploy to server
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
-          ssh -i ~/.ssh/deploy_key \
-            -o IdentitiesOnly=yes \
-            -o IdentityAgent=none \
-            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
-            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
-            "${{ env.DEPLOY_SERVICE }}"
-
-      # Post-deploy smoke test: poll the public endpoint until the nginx
-      # container answers 200, or give up. Without this step a "green"
-      # deploy can lie — a misconfigured nginx leaves the container
-      # Up-but-unresponsive while the workflow reports success. Mirrors
-      # the pattern from zkcoins/server `deploy-dev.yaml`.
-      #
-      # Probes the canonical root URL with `curl -L` so the default-locale
-      # redirect (`/` → `/de/`) is followed end to end: nginx up, root
-      # routing intact, locale `index.html` served. Pinning a specific
-      # locale path would re-rot if the locale layout ever changes.
-      - name: Smoke test public endpoint
-        env:
-          SMOKE_URL: https://handbook.realunit.app/
-        run: |
-          set -euo pipefail
-          for i in $(seq 1 30); do
-            code=$(curl -sS -L --max-redirs 3 -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE_URL" || echo "000")
-            if [ "$code" = "200" ]; then
-              echo "PRD handbook responded 200 after ${i} attempt(s)"
-              exit 0
-            fi
-            echo "[$i/30] $SMOKE_URL -> ${code} (waiting 10 s)"
-            sleep 10
-          done
-          echo "::error::PRD handbook never returned 200 within ~5 min after deploy"
-          exit 1
+  deploy:
+    uses: ./.github/workflows/handbook.yaml
+    with:
+      environment: PRD
+      docker_tag: dfxswiss/realunit-app-handbook:latest
+      smoke_url: https://handbook.realunit.app/
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_PRD_SSH_KEY }}
+      DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_PRD_USER }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_PRD_HOST }}

--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -1,0 +1,133 @@
+name: Handbook reusable CI/CD
+
+# Reusable workflow that builds the handbook nginx image, publishes it to
+# Docker Hub, and tells the target server to pull + recreate the container.
+#
+# Callers (handbook-dev.yaml, handbook-prd.yaml) provide the per-environment
+# parameters (tag, smoke URL, deploy secrets) so the deploy logic itself
+# lives in exactly one place.
+#
+# Mirrors infrastructure/templates/ssh-deploy-*.yaml from DFXServer/server.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Target environment label (dev | prd) — used in job name + smoke log lines"
+        required: true
+        type: string
+      docker_tag:
+        description: "Full Docker image tag, e.g. dfxswiss/realunit-app-handbook:beta"
+        required: true
+        type: string
+      smoke_url:
+        description: "Public URL to poll after deploy"
+        required: true
+        type: string
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      DEPLOY_SSH_KEY:
+        required: true
+      DEPLOY_SSH_KNOWN_HOSTS:
+        required: true
+      DEPLOY_USER:
+        required: true
+      DEPLOY_HOST:
+        required: true
+
+env:
+  DEPLOY_SERVICE: realunit-app-handbook
+
+jobs:
+  build-and-deploy:
+    name: Build and deploy to ${{ inputs.environment }}
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push handbook image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.handbook
+          push: true
+          tags: ${{ inputs.docker_tag }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cloudflared
+        env:
+          CLOUDFLARED_VERSION: "2025.4.0"
+          CLOUDFLARED_SHA256: "2561391ee9abdc828afcc52f5ac314b6551a9a6a31ff59cbc64efc63aec04615"
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-arm64" -o /usr/local/bin/cloudflared
+          echo "${CLOUDFLARED_SHA256}  /usr/local/bin/cloudflared" | sha256sum -c -
+          chmod +x /usr/local/bin/cloudflared
+
+      # Deploy via SSH through Cloudflare Tunnel. The `IdentitiesOnly=yes`
+      # and `IdentityAgent=none` options pin SSH to ONLY the explicit
+      # `deploy_key` and disable ssh-agent lookup — without them,
+      # OpenSSH probes default keys + agent identities first and may
+      # exhaust the server's MaxAuthTries before reaching deploy_key,
+      # producing intermittent "Permission denied … Too many
+      # authentication failures" on otherwise-healthy runs (root cause
+      # for the apparent smoke-test flakiness tracked in #487 Item 4).
+      - name: Deploy to server
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o IdentitiesOnly=yes \
+            -o IdentityAgent=none \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_HOST }}" \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"
+
+      # Post-deploy smoke test: poll the public endpoint until the nginx
+      # container answers 200, or give up. Without this step a "green"
+      # deploy can lie — a misconfigured nginx leaves the container
+      # Up-but-unresponsive while the workflow reports success. Failing
+      # this step blocks the auto-release PR from collecting a green
+      # check and surfaces the regression in CI. Mirrors the pattern
+      # from zkcoins/server `deploy-dev.yaml`.
+      #
+      # Probes the canonical root URL with `curl -L` so the default-locale
+      # redirect (`/` → `/de/`) is followed end to end: nginx up, root
+      # routing intact, locale `index.html` served. Pinning a specific
+      # locale path would re-rot if the locale layout ever changes.
+      - name: Smoke test public endpoint
+        env:
+          SMOKE_URL: ${{ inputs.smoke_url }}
+          ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            code=$(curl -sS -L --max-redirs 3 -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE_URL" || echo "000")
+            if [ "$code" = "200" ]; then
+              echo "${ENVIRONMENT} handbook responded 200 after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "[$i/30] $SMOKE_URL -> ${code} (waiting 10 s)"
+            sleep 10
+          done
+          echo "::error::${ENVIRONMENT} handbook never returned 200 within ~5 min after deploy"
+          exit 1

--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -38,6 +38,12 @@ on:
       DEPLOY_HOST:
         required: true
 
+# Reusable workflows do NOT inherit `permissions` from the caller — GITHUB_TOKEN
+# scopes are resolved per-workflow. Mirror the `contents: read` floor that both
+# callers set so the reusable behaves identically to the pre-extract setup.
+permissions:
+  contents: read
+
 env:
   DEPLOY_SERVICE: realunit-app-handbook
 


### PR DESCRIPTION
Refs #487 item 8.

## Summary

Collapses `handbook-dev.yaml` + `handbook-prd.yaml` (~95 % duplicate, ~220 lines total) into one reusable workflow + two thin callers.

- `.github/workflows/handbook.yaml` — new reusable workflow with `workflow_call` (`environment`, `docker_tag`, `smoke_url` inputs + 6 secrets). All build / push / deploy / smoke logic lives here.
- `.github/workflows/handbook-dev.yaml` — thin caller (~34 lines): `develop` branch, `:beta`, `dev-handbook.realunit.app`, `DEPLOY_DEV_*` secrets.
- `.github/workflows/handbook-prd.yaml` — thin caller (~34 lines): `main` branch, `:latest`, `handbook.realunit.app`, `DEPLOY_PRD_*` secrets.

## Preserved end-to-end (post-rebase)

After PR #502 + PR #500 merged into `develop`, this branch was rebased onto the new tip with manual conflict resolution. All of the following improvements are present in the consolidated `handbook.yaml`:

- **PR #500** SSH pin (`-o IdentitiesOnly=yes` + `-o IdentityAgent=none`) — fixes "Too many authentication failures" (#487 Item 4)
- **PR #502 item 10** Docker GHA cache: `cache-from: type=gha` + `cache-to: type=gha,mode=max` on `docker/build-push-action@v6`
- **PR #502 item 13** `timeout-minutes: 20` on the build-and-deploy job
- **PR #502 item 14** `set -euo pipefail` on every multi-line `run: |` block (cloudflared install, SSH deploy, smoke test)
- cloudflared pinned version + SHA256
- `linux/arm64`-only build (ARM64-only runner posture per repo memory)
- All inline comment density and rationale

Path filters in both callers now also watch `.github/workflows/handbook.yaml` so edits to the reusable trigger a deploy.

## Field-by-field audit

The two old files diverge only in these 10 places (everything else byte-identical):

| Field | DEV | PRD |
|---|---|---|
| `name:` | "Handbook DEV CI/CD" | "Handbook PRD CI/CD" |
| Header comment | `:beta` / dev / ssh-deploy-dev | `:latest` / prd / ssh-deploy-prd |
| `branches:` | `[develop]` | `[main]` |
| path-filter self-ref | `handbook-dev.yaml` | `handbook-prd.yaml` |
| `DOCKER_TAGS` | `…:beta` | `…:latest` |
| Job name | "Build and deploy to DEV" | "Build and deploy to PRD" |
| 4 SSH secrets | `DEPLOY_DEV_*` | `DEPLOY_PRD_*` |
| `SMOKE_URL` | `https://dev-handbook.realunit.app/` | `https://handbook.realunit.app/` |
| Smoke log strings | "DEV handbook…" | "PRD handbook…" |
| Smoke comment density | longer (mentions auto-release PR blocking) | shorter |

All 10 mapped to inputs or `inputs.environment`-templated. No functional divergence.

## Test plan

- [ ] Touch `docs/handbook/**` on a branch off `develop`, open PR → no handbook-dev run (push-only trigger; expected)
- [ ] After merge to develop: `handbook-dev.yaml` runs, calls `handbook.yaml`, builds + deploys + smoke-tests; log reads "DEV handbook responded 200"
- [ ] After develop→main merge: `handbook-prd.yaml` runs analogous; log reads "PRD handbook responded 200"
- [ ] Confirm 5 consecutive green handbook-dev runs (closes #487 Item 4 final verification)

## Files

- `-108 / +34` `.github/workflows/handbook-dev.yaml` (now thin caller)
- `-106 / +34` `.github/workflows/handbook-prd.yaml` (now thin caller)
- `+128` `.github/workflows/handbook.yaml` (new reusable workflow)
- Net: -18 lines, all duplicate-removal

