### PR TITLE
ci(handbook): harden flow 11 against tap-loss, fix stale flow counts

### DIFF
--- a/.github/workflows/tier3-handbook.yaml
+++ b/.github/workflows/tier3-handbook.yaml
@@ -120,7 +120,7 @@ jobs:
       || contains(github.event.pull_request.labels.*.name, 'tier3:full')
     runs-on: macos-latest
     # ~12 min setup (Flutter + tooling, build, sim erase/boot/install) plus
-    # ~26-33 min for the 24 handbook flows — each flow restarts the XCUITest
+    # ~26-33 min for the 26 handbook flows — each flow restarts the XCUITest
     # driver (~40-60 s). A full run lands around 40-46 min; 60 min gives
     # headroom for runner-speed variance and the per-flow retry budget.
     timeout-minutes: 60

--- a/.maestro/handbook/11-dashboard.yaml
+++ b/.maestro/handbook/11-dashboard.yaml
@@ -7,13 +7,28 @@
 # the simulator (see 10-biometric-prompt.yaml header). On CI runners
 # without enrollment the app jumps straight to the dashboard and
 # there is no "Überspringen" button to tap.
+#
+# When the prompt is present the skip tap is gated on the dashboard not
+# yet showing and re-tapped if it was silently dropped (Maestro/XCUITest
+# tap-loss on Apple Silicon + iOS 26, mobile-dev-inc/maestro#3137). The
+# gate stops the loop the instant the dashboard appears, so surplus
+# iterations no-op.
 appId: swiss.realunit.app
 ---
 - runFlow:
     when:
       visible: 'Überspringen'
     commands:
-      - tapOn: 'Überspringen'
+      - repeat:
+          times: 3
+          commands:
+            - runFlow:
+                when:
+                  notVisible: 'RealUnit kaufen'
+                commands:
+                  - tapOn:
+                      text: 'Überspringen'
+                      optional: true
       - waitForAnimationToEnd
 - extendedWaitUntil:
     visible: 'RealUnit kaufen'

--- a/.maestro/handbook/25-restore-wallet.yaml
+++ b/.maestro/handbook/25-restore-wallet.yaml
@@ -31,7 +31,7 @@
 # If the checkbox tap is the one that's silently dropped, the next
 # `extendedWaitUntil notVisible "Aus REALU Wallet abmelden"` (with the
 # Abmelden button still disabled) fails loudly rather than passing silently
-# downstream — and the same Semantics-id strategy that fixed flow 24's
+# downstream — and the same Semantics-id strategy that fixed flow 26's
 # Nutzungsbedingungen-link tap has been reliable enough since.
 #
 # All tap-leading steps (Abmelden, Start, Digitale Wallet, Wallet

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -46,18 +46,17 @@ Teilmenge:
 
 ```bash
 # Nur diesen einen Flow
-scripts/run-handbook-flows.sh 23-restore-wallet
+scripts/run-handbook-flows.sh 25-restore-wallet
 
-# Die ganze 20er-Serie (20..24)
+# Die ganze 20er-Serie (20..26)
 scripts/run-handbook-flows.sh '2*'
 ```
 
 Achtung: Die handbook-Flows sind eine **sequentielle Kette** und teilen sich den
 App-State — jeder Flow greift den Zustand auf, wo der vorherige ihn hingelegt
 hat. Ein Flow aus der Mitte der Kette schlägt einzeln fehl, sofern er nicht
-selbst mit einem `launchApp` beginnt. Die Flows `23-restore-wallet` und
-`24-terms` sind **eigenständig** (eigener `launchApp`) und können daher gefahrlos
-allein laufen.
+selbst mit einem `launchApp` beginnt. Der Flow `26-terms` ist **eigenständig**
+(eigener `launchApp`) und kann daher gefahrlos allein laufen.
 
 Auch der Tier-3-GitHub-Workflow hat dafür einen `flows`-`workflow_dispatch`-Input
 — so lässt sich in der CI gezielt eine Teilmenge der Flows neu generieren.

--- a/lib/screens/home/home_page.dart
+++ b/lib/screens/home/home_page.dart
@@ -72,7 +72,7 @@ class HomePage extends StatelessWidget {
                             // link as its own Semantics node so Maestro can
                             // target it deterministically via `tapOn: id:`
                             // instead of a flaky coordinate tap on the
-                            // surrounding RichText (handbook flow 24).
+                            // surrounding RichText (handbook flow 26).
                             highlightedSemanticsId: 'home-terms-link',
                             onHighlightedTap: () => context.pushNamed(LegalRoutes.terms),
                           ),

--- a/scripts/run-handbook-flows.sh
+++ b/scripts/run-handbook-flows.sh
@@ -40,8 +40,8 @@
 #
 # Usage:
 #   scripts/run-handbook-flows.sh                    # run ALL handbook flows
-#   scripts/run-handbook-flows.sh 23-restore-wallet  # run only matching flows
-#   scripts/run-handbook-flows.sh '2*' 30-settings   # multiple glob patterns
+#   scripts/run-handbook-flows.sh 25-restore-wallet  # run only matching flows
+#   scripts/run-handbook-flows.sh '2*' 12-settings   # multiple glob patterns
 #
 #   With no arguments every flow in .maestro/handbook/*.yaml runs (the
 #   default, full-suite behaviour). With one or more positional arguments,
@@ -143,7 +143,7 @@ unset IFS
 # arguments every flow runs (full suite). With arguments, keep only the
 # flows whose basename (filename without `.yaml`) matches at least one
 # pattern. Matching uses bash's `[[ == ]]` glob — NEVER `eval` — so
-# patterns like `2*` or `23-restore-wallet` work without shell injection.
+# patterns like `2*` or `25-restore-wallet` work without shell injection.
 if [ "$#" -gt 0 ]; then
   patterns=("$@")
   selected=()
@@ -171,7 +171,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 # Per-attempt retry budget for the upstream driver-hang class. The per-flow
 # / per-attempt timing logged below is the data to size the workflow's
 # `timeout-minutes` (see tier3-handbook.yaml) and to target a real speed-up.
-# Worst-case the entire suite is 3 × 24 × ~1 min plus 3 × ~6 min
+# Worst-case the entire suite is 3 × 26 × ~1 min plus 3 × ~6 min
 # driver-startup-timeout per failed attempt, which still fits inside
 # the workflow's 60 min envelope.
 MAESTRO_MAX_ATTEMPTS="${MAESTRO_MAX_ATTEMPTS:-3}"

--- a/scripts/run-handbook-flows.sh
+++ b/scripts/run-handbook-flows.sh
@@ -192,13 +192,13 @@ mkdir -p "$MAESTRO_DEBUG_ROOT"
 # close, so the next invocation finds nothing alive and has to
 # uninstall/install/start it again from scratch — the Maestro log line
 # `Restarting XCTest Runner (uninstalling, installing and starting)` + a
-# fresh `xcodebuild test-without-building`. Across 19 flows that one-time
-# ~5 min build is effectively paid 19×.
+# fresh `xcodebuild test-without-building`. Across 26 flows that one-time
+# ~5 min build is effectively paid 26×.
 #
 # `--reinstall-driver=false` (Maestro 2.0.10 TestCommand option, default
 # `true`) skips the uninstall step both at session start AND at session
 # close. So invocation 1 installs+starts the runner and then *leaves it
-# running*; invocations 2-19 hit Maestro's `isChannelAlive()` early-return
+# running*; invocations 2-26 hit Maestro's `isChannelAlive()` early-return
 # (`UI Test runner already running, returning`) and reuse it — no
 # reinstall, no rebuild. The first run on a freshly `simctl erase`-d
 # device has nothing to uninstall, so passing the flag there is harmless.


### PR DESCRIPTION
## Summary

- `11-dashboard.yaml` was the **last handbook flow** whose navigating tap (`tapOn 'Überspringen'`, the biometric-prompt skip) was not hardened. A develop Tier-3 run failed when that tap was silently dropped (Maestro/XCUITest on Apple Silicon + iOS 26, `mobile-dev-inc/maestro#3137`): the biometric sheet stayed up and the dashboard never rendered.
- This wraps the skip tap in the same **gated-repeat** pattern the other flows use — `repeat times:3` → `runFlow when notVisible 'RealUnit kaufen'` → `tapOn optional:true`. The outer `runFlow when visible 'Überspringen'` guard is kept (the prompt only appears with Face ID enrolled on the simulator).
- Reconciles stale handbook flow-count / flow-name references missed when the suite grew to 26 flows: `24 → 26` flows in the workflow + runner script, `23-restore-wallet → 25-restore-wallet` and `handbook flow 24 → flow 26` in script/README/source comments.

## Test plan

- [ ] Tier-3 run green with `tier3:full` label (verifies flow 11 + all 26 flows)
- [ ] `handbook-captures` artifact contains all 26 screenshots