### PR TITLE
fix(handbook): stop CF caching 401s (URGENT) + accept RealUnit username

### DIFF
--- a/handbook.htpasswd
+++ b/handbook.htpasswd
@@ -1,1 +1,2 @@
 realunit:$2y$10$D.wjpsIxKiezNtNLhZPRKeMdy9lII72SmEnmRYT.hRjllPfTlW5k6
+RealUnit:$2y$10$ABel/d76xqU.5JbUMF8SoeUc8Sc5mlVQTGVbw/vfLf/Q6vqRDXJzO

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -30,7 +30,19 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Cache-Control "public, max-age=300" always;
+    # Behind a Basic-Auth gate: never let Cloudflare or any shared cache
+    # store responses. With the previous `public, max-age=300` setting,
+    # Cloudflare extended the TTL to 4h and served cached 401s back to
+    # properly authenticated clients (handbook re-prompt incident
+    # 2026-05-23), and symmetrically cached authenticated 200s where
+    # any unauth client could pull them. `Vary: Authorization` doesn't
+    # save us — Cloudflare ignores Vary on non-Enterprise plans. The
+    # only safe answer for gated content on this plan is no-store. The
+    # handbook ships ~6 MB total (HTML + 26 PNG screenshots, ~225 KB
+    # each); a hard-refresh re-pulls all of it from origin, but dfxprd
+    # and dfxdev shrug at that, and the gate by design keeps the
+    # audience tiny.
+    add_header Cache-Control "private, no-store" always;
 
     # Gzip text assets — screenshots are PNG and skip compression.
     gzip on;


### PR DESCRIPTION
## TL;DR

Live re-prompt bug on https://handbook.realunit.app/de/ — Cloudflare is caching 401 challenges and serving them back to clients with valid credentials. Authenticated users get the auth dialog popping up after they're already logged in. Fix is a one-line `Cache-Control` change. Plus a follow-up to allow `RealUnit` as a username variant alongside `realunit`.

## Root cause (live-verified)

```
curl -sSI -u 'realunit:RealUnit@1291' https://handbook.realunit.app/de/screenshots/01-welcome.png
HTTP/2 401
cache-control: public, max-age=14400      <- Cloudflare bumped TTL to 4h
cf-cache-status: HIT
age: 173
www-authenticate: Basic realm="RealUnit Handbook"
```

A 401 served from the CF edge cache, ignoring the Authorization header, returned to a properly authenticated client. Symmetric data-leak risk: authenticated 200 responses with handbook content were also eligible for shared-cache storage, so an anonymous client could pull cached content without authenticating.

Trigger: nginx was emitting `Cache-Control: public, max-age=300` on every response (server-level `add_header` with `always`), including 401s. `Vary: Authorization` would normally cover this, but Cloudflare ignores `Vary` on Free / Pro / Business plans.

Investigation: two parallel subagents independently converged on the same root cause via chrome-devtools network inspection and live curl probes. Diagnosis written up inline in the commit body.

## Changes

- **`handbook.nginx.conf`** — `public, max-age=300` → `private, no-store`. `/healthz` keeps its own explicit `no-store` block, security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy) untouched.
- **`handbook.htpasswd`** — second line for `RealUnit` user (same password, same bcrypt cost) so users typing the brand spelling don't get 401.

## Required follow-up (manual, after merge + deploy)

Cloudflare cache for `handbook.realunit.app` needs to be purged once the new image rolls out — the existing bad 401 entries will otherwise keep serving until they age out (up to 4h).

Dashboard: **Cloudflare → realunit.app → Caching → Configuration → Purge Cache → Custom Purge → Hostname: `handbook.realunit.app` + `dev-handbook.realunit.app`**

Avoid "Purge by URL" (fragile, misses subresources). "Purge by Hostname" is the safe option.

A follow-up PR should automate this via `cloudflare/cloudflare-action` in the deploy workflow once a `CF_API_TOKEN` secret is provisioned — out of scope here.

## Test plan

- [ ] handbook-deploy CI builds + ships `:beta` with the cache-control change to DEV then PRD
- [ ] After CF purge, against both endpoints (`handbook.realunit.app` + `dev-handbook.realunit.app`):
  - [ ] `curl -sSI .../de/screenshots/*.png` → `cf-cache-status` is `BYPASS`/`MISS`/`DYNAMIC`, never `HIT`
  - [ ] `curl -sSI -u realunit:RealUnit@1291 .../de/` → `HTTP 200`, `cache-control: private, no-store`
  - [ ] `curl -sSI -u RealUnit:RealUnit@1291 .../de/` → `HTTP 200` (new username variant)
  - [ ] `curl -sSI .../de/` (no auth) → `HTTP 401`, `cache-control: private, no-store`, `WWW-Authenticate: Basic realm="RealUnit Handbook"`, `cf-cache-status` ≠ `HIT`
  - [ ] `curl -sSI -u realunit:wrong .../de/` → `HTTP 401`, `cache-control: private, no-store`, `cf-cache-status` ≠ `HIT`
  - [ ] `curl -sSI .../` (root redirect) → `HTTP 302`, `location: /de/`, `cache-control: private, no-store`, `cf-cache-status` ≠ `HIT`
  - [ ] `curl -sSI .../healthz` → `HTTP 200`, `cache-control: no-store`
- [ ] Browser: open fresh incognito, enter creds once, navigate sub-pages and reload → no re-prompt, all subresources load with single credential set