### PR TITLE
fix(bitbox): bound the sign queue so a hung sign can't deadlock all later signs

### DIFF
--- a/lib/packages/hardware_wallet/bitbox_credentials.dart
+++ b/lib/packages/hardware_wallet/bitbox_credentials.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;
-import 'dart:typed_data';
 
 import 'package:bitbox_flutter/bitbox_manager.dart';
 import 'package:convert/convert.dart' as convert;
+import 'package:flutter/foundation.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:web3dart/crypto.dart';
 import 'package:web3dart/web3dart.dart';
@@ -16,12 +16,34 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
 
   static const _defaultDerivationPath = "m/44'/60'/0'/0/0";
 
+  /// Upper bound on how long a single sign may hold the [_signQueue] slot.
+  ///
+  /// If a native sign hangs (e.g. an Android USB read with no transport
+  /// timeout) the queue must not stay poisoned forever — every subsequent
+  /// sign chains off it and would deadlock. This guard is deliberately well
+  /// above the caller-side [DFXAuthService] sign timeout (3 minutes) so a
+  /// legitimately slow on-device confirmation is never cut short; it only
+  /// trips on a genuine hang.
+  static const signQueueTimeout = Duration(minutes: 5);
+
   final String _address;
 
   BitboxManager? bitboxManager;
   String? derivationPath;
 
   BitboxCredentials(this._address);
+
+  /// Re-seeds the static sign queue with a freshly-completed future.
+  ///
+  /// Production code never needs this — the queue self-heals via
+  /// [signQueueTimeout]. It exists so a `fakeAsync` test starts each case
+  /// with a queue head completed inside the test's own zone; a future
+  /// completed in a previous test's zone would not deliver its `.then`
+  /// continuations under `fakeAsync` and would wedge the chain.
+  @visibleForTesting
+  static void resetSignQueue() {
+    _signQueue = Future.value();
+  }
 
   static Future<T> _synchronizeSign<T>(Future<T> Function() sign) {
     final previous = _signQueue;
@@ -33,6 +55,26 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
         return await sign();
       } finally {
         completer.complete();
+      }
+    });
+  }
+
+  /// Runs [sign] under the queue slot but bounds it with [signQueueTimeout].
+  ///
+  /// A hung native sign would otherwise leave [_signQueue] permanently
+  /// pending and deadlock every later sign. On timeout the device is treated
+  /// as lost: [clearBitbox] nulls out [bitboxManager] so subsequent signs hit
+  /// the `manager == null` guard and fail fast with
+  /// [BitboxNotConnectedException] instead of racing the still-in-flight
+  /// native op on the shared noise cipher. The caller re-pairs to get a fresh
+  /// noise channel.
+  Future<T> _synchronizeBoundedSign<T>(Future<T> Function() sign) {
+    return _synchronizeSign(() async {
+      try {
+        return await sign().timeout(signQueueTimeout);
+      } on TimeoutException {
+        clearBitbox();
+        throw const BitboxNotConnectedException();
       }
     });
   }
@@ -64,7 +106,7 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
     int? chainId,
     bool isEIP1559 = false,
   }) {
-    return _synchronizeSign(() async {
+    return _synchronizeBoundedSign(() async {
       // Snapshot the manager + path up-front so an observer-driven null-out
       // between the connection check and the sign call doesn't NoSuchMethod.
       final manager = bitboxManager;
@@ -115,7 +157,7 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
 
   @override
   Future<Uint8List> signPersonalMessage(Uint8List payload, {int? chainId}) {
-    return _synchronizeSign(() async {
+    return _synchronizeBoundedSign(() async {
       final manager = bitboxManager;
       final path = derivationPath;
       if (manager == null || path == null) {
@@ -133,7 +175,7 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
       throw UnimplementedError('EvmLedgerCredentials.signPersonalMessageToUint8List');
 
   Future<String> signTypedDataV4(int chainId, String jsonData) {
-    return _synchronizeSign(() async {
+    return _synchronizeBoundedSign(() async {
       final manager = bitboxManager;
       final path = derivationPath;
       if (manager == null || path == null) {

--- a/test/packages/hardware_wallet/bitbox_credentials_test.dart
+++ b/test/packages/hardware_wallet/bitbox_credentials_test.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:bitbox_flutter/bitbox_flutter.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
@@ -20,6 +22,9 @@ void main() {
   });
 
   setUp(() {
+    // The sign queue is a process-wide static; reset it so a hung-sign test
+    // cannot leak a pending (or wrong-zone) queue head into the next test.
+    BitboxCredentials.resetSignQueue();
     manager = _MockBitboxManager();
     // _runOrThrowDisconnect probes manager.devices to distinguish a real
     // disconnect from a sign-internal failure. Tests below that expect the
@@ -283,6 +288,133 @@ void main() {
         expect(c.isConnected, isFalse, reason: 'clearBitbox must have run on lost device');
       },
     );
+
+    // A hung native sign must not poison the static queue forever. After
+    // `signQueueTimeout` the queue slot frees and the hung sign surfaces as
+    // BitboxNotConnectedException to its caller.
+    test('a never-completing sign resolves within signQueueTimeout', () {
+      fakeAsync((async) {
+        // Seed the queue head inside this zone (see resetSignQueue doc).
+        BitboxCredentials.resetSignQueue();
+        async.flushMicrotasks();
+
+        // Native sign that never returns — simulates an Android USB hang.
+        when(() => manager.signETHTypedMessage(any(), any(), any()))
+            .thenAnswer((_) => Completer<Uint8List>().future);
+
+        final c = connected();
+        Object? thrown;
+        c.signTypedDataV4(1, '{"primaryType":"A"}').catchError((Object e) {
+          thrown = e;
+          return '';
+        });
+
+        // Just before the bound: still pending.
+        async.elapse(BitboxCredentials.signQueueTimeout - const Duration(seconds: 1));
+        expect(thrown, isNull);
+
+        // Past the bound: the hung sign surfaces as a typed exception.
+        async.elapse(const Duration(seconds: 2));
+        expect(thrown, isA<BitboxNotConnectedException>());
+      });
+    });
+
+    // The whole point of the bug fix: one hung sign must not deadlock every
+    // later sign chained off the static queue.
+    test('a sign issued after a hung sign is not deadlocked', () {
+      fakeAsync((async) {
+        BitboxCredentials.resetSignQueue();
+        async.flushMicrotasks();
+
+        var call = 0;
+        when(() => manager.signETHTypedMessage(any(), any(), any())).thenAnswer((_) async {
+          call++;
+          if (call == 1) return Completer<Uint8List>().future; // first sign hangs
+          return Uint8List.fromList([0x42]);
+        });
+
+        final c = connected();
+        Object? firstThrown;
+        c.signTypedDataV4(1, '{"primaryType":"A"}').catchError((Object e) {
+          firstThrown = e;
+          return '';
+        });
+
+        String? secondResult;
+        Object? secondThrown;
+        c.signTypedDataV4(1, '{"primaryType":"B"}').then((v) {
+          secondResult = v;
+        }).catchError((Object e) {
+          secondThrown = e;
+        });
+
+        // Drain past the queue guard so the hung slot frees.
+        async.elapse(BitboxCredentials.signQueueTimeout + const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        expect(firstThrown, isA<BitboxNotConnectedException>());
+        // The second sign must NOT hang — but since the device was cleared by
+        // the timed-out first sign, it fails fast rather than racing the
+        // device.
+        expect(secondResult, isNull);
+        expect(secondThrown, isA<BitboxNotConnectedException>());
+      });
+    });
+
+    // Requirement 3: a timed-out sign clears the device so a subsequent sign
+    // cannot talk to a device whose native op may still be in flight — it hits
+    // the `manager == null` guard and fails fast without touching the device.
+    test('device is cleared after a hung sign so the next sign fails fast', () {
+      fakeAsync((async) {
+        BitboxCredentials.resetSignQueue();
+        async.flushMicrotasks();
+
+        // First sign hangs forever; later signs would otherwise hit the mock.
+        when(() => manager.signETHTypedMessage(any(), any(), any()))
+            .thenAnswer((_) => Completer<Uint8List>().future);
+
+        final c = connected();
+        expect(c.isConnected, isTrue);
+
+        c.signTypedDataV4(1, '{"primaryType":"A"}').catchError((Object _) => '');
+        async.elapse(BitboxCredentials.signQueueTimeout + const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        expect(c.isConnected, isFalse, reason: 'clearBitbox must run on a timed-out sign');
+
+        // The next sign hits the manager == null guard: it fails fast with a
+        // typed exception and never invokes the device sign mock again.
+        Object? nextThrown;
+        c.signTypedDataV4(1, '{"primaryType":"B"}').catchError((Object e) {
+          nextThrown = e;
+          return '';
+        });
+        async.flushMicrotasks();
+
+        expect(nextThrown, isA<BitboxNotConnectedException>());
+        verify(() => manager.signETHTypedMessage(any(), any(), any())).called(1);
+      });
+    });
+
+    // Requirement 5: the normal path must stay serialised and in order.
+    test('normal serialised signing completes in order', () async {
+      final order = <String>[];
+      when(() => manager.signETHTypedMessage(any(), any(), any())).thenAnswer((invocation) async {
+        final data = invocation.positionalArguments[2] as Uint8List;
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        order.add(String.fromCharCodes(data));
+        return Uint8List.fromList([0x01]);
+      });
+
+      final c = connected();
+      await Future.wait([
+        c.signTypedDataV4(1, 'A'),
+        c.signTypedDataV4(1, 'B'),
+        c.signTypedDataV4(1, 'C'),
+      ]);
+
+      expect(order, ['A', 'B', 'C']);
+    });
 
     test('sign on cleared credentials throws BitboxNotConnectedException, not NoSuchMethod',
         () async {


### PR DESCRIPTION
## Problem

`BitboxCredentials` serialises every hardware-wallet sign through a **static** `_signQueue` — one device, one noise cipher, so concurrent signs would corrupt the cipher nonce. Defect: if a queued native sign hangs (e.g. an Android USB read with no transport timeout), `_synchronizeSign`'s `completer.complete()` (in a `finally`) never runs, `_signQueue` stays permanently pending, and **every subsequent sign — buy / sell / KYC — deadlocks until the app is restarted**. The queue is `static`, so one hung sign poisons the whole process.

## Fix

A new `_synchronizeBoundedSign` bounds each queued sign with `.timeout(signQueueTimeout)` — `static const signQueueTimeout = Duration(minutes: 5)`, comfortably above the 3-minute caller-side `DFXAuthService` sign timeout so a legitimately slow on-device confirmation is never cut short. The three sign methods (`signToSignature`, `signPersonalMessage`, `signTypedDataV4`) route through it.

On timeout the device is treated as lost: `clearBitbox()` nulls `bitboxManager`, so every subsequent sign hits the existing `manager == null` guard and fails fast with `BitboxNotConnectedException` — it cannot race the possibly-still-in-flight native op on the shared noise cipher. The queue frees within the bound (the timed-out closure throws → `_synchronizeSign`'s `finally` runs `completer.complete()`). The user re-pairs to get a fresh noise channel. The normal sign path is byte-for-byte unchanged.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — all pass (4 new tests: hung sign throws within the bound · no deadlock for a sign issued after a hung one · device cleared → next sign fails fast · normal serialised order)
- [x] Independent review — queue-unblock + noise-cipher invariant traced — passed