### PR TITLE
ci(handbook): reuse XCUITest driver across flows to speed up Tier 3

### DIFF
--- a/scripts/run-handbook-flows.sh
+++ b/scripts/run-handbook-flows.sh
@@ -142,6 +142,31 @@ MAESTRO_MAX_ATTEMPTS="${MAESTRO_MAX_ATTEMPTS:-3}"
 MAESTRO_DEBUG_ROOT="$TMP_DIR/maestro-debug"
 mkdir -p "$MAESTRO_DEBUG_ROOT"
 
+# XCUITest-driver reuse across the per-flow `maestro test` invocations.
+#
+# Each `maestro test` invocation otherwise pays the full XCUITest-runner
+# lifecycle: by default Maestro 2.0.10 *uninstalls* the runner on session
+# close, so the next invocation finds nothing alive and has to
+# uninstall/install/start it again from scratch — the Maestro log line
+# `Restarting XCTest Runner (uninstalling, installing and starting)` + a
+# fresh `xcodebuild test-without-building`. Across 19 flows that one-time
+# ~5 min build is effectively paid 19×.
+#
+# `--reinstall-driver=false` (Maestro 2.0.10 TestCommand option, default
+# `true`) skips the uninstall step both at session start AND at session
+# close. So invocation 1 installs+starts the runner and then *leaves it
+# running*; invocations 2-19 hit Maestro's `isChannelAlive()` early-return
+# (`UI Test runner already running, returning`) and reuse it — no
+# reinstall, no rebuild. The first run on a freshly `simctl erase`-d
+# device has nothing to uninstall, so passing the flag there is harmless.
+#
+# Exception: the IOSDriverTimeoutException retry path below reboots the
+# simulator, which kills the running runner. After a reboot the next
+# attempt MUST do a full reinstall (a clean driver is exactly the recovery
+# the retry exists for), so `reinstall_driver` is flipped back to `true`
+# for that one attempt and reset to `false` afterwards.
+reinstall_driver=false
+
 # Whole-second duration → `Nm SSs`. Drives the per-attempt / per-flow /
 # suite timing lines below — the data for sizing the CI envelope and
 # finding which flows to speed up.
@@ -166,8 +191,12 @@ for flow in "${flows[@]}"; do
     attempt_start=$(date +%s)
     flow_log="$TMP_DIR/$base.attempt-$attempt.log"
     debug_dir="$MAESTRO_DEBUG_ROOT/$base-attempt-$attempt"
-    if "$MAESTRO" test --debug-output "$debug_dir" --flatten-debug-output "$flow" 2>&1 | tee "$flow_log"; then
+    if "$MAESTRO" test --reinstall-driver="$reinstall_driver" \
+         --debug-output "$debug_dir" --flatten-debug-output "$flow" 2>&1 | tee "$flow_log"; then
       echo "  attempt $attempt passed in $(fmt_duration $(( $(date +%s) - attempt_start )))"
+      # Driver is up after a successful invocation — keep reusing it
+      # (a prior retry may have flipped this to true for a reinstall).
+      reinstall_driver=false
       break
     fi
     # Only retry the upstream driver-hang class. Assertion failures
@@ -178,6 +207,10 @@ for flow in "${flows[@]}"; do
       xcrun simctl shutdown "$UDID" || true
       xcrun simctl boot "$UDID"
       xcrun simctl bootstatus "$UDID" -b >/dev/null
+      # The reboot killed the XCUITest runner. Force a full reinstall on
+      # the retry attempt so it recovers from a clean driver state; the
+      # successful-attempt branch above resets this back to false.
+      reinstall_driver=true
       continue
     fi
     # Real failure OR retries exhausted: post-mortem + exit.


### PR DESCRIPTION
## Problem

The Tier 3 handbook CI runs the 19 `.maestro/handbook/*.yaml` flows as 19 separate `maestro test` invocations. By default Maestro uninstalls the XCUITest driver on session close, so each invocation re-runs the full `uninstall → install → xcodebuild test-without-building → start` cycle. The per-flow timing (logged by the script) showed the cost: `01-welcome` — a near-empty flow — took 5m29s (the one-time XCUITest-runner build), and the whole flow phase was 22m42s.

## Fix

Pass `--reinstall-driver=false` to the per-flow `maestro test` call — a Maestro `test` option available in the pinned 2.0.10. The driver is installed once on the first flow and reused by flows 2-19 (Maestro's `isChannelAlive()` early-return), so the per-flow reinstall/rebuild is gone.

The `IOSDriverTimeoutException` retry path reboots the simulator (killing the runner), so it flips back to `--reinstall-driver=true` for that one retry attempt, then resets to `false` after a successful invocation.

Only `scripts/run-handbook-flows.sh` changed. The screenshot mechanism (`xcrun simctl io booted screenshot`, required for the BackdropFilter seed screens), the retry loop, the per-flow timing logging and the `simctl` clean-state setup are all untouched.

## Impact — confirmed by the Tier 3 run on this PR

Flow phase: **22m42s → 11m38s** (~49% faster). All 19 flows passed and all 19 screenshots were captured. The ~5 min XCUITest-runner build is paid once instead of 19×.

## Test plan

- [x] `bash -n` clean; `shellcheck` shows no new findings
- [x] Independent review — state-machine trace + all 5 hard constraints — passed
- [x] Tier 3 handbook run on this PR — green, all 19 flows + screenshots captured, 22m42s → 11m38s