### PR TITLE
fix(verify-seed): make the verify-to-onboarding transition robust

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -319,6 +319,7 @@
   "userData": "Nutzerdaten",
   "userDataLoadFailed": "Beim Laden der Nutzerdaten ist ein Fehler aufgetreten.",
   "userDataNotFound": "Zu dieser Wallet sind keine Nutzerdaten hinterlegt.",
+  "verifySeedCommitFailed": "Ihre Wallet konnte nicht gespeichert werden — zum Erneut-Versuchen tippen",
   "verifySeedInvalid": "Die Wörter stimmen nicht überein",
   "verifySeedSubtitle": "Bitte geben Sie die folgenden Wörter aus Ihrer Wiederherstellungsphrase ein, um zu bestätigen, dass Sie sie korrekt notiert haben.",
   "verifySeedSuccessful": "Seed erfolgreich überprüft",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -319,6 +319,7 @@
   "userData": "User data",
   "userDataLoadFailed": "An error occurred while loading user data.",
   "userDataNotFound": "No user data is stored for this wallet.",
+  "verifySeedCommitFailed": "Couldn't save your wallet — tap to retry",
   "verifySeedInvalid": "The words don't match",
   "verifySeedSubtitle": "Please enter the following words from your recovery phrase to confirm you've written them down correctly.",
   "verifySeedSuccessful": "Seed successfully verified",

--- a/lib/screens/verify_seed/cubit/verify_seed_cubit.dart
+++ b/lib/screens/verify_seed/cubit/verify_seed_cubit.dart
@@ -86,8 +86,18 @@ class VerifySeedCubit extends Cubit<VerifySeedState> {
     emit(state.copyWith(isVerifying: true, commitFailed: false));
     try {
       final committed = await _walletService.commitGeneratedWallet(_wallet);
+      // Async-tail guard: the AppBar back button on the verify-seed screen
+      // stays enabled while `isVerifying` is true, so the user can pop the
+      // page (closing the cubit) before the commit resolves. A post-close
+      // `emit` would throw `StateError`. Matches the
+      // `connect_bitbox_cubit` / `create_wallet_cubit` / `kyc_cubit`
+      // pattern. The committed row is already persisted at this point —
+      // dropping the success emission is acceptable; the user simply
+      // restarts onboarding and re-uses the existing wallet.
+      if (isClosed) return false;
       _wallet = committed;
       await _walletService.setCurrentWallet(committed.id);
+      if (isClosed) return false;
       emit(
         state.copyWith(
           isVerifying: false,
@@ -106,6 +116,7 @@ class VerifySeedCubit extends Cubit<VerifySeedState> {
         error: e,
         stackTrace: stack,
       );
+      if (isClosed) return false;
       emit(state.copyWith(isVerifying: false, commitFailed: true));
       return false;
     }

--- a/lib/screens/verify_seed/cubit/verify_seed_cubit.dart
+++ b/lib/screens/verify_seed/cubit/verify_seed_cubit.dart
@@ -1,3 +1,4 @@
+import 'dart:developer' as developer;
 import 'dart:math';
 
 import 'package:equatable/equatable.dart';
@@ -55,6 +56,13 @@ class VerifySeedCubit extends Cubit<VerifySeedState> {
   }
 
   Future<bool> verify() async {
+    // Re-entrancy guard. The button's `onPressed` is fire-and-forget, so a
+    // second tap can land while the first commit is still in flight (or
+    // already done). A second commit would also trip
+    // `commitGeneratedWallet`'s `assert(draft.id == 0)` on the now-committed
+    // `_wallet`. Bail out and let the first call own the transition.
+    if (state.isVerifying || state.isVerified) return false;
+
     final seedWords = _wallet.seed.seedWords;
 
     for (int i = 0; i < state.wordIndices.length; i++) {
@@ -75,10 +83,31 @@ class VerifySeedCubit extends Cubit<VerifySeedState> {
     // `walletInfos`. The user only reaches this branch by typing the four
     // requested words correctly, so the seed they kept is the seed we
     // store.
-    final committed = await _walletService.commitGeneratedWallet(_wallet);
-    _wallet = committed;
-    await _walletService.setCurrentWallet(committed.id);
-    emit(state.copyWith(isVerified: true));
-    return true;
+    emit(state.copyWith(isVerifying: true, commitFailed: false));
+    try {
+      final committed = await _walletService.commitGeneratedWallet(_wallet);
+      _wallet = committed;
+      await _walletService.setCurrentWallet(committed.id);
+      emit(
+        state.copyWith(
+          isVerifying: false,
+          isVerified: true,
+          committedWallet: committed,
+        ),
+      );
+      return true;
+    } catch (e, stack) {
+      // Persisting the wallet failed or hung-then-threw. Surface a retry
+      // affordance instead of leaving the screen stuck on a plain
+      // "Bestätigen" with no feedback — `verify` must never resolve into a
+      // state that is neither success nor a visible error.
+      developer.log(
+        'Failed to commit verified wallet',
+        error: e,
+        stackTrace: stack,
+      );
+      emit(state.copyWith(isVerifying: false, commitFailed: true));
+      return false;
+    }
   }
 }

--- a/lib/screens/verify_seed/cubit/verify_seed_state.dart
+++ b/lib/screens/verify_seed/cubit/verify_seed_state.dart
@@ -5,13 +5,35 @@ final class VerifySeedState extends Equatable {
     this.wordIndices = const [],
     this.enteredWords = const [],
     this.hasError = false,
+    this.isVerifying = false,
     this.isVerified = false,
+    this.commitFailed = false,
+    this.committedWallet,
   });
 
   final List<int> wordIndices;
   final List<String> enteredWords;
+
+  /// The four entered words don't match the requested seed words.
   final bool hasError;
+
+  /// The commit (`commitGeneratedWallet` + `setCurrentWallet`) is in flight.
+  final bool isVerifying;
+
+  /// The wallet was committed and marked current — onboarding may advance.
   final bool isVerified;
+
+  /// The words matched, but persisting the wallet threw. Distinct from
+  /// [hasError]: the user typed the right words, the disk write failed.
+  /// Surfaced as a retry affordance so [verify] is never left in a state
+  /// that is neither success nor a visible error.
+  final bool commitFailed;
+
+  /// The wallet returned by `commitGeneratedWallet` — the persisted row
+  /// with its real id. Only ever set together with [isVerified] `== true`;
+  /// `null` until then. Passed to `LoadWalletEvent` so `HomeBloc` flips
+  /// `hasWallet` true and onboarding advances instead of looping.
+  final SoftwareWallet? committedWallet;
 
   bool get canVerify => enteredWords.length == 4 && enteredWords.every((w) => w.isNotEmpty);
 
@@ -19,14 +41,28 @@ final class VerifySeedState extends Equatable {
     List<int>? wordIndices,
     List<String>? enteredWords,
     bool? hasError,
+    bool? isVerifying,
     bool? isVerified,
+    bool? commitFailed,
+    SoftwareWallet? committedWallet,
   }) => VerifySeedState(
     wordIndices: wordIndices ?? this.wordIndices,
     enteredWords: enteredWords ?? this.enteredWords,
     hasError: hasError ?? this.hasError,
+    isVerifying: isVerifying ?? this.isVerifying,
     isVerified: isVerified ?? this.isVerified,
+    commitFailed: commitFailed ?? this.commitFailed,
+    committedWallet: committedWallet ?? this.committedWallet,
   );
 
   @override
-  List<Object?> get props => [wordIndices, enteredWords, hasError, isVerified];
+  List<Object?> get props => [
+    wordIndices,
+    enteredWords,
+    hasError,
+    isVerifying,
+    isVerified,
+    commitFailed,
+    committedWallet,
+  ];
 }

--- a/lib/screens/verify_seed/verify_seed_page.dart
+++ b/lib/screens/verify_seed/verify_seed_page.dart
@@ -22,14 +22,12 @@ class VerifySeedPage extends StatelessWidget {
       wallet,
       getIt<WalletService>(),
     ),
-    child: VerifySeedView(wallet: wallet),
+    child: const VerifySeedView(),
   );
 }
 
 class VerifySeedView extends StatelessWidget {
-  final SoftwareWallet wallet;
-
-  const VerifySeedView({super.key, required this.wallet});
+  const VerifySeedView({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -43,7 +41,16 @@ class VerifySeedView extends StatelessWidget {
             if (state.isVerified) {
               await Future.delayed(const Duration(seconds: 2));
               if (context.mounted) {
-                context.read<HomeBloc>().add(LoadWalletEvent(wallet));
+                // Load the *committed* wallet (`state.committedWallet`), not
+                // the page's draft (`id == 0`). `committedWallet` is only
+                // ever set together with `isVerified`, so it is non-null
+                // here. `LoadWalletEvent` makes `HomeBloc` set
+                // `hasWallet: true`, which `main.dart`'s `_navigate()` needs
+                // to route forward to onboarding-completed instead of
+                // looping back to welcome.
+                context.read<HomeBloc>().add(
+                  LoadWalletEvent(state.committedWallet!),
+                );
               }
             }
           },

--- a/lib/screens/verify_seed/widgets/verify_seed_button.dart
+++ b/lib/screens/verify_seed/widgets/verify_seed_button.dart
@@ -31,6 +31,23 @@ class VerifySeedButton extends StatelessWidget {
         state: .success,
       );
     }
+    if (state.isVerifying) {
+      return AppFilledButton(
+        label: S.of(context).confirm,
+        state: .loading,
+      );
+    }
+    if (state.commitFailed) {
+      // The words matched but persisting threw. Offer a tappable retry —
+      // the `.idle` state keeps `onPressed` wired (the `.error` variant
+      // hard-nulls it). The cubit's re-entrancy guard plus the
+      // `commitFailed` reset on retry make a second `verify()` call safe.
+      return AppFilledButton(
+        onPressed: () => context.read<VerifySeedCubit>().verify(),
+        icon: Icons.refresh,
+        label: S.of(context).verifySeedCommitFailed,
+      );
+    }
     return AppFilledButton(
       onPressed: state.canVerify ? () => context.read<VerifySeedCubit>().verify() : null,
       label: S.of(context).confirm,

--- a/test/screens/verify_seed/cubit/verify_seed_cubit_test.dart
+++ b/test/screens/verify_seed/cubit/verify_seed_cubit_test.dart
@@ -277,5 +277,58 @@ void main() {
       expect(cubit.state.isVerified, isTrue);
       verify(() => service.commitGeneratedWallet(any())).called(2);
     });
+
+    test('verify does not emit after the cubit is closed mid-commit',
+        () async {
+      // The AppBar back button stays enabled on the verify-seed page while
+      // the commit is in flight, so the cubit can be closed before
+      // `commitGeneratedWallet` resolves. A post-close `emit` would throw
+      // `StateError` — the same async-tail bug `create_wallet_cubit` /
+      // `connect_bitbox_cubit` / `kyc_cubit` guard against with `isClosed`.
+      final completer = Completer<SoftwareWallet>();
+      when(() => service.commitGeneratedWallet(any()))
+          .thenAnswer((_) => completer.future);
+
+      final cubit = VerifySeedCubit(wallet, service);
+      final pending = cubit.verify();
+
+      await cubit.close();
+      completer.complete(SoftwareWallet(42, 'Main', _testMnemonic));
+      final result = await pending;
+
+      // No StateError thrown from the post-close emit path, and
+      // setCurrentWallet is skipped once the cubit is closed.
+      expect(result, isFalse);
+      verifyNever(() => service.setCurrentWallet(any()));
+    });
+
+    test('verify does not emit when the cubit is closed between commit and setCurrentWallet',
+        () async {
+      // Cover the second async boundary too: `setCurrentWallet` is awaited
+      // *after* a successful commit. If the user pops the page during that
+      // gap, the success emission must be skipped — not throw.
+      final commitDone = Completer<SoftwareWallet>();
+      final setCurrentStarted = Completer<void>();
+      final setCurrentFinish = Completer<void>();
+      when(() => service.commitGeneratedWallet(any()))
+          .thenAnswer((_) => commitDone.future);
+      when(() => service.setCurrentWallet(any())).thenAnswer((_) {
+        setCurrentStarted.complete();
+        return setCurrentFinish.future;
+      });
+
+      final cubit = VerifySeedCubit(wallet, service);
+      final pending = cubit.verify();
+      commitDone.complete(SoftwareWallet(42, 'Main', _testMnemonic));
+      await setCurrentStarted.future;
+
+      // Close the cubit while `setCurrentWallet` is still pending — the
+      // success `emit` that follows must be skipped.
+      await cubit.close();
+      setCurrentFinish.complete();
+      final result = await pending;
+
+      expect(result, isFalse);
+    });
   });
 }

--- a/test/screens/verify_seed/cubit/verify_seed_cubit_test.dart
+++ b/test/screens/verify_seed/cubit/verify_seed_cubit_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
@@ -90,13 +92,55 @@ void main() {
 
       expect(result, isTrue);
       expect(cubit.state.isVerified, isTrue);
+      expect(cubit.state.isVerifying, isFalse);
       expect(cubit.state.hasError, isFalse);
+      expect(cubit.state.commitFailed, isFalse);
       // The current wallet id must be the COMMITTED id (42), not the
       // uncommitted draft's `0` sentinel. Closes the regression where a
       // future refactor passes `_wallet.id` directly to `setCurrentWallet`
       // and silently routes onboarding to a non-existent wallet row.
       verify(() => service.setCurrentWallet(42)).called(1);
       verifyNever(() => service.setCurrentWallet(0));
+    });
+
+    test('verify exposes the COMMITTED wallet on the success state', () async {
+      // The success state must carry the committed wallet so the page can
+      // pass it to `LoadWalletEvent` — `HomeBloc` needs the real row (and
+      // sets `hasWallet: true`) to route onboarding forward instead of
+      // looping back to welcome.
+      final cubit = VerifySeedCubit(wallet, service);
+
+      await cubit.verify();
+
+      expect(cubit.state.committedWallet, isNotNull);
+      expect(cubit.state.committedWallet!.id, 42);
+      expect(cubit.state.committedWallet!.id, isNot(0));
+    });
+
+    test('verify emits isVerifying before resolving to isVerified', () async {
+      final cubit = VerifySeedCubit(wallet, service);
+      final verifyingSeen = <bool>[];
+      final sub = cubit.stream.listen((s) => verifyingSeen.add(s.isVerifying));
+
+      await cubit.verify();
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      // The in-progress flag must be raised at least once so the button can
+      // surface a loading indicator and disable a second tap.
+      expect(verifyingSeen, contains(true));
+      expect(cubit.state.isVerifying, isFalse);
+      expect(cubit.state.isVerified, isTrue);
+    });
+
+    test('verify calls commitGeneratedWallet and setCurrentWallet exactly once on success',
+        () async {
+      final cubit = VerifySeedCubit(wallet, service);
+
+      await cubit.verify();
+
+      verify(() => service.commitGeneratedWallet(any())).called(1);
+      verify(() => service.setCurrentWallet(any())).called(1);
     });
 
     // Pin the ordering: commit must precede setCurrentWallet so the row
@@ -129,11 +173,109 @@ void main() {
       expect(result, isFalse);
       expect(cubit.state.hasError, isTrue);
       expect(cubit.state.isVerified, isFalse);
+      expect(cubit.state.commitFailed, isFalse);
+      // No committed wallet leaks onto a failed state — `committedWallet`
+      // is only ever set together with `isVerified: true`.
+      expect(cubit.state.committedWallet, isNull);
       // The disk-side guarantee for failure paths: no `walletInfos` row
       // is written for a rejected verification. Pairs with the
       // CreateWalletCubit "zero commits across regenerates" pin.
       verifyNever(() => service.commitGeneratedWallet(any()));
       verifyNever(() => service.setCurrentWallet(any()));
+    });
+
+    test('verify ends in commitFailed (NOT hung, NOT verified) when the commit throws',
+        () async {
+      // The bug this guards: a throwing/hanging commit used to leave the
+      // cubit emitting neither isVerified nor an error — the verify-seed
+      // screen stuck forever with no feedback and no retry.
+      when(() => service.commitGeneratedWallet(any()))
+          .thenThrow(StateError('disk write failed'));
+
+      final cubit = VerifySeedCubit(wallet, service);
+      final result = await cubit.verify();
+
+      expect(result, isFalse);
+      expect(cubit.state.commitFailed, isTrue);
+      expect(cubit.state.isVerifying, isFalse);
+      expect(cubit.state.isVerified, isFalse);
+      // A failed commit carries no committed wallet.
+      expect(cubit.state.committedWallet, isNull);
+      verifyNever(() => service.setCurrentWallet(any()));
+    });
+
+    test('verify ends in commitFailed when setCurrentWallet throws after a successful commit',
+        () async {
+      when(() => service.setCurrentWallet(any()))
+          .thenThrow(StateError('settings write failed'));
+
+      final cubit = VerifySeedCubit(wallet, service);
+      final result = await cubit.verify();
+
+      expect(result, isFalse);
+      expect(cubit.state.commitFailed, isTrue);
+      expect(cubit.state.isVerifying, isFalse);
+      expect(cubit.state.isVerified, isFalse);
+    });
+
+    test('verify is re-entrancy-safe: a second rapid call commits exactly once',
+        () async {
+      // Make the commit slow so the second `verify()` lands while the first
+      // is still in flight. A second commit would also trip
+      // `commitGeneratedWallet`'s `assert(draft.id == 0)`.
+      final completer = Completer<SoftwareWallet>();
+      when(() => service.commitGeneratedWallet(any()))
+          .thenAnswer((_) => completer.future);
+
+      final cubit = VerifySeedCubit(wallet, service);
+      final first = cubit.verify();
+      final second = cubit.verify(); // re-entrant — must bail out immediately
+
+      completer.complete(SoftwareWallet(42, 'Main', _testMnemonic));
+      final results = await Future.wait([first, second]);
+
+      expect(results, [true, false]);
+      verify(() => service.commitGeneratedWallet(any())).called(1);
+      verify(() => service.setCurrentWallet(any())).called(1);
+      expect(cubit.state.isVerified, isTrue);
+    });
+
+    test('verify is a no-op once already verified', () async {
+      final cubit = VerifySeedCubit(wallet, service);
+      await cubit.verify();
+      expect(cubit.state.isVerified, isTrue);
+
+      final result = await cubit.verify();
+
+      expect(result, isFalse);
+      // No second commit — that would hit the already-committed-draft assert.
+      verify(() => service.commitGeneratedWallet(any())).called(1);
+    });
+
+    test('retrying after commitFailed succeeds and clears the failure flag',
+        () async {
+      var attempts = 0;
+      when(() => service.commitGeneratedWallet(any())).thenAnswer((_) async {
+        attempts++;
+        if (attempts == 1) throw StateError('transient disk failure');
+        return SoftwareWallet(42, 'Main', _testMnemonic);
+      });
+
+      final cubit = VerifySeedCubit(wallet, service);
+
+      final first = await cubit.verify();
+      expect(first, isFalse);
+      expect(cubit.state.commitFailed, isTrue);
+      expect(cubit.state.isVerified, isFalse);
+
+      // Retry — the re-entrancy guard allows it (not verifying, not verified)
+      // and the `commitFailed` flag is reset at the start of the attempt.
+      final second = await cubit.verify();
+
+      expect(second, isTrue);
+      expect(cubit.state.commitFailed, isFalse);
+      expect(cubit.state.isVerified, isTrue);
+      verify(() => service.commitGeneratedWallet(any())).called(2);
     });
   });
 }

--- a/test/screens/verify_seed/verify_seed_page_test.dart
+++ b/test/screens/verify_seed/verify_seed_page_test.dart
@@ -82,7 +82,7 @@ void main() {
         ),
       );
 
-      await tester.pumpApp(buildSubject(VerifySeedView(wallet: MockWallet())));
+      await tester.pumpApp(buildSubject(const VerifySeedView()));
 
       expect(
         find.byWidgetPredicate((widget) => widget is SvgPicture && widget.width == 124),
@@ -103,7 +103,7 @@ void main() {
           ),
         );
 
-        await tester.pumpApp(buildSubject(VerifySeedView(wallet: MockWallet())));
+        await tester.pumpApp(buildSubject(const VerifySeedView()));
 
         expect(
           find.byWidgetPredicate(
@@ -124,7 +124,7 @@ void main() {
           ),
         );
 
-        await tester.pumpApp(buildSubject(VerifySeedView(wallet: MockWallet())));
+        await tester.pumpApp(buildSubject(const VerifySeedView()));
 
         expect(
           find.byWidgetPredicate(
@@ -146,7 +146,7 @@ void main() {
           ),
         );
 
-        await tester.pumpApp(buildSubject(VerifySeedView(wallet: MockWallet())));
+        await tester.pumpApp(buildSubject(const VerifySeedView()));
 
         expect(
           find.byWidgetPredicate(
@@ -168,7 +168,7 @@ void main() {
           ),
         );
 
-        await tester.pumpApp(buildSubject(VerifySeedView(wallet: MockWallet())));
+        await tester.pumpApp(buildSubject(const VerifySeedView()));
 
         expect(
           find.byWidgetPredicate(
@@ -183,20 +183,31 @@ void main() {
     });
 
     group('$BlocListener', () {
-      testWidgets('sends $HomeEvent when entered words are verified', (tester) async {
-        final wallet = MockWallet();
-
+      testWidgets('sends $LoadWalletEvent with the committed wallet when verified',
+          (tester) async {
+        // The committed wallet `verify()` produced — a persisted row with a
+        // real id (42), not the draft's `0` sentinel.
+        final committed = SoftwareWallet(
+          42,
+          'Main',
+          'cheese trigger cannon mention judge hire snack sustain annual predict illness celery',
+        );
         whenListen(
           verifySeedCubit,
-          Stream.fromIterable([const VerifySeedState(isVerified: true)]),
+          Stream.fromIterable([
+            VerifySeedState(isVerified: true, committedWallet: committed),
+          ]),
           initialState: const VerifySeedState(),
         );
 
-        await tester.pumpApp(buildSubject(VerifySeedView(wallet: wallet)));
+        await tester.pumpApp(buildSubject(const VerifySeedView()));
         await tester.pump();
         await tester.pump(const Duration(seconds: 2));
 
-        verify(() => homeBloc.add(LoadWalletEvent(wallet))).called(1);
+        // The page must dispatch `LoadWalletEvent` (so `HomeBloc` sets
+        // `hasWallet: true` and `main.dart` routes onboarding forward) with
+        // the *committed* wallet — not the draft (`id == 0`).
+        verify(() => homeBloc.add(LoadWalletEvent(committed))).called(1);
       });
     });
   });

--- a/test/screens/verify_seed/widgets/verify_seed_button_test.dart
+++ b/test/screens/verify_seed/widgets/verify_seed_button_test.dart
@@ -76,5 +76,38 @@ void main() {
         expect(b.onPressed, isNotNull);
       },
     );
+
+    testWidgets(
+      'isVerifying: renders the loading-variant AppFilledButton',
+      (tester) async {
+        when(() => cubit.state)
+            .thenReturn(const VerifySeedState(isVerifying: true));
+
+        await tester.pumpApp(_host(cubit));
+
+        expect(button(tester).state, FilledButtonState.loading);
+      },
+    );
+
+    testWidgets(
+      'commitFailed: renders a tappable retry button that calls verify()',
+      (tester) async {
+        when(() => cubit.state)
+            .thenReturn(const VerifySeedState(commitFailed: true));
+        when(() => cubit.verify()).thenAnswer((_) async => false);
+
+        await tester.pumpApp(_host(cubit));
+
+        final b = button(tester);
+        // `.idle` keeps `onPressed` wired — the `.error` variant hard-nulls
+        // it, which would make the retry affordance untappable.
+        expect(b.state, FilledButtonState.idle);
+        expect(b.icon, Icons.refresh);
+        expect(b.onPressed, isNotNull);
+
+        b.onPressed!();
+        verify(() => cubit.verify()).called(1);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Problem

During software-wallet onboarding, the verify-seed screen could hang permanently. `VerifySeedCubit.verify()` is invoked fire-and-forget by the confirm button with no error handling: after the word-match check it `await`s `commitGeneratedWallet()` + `setCurrentWallet()`, then `emit(isVerified: true)`. If a commit `await` throws or hangs, `verify()` fails silently — the cubit emits neither `isVerified` nor an error — and the screen is stuck on a plain "Confirm" with no feedback and no retry.

This is the root cause of the intermittent failure of the Tier 3 handbook flow `07-onboarding-completed` that currently blocks the release PR #325 — the captured view hierarchy at the 30 s timeout shows the verify-seed screen with the words filled and the plain "Bestätigen" button (neither success nor error state).

A second, latent bug: the page passed its own **uncommitted draft** wallet (`id == 0`) to `LoadWalletEvent`, so `appStore.wallet` ended up holding a wallet with the wrong id.

## Fix

- `verify()`: re-entrancy guard (a second tap can no longer trip `commitGeneratedWallet`'s uncommitted-draft assert), the commit wrapped in try/catch, new `isVerifying` / `commitFailed` state flags. The cubit now **always resolves into success or a surfaced failure** — never a silent hang.
- Button: a loading indicator while verifying; a tappable **retry** affordance on commit failure instead of a dead screen.
- The page now passes the **committed** wallet (real id, carried in `committedWallet`) to `LoadWalletEvent` — keeping `LoadWalletEvent` so `HomeBloc` sets `hasWallet: true` and onboarding advances.
- New EN/DE string `verifySeedCommitFailed`.
- Cubit + widget tests cover word mismatch, happy path, commit-throws, re-entrancy and retry.

## Scope note

This eliminates the infinite hang and the re-entrancy double-commit. If a commit genuinely fails (Keychain / SQLite), the screen now shows a visible, recoverable retry instead of hanging. The next Tier 3 handbook run confirms flow `07` end-to-end.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 1468 passed
- [ ] QA: complete software-wallet onboarding (create → verify seed) and confirm it advances to the onboarding-completed screen