### PR TITLE
docs(testing): refresh testing guide to match current code & CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Flutter wallet for Real Unit investors. Multi-chain, BitBox-ready, KYC-aware.
 
 **Coverage scope:** `lib/packages/**` (services, repositories, signers, utils) and the `cubits/` + `bloc/` directories under each `lib/screens/<feature>/`. Widget files (`lib/screens/<feature>/<feature>_page.dart` and `lib/widgets/**`) are exercised via `testWidgets` specs and excluded from the line-coverage gate — widget tests count as `widget` coverage in the feature matrix, not as line %.
 
-The four-tier testing model (Tier 0 Cubit unit · Tier 1 FakeBitbox integration · Tier 2 firmware simulator · Tier 3 Maestro flows (handbook simulator + deferred BitBox02 hardware)) is tracked in [#314](https://github.com/DFXswiss/realunit-app/issues/314). New BitBox-touching PRs are expected to add tests at the appropriate tier(s).
+The five-tier testing model (Tier 0 Cubit unit · Tier 1 FakeBitbox integration · Tier 2 firmware simulator · Tier 3 Maestro flows (handbook simulator + deferred BitBox02 hardware) · Tier 4 BLE VCR/replay stretch) is tracked in [#314](https://github.com/DFXswiss/realunit-app/issues/314). See [`docs/testing.md`](docs/testing.md) for the full tier picker. New BitBox-touching PRs are expected to add tests at the appropriate tier(s).
 
 ## Coverage infrastructure roadmap
 
@@ -42,9 +42,9 @@ User-facing functions, their activation status, and the tests that cover them. I
 
 **Triage legend** (MVP testing decision): `mvp` = in MVP scope, must reach full test coverage before launch · `defer` = ships but does not block MVP coverage (coverage required eventually, no hard deadline) · `planned` = not in scope for MVP.
 
-**Tests legend:** `widget` = `testWidgets` spec under `test/screens/**` · `unit` = pure-Dart `test/packages/**` spec · `cubit` = `bloc_test`-style spec for a Bloc/Cubit · `integration` = `integration_test/**` spec driving the full app with `FakeBitboxCredentials` · `e2e` = Maestro YAML flow on real hardware · `—` = no test exists.
+**Tests legend:** `widget` = `testWidgets` spec under `test/screens/**` · `unit` = pure-Dart `test/packages/**` spec · `cubit` = `bloc_test`-style spec for a Bloc/Cubit · `integration` = `test/integration/**` spec crossing ≥ 2 production layers with `FakeBitboxCredentials` · `e2e` = Maestro YAML flow on real hardware · `—` = no test exists.
 
-> Per-feature line-coverage % is omitted today because `--coverage` is not yet wired into CI. Once roadmap items 1 + 2 land, this column will be populated automatically.
+> Per-feature line-coverage % is not surfaced in this table. The repo-wide scoped coverage is enforced by the `Coverage Floor Gate` CI job against `.coverage-floor-lines` / `.coverage-floor-functions`; the lcov artifact attached to every PR run holds the per-file breakdown.
 
 ### Supported hardware wallets
 
@@ -135,13 +135,14 @@ Features tagged `mvp` whose current test coverage is insufficient — these bloc
 
 ## Testing tiers
 
-[#314](https://github.com/DFXswiss/realunit-app/issues/314) defines a 4-tier model for BitBox-touching code:
+[#314](https://github.com/DFXswiss/realunit-app/issues/314) defines a 5-tier model for BitBox-touching code:
 
 - **Tier 0 — Cubit unit tests** (`bloc_test` + `mocktail`). Fast, no platform, no BitBox. Covers every state transition.
-- **Tier 1 — FakeBitbox integration tests** (`integration_test/` + `FakeBitboxCredentials`). Drives full app flow without hardware. Phase landing in [#320](https://github.com/DFXswiss/realunit-app/pull/320).
+- **Tier 1 — FakeBitbox integration tests** (`FakeBitboxCredentials` at the BitBox boundary, runs under `flutter test --coverage`). Drives multi-layer flows without hardware. Specs live under `test/integration/`.
 - **Tier 2 — Firmware simulator** (TCP transport + Docker `bitbox02-firmware/simulator`). End-to-end with real crypto, no hardware. Planned.
 - **Tier 3a — Maestro handbook flows** (`.maestro/handbook/*.yaml`). Software-only flows run on a fresh iOS Simulator. Automated via [`tier3-handbook.yaml`](.github/workflows/tier3-handbook.yaml) — opt-in on PRs via the `tier3:full` label (an upstream Maestro driver-hang regression on `macos-latest` runners makes intermittent first-attempt failures expected; `scripts/run-handbook-flows.sh` retries the driver-hang class up to 3× per flow; tracked in [#487](https://github.com/DFXswiss/realunit-app/issues/487)), always runs on push to `develop`.
 - **Tier 3b — Maestro hardware flows** (`.maestro/*.yaml`, BitBox02 device). Status: deferred — still manually triggered before each release.
+- **Tier 4 — BLE VCR / replay** (capture on hardware once, replay deterministically). Stretch — most of its value is covered by Tier 2 + Tier 3 in tandem.
 
 Non-BitBox code only needs Tier 0 + widget tests; Tier 1+ are reserved for hardware-coupled paths.
 
@@ -153,7 +154,7 @@ Non-BitBox code only needs Tier 0 + widget tests; Tier 1+ are reserved for hardw
 | Coverage | `flutter test --coverage` | Writes `coverage/lcov.info`. CI narrows it to the activated surface and hard-fails when scoped coverage drops below the floor in `.coverage-floor-lines` / `.coverage-floor-functions`. See "Coverage infrastructure roadmap" above for the ratchet protocol. |
 | Analyzer | `flutter analyze`         | Dart static analysis per `analysis_options.yaml`                                                                                                                                                          |
 
-Tier 1 (`integration_test/`) is tracked under "Testing tiers" above but not yet committed. Tier 3a (Maestro handbook flows on iOS Simulator) is wired via [`tier3-handbook.yaml`](.github/workflows/tier3-handbook.yaml); Tier 3b (BitBox02 real-hardware variant) remains deferred.
+Tier 1 specs live under `test/integration/**` and run inside the same `flutter test --coverage` invocation as Tier 0 — no separate `integration_test/` harness today (that Flutter-convention directory is reserved for on-device runs that are not yet wired up). Tier 3a (Maestro handbook flows on iOS Simulator) is wired via [`tier3-handbook.yaml`](.github/workflows/tier3-handbook.yaml); Tier 3b (BitBox02 real-hardware variant) remains deferred.
 
 ## CI/CD
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The 100% rule above is the target state. Until the items below land, it is aspir
 
 > **Before first use:** two PR labels are referenced by this tooling but are not auto-created. Run `gh label create tier3:full` once on the repo to enable per-PR opt-in for the Tier 3 handbook workflow — without the label the workflow's `if:` gate never matches and the job silently skips on PRs. Run `gh label create coverage:lower-floor` once to make floor-lowering PRs grep-able; the coverage floor gate itself runs unconditionally on every PR, this label is a review-convention marker only and is not read by any workflow.
 
-Three PRs already in flight close the largest gaps for KYC + BitBox logic: [#319](https://github.com/DFXswiss/realunit-app/pull/319) (Tier 0 cubit tests), [#320](https://github.com/DFXswiss/realunit-app/pull/320) (Tier 1 FakeBitbox integration), [#321](https://github.com/DFXswiss/realunit-app/pull/321) (dashboard buy actions + auth service tests).
+Three PRs have closed the largest gaps for KYC + BitBox logic: [#319](https://github.com/DFXswiss/realunit-app/pull/319) (Tier 0 cubit tests), [#320](https://github.com/DFXswiss/realunit-app/pull/320) (Tier 1 FakeBitbox integration), [#321](https://github.com/DFXswiss/realunit-app/pull/321) (dashboard buy actions + auth service tests).
 
 ## Features
 
@@ -63,7 +63,7 @@ The transport is USB on Android and Bluetooth on iOS; the original BitBox 02 has
 | --- | --- | --- | --- |
 | Welcome screen | always | mvp | widget (`welcome_page_test.dart`, `welcome/widgets/welcome_card_test.dart`) |
 | Create wallet — software (generate seed) | always | mvp | widget (`create_wallet/create_wallet_page_test.dart`); no cubit/service test |
-| Create wallet — BitBox (hardware connect) | hardware | mvp | — (integration test landing in [#320](https://github.com/DFXswiss/realunit-app/pull/320)) |
+| Create wallet — BitBox (hardware connect) | hardware | mvp | — (integration test added via [#320](https://github.com/DFXswiss/realunit-app/pull/320)) |
 | Restore wallet — software seed phrase | always | mvp | widget (`restore_wallet/restore_wallet_page_test.dart`) |
 | Verify seed phrase (3-word challenge) | always | mvp | widget (`verify_seed/verify_seed_page_test.dart`) |
 | Setup PIN | always | mvp | widget (`pin/setup_pin_page_test.dart`) |
@@ -85,16 +85,16 @@ The transport is USB on Android and Bluetooth on iOS; the original BitBox 02 has
 
 | Feature | Status | Triage | Tests |
 | --- | --- | --- | --- |
-| Buy — DFX fiat on-ramp (SEPA) | always | mvp | widget (`buy/buy_page_test.dart`) + unit (`real_unit_buy_payment_info_service_test.dart`); extended in [#321](https://github.com/DFXswiss/realunit-app/pull/321) |
-| Sell — DFX fiat off-ramp (IBAN) | always | mvp | widget (`sell/sell_page_test.dart`); extended in [#321](https://github.com/DFXswiss/realunit-app/pull/321) |
-| KYC: Email + 2FA gate | always | mvp | widget (`kyc_email_page_test.dart`, `kyc_2fa_page_test.dart`); cubit landing in [#319](https://github.com/DFXswiss/realunit-app/pull/319) |
-| KYC: Registration + BitBox EIP-712 sign | always | mvp | widget (`kyc_registration_page_test.dart`) + unit (`eip712_signer_test.dart`); cubit / `registration_submit` / sign-flow integration tests landing in [#319](https://github.com/DFXswiss/realunit-app/pull/319) + [#320](https://github.com/DFXswiss/realunit-app/pull/320) |
+| Buy — DFX fiat on-ramp (SEPA) | always | mvp | widget (`buy/buy_page_test.dart`) + unit (`real_unit_buy_payment_info_service_test.dart`); added via [#321](https://github.com/DFXswiss/realunit-app/pull/321) |
+| Sell — DFX fiat off-ramp (IBAN) | always | mvp | widget (`sell/sell_page_test.dart`); added via [#321](https://github.com/DFXswiss/realunit-app/pull/321) |
+| KYC: Email + 2FA gate | always | mvp | widget (`kyc_email_page_test.dart`, `kyc_2fa_page_test.dart`); cubit added via [#319](https://github.com/DFXswiss/realunit-app/pull/319) |
+| KYC: Registration + BitBox EIP-712 sign | always | mvp | widget (`kyc_registration_page_test.dart`) + unit (`eip712_signer_test.dart`); cubit / `registration_submit` / sign-flow integration tests added via [#319](https://github.com/DFXswiss/realunit-app/pull/319) + [#320](https://github.com/DFXswiss/realunit-app/pull/320) |
 | KYC: Nationality | always | mvp | widget (`kyc_nationality_page_test.dart`) |
 | KYC: Financial data | always | mvp | widget (`kyc_financial_data_page_test.dart`) |
 | KYC: Ident | always | mvp | widget (`kyc_ident_page_test.dart`) |
 | KYC: Pending / Completed / Failure | always | mvp | widget (`kyc/subpages/kyc_*_page_test.dart`) |
-| KYC: AccountMergeRequested / UnsupportedStepFailure | always | mvp | — (cubit paths landing in [#319](https://github.com/DFXswiss/realunit-app/pull/319)) |
-| `DFXAuthService` (lazy auth + 401 retry) | always | mvp | — (unit tests landing in [#319](https://github.com/DFXswiss/realunit-app/pull/319) + [#321](https://github.com/DFXswiss/realunit-app/pull/321)) |
+| KYC: AccountMergeRequested / UnsupportedStepFailure | always | mvp | — (cubit paths added via [#319](https://github.com/DFXswiss/realunit-app/pull/319)) |
+| `DFXAuthService` (lazy auth + 401 retry) | always | mvp | — (unit tests added via [#319](https://github.com/DFXswiss/realunit-app/pull/319) + [#321](https://github.com/DFXswiss/realunit-app/pull/321)) |
 | `balance_service` (balance fetch + cache) | always | mvp | unit (`balance_service_test.dart`) |
 | `format_fixed` / `parse_fixed` (decimal helpers) | always | mvp | unit (`format_fixed_test.dart`, `parse_fixed_test.dart`) |
 | `ApiException` mapping | always | mvp | unit (`exceptions/api_exception_test.dart`) |
@@ -125,12 +125,12 @@ The transport is USB on Android and Bluetooth on iOS; the original BitBox 02 has
 
 Features tagged `mvp` whose current test coverage is insufficient — these block "100% on activated features":
 
-- **Create wallet — BitBox** — no test today; integration test landing in [#320](https://github.com/DFXswiss/realunit-app/pull/320)
+- **Create wallet — BitBox** — covered by the integration test added in [#320](https://github.com/DFXswiss/realunit-app/pull/320); verify the spec still maps to the current `create_wallet` flow when in doubt
 - **Receive** — no test for the address/QR screen
 - **Biometric unlock** — no test (`biometric_service.dart` has no unit spec; no widget spec asserts the unlock surface)
 - **Legal disclaimer gate** — widget exists, cubit transition not directly tested
 - **KYC cubit + sign-flow logic** — widget tests cover individual pages, but state transitions (`KycCubit`, `KycRegistrationSubmitCubit`, `Eip712Signer` guard paths) land in [#319](https://github.com/DFXswiss/realunit-app/pull/319) + [#320](https://github.com/DFXswiss/realunit-app/pull/320)
-- **DFX backend services** — `DFXAuthService`, `real_unit_registration_service`, `real_unit_pdf_service`, `dfx_kyc_service`, `dfx_price_service`, `dfx_widget_service`, `dfx_brokerbot_service`, `dfx_bank_account_service`, `dfx_blockchain_api_service`, `dfx_country_service`, `dfx_faucet_service`, `dfx_support_service`, `transaction_history_service`, `wallet_service`, `price_service`, `session_cache`, `settings_service`, `app_store`, `biometric_service`, `debug_auth_service` — none have a unit spec today; in flight via [#319](https://github.com/DFXswiss/realunit-app/pull/319) (`DFXAuthService`) and [#321](https://github.com/DFXswiss/realunit-app/pull/321) (`real_unit_buy_payment_info_service`)
+- **DFX backend services** — `DFXAuthService`, `real_unit_registration_service`, `real_unit_pdf_service`, `dfx_kyc_service`, `dfx_price_service`, `dfx_widget_service`, `dfx_brokerbot_service`, `dfx_bank_account_service`, `dfx_blockchain_api_service`, `dfx_country_service`, `dfx_faucet_service`, `dfx_support_service`, `transaction_history_service`, `wallet_service`, `price_service`, `session_cache`, `settings_service`, `app_store`, `biometric_service`, `debug_auth_service` — partially covered after [#319](https://github.com/DFXswiss/realunit-app/pull/319) (`DFXAuthService`) and [#321](https://github.com/DFXswiss/realunit-app/pull/321) (`real_unit_buy_payment_info_service`); most other services still lack a unit spec
 - **Hook / screen state tests** — `home_page` widget renders but the underlying balance/price hook has no spec; same for `dashboard` bloc and most screen-level cubits
 
 ## Testing tiers

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -179,6 +179,7 @@ Services with a `Timer`, an observer/subscription loop, or a platform/`MethodCha
 Time-bound assertions must drive time via `package:fake_async`. Wall-clock `Future.delayed` is not acceptable: it makes tests slow and flaky.
 
 ```dart
+import 'package:bitbox_flutter/bitbox_flutter.dart';
 import 'package:bitbox_flutter/testing.dart';
 import 'package:bitbox_flutter/usb/bitbox_usb_platform_interface.dart';
 import 'package:fake_async/fake_async.dart';
@@ -194,12 +195,24 @@ tearDown(() {
   BitboxUsbPlatform.instance = previousPlatform;
 });
 
+// Pairing must run inside the fakeAsync zone so the periodic timer the
+// service installs is bound to the fake clock — otherwise `async.elapse`
+// will not pump it.
+BitboxService pairedServiceSync(FakeAsync async) {
+  final service = BitboxService(
+    connectionStatusInterval: const Duration(milliseconds: 50),
+  );
+  late List<BitboxDevice> devices;
+  service.getAllUsbDevices().then((d) => devices = d);
+  async.flushMicrotasks();
+  service.init(devices.single);
+  async.flushMicrotasks();
+  return service;
+}
+
 test('observer releases USB transport when device vanishes', () {
   fakeAsync((async) {
-    final service = BitboxService(
-      connectionStatusInterval: const Duration(milliseconds: 50),
-    ); // real instance, not a mock
-    // … pair the service inside the fakeAsync zone …
+    final service = pairedServiceSync(async); // real instance, not a mock
 
     platform.when(
       SimulatedBitboxMethod.getDevices,
@@ -229,7 +242,7 @@ Exceptions surface in logs, Sentry, and user-facing error states — the Dart de
 
 ### Platform-coupled code without an integration test
 
-Platform-specific paths (USB transports, BLE lifecycle, secure storage, biometric prompts, deep links) must either ship a Tier 1/2 counterpart that exercises the real plugin (or vendor simulator), or carry an inline `// @no-integration-test: <reason>` annotation. The annotation works at file level (as a dartdoc comment) or immediately above the function/method declaration. Grep current annotations with:
+Platform-specific paths (USB transports, BLE lifecycle, secure storage, biometric prompts, deep links) must either ship a Tier 2/3 counterpart that exercises the real plugin (firmware simulator) or the real transport (Maestro on a device/simulator), or carry an inline `// @no-integration-test: <reason>` annotation. Today the simulator/Maestro counterpart is the long-term option but no `integration_test/` harness is wired up yet (see `CONTRIBUTING.md` footnote on the Tier-1 integration-test slot), so in practice the annotation is the documenting form on every new platform-coupled path. The annotation works at file level (as a dartdoc comment) or immediately above the function/method declaration. Grep current annotations with:
 
 ```bash
 rg "^//\s*@no-integration-test:" lib/

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -179,14 +179,23 @@ Services with a `Timer`, an observer/subscription loop, or a platform/`MethodCha
 Time-bound assertions must drive time via `package:fake_async`. Wall-clock `Future.delayed` is not acceptable: it makes tests slow and flaky.
 
 ```dart
-fakeAsync((async) {
-  final service = BitboxService(); // real instance
-  addTearDown(() => BitboxUsbPlatform.instance = _realPlatform);
-  BitboxUsbPlatform.instance = _FakePlatform();
+late BitboxUsbPlatform previousPlatform;
 
-  service.start();
-  async.elapse(const Duration(seconds: 30));
-  expect(service.didTick, isTrue);
+setUp(() {
+  previousPlatform = BitboxUsbPlatform.instance;
+  BitboxUsbPlatform.instance = _FakePlatform();
+});
+tearDown(() {
+  BitboxUsbPlatform.instance = previousPlatform;
+});
+
+test('observer fires after the configured interval', () {
+  fakeAsync((async) {
+    final service = BitboxService(); // real instance, not a mock
+    service.start();
+    async.elapse(const Duration(seconds: 30));
+    expect(service.didTick, isTrue);
+  });
 });
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -179,22 +179,39 @@ Services with a `Timer`, an observer/subscription loop, or a platform/`MethodCha
 Time-bound assertions must drive time via `package:fake_async`. Wall-clock `Future.delayed` is not acceptable: it makes tests slow and flaky.
 
 ```dart
+import 'package:bitbox_flutter/testing.dart';
+import 'package:bitbox_flutter/usb/bitbox_usb_platform_interface.dart';
+import 'package:fake_async/fake_async.dart';
+
 late BitboxUsbPlatform previousPlatform;
+late SimulatedBitboxPlatform platform;
 
 setUp(() {
   previousPlatform = BitboxUsbPlatform.instance;
-  BitboxUsbPlatform.instance = _FakePlatform();
+  platform = installSimulatedBitboxPlatform();
 });
 tearDown(() {
   BitboxUsbPlatform.instance = previousPlatform;
 });
 
-test('observer fires after the configured interval', () {
+test('observer releases USB transport when device vanishes', () {
   fakeAsync((async) {
-    final service = BitboxService(); // real instance, not a mock
-    service.start();
-    async.elapse(const Duration(seconds: 30));
-    expect(service.didTick, isTrue);
+    final service = BitboxService(
+      connectionStatusInterval: const Duration(milliseconds: 50),
+    ); // real instance, not a mock
+    // … pair the service inside the fakeAsync zone …
+
+    platform.when(
+      SimulatedBitboxMethod.getDevices,
+      (_) async => const <BitboxDevice>[],
+    );
+    service.startConnectionStatusObserver();
+    async.elapse(const Duration(milliseconds: 150));
+
+    expect(
+      platform.count(SimulatedBitboxMethod.close),
+      greaterThanOrEqualTo(1),
+    );
   });
 });
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -172,9 +172,48 @@ final privKey = EthPrivateKey.fromHex(_testPrivateKeyHex);
 
 Sharing the key lets cross-layer tests assert on a single recovered signer address — and means any envelope encoded by `FakeBitboxCredentials(success)` round-trips through `Eip712Signer.signRegistration` to the same byte sequence.
 
+### Service lifecycle (fake_async)
+
+Services with a `Timer`, an observer/subscription loop, or a platform/`MethodChannel` dependency must have a lifecycle test that instantiates the real class — never a mock of the service-under-test. Mocking the service hides timer leaks, unsubscribed listeners, and double-init bugs.
+
+Time-bound assertions must drive time via `package:fake_async`. Wall-clock `Future.delayed` is not acceptable: it makes tests slow and flaky.
+
+```dart
+fakeAsync((async) {
+  final service = BitboxService(); // real instance
+  addTearDown(() => BitboxUsbPlatform.instance = _realPlatform);
+  BitboxUsbPlatform.instance = _FakePlatform();
+
+  service.start();
+  async.elapse(const Duration(seconds: 30));
+  expect(service.didTick, isTrue);
+});
+```
+
+See `test/packages/hardware_wallet/bitbox_service_test.dart`. The rule is also documented in `CONTRIBUTING.md` ("Service-lifecycle tests are mandatory").
+
+### Exception surface
+
+Every typed exception in `lib/` (any class that `implements Exception` or `extends Exception`) must:
+
+1. Override `toString()` so the rendered string is non-empty and does not contain `Instance of '...'`.
+2. Be enumerated in `test/packages/service/dfx/exceptions/exception_surface_test.dart` in the same PR that introduces it.
+
+Exceptions surface in logs, Sentry, and user-facing error states — the Dart default `Instance of '...'` is useless for debugging and unfriendly for users. The surface test catches drift the moment a new exception is added without an enumeration entry.
+
+### Platform-coupled code without an integration test
+
+Platform-specific paths (USB transports, BLE lifecycle, secure storage, biometric prompts, deep links) must either ship a Tier 1/2 counterpart that exercises the real plugin (or vendor simulator), or carry an inline `// @no-integration-test: <reason>` annotation. The annotation works at file level (as a dartdoc comment) or immediately above the function/method declaration. Grep current annotations with:
+
+```bash
+rg "^//\s*@no-integration-test:" lib/
+```
+
+Unit tests with mocked platform channels cannot catch real-device regressions (permission prompts, OS-level lifecycle, transport quirks); the annotation makes the absence of an integration test a deliberate, reviewable decision rather than a silent gap.
+
 ## Tier 1 — cubit / widget + SDK-boundary fake
 
-Tier 1 reuses the same `flutter_test` runner but swaps in [`FakeBitboxCredentials`](../lib/packages/hardware_wallet/fake_bitbox_credentials.dart) at the BitBox boundary. The fake `is BitboxCredentials`, so every production type guard (e.g. the `BitboxNotConnectedException` check in `RealUnitRegistrationService`) treats it identically to a real device.
+Tier 1 reuses the same `flutter_test` runner but swaps in [`FakeBitboxCredentials`](../test/helper/fake_bitbox_credentials.dart) at the BitBox boundary. The fake `is BitboxCredentials`, so every production type guard (e.g. the `BitboxNotConnectedException` check in `RealUnitRegistrationService`) treats it identically to a real device.
 
 `FakeBitboxBehavior` covers the five real-world ceremony outcomes:
 
@@ -254,7 +293,7 @@ Capture iOS BLE traffic once on hardware, replay it deterministically thereafter
 
 ## CI
 
-Every PR runs Tier 0 and Tier 1 via the `RealUnit Build` workflow:
+Every PR runs Tier 0 and Tier 1 via the `RealUnit Build` workflow (`.github/workflows/pull-request.yaml`):
 
 ```bash
 flutter pub get
@@ -264,7 +303,13 @@ flutter analyze
 flutter test --coverage
 ```
 
-Coverage is uploaded as an artifact (see [#323](https://github.com/DFXswiss/realunit-app/pull/323)). The repo holds a [100 % coverage rule](https://github.com/DFXswiss/realunit-app/pull/322) for new code — drop the threshold only with reviewer sign-off and a written reason.
+The workflow runs three jobs:
+
+- **`Analyze & Test`** — the block above, plus a `lcov --extract` step that narrows `coverage/lcov.info` to the activated surface (`lib/packages/**`, `lib/screens/**/cubit(s)/**`, `lib/screens/**/bloc/**`) and uploads both the filtered tracefile (`coverage-lcov`) and a one-line summary (`coverage-summary`) as artifacts.
+- **`Coverage Floor Gate`** — downloads `coverage-summary` and fails the build when scoped line/function coverage drops below the integers committed to `.coverage-floor-lines` and `.coverage-floor-functions`. This job is the required status check on `develop`; the ratchet protocol is documented in `README.md`.
+- **`BitBox quirks audit`** — runs `bitbox-audit` against the diff and inlines its report into the workflow run summary; uploaded as `bitbox-audit-report`.
+
+Tier 3 runs separately under `tier3-handbook.yaml` (push to `develop`, manual, or PRs with the `tier3:full` label). Coverage is uploaded as an artifact (see [#323](https://github.com/DFXswiss/realunit-app/pull/323)). The repo holds a [100 % coverage rule](https://github.com/DFXswiss/realunit-app/pull/322) for new code — drop the threshold only with reviewer sign-off and a written reason.
 
 ## Surface that needs infra work before it can be unit-tested
 
@@ -272,10 +317,10 @@ Some files are deliberately uncovered today because exercising them would change
 
 | Area | Why it's not unit-tested | What it would take |
 |---|---|---|
-| `lib/packages/repository/*` (Drift wrappers) | `AppDatabase(String encryptionPassword)` builds a native SQLCipher executor; no in-memory injection point | Add `AppDatabase.forTesting(QueryExecutor e) : super(e)` and let tests pass `NativeDatabase.memory()` |
+| `lib/packages/repository/*` (Drift wrappers) | `AppDatabase(String encryptionPassword)` builds a native SQLCipher executor; the in-memory injection point exists (`AppDatabase.forTesting`, `database.dart`), but the wrapper specs are not written yet | Write repository unit tests that pass `NativeDatabase.memory()` into `AppDatabase.forTesting` |
 | `lib/screens/*/`-Page widgets that call `getIt<X>()` directly (Dashboard, Receive, Settings sub-pages) | Service locator usage inside `build` makes the cubits the page wires up impossible to swap | Move the `BlocProvider(create: (_) => Cubit(getIt<X>()))` lookup up one layer so tests can `BlocProvider.value` a mock |
 | `transaction_history_*receipt_cubit`, `settings_tax_report_cubit` | Call `getApplicationDocumentsDirectory()` from `path_provider` directly | Inject the path lookup (or use [`path_provider_platform_interface`](https://pub.dev/packages/path_provider_platform_interface) with a fake) |
-| `lib/screens/kyc/steps/ident/cubits/kyc_ident_cubit.dart` | Drives the Sumsub `flutter_idensic_mobile_sdk_plugin` directly | Move the SDK call behind a port the cubit takes via constructor injection |
+| `lib/screens/kyc/steps/ident/cubits/kyc_ident/kyc_ident_cubit.dart` | Drives the Sumsub `flutter_idensic_mobile_sdk_plugin` directly | Move the SDK call behind a port the cubit takes via constructor injection |
 | `lib/widgets/chain_asset_icon.dart`, `lib/widgets/image_picker_sheet.dart` | `Image.asset` / `ImagePicker` need a real asset bundle / platform channel | Mock the asset loader / use the platform-interface fake |
 
 When you find yourself wanting to test one of these, do the infra PR first and document the new injection point in this file.


### PR DESCRIPTION
## Summary

Audit-driven refresh of `docs/testing.md` + `README.md` to bring the testing/coverage documentation back in line with the current codebase, CI and `CONTRIBUTING.md`.

### Veraltete Aussagen korrigiert
- `docs/testing.md`: dead link auf `lib/packages/hardware_wallet/fake_bitbox_credentials.dart` → korrigiert auf `test/helper/fake_bitbox_credentials.dart` (echter Pfad)
- `docs/testing.md`: Pfad zu `kyc_ident_cubit.dart` war eine Verzeichnisebene zu flach → korrigiert auf `lib/screens/kyc/steps/ident/cubits/kyc_ident/kyc_ident_cubit.dart`
- `docs/testing.md`: "Surface that needs infra work"-Tabelle behauptete `AppDatabase.forTesting` müsse noch eingebaut werden — der Konstruktor existiert bereits in `lib/packages/storage/database.dart` (`@visibleForTesting AppDatabase.forTesting(super.executor);`). Eintrag umformuliert auf "Repository-Specs schreiben".
- `README.md`: "four-tier testing model" / "4-tier model" widersprach `docs/testing.md` ("five tiers" inkl. Tier 4 BLE VCR) → auf fünf Tiers angeglichen.
- `README.md`: zwei Sätze entfernt, die Coverage als "noch nicht in CI gewired" und `test/integration/` als "not yet committed" bezeichneten — Coverage + Floor-Gate sind seit Längerem aktiv, `test/integration/kyc_sign_flow_test.dart` existiert.

### Fehlende Pflicht-Patterns aus CONTRIBUTING.md spiegeln
In `docs/testing.md`, neuer Block am Ende des Tier-0-Abschnitts:

- **Service lifecycle (fake_async)** — Pflicht für Services mit `Timer`/Observer/`MethodChannel`-Abhängigkeiten, mit Beispiel und Verweis auf `test/packages/hardware_wallet/bitbox_service_test.dart`.
- **Exception surface** — Pflicht-Enumeration in `test/packages/service/dfx/exceptions/exception_surface_test.dart` + `toString()`-Override.
- **`// @no-integration-test:` Annotation** — Doku-Form für plattformgekoppelten Code ohne Integrationstest.

### CI-Jobs benennen
Der CI-Abschnitt in `docs/testing.md` listet jetzt explizit die drei Jobs aus `.github/workflows/pull-request.yaml`:

- `Analyze & Test`
- `Coverage Floor Gate` (required check auf `develop`)
- `BitBox quirks audit`

## Test plan

- [ ] `docs/testing.md` und `README.md` rendern in GitHub korrekt (Links + Tabellen)
- [ ] Alle korrigierten Pfade sind klickbar (`test/helper/fake_bitbox_credentials.dart`, `lib/packages/storage/database.dart`, `lib/screens/kyc/steps/ident/cubits/kyc_ident/kyc_ident_cubit.dart`)
- [ ] CI grün (nur Doku-Änderungen, sollte trivial sein)