### PR TITLE
docs: comprehensive test/coverage doc audit fixes

### DIFF
--- a/.github/workflows/bitbox-simulator.yml
+++ b/.github/workflows/bitbox-simulator.yml
@@ -19,7 +19,7 @@ name: bitbox-simulator
 # FIRMWARE side of the protocol; the Dart consumer side is exercised
 # by Tier 1 (SDK-boundary fake, cross-layer tests under
 # `test/integration/`) and ultimately by Tier 3 Maestro flows on
-# real hardware. See `docs/testing.md` for the four-tier model and
+# real hardware. See `docs/testing.md` for the five-tier model and
 # issue #314 for the rollout plan. The pinned bitbox_flutter version
 # lives in `pubspec.yaml`.
 #

--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -94,7 +94,8 @@ jobs:
       # exhaust the server's MaxAuthTries before reaching deploy_key,
       # producing intermittent "Permission denied … Too many
       # authentication failures" on otherwise-healthy runs (root cause
-      # for the apparent smoke-test flakiness tracked in #487 Item 4).
+      # for the apparent smoke-test flakiness originally tracked in
+      # #487, now closed).
       - name: Deploy to server
         run: |
           set -euo pipefail

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -135,11 +135,13 @@ jobs:
 
       # The scoped summary is the input to the `coverage-floor` gate job.
       # `if-no-files-found: error` (not `warn`) is load-bearing: the floor
-      # gate is a required status check on `develop`, and a missing summary
-      # MUST surface as a red upload here rather than reach the gate job as
-      # a silent "nothing to compare against". Pairs with the hard `exit 1`
-      # on the gate job's download path — together they make the gate
-      # fail-closed instead of the previous fail-open (silent `exit 0`).
+      # gate is wire-up-ready as a required status check on `develop`
+      # (the ruleset switch is the open roadmap item in README.md), and
+      # a missing summary MUST surface as a red upload here rather than
+      # reach the gate job as a silent "nothing to compare against".
+      # Pairs with the hard `exit 1` on the gate job's download path —
+      # together they make the gate fail-closed instead of the previous
+      # fail-open (silent `exit 0`).
       - name: Upload coverage summary
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tier3-handbook.yaml
+++ b/.github/workflows/tier3-handbook.yaml
@@ -2,7 +2,7 @@ name: Tier 3 — Handbook flows
 
 # Drives every `.maestro/handbook/*.yaml` flow against a freshly-erased iOS
 # Simulator and uploads the captured PNGs as a build artifact. Tier 3 in the
-# four-tier model defined in `docs/testing.md`: real BitBox hardware is
+# five-tier model defined in `docs/testing.md`: real BitBox hardware is
 # explicitly out of scope here — the handbook flows only need the software
 # wallet path, so a hosted macOS runner is enough.
 #
@@ -62,8 +62,8 @@ name: Tier 3 — Handbook flows
 #   `IOSDriverTimeoutException` — assertion failures are never
 #   retried. The post-mortem block (lsof / ps / simctl log + Maestro
 #   `--debug-output`) captures failure state so future regressions
-#   can be diagnosed forensically. Reliability tracking lives in
-#   DFXswiss/realunit-app#487 Hard Risk 2b.
+#   can be diagnosed forensically. The CI-hardening track that landed
+#   this guard was DFXswiss/realunit-app#487 (now closed).
 #
 # Why no pixel-diff in v1:
 #   Font antialiasing differs between runner image versions and a strict

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ The transport is USB on Android and Bluetooth on iOS; the original BitBox 02 has
 
 | Feature | Status | Triage | Tests |
 | --- | --- | --- | --- |
-| Dashboard — asset list + total balance | always | mvp | widget (`home/home_page_test.dart`); no hook/service test |
-| Receive — address + QR code | always | mvp | — |
+| Dashboard — asset list + total balance | always | mvp | cubit/bloc (`dashboard/dashboard_bloc_test.dart`, `dashboard/balance_cubit_test.dart`, `dashboard/portfolio_chart_cubit_test.dart`, `dashboard/price_chart_cubit_test.dart`, `dashboard/pending_transactions_cubit_test.dart`, `dashboard/dashboard_transaction_history_cubit_test.dart`) + widget (`dashboard/widgets/**`) |
+| Receive — address + QR code | always | mvp | widget (`receive/widgets/qr_address_widget_test.dart`) |
 | Transaction history | always | mvp | widget (`transaction_history/transaction_history_page_test.dart`) |
 | Sell to BitBox (on-chain transfer) | hardware | defer | — |
 
@@ -126,12 +126,11 @@ The transport is USB on Android and Bluetooth on iOS; the original BitBox 02 has
 Features tagged `mvp` whose current test coverage is insufficient — these block "100% on activated features":
 
 - **Create wallet — BitBox** — covered by the integration test added in [#320](https://github.com/DFXswiss/realunit-app/pull/320); verify the spec still maps to the current `create_wallet` flow when in doubt
-- **Receive** — no test for the address/QR screen
 - **Biometric unlock** — no test (`biometric_service.dart` has no unit spec; no widget spec asserts the unlock surface)
 - **Legal disclaimer gate** — widget exists, cubit transition not directly tested
 - **KYC cubit + sign-flow logic** — widget tests cover individual pages, but state transitions (`KycCubit`, `KycRegistrationSubmitCubit`, `Eip712Signer` guard paths) land in [#319](https://github.com/DFXswiss/realunit-app/pull/319) + [#320](https://github.com/DFXswiss/realunit-app/pull/320)
 - **DFX backend services** — `DFXAuthService`, `real_unit_registration_service`, `real_unit_pdf_service`, `dfx_kyc_service`, `dfx_price_service`, `dfx_widget_service`, `dfx_brokerbot_service`, `dfx_bank_account_service`, `dfx_blockchain_api_service`, `dfx_country_service`, `dfx_faucet_service`, `dfx_support_service`, `transaction_history_service`, `wallet_service`, `price_service`, `session_cache`, `settings_service`, `app_store`, `biometric_service`, `debug_auth_service` — partially covered after [#319](https://github.com/DFXswiss/realunit-app/pull/319) (`DFXAuthService`) and [#321](https://github.com/DFXswiss/realunit-app/pull/321) (`real_unit_buy_payment_info_service`); most other services still lack a unit spec
-- **Hook / screen state tests** — `home_page` widget renders but the underlying balance/price hook has no spec; same for `dashboard` bloc and most screen-level cubits
+- **Remaining KYC-step cubits without a spec** — `kyc/steps/2fa/cubits`, `kyc/steps/nationality/cubit`, and `kyc/steps/ident/cubits` (the Ident cubit is the Sumsub-SDK wrapper listed under "Surface that needs infra work" in `docs/testing.md`; the other two are unblocked)
 
 ## Testing tiers
 
@@ -140,8 +139,7 @@ Features tagged `mvp` whose current test coverage is insufficient — these bloc
 - **Tier 0 — Cubit unit tests** (`bloc_test` + `mocktail`). Fast, no platform, no BitBox. Covers every state transition.
 - **Tier 1 — FakeBitbox integration tests** (`FakeBitboxCredentials` at the BitBox boundary, runs under `flutter test --coverage`). Drives multi-layer flows without hardware. Specs live under `test/integration/`.
 - **Tier 2 — Firmware simulator** (TCP transport + Docker `bitbox02-firmware/simulator`). End-to-end with real crypto, no hardware. Planned.
-- **Tier 3a — Maestro handbook flows** (`.maestro/handbook/*.yaml`). Software-only flows run on a fresh iOS Simulator. Automated via [`tier3-handbook.yaml`](.github/workflows/tier3-handbook.yaml) — opt-in on PRs via the `tier3:full` label (an upstream Maestro driver-hang regression on `macos-latest` runners makes intermittent first-attempt failures expected; `scripts/run-handbook-flows.sh` retries the driver-hang class up to 3× per flow; tracked in [#487](https://github.com/DFXswiss/realunit-app/issues/487)), always runs on push to `develop`.
-- **Tier 3b — Maestro hardware flows** (`.maestro/*.yaml`, BitBox02 device). Status: deferred — still manually triggered before each release.
+- **Tier 3 — Maestro flows** (`.maestro/handbook/*.yaml` for software-only flows; the BitBox02-hardware variant is deferred and has no flow files committed yet). The handbook flows run on a fresh iOS Simulator, automated via [`tier3-handbook.yaml`](.github/workflows/tier3-handbook.yaml) — opt-in on PRs via the `tier3:full` label, always runs on push to `develop`. An upstream Maestro driver-hang regression on `macos-latest` runners makes intermittent first-attempt failures expected; `scripts/run-handbook-flows.sh` retries the driver-hang class up to 3× per flow (CI-hardening work originally tracked in [#487](https://github.com/DFXswiss/realunit-app/issues/487), now closed). The hardware variant remains manually triggered before each release until Phase 3 of [#314](https://github.com/DFXswiss/realunit-app/issues/314) lands.
 - **Tier 4 — BLE VCR / replay** (capture on hardware once, replay deterministically). Stretch — most of its value is covered by Tier 2 + Tier 3 in tandem.
 
 Non-BitBox code only needs Tier 0 + widget tests; Tier 1+ are reserved for hardware-coupled paths.
@@ -154,21 +152,21 @@ Non-BitBox code only needs Tier 0 + widget tests; Tier 1+ are reserved for hardw
 | Coverage | `flutter test --coverage` | Writes `coverage/lcov.info`. CI narrows it to the activated surface and hard-fails when scoped coverage drops below the floor in `.coverage-floor-lines` / `.coverage-floor-functions`. See "Coverage infrastructure roadmap" above for the ratchet protocol. |
 | Analyzer | `flutter analyze`         | Dart static analysis per `analysis_options.yaml`                                                                                                                                                          |
 
-Tier 1 specs live under `test/integration/**` and run inside the same `flutter test --coverage` invocation as Tier 0 — no separate `integration_test/` harness today (that Flutter-convention directory is reserved for on-device runs that are not yet wired up). Tier 3a (Maestro handbook flows on iOS Simulator) is wired via [`tier3-handbook.yaml`](.github/workflows/tier3-handbook.yaml); Tier 3b (BitBox02 real-hardware variant) remains deferred.
+Tier 1 specs live under `test/integration/**` and run inside the same `flutter test --coverage` invocation as Tier 0 — no separate `integration_test/` harness today (that Flutter-convention directory is reserved for on-device runs that are not yet wired up). Tier 3 handbook flows (iOS Simulator) are wired via [`tier3-handbook.yaml`](.github/workflows/tier3-handbook.yaml); the BitBox02 hardware variant remains deferred.
 
 ## CI/CD
 
 | Workflow                     | Trigger                                                       | Action                                                                                  |
 | ---------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `pull-request.yaml`          | PR to `develop` / `main` · manual                             | `flutter analyze` + `flutter test --coverage`, scope lcov to the activated surface, fail below the committed floor, upload lcov artifact |
+| `pull-request.yaml`          | PR to `develop` · push `develop` · manual                     | `flutter analyze` + `flutter test --coverage`, scope lcov to the activated surface, fail below the committed floor, upload lcov artifact. Jobs: `Analyze & Test`, `Coverage Floor Gate`, `BitBox quirks audit`. |
 | `tier3-handbook.yaml`        | PR to `develop` with label `tier3:full` · push `develop` · manual | Runs every `.maestro/handbook/*.yaml` flow on a fresh iOS Simulator (`iPhone 17`) and uploads captured screenshots (Tier 3) |
-| `bitbox-simulator.yml`       | PR touching `lib/packages/hardware_wallet/**` or `wallet/**`  | Runs the BitBox02 firmware simulator with `bitbox-testkit` baselines (Tier 2)           |
+| `bitbox-simulator.yml`       | PR to `develop` touching `lib/packages/hardware_wallet/**`, `lib/packages/wallet/**`, `lib/screens/hardware_connect_bitbox/**`, their test mirrors, `pubspec.yaml`, or the workflow itself · manual | Runs the BitBox02 firmware simulator with `bitbox-testkit` baselines (Tier 2)           |
 | `bitbox-simulator-slash.yml` | `/bitbox-simulator` comment on any PR                         | Same engine as above, on-demand per PR (variants: default / `ref=main`)                 |
 | `auto-release-pr.yaml`       | Push `develop` · manual                                       | Opens Release PR `develop` → `main`                                                     |
 | `auto-tag.yaml`              | Push `develop`                                                | Creates the next `vX.Y.Z` patch tag (PATCH = previous + 1, MINOR/MAJOR from pubspec floor) |
 | `release.yaml`               | Tag `v*` · manual                                             | Single store-release pipeline. Guard job routes by PATCH: `vX.Y.0` → production candidate (GitHub release, prerelease: false); `vX.Y.Z` (Z >= 1) → internal release (GitHub pre-release). Both lanes deploy Android + iOS to Play Internal + TestFlight; production promotion stays manual in the store backends. |
-| `handbook-dev.yaml`          | Push `develop` under `docs/handbook/**` · manual              | Builds `dfxswiss/realunit-app-handbook:beta`, redeploys the handbook DEV container      |
-| `handbook-prd.yaml`          | Push `main` under `docs/handbook/**` · manual                 | Builds `dfxswiss/realunit-app-handbook:latest`, redeploys the handbook PRD container    |
+| `handbook-deploy.yaml`       | Push `develop` under `docs/handbook/**`, `Dockerfile.handbook`, `handbook.nginx.conf`, `handbook.htpasswd`, or the workflow files · manual | Builds the handbook image once and rolls it out to DEV (`:beta`) then PRD (`:latest`) sequentially via the reusable `handbook.yaml` — PRD only runs after DEV is green |
+| `handbook.yaml`              | Called by `handbook-deploy.yaml` (`workflow_call`)            | Reusable build → Docker Hub push → server pull/recreate → smoke check, parameterised per environment |
 
 ## Release versioning
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,7 +34,22 @@ If you can write a Tier 0 test, do that. Drop down only when a Tier 0 test would
 
 ## Tier 0 — pure Dart
 
-Test layout mirrors `lib/`. Stack: [`flutter_test`](https://pub.dev/packages/flutter_test), [`bloc_test`](https://pub.dev/packages/bloc_test), [`mocktail`](https://pub.dev/packages/mocktail) (NOT mockito).
+Test layout mirrors `lib/`. Stack: [`flutter_test`](https://pub.dev/packages/flutter_test), [`bloc_test`](https://pub.dev/packages/bloc_test), [`mocktail`](https://pub.dev/packages/mocktail) (NOT mockito), [`fake_async`](https://pub.dev/packages/fake_async) for time-bound assertions. Versions are pinned in `pubspec.yaml`.
+
+### Where things go under `test/`
+
+| Path | What goes here |
+|---|---|
+| `test/packages/**` | Pure-Dart services, signers, parsers, exceptions (mirrors `lib/packages/**`) |
+| `test/screens/<feature>/cubit(s)/**` and `test/screens/<feature>/bloc/**` | Cubit/Bloc state-transition specs (in the activated surface for line-coverage) |
+| `test/screens/<feature>/**/*_page_test.dart` | `testWidgets` view specs (cover the page, not the cubit logic) |
+| `test/integration/` | Cross-layer Tier-1 specs using `FakeBitboxCredentials` (e.g. `kyc_sign_flow_test.dart`) |
+| `test/helper/` | Shared test infra: [`pump_app.dart`](../test/helper/pump_app.dart), [`fake_bitbox_credentials.dart`](../test/helper/fake_bitbox_credentials.dart) |
+| `test/models/` | DTO / marshalling specs (`asset_test.dart`, `balance_test.dart`, `transaction_test.dart`, …) |
+| `test/setup/` | App lifecycle / bootstrap specs (`lifecycle_initializer_test.dart`) |
+| `test/styles/` | Currency / language fixtures (`currency_test.dart`, `language_test.dart`) |
+| `test/tool/` | Specs for the Dart scripts under `tool/` (`generate_release_info_test.dart`) |
+| `test/widgets/` | Shared widget specs that are not bound to one feature screen |
 
 ### Cubit / Bloc
 
@@ -248,6 +263,8 @@ Platform-specific paths (USB transports, BLE lifecycle, secure storage, biometri
 rg "^//\s*@no-integration-test:" lib/
 ```
 
+As of today there are 0 annotations in `lib/` — the convention is in place but no platform-coupled path has needed it yet (the Tier 1 `test/integration/` specs cover the BitBox boundary via `FakeBitboxCredentials`, and the other platform surfaces above are not yet referenced from `lib/` in a way that would trip the rule). The block of files listed under "Surface that needs infra work" below is the practical near-term target.
+
 Unit tests with mocked platform channels cannot catch real-device regressions (permission prompts, OS-level lifecycle, transport quirks); the annotation makes the absence of an integration test a deliberate, reviewable decision rather than a silent gap.
 
 ## Tier 1 — cubit / widget + SDK-boundary fake
@@ -321,8 +338,9 @@ The pinned version is the workaround the upstream issue closed with.
 class up to three times per flow as a safety net, and Tier 3 is
 opt-in via the `tier3:full` label rather than a required status
 check on `develop` until the reliability is proven on the pinned
-version over time. See realunit-app#487 Hard Risk 2b for the
-hardening track.
+version over time. The CI-hardening track that landed this guard
+was [#487](https://github.com/DFXswiss/realunit-app/issues/487)
+(now closed).
 
 The real-hardware variant (BitBox02 Nova) stays deferred — Phase 3 of #314 — and is the entry point for any PR that adds a `bitbox:full` label later.
 
@@ -345,7 +363,7 @@ flutter test --coverage
 The workflow runs three jobs:
 
 - **`Analyze & Test`** — the block above, plus a `lcov --extract` step that narrows `coverage/lcov.info` to the activated surface (`lib/packages/**`, `lib/screens/**/cubit(s)/**`, `lib/screens/**/bloc/**`) and uploads both the filtered tracefile (`coverage-lcov`) and a one-line summary (`coverage-summary`) as artifacts.
-- **`Coverage Floor Gate`** — downloads `coverage-summary` and fails the build when scoped line/function coverage drops below the integers committed to `.coverage-floor-lines` and `.coverage-floor-functions`. This job is the required status check on `develop`; the ratchet protocol is documented in `README.md`.
+- **`Coverage Floor Gate`** — downloads `coverage-summary` and fails the build when scoped line/function coverage drops below the integers committed to `.coverage-floor-lines` and `.coverage-floor-functions`. The job is wire-up-ready as a separately required check, but the `develop` branch ruleset currently only requires `Analyze & Test` — see the `Coverage infrastructure roadmap` in `README.md` for the open item. The ratchet protocol is documented there too.
 - **`BitBox quirks audit`** — runs `bitbox-audit` against the diff and inlines its report into the workflow run summary; uploaded as `bitbox-audit-report`.
 
 Tier 3 runs separately under `tier3-handbook.yaml` (push to `develop`, manual, or PRs with the `tier3:full` label). Coverage is uploaded as an artifact (see [#323](https://github.com/DFXswiss/realunit-app/pull/323)). The repo holds a [100 % coverage rule](https://github.com/DFXswiss/realunit-app/pull/322) for new code — drop the threshold only with reviewer sign-off and a written reason.


### PR DESCRIPTION
## Summary

Follow-up auf den vorigen Doku-Refresh ([#533](https://github.com/DFXswiss/realunit-app/pull/533)). Comprehensive Audit hat 12 Issues über `README.md`, `docs/testing.md` und vier Workflow-YAMLs gefunden — alle in diesem PR gefixt, in zwei Subagent-Review-Pässen verifiziert.

### Kritische Fixes (faktisch falsch)

- **`README.md` CI/CD-Tabelle (4 Zeilen):**
  - `pull-request.yaml` triggert nur auf `develop`, nicht `develop`/`main`. Zusätzlich die drei realen Jobs (`Analyze & Test`, `Coverage Floor Gate`, `BitBox quirks audit`) explizit benannt.
  - `bitbox-simulator.yml`: Trigger-Pfade waren zu eng gelistet — jetzt deckungsgleich mit dem `paths:`-Block (lib/test/pubspec + workflow self).
  - `handbook-dev.yaml` + `handbook-prd.yaml` als getrennte Workflows existieren nicht mehr — ersetzt durch konsolidierten `handbook-deploy.yaml` (push develop, sequentielle DEV→PRD) + reusable `handbook.yaml` (gelandet via [#532](https://github.com/DFXswiss/realunit-app/pull/532)).

- **`README.md:79` Dashboard-Zeile:** mappte fälschlich auf `home_page_test.dart` (das ist Onboarding-`/home`-Route, nicht Dashboard). Jetzt korrekt: alle sechs Dashboard-Cubit-/Bloc-Tests + `dashboard/widgets/**`.

- **`README.md:129` Triage-Bullet:** "Hook / screen state tests" — "Hook" ist React-Begriff, Flutter hat Cubits/Blocs. Erste Iteration behauptete Buy/Sell/Settings hätten keine Cubit-Specs — Re-Review fand: doch, alle haben welche. Endgültige Formulierung: die drei realen Lücken (`kyc/steps/{2fa,nationality,ident}` Cubits ohne Spec).

- **`README.md:80` Receive-Zeile + `:129` Triage:** `qr_address_widget_test.dart` existiert seit Längerem — die "no test"-Aussagen entfernt.

- **`docs/testing.md` "Coverage Floor Gate":** Behauptete "required status check on develop". Realität: Repo-Ruleset `11317379` requiret nur `Analyze & Test`; `Coverage Floor Gate` ist wire-up-ready aber noch nicht required. Formulierung an Realität + README-Roadmap-Item angeglichen.

- **`#487`-Referenzen (4 Stellen):** Issue ist seit 2026-05-21 closed (Titel: "CI hardening: required checks, caching, setup-DRY, release-workflow consolidation"). In `README.md:142`, `docs/testing.md:342`, `tier3-handbook.yaml:66`, `handbook.yaml:97` jeweils als "originally tracked in #487, now closed" markiert.

### Wichtige Fixes

- **`README.md` Tier 3a/3b → Tier 3:** README hatte 3a/3b-Split, `docs/testing.md` nur "Tier 3 mit Unterstatus". Vereinheitlicht zu einem Bullet (handbook + deferred hardware). Inkonsistent gelisteter `.maestro/*.yaml`-Pfad für Hardware-Flows entfernt — keine Flow-Files committed.
- **`docs/testing.md` `@no-integration-test:`-Sektion:** `rg "^//\s*@no-integration-test:" lib/` zählt heute 0 — explizit als "0 annotations heute, Konvention für Zukunft" markiert, damit die Doku ehrlich ist.
- **Workflow-Kommentar "four-tier" → "five-tier"** in `bitbox-simulator.yml` und `tier3-handbook.yaml` (konsistent mit `README.md` + `docs/testing.md`).
- **`pull-request.yaml:138` Inline-Kommentar** ebenfalls "required status check on develop" entstaled.

### Nice-to-have

- **Neue "Where things go under `test/`"-Tabelle** in `docs/testing.md`: deckt alle 9 Test-Unterverzeichnisse (`helper`, `integration`, `models`, `packages`, `screens`, `setup`, `styles`, `tool`, `widgets`) mit konkretem Beispiel-File. Neuer Mitarbeiter weiss endlich wo Model-/Style-/Tool-Tests reingehören.

### Bewusst nicht angefasst (Follow-up)

Aus den strukturellen Empfehlungen des Audits:
- README = Map / docs/testing.md = Detail-Refactor (Tier-Tabelle nicht zweimal pflegen)
- Trigger-Tabelle generieren statt handpflegen
- CHANGELOG-Sektion für historische PR-Refs

Diese sind invasiver Restrukturierungs-Arbeit und gehören in einen separaten PR.

## Test plan

- [ ] `README.md` + `docs/testing.md` rendern in GitHub korrekt (Tabellen, Code-Fences)
- [ ] CI grün (reine Doku/Kommentar-Änderungen)