### PR TITLE
fix(kyc): skip completed steps in pendingReview, remove canTrade

### DIFF
--- a/lib/packages/service/dfx/models/user/dto/user_dto.dart
+++ b/lib/packages/service/dfx/models/user/dto/user_dto.dart
@@ -26,19 +26,11 @@ class UserKycDto {
   final String hash;
   final KycLevel level;
   final bool dataComplete;
-  // Authoritative trading-permission flag from the backend. `true` ⇔ the
-  // user may perform sensitive actions right now (level ≥ 30 + all required
-  // steps Completed + no Outdated/InProgress Ident or FinancialData). The
-  // app no longer compares `level` against a hardcoded threshold.
-  // Defaults to `false` for old API responses (safe default — old clients
-  // would have computed it themselves).
-  final bool canTrade;
 
   const UserKycDto({
     required this.hash,
     required this.level,
     required this.dataComplete,
-    this.canTrade = false,
   });
 
   factory UserKycDto.fromJson(Map<String, dynamic> json) {
@@ -46,7 +38,6 @@ class UserKycDto {
       hash: json['hash'] as String,
       level: KycLevelExtension.fromValue(json['level'] as int),
       dataComplete: json['dataComplete'] as bool,
-      canTrade: json['canTrade'] as bool? ?? false,
     );
   }
 }

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -139,7 +139,7 @@ class KycCubit extends Cubit<KycState> {
           // `KycUnsupportedStepFailure` so the user gets an explicit error
           // instead of a silent dashboard handoff.
           final pending = kycStatus.kycSteps.firstWhereOrNull(
-            (s) => s.isRequired,
+            (s) => s.isRequired && s.status != KycStepStatus.completed,
           );
           if (pending == null) {
             emit(const KycUnsupportedStepFailure(null));


### PR DESCRIPTION
## Summary
- **pendingReview step selection** picked the first `isRequired` step, but could land on one that was already `completed`. Now filters `isRequired && status != completed` so it always selects the step actually under review.
- **Removed `UserKycDto.canTrade`** — field, comment, constructor param, and JSON deserialization — since the API no longer returns it.

## Test plan
- [x] All 23 existing `kyc_cubit_test` cases pass
- [ ] Verify pendingReview routes to the correct in-review step when earlier required steps are already completed
- [ ] Confirm no runtime references to `canTrade` remain