### PR TITLE
feat: tag API requests with X-Client header

### DIFF
--- a/lib/packages/service/app_store.dart
+++ b/lib/packages/service/app_store.dart
@@ -1,12 +1,13 @@
 import 'package:http/http.dart';
 import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/service/dfx/api_client.dart';
 import 'package:realunit_wallet/packages/service/session_cache.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 
 class AppStore {
   final ApiConfig Function() getApiConfig;
   final SessionCache sessionCache;
-  final httpClient = Client();
+  final Client httpClient = RealUnitApiClient();
 
   AWallet? _wallet;
 

--- a/lib/packages/service/dfx/api_client.dart
+++ b/lib/packages/service/dfx/api_client.dart
@@ -1,0 +1,28 @@
+import 'package:http/http.dart';
+import 'package:realunit_wallet/generated/release_info.dart';
+
+/// HTTP client wrapper that tags every outgoing request with an `X-Client`
+/// header, so the DFX API can attribute and trace realunit-app traffic.
+///
+/// Wraps the single shared [Client] in [AppStore.httpClient]; every service
+/// — directly or via [DFXAuthService] — routes through it, so the header is
+/// added to all calls without touching individual call sites.
+///
+/// [putIfAbsent] leaves any header a caller already set untouched.
+class RealUnitApiClient extends BaseClient {
+  static const _clientId = 'realunit-app';
+
+  final Client _inner;
+
+  RealUnitApiClient([Client? inner]) : _inner = inner ?? Client();
+
+  @override
+  Future<StreamedResponse> send(BaseRequest request) {
+    request.headers.putIfAbsent('X-Client', () => _clientId);
+    request.headers.putIfAbsent('X-Client-Version', () => releaseMarketingVersion);
+    return _inner.send(request);
+  }
+
+  @override
+  void close() => _inner.close();
+}

--- a/test/packages/service/dfx/api_client_test.dart
+++ b/test/packages/service/dfx/api_client_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:realunit_wallet/generated/release_info.dart';
+import 'package:realunit_wallet/packages/service/dfx/api_client.dart';
+
+void main() {
+  group('RealUnitApiClient', () {
+    test('tags every request with X-Client headers', () async {
+      late Map<String, String> sent;
+      final client = RealUnitApiClient(
+        MockClient((request) async {
+          sent = request.headers;
+          return http.Response('{}', 200);
+        }),
+      );
+
+      await client.get(Uri.parse('https://dev.api.dfx.swiss/v1/realunit/price'));
+
+      expect(sent['X-Client'], 'realunit-app');
+      expect(sent['X-Client-Version'], releaseMarketingVersion);
+    });
+
+    test('does not overwrite an X-Client header set by the caller', () async {
+      late Map<String, String> sent;
+      final client = RealUnitApiClient(
+        MockClient((request) async {
+          sent = request.headers;
+          return http.Response('{}', 200);
+        }),
+      );
+
+      await client.get(
+        Uri.parse('https://dev.api.dfx.swiss/v1/realunit/price'),
+        headers: {'X-Client': 'custom-client'},
+      );
+
+      expect(sent['X-Client'], 'custom-client');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Wraps the shared `http.Client` (`AppStore.httpClient`) in a new `RealUnitApiClient` that adds an `X-Client: realunit-app` (and `X-Client-Version`) header to every outgoing request.
- Single chokepoint — every service goes through `appStore.httpClient` directly or via `DFXAuthService`, so all calls (`/v1/realunit/*` and generic endpoints) are tagged without touching call sites.
- Header set via `putIfAbsent`, so a caller-supplied value is preserved.

## Context
Internal test phase of the RealUnit wallet starts in the next days. The DFX API gets a DEV-only tracer ([DFXswiss/api#3747](https://github.com/DFXswiss/api/pull/3747)) that uses this header to attribute and log every app↔API call centrally.

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — new `api_client_test.dart` (header injection + no-overwrite) + `app_store_test.dart` pass
- [ ] Against DEV: confirm the API tracer logs realunit-app calls with `client=realunit-app`