### PR TITLE
ci(handbook): harden remaining handbook flows against silent tap-loss

### DIFF
--- a/.maestro/handbook/02-create-vs-restore.yaml
+++ b/.maestro/handbook/02-create-vs-restore.yaml
@@ -1,8 +1,23 @@
 # Captures docs/handbook/screenshots/02-create-vs-restore.png
 # Depends on 01-welcome being the previous flow (no clearState, continues from Start screen).
+#
+# The tap is gated on the next screen not yet showing and re-tapped if it
+# was silently dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). The gate stops the loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn: 'Start'
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              text: '.*Digitale Wallet.*'
+          commands:
+            - tapOn:
+                text: 'Start'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible:

--- a/.maestro/handbook/03-software-wallet-terms.yaml
+++ b/.maestro/handbook/03-software-wallet-terms.yaml
@@ -1,8 +1,22 @@
 # Captures docs/handbook/screenshots/03-software-wallet-terms.png
+#
+# The tap is gated on the next screen not yet showing and re-tapped if it
+# was silently dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). The gate stops the loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn:
-    text: '.*Digitale Wallet.*'
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              text: '.*Neue Wallet erstellen.*'
+          commands:
+            - tapOn:
+                text: '.*Digitale Wallet.*'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible:

--- a/.maestro/handbook/04-seed-hidden.yaml
+++ b/.maestro/handbook/04-seed-hidden.yaml
@@ -1,10 +1,23 @@
 # Captures docs/handbook/screenshots/04-seed-hidden.png
 # Seed-backup screen with the SeedBlurCard still covered. BackdropFilter screen —
 # Maestro's own takeScreenshot would render black; xcrun captures correctly.
+#
+# The tap is gated on the seed-backup screen not yet showing and re-tapped if
+# it was silently dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). The gate stops the loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn:
-    text: '.*Neue Wallet erstellen.*'
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible: 'Wallet-Sicherung'
+          commands:
+            - tapOn:
+                text: '.*Neue Wallet erstellen.*'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible: 'Wallet-Sicherung'

--- a/.maestro/handbook/05-seed-revealed.yaml
+++ b/.maestro/handbook/05-seed-revealed.yaml
@@ -1,9 +1,22 @@
 # Captures docs/handbook/screenshots/05-seed-revealed.png
 # Tap the SeedBlurCard (wrapped in ExcludeSemantics, so coordinate-based tap).
+#
+# The tap is gated on the revealed seed not yet showing and re-tapped if it
+# was silently dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). The gate stops the loop the instant the
+# card is revealed, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn:
-    point: 50%,50%
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible: 'Ich habe es gesichert'
+          commands:
+            - tapOn:
+                point: 50%,50%
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible: 'Ich habe es gesichert'

--- a/.maestro/handbook/06-verify-seed.yaml
+++ b/.maestro/handbook/06-verify-seed.yaml
@@ -3,9 +3,23 @@
 # generated seed, so the input fields are visibly pre-populated. The screenshot
 # documents the verify step UI; the user-facing flow asks the user to type
 # the words manually in release builds.
+#
+# The tap is gated on the verify screen not yet showing and re-tapped if it
+# was silently dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). The gate stops the loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn: 'Ich habe es gesichert'
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible: 'Sicherung überprüfen'
+          commands:
+            - tapOn:
+                text: 'Ich habe es gesichert'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible: 'Sicherung überprüfen'

--- a/.maestro/handbook/07-onboarding-completed.yaml
+++ b/.maestro/handbook/07-onboarding-completed.yaml
@@ -1,8 +1,22 @@
 # Captures docs/handbook/screenshots/07-onboarding-completed.png
 # Wallet created — final onboarding confirmation screen "Ihre Wallet ist bereit".
+#
+# The tap is gated on the confirmation screen not yet showing and re-tapped if
+# it was silently dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). The gate stops the loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn: 'Bestätigen'
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible: 'Weiter'
+          commands:
+            - tapOn:
+                text: 'Bestätigen'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible: 'Weiter'

--- a/.maestro/handbook/08-pin-setup.yaml
+++ b/.maestro/handbook/08-pin-setup.yaml
@@ -1,8 +1,22 @@
 # Captures docs/handbook/screenshots/08-pin-setup.png
 # Empty PIN setup numpad — "Erstellen Sie Ihre PIN".
+#
+# The tap is gated on the PIN numpad not yet showing and re-tapped if it was
+# silently dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). The gate stops the loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn: 'Weiter'
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible: 'Erstellen Sie Ihre PIN'
+          commands:
+            - tapOn:
+                text: 'Weiter'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible: 'Erstellen Sie Ihre PIN'

--- a/.maestro/handbook/12-settings.yaml
+++ b/.maestro/handbook/12-settings.yaml
@@ -1,10 +1,23 @@
 # Captures docs/handbook/screenshots/12-settings.png
 # Tap the top-right hamburger icon. It's an IconButton(Icons.menu) with no
 # tooltip/semantic label, so we tap by coordinate.
+#
+# The tap is gated on the settings screen not yet showing and re-tapped if it
+# was silently dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). The gate stops the loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn:
-    point: 91%,10%
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible: 'Einstellungen'
+          commands:
+            - tapOn:
+                point: 91%,10%
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible: 'Einstellungen'

--- a/.maestro/handbook/13-settings-languages.yaml
+++ b/.maestro/handbook/13-settings-languages.yaml
@@ -1,8 +1,22 @@
 # Captures docs/handbook/screenshots/13-settings-languages.png
+#
+# The tap is gated on the languages screen not yet showing and re-tapped if it
+# was silently dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). The gate stops the loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn:
-    text: '.*Sprachen.*'
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              text: '.*Deutsch.*'
+          commands:
+            - tapOn:
+                text: '.*Sprachen.*'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible:

--- a/.maestro/handbook/14-settings-currency.yaml
+++ b/.maestro/handbook/14-settings-currency.yaml
@@ -1,11 +1,34 @@
 # Captures docs/handbook/screenshots/14-settings-currency.png
+#
+# Both taps (back to the settings list, then into the currency screen) are
+# gated on their target not yet showing and re-tapped if one was silently
+# dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). Each gate stops its loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn:
-    point: 8%,8%
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible: 'Einstellungen'
+          commands:
+            - tapOn:
+                point: 8%,8%
+                optional: true
 - waitForAnimationToEnd
-- tapOn:
-    text: '.*Währung.*'
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              text: '.*Schweizer.*'
+          commands:
+            - tapOn:
+                text: '.*Währung.*'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible:

--- a/.maestro/handbook/15-settings-network.yaml
+++ b/.maestro/handbook/15-settings-network.yaml
@@ -1,11 +1,34 @@
 # Captures docs/handbook/screenshots/15-settings-network.png
+#
+# Both taps (back to the settings list, then into the network screen) are
+# gated on their target not yet showing and re-tapped if one was silently
+# dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). Each gate stops its loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn:
-    point: 8%,8%
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible: 'Einstellungen'
+          commands:
+            - tapOn:
+                point: 8%,8%
+                optional: true
 - waitForAnimationToEnd
-- tapOn:
-    text: '.*Netzwerk.*'
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              text: '.*Mainnet.*'
+          commands:
+            - tapOn:
+                text: '.*Netzwerk.*'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible:

--- a/.maestro/handbook/16-settings-wallet-address.yaml
+++ b/.maestro/handbook/16-settings-wallet-address.yaml
@@ -1,12 +1,35 @@
 # Captures docs/handbook/screenshots/16-settings-wallet-address.png
 # Receive equivalent — shows the wallet's EVM address + QR code.
+#
+# Both taps (back to the settings list, then into the wallet-address screen)
+# are gated on their target not yet showing and re-tapped if one was silently
+# dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). Each gate stops its loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn:
-    point: 8%,8%
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible: 'Einstellungen'
+          commands:
+            - tapOn:
+                point: 8%,8%
+                optional: true
 - waitForAnimationToEnd
-- tapOn:
-    text: '.*Wallet-Adresse.*'
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              text: '.*0x.*'
+          commands:
+            - tapOn:
+                text: '.*Wallet-Adresse.*'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible:

--- a/.maestro/handbook/17-settings-backup-pin.yaml
+++ b/.maestro/handbook/17-settings-backup-pin.yaml
@@ -1,13 +1,36 @@
 # Captures docs/handbook/screenshots/17-settings-backup-pin.png
 # Tapping "Wallet-Sicherung" routes through the PIN gate before showing the
 # recovery phrase. The numeric keypad re-appears with the verify-PIN copy.
+#
+# Both taps (back to the settings list, then into the wallet-backup PIN gate)
+# are gated on their target not yet showing and re-tapped if one was silently
+# dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). Each gate stops its loop the instant the
+# screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn:
-    point: 8%,8%
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible: 'Einstellungen'
+          commands:
+            - tapOn:
+                point: 8%,8%
+                optional: true
 - waitForAnimationToEnd
-- tapOn:
-    text: '.*Wallet-Sicherung.*'
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            notVisible:
+              text: '.*PIN.*'
+          commands:
+            - tapOn:
+                text: '.*Wallet-Sicherung.*'
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible:

--- a/.maestro/handbook/19-settings-seed-revealed.yaml
+++ b/.maestro/handbook/19-settings-seed-revealed.yaml
@@ -1,9 +1,22 @@
 # Captures docs/handbook/screenshots/19-settings-seed-revealed.png
 # Same BIP-39 grid as 05-seed-revealed; lives behind the PIN gate inside Settings.
+#
+# The tap is gated on the reveal prompt still showing and re-tapped if it was
+# silently dropped (Maestro/XCUITest tap-loss on Apple Silicon + iOS 26,
+# mobile-dev-inc/maestro#3137). The gate stops the loop the instant the
+# prompt disappears, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn:
-    point: 50%,65%
+- repeat:
+    times: 3
+    commands:
+      - runFlow:
+          when:
+            visible: 'Hier tippen, um anzuzeigen'
+          commands:
+            - tapOn:
+                point: 50%,65%
+                optional: true
 - waitForAnimationToEnd
 - extendedWaitUntil:
     notVisible: 'Hier tippen, um anzuzeigen'


### PR DESCRIPTION
## Root cause

The Tier 3 handbook CI (`.github/workflows/tier3-handbook.yaml`) intermittently fails on Apple Silicon + iOS 26 runners. Maestro's `tapOn` reports the tap as "completed" while the Flutter app never actually receives the touch — the documented Maestro/XCUITest silent tap-loss bug, [mobile-dev-inc/maestro#3137](https://github.com/mobile-dev-inc/maestro/issues/3137).

The most recent failure was `06-verify-seed.yaml`: the `tapOn: 'Ich habe es gesichert'` was reported done, but the failure-debug view hierarchy showed the app still on the seed-backup screen ("Wallet-Sicherung"), so the `"Sicherung überprüfen" is visible` assertion failed. This is **not an app bug** — the identical app code passed on the previous run.

## Fix

PR #508 hardened the PIN-entry flows (`09`, `10`, `18`) with a gated-repeat pattern: the tap is wrapped in a `repeat` whose inner `runFlow` only fires `when: notVisible:` the post-tap target screen. A lost tap is re-tapped; once the screen changes, surplus iterations no-op.

This PR extends that same approach to every remaining handbook flow whose leading action is a navigating tap, so the next flaky run doesn't simply fail on a different flow:

- **Changed (14 flows):** `02`, `03`, `04`, `05` (coordinate tap), `06`, `07`, `08`, `12` (coordinate tap), `13`, `14`–`17` (back-nav coordinate tap + sub-page tap, both gated independently), `19` (gate inverted — taps `while visible`, since its assert is `notVisible`).
- **Left unchanged:** `01-welcome` (no tap, only `launchApp`); `09`, `10`, `18` (already hardened by #508); `11-dashboard` (leading action is an already-conditional skip `runFlow`, not a direct navigating tap).

Each gate uses the flow's own `extendedWaitUntil` target marker (mirroring regex `text:` forms where the assertion uses one). `times: 3` is used for single navigating taps (~10% loss rate → ~0.1% residual); #508's `times: 12` was specific to entering 6 PIN digits. Trailing `waitForAnimationToEnd` + `extendedWaitUntil` are unchanged in every flow.

No Dart code, workflow, or driver script was touched.

## Verification

All 19 `.maestro/handbook/*.yaml` files validated as YAML (`yaml.safe_load_all`, since Maestro flows are intentionally two-document files). There is no local Maestro run; the real test is the next Tier 3 CI run.