### PR TITLE
fix(ci): group concurrency by PR number, not commit SHA

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -25,13 +25,17 @@ on:
     branches: [develop]
     types: [opened, synchronize, reopened, ready_for_review]
 
-# Group by SHA so a new push cancels the in-flight run for the
-# outdated commit. macOS runners are scarce — letting an obsolete
-# run finish wastes ~10 minutes per push. Falls back to `github.sha`
-# for `push` and `workflow_dispatch` events (where there is no
-# `pull_request.head.sha`).
+# Group by PR number so a new push to the same PR cancels the
+# in-flight run for the outdated commit. macOS runners are scarce —
+# letting an obsolete run finish wastes ~10 minutes per push. Grouping
+# by SHA (the previous approach) put every commit in its own group,
+# which meant no cancellation ever happened and back-to-back pushes
+# queued sequentially.
+# Falls back to `github.ref` for `push` and `workflow_dispatch` events
+# (where there is no `pull_request.number`): `refs/heads/develop` for
+# post-merge runs, the dispatched ref for manual triggers.
 concurrency:
-  group: ci-${{ github.event.pull_request.head.sha || github.sha }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,9 +5,10 @@ name: RealUnit Build
 #    (develop → main) is opened automatically by `auto-release-pr.yaml`,
 #    so we deliberately do NOT include `main` in `pull_request.branches`:
 #    every push to develop would otherwise fire a second `pull_request`
-#    run on the release PR for the same SHA, and the concurrency block
-#    below would cancel one of them and surface a red "cancelled" check
-#    on the release PR.
+#    run on the release PR for the same SHA, doubling macOS-runner load
+#    on a check that already runs via `push: develop`. (The concurrency
+#    block below would not deduplicate them — `push: develop` and the
+#    release PR land in different groups under PR-number grouping.)
 #  - `ready_for_review` makes the workflow fire the moment a draft PR
 #    is marked ready — drafts themselves skip via the `if:` guard
 #    below (saves macOS-runner minutes while work is still in progress).

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,9 +6,9 @@ name: RealUnit Build
 #    so we deliberately do NOT include `main` in `pull_request.branches`:
 #    every push to develop would otherwise fire a second `pull_request`
 #    run on the release PR for the same SHA, doubling macOS-runner load
-#    on a check that already runs via `push: develop`. (The concurrency
-#    block below would not deduplicate them — `push: develop` and the
-#    release PR land in different groups under PR-number grouping.)
+#    on a check that `push: develop` already covers. (Under PR-number
+#    grouping the two runs land in different concurrency groups, so the
+#    block below would not deduplicate them.)
 #  - `ready_for_review` makes the workflow fire the moment a draft PR
 #    is marked ready — drafts themselves skip via the `if:` guard
 #    below (saves macOS-runner minutes while work is still in progress).

--- a/.github/workflows/tier3-handbook.yaml
+++ b/.github/workflows/tier3-handbook.yaml
@@ -22,14 +22,14 @@ name: Tier 3 — Handbook flows
 #     run; removing it cancels via the concurrency block below.
 #
 # Concurrency:
-#   Same trick as `pull-request.yaml`: group by `pull_request.number`
+#   Same pattern as `pull-request.yaml`: group by `pull_request.number`
 #   (or `github.ref` for push/dispatch) so a new push to the same PR
 #   cancels the in-flight run. Grouping by SHA (the previous approach)
 #   put every commit in its own group, which meant no cancellation
 #   ever happened and back-to-back pushes queued sequentially on the
 #   scarce macOS runner. The exception: `labeled` / `unlabeled` events
-#   get their own `tier3-label-<run_id>` group so a label toggle does
-#   NOT kill an already-running ~15-minute flow execution — the user
+#   get their own `ci-<workflow>-label-<run_id>` group so a label toggle
+#   does NOT kill an already-running ~15-minute flow execution — the user
 #   experience of "I added the label, the previous run died" is worse
 #   than the cost of one extra runner-minute.
 #
@@ -102,8 +102,8 @@ concurrency:
   group: >-
     ${{
       (github.event.action == 'labeled' || github.event.action == 'unlabeled')
-        && format('tier3-label-{0}', github.run_id)
-        || format('tier3-{0}', github.event.pull_request.number || github.ref)
+        && format('ci-{0}-label-{1}', github.workflow, github.run_id)
+        || format('ci-{0}-{1}', github.workflow, github.event.pull_request.number || github.ref)
     }}
   cancel-in-progress: true
 

--- a/.github/workflows/tier3-handbook.yaml
+++ b/.github/workflows/tier3-handbook.yaml
@@ -26,8 +26,8 @@ name: Tier 3 — Handbook flows
 #   (or `github.ref` for push/dispatch) so a new push to the same PR
 #   cancels the in-flight run. Grouping by SHA (the previous approach)
 #   put every commit in its own group, which meant no cancellation
-#   ever happened and back-to-back pushes queued sequentially on the
-#   scarce macOS runner. The exception: `labeled` / `unlabeled` events
+#   ever happened and back-to-back pushes queued sequentially on
+#   scarce macOS runners. The exception: `labeled` / `unlabeled` events
 #   get their own `ci-<workflow>-label-<run_id>` group so a label toggle
 #   does NOT kill an already-running ~15-minute flow execution — the user
 #   experience of "I added the label, the previous run died" is worse

--- a/.github/workflows/tier3-handbook.yaml
+++ b/.github/workflows/tier3-handbook.yaml
@@ -22,11 +22,13 @@ name: Tier 3 — Handbook flows
 #     run; removing it cancels via the concurrency block below.
 #
 # Concurrency:
-#   Same trick as zk-coins/server `ci.yaml` and adapted in
-#   `pull-request.yaml`: group by `pull_request.head.sha` (or `github.sha`
-#   for push/dispatch) so a new push cancels the in-flight run. The
-#   exception: `labeled` / `unlabeled` events get their own
-#   `tier3-label-<run_id>` group so a label toggle on the same SHA does
+#   Same trick as `pull-request.yaml`: group by `pull_request.number`
+#   (or `github.ref` for push/dispatch) so a new push to the same PR
+#   cancels the in-flight run. Grouping by SHA (the previous approach)
+#   put every commit in its own group, which meant no cancellation
+#   ever happened and back-to-back pushes queued sequentially on the
+#   scarce macOS runner. The exception: `labeled` / `unlabeled` events
+#   get their own `tier3-label-<run_id>` group so a label toggle does
 #   NOT kill an already-running ~15-minute flow execution — the user
 #   experience of "I added the label, the previous run died" is worse
 #   than the cost of one extra runner-minute.
@@ -101,7 +103,7 @@ concurrency:
     ${{
       (github.event.action == 'labeled' || github.event.action == 'unlabeled')
         && format('tier3-label-{0}', github.run_id)
-        || format('tier3-{0}', github.event.pull_request.head.sha || github.sha)
+        || format('tier3-{0}', github.event.pull_request.number || github.ref)
     }}
   cancel-in-progress: true
 


### PR DESCRIPTION
## Problem

When pushing multiple commits back-to-back to a PR, every commit triggered a fresh CI run and the older runs kept running instead of being cancelled. macOS runners are scarce, so each obsolete run wasted ~10 min while the new commit waited in queue.

## Root cause

Both `pull-request.yaml` and `tier3-handbook.yaml` grouped concurrency by **commit SHA**:

```yaml
group: ci-${{ github.event.pull_request.head.sha || github.sha }}
```

Every commit gets its own group, so `cancel-in-progress: true` never triggered. The block's stated intent ("a new push cancels the in-flight run") was the opposite of what actually happened.

## Fix

Group by **PR number** (with `github.ref` fallback for push/dispatch):

```yaml
group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
```

A new push to the same PR now lands in the same group as the previous run → old run gets cancelled, new run starts immediately.

Both workflows share the same `ci-<workflow>-<key>` shape, including the tier3 label-exception (`ci-<workflow>-label-<run_id>`).

The trigger-block rationale in `pull-request.yaml` for omitting `main` from `pull_request.branches` was also updated: the previous "concurrency would cancel one of them" argument no longer applies under PR-number grouping (the release PR and `push: develop` now land in different groups), but the omission is still correct because it avoids double-loading the same SHA.

## Behaviour

| Event | Group | Effect |
|---|---|---|
| 2nd push to PR #42 | `ci-<workflow>-42` | cancels in-flight run for #42, starts fresh run |
| Push to `develop` (post-merge) | `ci-<workflow>-refs/heads/develop` | own group, doesn't touch open PRs |
| `workflow_dispatch` | `ci-<workflow>-<dispatched ref>` | own group per ref |
| `tier3` label toggle | `ci-<workflow>-label-<run_id>` | unique per event — label toggle never kills an in-flight ~15-min flow |

## Files

- `.github/workflows/pull-request.yaml`
- `.github/workflows/tier3-handbook.yaml`

Header comments updated in both files to explain the new grouping.

## Test plan

- [ ] Push a second commit to this PR → first run gets cancelled, second runs without queueing
- [ ] After merge: `push: develop` run on `pull-request.yaml` fires independently of any open PR
