### PR TITLE
feat(handbook): pull RealUnit mail previews from api repo at build time

### DIFF
--- a/.github/workflows/handbook-deploy.yaml
+++ b/.github/workflows/handbook-deploy.yaml
@@ -24,15 +24,6 @@ on:
       - ".github/workflows/handbook-deploy.yaml"
       - ".github/workflows/handbook.yaml"
   workflow_dispatch:
-  # The api repo triggers this workflow whenever the RealUnit mail templates,
-  # the German i18n strings, or the generator script change on its develop
-  # branch (see DFXswiss/api/.github/workflows/notify-handbook-on-mail-change.yaml).
-  # The handbook reusable workflow re-pulls api@develop at build time and
-  # bakes the freshly generated mail previews into the image, so a change
-  # over there flows into both DEV and PRD handbook deployments without a
-  # manual sync PR. Single source of truth = api repo.
-  repository_dispatch:
-    types: [mails-updated]
 
 permissions:
   contents: read

--- a/.github/workflows/handbook-deploy.yaml
+++ b/.github/workflows/handbook-deploy.yaml
@@ -24,6 +24,15 @@ on:
       - ".github/workflows/handbook-deploy.yaml"
       - ".github/workflows/handbook.yaml"
   workflow_dispatch:
+  # The api repo triggers this workflow whenever the RealUnit mail templates,
+  # the German i18n strings, or the generator script change on its develop
+  # branch (see DFXswiss/api/.github/workflows/notify-handbook-on-mail-change.yaml).
+  # The handbook reusable workflow re-pulls api@develop at build time and
+  # bakes the freshly generated mail previews into the image, so a change
+  # over there flows into both DEV and PRD handbook deployments without a
+  # manual sync PR. Single source of truth = api repo.
+  repository_dispatch:
+    types: [mails-updated]
 
 permissions:
   contents: read
@@ -52,6 +61,9 @@ jobs:
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}
       DEPLOY_USER: ${{ secrets.DEPLOY_DEV_USER }}
       DEPLOY_HOST: ${{ secrets.DEPLOY_DEV_HOST }}
+      # Needed to clone DFXswiss/api at build time for the mail-preview
+      # generation step in handbook.yaml.
+      API_REPO_TOKEN: ${{ secrets.API_REPO_TOKEN }}
 
   deploy-prd:
     needs: deploy-dev
@@ -67,3 +79,6 @@ jobs:
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}
       DEPLOY_USER: ${{ secrets.DEPLOY_PRD_USER }}
       DEPLOY_HOST: ${{ secrets.DEPLOY_PRD_HOST }}
+      # Needed to clone DFXswiss/api at build time for the mail-preview
+      # generation step in handbook.yaml.
+      API_REPO_TOKEN: ${{ secrets.API_REPO_TOKEN }}

--- a/.github/workflows/handbook-deploy.yaml
+++ b/.github/workflows/handbook-deploy.yaml
@@ -61,9 +61,6 @@ jobs:
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}
       DEPLOY_USER: ${{ secrets.DEPLOY_DEV_USER }}
       DEPLOY_HOST: ${{ secrets.DEPLOY_DEV_HOST }}
-      # Needed to clone DFXswiss/api at build time for the mail-preview
-      # generation step in handbook.yaml.
-      API_REPO_TOKEN: ${{ secrets.API_REPO_TOKEN }}
 
   deploy-prd:
     needs: deploy-dev
@@ -79,6 +76,3 @@ jobs:
       DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}
       DEPLOY_USER: ${{ secrets.DEPLOY_PRD_USER }}
       DEPLOY_HOST: ${{ secrets.DEPLOY_PRD_HOST }}
-      # Needed to clone DFXswiss/api at build time for the mail-preview
-      # generation step in handbook.yaml.
-      API_REPO_TOKEN: ${{ secrets.API_REPO_TOKEN }}

--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -61,9 +61,11 @@ jobs:
       # (scripts/generate-realunit-previews.js). We pull them in at build time
       # instead of checking them into this repo, so a change to a template or
       # i18n string in the api repo flows into the handbook image on the next
-      # build without a manual sync PR. The api repo triggers this workflow
-      # via repository_dispatch (see handbook-deploy.yaml + the api repo's
-      # .github/workflows/notify-handbook-on-mail-change.yaml).
+      # build without a manual sync PR. A handbook-relevant push to develop
+      # (or a manual workflow_dispatch on handbook-deploy.yaml in this repo)
+      # rebuilds the image and re-pulls api@develop here — so mail-template
+      # changes in the api repo only flow in after such a push/dispatch in
+      # this repo. There is NO auto-dispatch from the api repo.
       - name: Check out DFXswiss/api at develop into _api-checkout/
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -38,6 +38,12 @@ on:
         required: true
       DEPLOY_HOST:
         required: true
+      # PAT (classic, scope: repo) for reading DFXswiss/api at build time.
+      # DFXswiss/api is private — GITHUB_TOKEN of THIS repo cannot reach it,
+      # so we need a dedicated cross-repo token. Used only by the mail-preview
+      # generation step below.
+      API_REPO_TOKEN:
+        required: true
 
 # Reusable workflows do NOT inherit `permissions` from the caller — GITHUB_TOKEN
 # scopes are resolved per-workflow. Mirror the `contents: read` floor that both
@@ -56,6 +62,95 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # RealUnit mail previews are the single source of truth in DFXswiss/api
+      # (scripts/generate-realunit-previews.js). We pull them in at build time
+      # instead of checking them into this repo, so a change to a template or
+      # i18n string in the api repo flows into the handbook image on the next
+      # build without a manual sync PR. The api repo triggers this workflow
+      # via repository_dispatch (see handbook-deploy.yaml + the api repo's
+      # .github/workflows/notify-handbook-on-mail-change.yaml).
+      - name: Check out DFXswiss/api at develop into _api-checkout/
+        uses: actions/checkout@v4
+        with:
+          # DFXswiss/api is a separate private repo; the runner's default
+          # GITHUB_TOKEN is scoped to THIS repo only, so we need an explicit
+          # cross-repo PAT (stored as API_REPO_TOKEN).
+          repository: DFXswiss/api
+          ref: develop
+          token: ${{ secrets.API_REPO_TOKEN }}
+          path: _api-checkout
+
+      - name: Set up Node.js for mail-preview generator
+        uses: actions/setup-node@v4
+        with:
+          # api repo currently does not pin a node version in package.json#engines
+          # or .nvmrc — its CI workflows use NODE_VERSION='20.x' (see
+          # DFXswiss/api/.github/workflows/api-pr.yaml). Mirror that.
+          node-version: '20'
+
+      - name: Generate RealUnit mail previews from api repo
+        env:
+          API_DIR: _api-checkout
+          HANDLEBARS_PREFIX: _handlebars-only
+        run: |
+          set -euo pipefail
+
+          # The generator script only requires 'handlebars' at runtime (verified
+          # via `grep require ${API_DIR}/scripts/generate-realunit-previews.js`).
+          # We deliberately AVOID `npm ci` against the api package-lock — that
+          # would install ~2400 packages (5+ min wall-clock) just to run a
+          # single 600-line script. Installing handlebars into an isolated
+          # prefix outside the api tree keeps `_api-checkout/` clean (its
+          # package.json/lockfile must remain untouched so a future
+          # `git status` on the api checkout would still be "clean") and the
+          # NODE_PATH override below makes `require('handlebars')` resolve
+          # against the isolated install.
+          npm install --prefix "./${HANDLEBARS_PREFIX}" --no-save --no-audit --no-fund handlebars
+
+          # Run the generator. Output goes to ${API_DIR}/scripts/email-previews/realunit/
+          # (path baked into the script).
+          NODE_PATH="./${HANDLEBARS_PREFIX}/node_modules" node "${API_DIR}/scripts/generate-realunit-previews.js"
+
+          # Verify: the script generates one index + N mails. As of writing
+          # there are 24 mails (25 files total). Lower bound 25 catches the
+          # "script silently produced nothing" failure mode without being so
+          # tight that adding a new mail breaks CI (any growth is fine, any
+          # shrink to <25 is suspicious and fails fast here).
+          OUT_DIR="${API_DIR}/scripts/email-previews/realunit"
+          HTML_COUNT=$(ls "${OUT_DIR}"/*.html 2>/dev/null | wc -l | tr -d ' ')
+          if [ "${HTML_COUNT}" -lt 25 ]; then
+            echo "::error::Expected at least 25 mail preview HTML files in ${OUT_DIR}, got ${HTML_COUNT}"
+            exit 1
+          fi
+          if [ ! -s "${OUT_DIR}/00_index.html" ]; then
+            echo "::error::Mail preview index ${OUT_DIR}/00_index.html is missing or empty"
+            exit 1
+          fi
+
+          # Stage the generated files into docs/handbook/mails/ so the Docker
+          # build context picks them up (Dockerfile.handbook does
+          # `COPY docs/handbook/ /usr/share/nginx/html/`).
+          mkdir -p docs/handbook/mails
+          cp "${OUT_DIR}"/*.html docs/handbook/mails/
+
+          # nginx has `index index.html` (handbook.nginx.conf line 15) and
+          # `try_files $uri $uri/ =404` (line 82). A request for /mails/ would
+          # therefore look up /mails/index.html and 404 because the generator
+          # names its index `00_index.html` (so it sorts first in a directory
+          # listing). Duplicating the index as `index.html` lets `/mails/`
+          # resolve directly without adding a per-location nginx rule.
+          cp docs/handbook/mails/00_index.html docs/handbook/mails/index.html
+
+          # Drop the api checkout BEFORE the Docker build. Otherwise the build
+          # context (`.`) sends the entire api repo to the BuildKit daemon,
+          # bloating the layer cache and slowing every subsequent build, even
+          # though COPY only references docs/handbook/.
+          rm -rf "./${API_DIR}" "./${HANDLEBARS_PREFIX}"
+
+          # Final verify (visible in CI log so a future regression is grepable).
+          ls -la docs/handbook/mails/ | head -40
+          echo "Generated $(ls docs/handbook/mails/*.html | wc -l | tr -d ' ') mail preview files"
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -38,12 +38,6 @@ on:
         required: true
       DEPLOY_HOST:
         required: true
-      # PAT (classic, scope: repo) for reading DFXswiss/api at build time.
-      # DFXswiss/api is private — GITHUB_TOKEN of THIS repo cannot reach it,
-      # so we need a dedicated cross-repo token. Used only by the mail-preview
-      # generation step below.
-      API_REPO_TOKEN:
-        required: true
 
 # Reusable workflows do NOT inherit `permissions` from the caller — GITHUB_TOKEN
 # scopes are resolved per-workflow. Mirror the `contents: read` floor that both
@@ -73,12 +67,15 @@ jobs:
       - name: Check out DFXswiss/api at develop into _api-checkout/
         uses: actions/checkout@v4
         with:
-          # DFXswiss/api is a separate private repo; the runner's default
-          # GITHUB_TOKEN is scoped to THIS repo only, so we need an explicit
-          # cross-repo PAT (stored as API_REPO_TOKEN).
+          # DFXswiss/api is a PUBLIC repo, so the runner's default GITHUB_TOKEN
+          # is sufficient to clone it — no cross-repo PAT setup needed. If the
+          # api repo is ever flipped to private, this step will start failing
+          # with HTTP 404 on checkout; the fix is then to add a PAT secret on
+          # the realunit-app repo and pass it through as `token:` here (and
+          # through the secrets: block of this reusable workflow + the
+          # handbook-deploy.yaml caller).
           repository: DFXswiss/api
           ref: develop
-          token: ${{ secrets.API_REPO_TOKEN }}
           path: _api-checkout
 
       - name: Set up Node.js for mail-preview generator
@@ -160,17 +157,12 @@ jobs:
 
           OUT_DIR="${API_DIR}/scripts/email-previews/realunit"
 
-          # Explicit existence check for OUT_DIR BEFORE counting. Under
-          # `set -euo pipefail` the assignment
-          #   HTML_COUNT=$(ls "${OUT_DIR}"/*.html 2>/dev/null | wc -l | tr -d ' ')
-          # would *not* fail when the directory is missing or the glob matches
-          # nothing — bash propagates only the LAST command's exit (here `tr`,
-          # which is happy) up to the assignment, and `pipefail` does not save
-          # us because the assignment itself swallows the pipeline status (this
-          # is a long-standing bash design wart, not a bug here). The count
-          # would silently come out as `0`, the `-ne ${EXPECTED}` check below
-          # would still catch it today — but a future refactor of that check
-          # could quietly drop the safety net. Fail loud and early instead.
+          # Explicit existence check for OUT_DIR so we emit a friendly
+          # `::error::` annotation pointing at the generator, instead of dying
+          # one line later with a raw bash pipeline-failure trace from
+          # `ls "${OUT_DIR}"/*.html | wc -l | tr -d ' '` when the directory is
+          # missing. The count check below would also catch this, but this
+          # early-exit gives a clearer signal in the CI log.
           if [ ! -d "${OUT_DIR}" ]; then
             echo "::error::Generator did not create ${OUT_DIR} — it likely crashed before writing any output. See generator log above."
             exit 1

--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -86,13 +86,28 @@ jobs:
         with:
           # api repo currently does not pin a node version in package.json#engines
           # or .nvmrc — its CI workflows use NODE_VERSION='20.x' (see
-          # DFXswiss/api/.github/workflows/api-pr.yaml). Mirror that.
-          node-version: '20'
+          # DFXswiss/api/.github/workflows/api-pr.yaml). Mirror that exact string
+          # so a future api-side bump (e.g. to '22.x') stays a one-place change
+          # to track.
+          node-version: '20.x'
 
       - name: Generate RealUnit mail previews from api repo
         env:
           API_DIR: _api-checkout
           HANDLEBARS_PREFIX: _handlebars-only
+          # Exact expected mail-preview file count: 24 mails + 1 index = 25.
+          # `-ne` below makes ANY drift (drop OR addition) fail the build —
+          # adding a new mail upstream therefore requires an explicit edit
+          # here, which is the whole point: a silently-added (or silently-
+          # removed) mail must never reach the handbook image undetected.
+          # When you legitimately add/remove a mail in
+          # DFXswiss/api/scripts/generate-realunit-previews.js, bump this
+          # number in the SAME PR as the api-side change-PR (or its
+          # follow-up). The exact count is computed as:
+          #   N(add() calls in the generator)
+          #   + N(pendingTypes entries the for-loop expands)
+          #   + 1 (00_index.html)
+          EXPECTED_HTML_COUNT: 25
         run: |
           set -euo pipefail
 
@@ -108,19 +123,63 @@ jobs:
           # against the isolated install.
           npm install --prefix "./${HANDLEBARS_PREFIX}" --no-save --no-audit --no-fund handlebars
 
-          # Run the generator. Output goes to ${API_DIR}/scripts/email-previews/realunit/
-          # (path baked into the script).
-          NODE_PATH="./${HANDLEBARS_PREFIX}/node_modules" node "${API_DIR}/scripts/generate-realunit-previews.js"
+          # Defensive cleanup of any prior staging dir (no-op on ephemeral CI
+          # runners, but matters when this step is reproduced locally — see
+          # docs/handbook/README.md → "E-Mail Previews → Lokal regenerieren").
+          # Without this, a stale html in docs/handbook/mails/ from a previous
+          # run would survive into the build context and end up shipped in the
+          # image even though the upstream generator no longer produces it.
+          rm -rf docs/handbook/mails
+          mkdir -p docs/handbook/mails
 
-          # Verify: the script generates one index + N mails. As of writing
-          # there are 24 mails (25 files total). Lower bound 25 catches the
-          # "script silently produced nothing" failure mode without being so
-          # tight that adding a new mail breaks CI (any growth is fine, any
-          # shrink to <25 is suspicious and fails fast here).
+          # Run the generator. Output goes to ${API_DIR}/scripts/email-previews/realunit/
+          # (path baked into the script). We `tee` stdout+stderr into a log so the
+          # next step can grep for the script's own `console.warn` output —
+          # specifically the "[trigger] Missing explanation for ..." warning,
+          # which the script emits (NOT throws) when a mail file stem has no
+          # entry in the `triggers` map. The script lives in the api repo and
+          # we cannot upgrade that warning to a throw from here, so the grep
+          # below is our only line of defence against silently shipping the
+          # handbook with mails that have no trigger-explanation card.
+          #
+          # `pipefail` is already on from `set -euo pipefail`, so a non-zero
+          # exit from `node` here fails the step — `tee` does not mask it.
+          LOG_FILE="$(mktemp)"
+          NODE_PATH="./${HANDLEBARS_PREFIX}/node_modules" \
+            node "${API_DIR}/scripts/generate-realunit-previews.js" 2>&1 \
+            | tee "${LOG_FILE}"
+
+          # Cross-repo coupling check: the generator only warns; we promote it
+          # to an error so the build fails fast. Anchor `^` so a future log
+          # line that happens to contain the substring "[trigger] Missing"
+          # somewhere mid-line does not trip the check.
+          if grep -q '^\[trigger\] Missing' "${LOG_FILE}"; then
+            echo "::error::Generator emitted a '[trigger] Missing explanation for …' warning — see log above. Add the missing entry to the triggers map in DFXswiss/api/scripts/generate-realunit-previews.js."
+            exit 1
+          fi
+
           OUT_DIR="${API_DIR}/scripts/email-previews/realunit"
+
+          # Explicit existence check for OUT_DIR BEFORE counting. Under
+          # `set -euo pipefail` the assignment
+          #   HTML_COUNT=$(ls "${OUT_DIR}"/*.html 2>/dev/null | wc -l | tr -d ' ')
+          # would *not* fail when the directory is missing or the glob matches
+          # nothing — bash propagates only the LAST command's exit (here `tr`,
+          # which is happy) up to the assignment, and `pipefail` does not save
+          # us because the assignment itself swallows the pipeline status (this
+          # is a long-standing bash design wart, not a bug here). The count
+          # would silently come out as `0`, the `-ne ${EXPECTED}` check below
+          # would still catch it today — but a future refactor of that check
+          # could quietly drop the safety net. Fail loud and early instead.
+          if [ ! -d "${OUT_DIR}" ]; then
+            echo "::error::Generator did not create ${OUT_DIR} — it likely crashed before writing any output. See generator log above."
+            exit 1
+          fi
+
+          # Exact-match check (see EXPECTED_HTML_COUNT comment at env: above).
           HTML_COUNT=$(ls "${OUT_DIR}"/*.html 2>/dev/null | wc -l | tr -d ' ')
-          if [ "${HTML_COUNT}" -lt 25 ]; then
-            echo "::error::Expected at least 25 mail preview HTML files in ${OUT_DIR}, got ${HTML_COUNT}"
+          if [ "${HTML_COUNT}" -ne "${EXPECTED_HTML_COUNT}" ]; then
+            echo "::error::Expected exactly ${EXPECTED_HTML_COUNT} mail preview HTML files in ${OUT_DIR}, got ${HTML_COUNT}. If this drift is intentional (mail added/removed upstream), update EXPECTED_HTML_COUNT in this workflow in the same PR."
             exit 1
           fi
           if [ ! -s "${OUT_DIR}/00_index.html" ]; then
@@ -131,7 +190,6 @@ jobs:
           # Stage the generated files into docs/handbook/mails/ so the Docker
           # build context picks them up (Dockerfile.handbook does
           # `COPY docs/handbook/ /usr/share/nginx/html/`).
-          mkdir -p docs/handbook/mails
           cp "${OUT_DIR}"/*.html docs/handbook/mails/
 
           # nginx has `index index.html` (handbook.nginx.conf line 15) and
@@ -142,15 +200,26 @@ jobs:
           # resolve directly without adding a per-location nginx rule.
           cp docs/handbook/mails/00_index.html docs/handbook/mails/index.html
 
-          # Drop the api checkout BEFORE the Docker build. Otherwise the build
-          # context (`.`) sends the entire api repo to the BuildKit daemon,
-          # bloating the layer cache and slowing every subsequent build, even
-          # though COPY only references docs/handbook/.
-          rm -rf "./${API_DIR}" "./${HANDLEBARS_PREFIX}"
-
           # Final verify (visible in CI log so a future regression is grepable).
           ls -la docs/handbook/mails/ | head -40
           echo "Generated $(ls docs/handbook/mails/*.html | wc -l | tr -d ' ') mail preview files"
+
+      # Cleanup runs even when the generator step above (or any other step
+      # between staging and `docker build`) fails. Without `if: always()`, a
+      # crash mid-pipeline would leave _api-checkout/ + _handlebars-only/
+      # in the workspace, and the subsequent `docker build` (context: .)
+      # would ship them to BuildKit — bloating the build context with
+      # ~hundreds of MB of api source the image does not need (Dockerfile
+      # only `COPY docs/handbook/`, so the files would not enter the image
+      # itself, but they'd still slow every cached/uncached build).
+      - name: Drop api checkout + handlebars install from build context
+        if: always()
+        env:
+          API_DIR: _api-checkout
+          HANDLEBARS_PREFIX: _handlebars-only
+        run: |
+          set -euo pipefail
+          rm -rf "./${API_DIR}" "./${HANDLEBARS_PREFIX}"
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,10 @@ app.*.map.json
 # (see .github/workflows/handbook.yaml — step "Generate RealUnit mail previews
 # from api repo"). Never commit; source of truth is the api repo.
 docs/handbook/mails/
+
+# Scratch directories produced when reproducing the handbook CI's
+# mail-preview generation locally (see docs/handbook/README.md → "E-Mail
+# Previews → Lokal regenerieren"). Mirrors the names the CI uses so a
+# `git status` after a local repro stays clean.
+_api-checkout/
+_handlebars-only/

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ app.*.map.json
 # FVM Version Cache
 .fvm/
 .fvmrc
+
+# Auto-generated at handbook build time from DFXswiss/api
+# (see .github/workflows/handbook.yaml — step "Generate RealUnit mail previews
+# from api repo"). Never commit; source of truth is the api repo.
+docs/handbook/mails/

--- a/Dockerfile.handbook
+++ b/Dockerfile.handbook
@@ -5,6 +5,12 @@
 #
 # Built independently of the Flutter app: no Flutter toolchain, no app code.
 # Build context is the repo root; only docs/handbook/ is copied in.
+#
+# Note: docs/handbook/mails/ is git-ignored and populated at CI build time
+# by the "Generate RealUnit mail previews from api repo" step in
+# .github/workflows/handbook.yaml — DFXswiss/api is the single source of
+# truth for those previews. The COPY below picks them up automatically as
+# part of the docs/handbook/ tree.
 
 FROM nginx:1.27.5-alpine
 

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -96,11 +96,29 @@ divergieren Image-Stand und Source-of-Truth.
 
 ### Trigger
 
-Ändert sich im api-Repo eine Mail-Vorlage, eine Übersetzung oder das
-Generator-Skript, schickt
-`DFXswiss/api/.github/workflows/notify-handbook-on-mail-change.yaml` ein
-`repository_dispatch (mails-updated)` an dieses Repo und der
-Handbook-Deploy läuft automatisch (DEV → PRD).
+Der Handbook-Deploy läuft bei einem `push` auf `develop` mit Änderungen
+unter handbook-relevanten Pfaden (siehe `handbook-deploy.yaml`) oder bei
+einem manuellen `workflow_dispatch` auf `handbook-deploy.yaml` in
+**diesem** Repo. Eine reine Mail-Template-, i18n- oder Generator-Änderung
+im api-Repo löst **keinen** automatischen Rebuild aus — sie fliesst erst
+mit dem nächsten Handbook-Deploy hier rein.
+
+Wer eine reine Mail-Änderung sofort live haben will, hat zwei Optionen
+im realunit-app-Repo:
+
+```bash
+# Variante A: No-op-Touch unter einem handbook-relevanten Pfad,
+# damit der path-Filter von handbook-deploy.yaml zieht. `--allow-empty`
+# alleine reicht NICHT — der Push muss eine Datei unter docs/handbook/
+# (oder Dockerfile.handbook / handbook.nginx.conf / handbook.htpasswd /
+# einen der beiden handbook-Workflows) tatsächlich anfassen.
+touch docs/handbook/.sync && git add docs/handbook/.sync \
+  && git commit -m "chore(handbook): pull latest mail templates from api" \
+  && git push origin develop
+
+# Variante B: manuell dispatchen (kein Commit nötig)
+gh workflow run handbook-deploy.yaml --ref develop
+```
 
 ### Lokal regenerieren
 

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -104,20 +104,30 @@ Handbook-Deploy läuft automatisch (DEV → PRD).
 
 ### Lokal regenerieren
 
-Mit beiden Repos nebeneinander ausgecheckt:
+Mit beiden Repos nebeneinander ausgecheckt — alle Befehle laufen im
+realunit-app-Root. Wir installieren handlebars **isoliert** in einen scratch
+Prefix (`_handlebars-only/`), genau wie der CI-Step in `handbook.yaml`. So
+bleiben `package.json` und `package-lock.json` im api-Klon unangetastet
+(sonst wäre `git status` im api-Repo nach dem Repro dreckig).
 
 ```bash
-# Einmalig: handlebars in den api-Klon installieren (falls noch nicht da)
-cd ../api && npm install handlebars
+# 1. handlebars isoliert installieren (idempotent — kann beliebig oft laufen)
+npm install --prefix ./_handlebars-only --no-save --no-audit --no-fund handlebars
 
-# Generieren + ins Handbook übernehmen
-node ../api/scripts/generate-realunit-previews.js
+# 2. Generator aus dem api-Repo ausführen (NODE_PATH zeigt auf den scratch-Install)
+NODE_PATH="./_handlebars-only/node_modules" \
+  node ../api/scripts/generate-realunit-previews.js
+
+# 3. Ergebnis ins Handbook übernehmen
 mkdir -p docs/handbook/mails
 cp ../api/scripts/email-previews/realunit/*.html docs/handbook/mails/
 cp docs/handbook/mails/00_index.html docs/handbook/mails/index.html
 
-# Lokal ansehen
+# 4. Lokal ansehen
 open docs/handbook/mails/index.html
+
+# 5. Scratch-Dir aufräumen (in .gitignore — aber sauber ist sauber)
+rm -rf ./_handlebars-only
 ```
 
 (Den finalen Build-Step macht aber immer der CI — lokale Files sind nur fürs

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -78,6 +78,51 @@ Auch der Tier-3-GitHub-Workflow hat dafür einen `flows`-`workflow_dispatch`-Inp
 4. Nur bei einem neuen Thema: eine neue `<details id="spec-NN" class="spec">`
    anlegen und den Anker `#spec-NN` in `<nav class="toc">` ergänzen.
 
+## E-Mail Previews
+
+Die HTML-Vorschauen aller vom Backend an Endkunden versendeten Mails liegen
+**nicht in diesem Repo**. Quelle ist `DFXswiss/api`:
+
+- Generator: `scripts/generate-realunit-previews.js`
+- Vorlage: `src/subdomains/supporting/notification/templates/realunit.hbs`
+- Übersetzungen: `src/shared/i18n/de/mail-realunit.json` (RealUnit-Texte) mit
+  Fallback auf `src/shared/i18n/de/mail.json` (DFX-Defaults)
+
+Der Handbook-CI-Build (`.github/workflows/handbook.yaml`) checkt das api-Repo
+zur Build-Zeit aus, führt den Generator aus und kopiert das Ergebnis nach
+`docs/handbook/mails/`, bevor das Docker-Image gebaut wird. `docs/handbook/mails/`
+ist in `.gitignore` — der Inhalt darf nie ins Repo eingecheckt werden, sonst
+divergieren Image-Stand und Source-of-Truth.
+
+### Trigger
+
+Ändert sich im api-Repo eine Mail-Vorlage, eine Übersetzung oder das
+Generator-Skript, schickt
+`DFXswiss/api/.github/workflows/notify-handbook-on-mail-change.yaml` ein
+`repository_dispatch (mails-updated)` an dieses Repo und der
+Handbook-Deploy läuft automatisch (DEV → PRD).
+
+### Lokal regenerieren
+
+Mit beiden Repos nebeneinander ausgecheckt:
+
+```bash
+# Einmalig: handlebars in den api-Klon installieren (falls noch nicht da)
+cd ../api && npm install handlebars
+
+# Generieren + ins Handbook übernehmen
+node ../api/scripts/generate-realunit-previews.js
+mkdir -p docs/handbook/mails
+cp ../api/scripts/email-previews/realunit/*.html docs/handbook/mails/
+cp docs/handbook/mails/00_index.html docs/handbook/mails/index.html
+
+# Lokal ansehen
+open docs/handbook/mails/index.html
+```
+
+(Den finalen Build-Step macht aber immer der CI — lokale Files sind nur fürs
+Vorab-Anschauen während eines Template-Refactors.)
+
 ## Beziehung zu den Tier-0/Tier-1-Tests
 
 Tier 0/1 (Unit + Widget + integration-mit-FakeBitboxCredentials) prüfen

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -1329,11 +1329,13 @@
           </div>
 
           <p>
-            Bei Änderung einer Mail-Vorlage, einer i18n-Übersetzung oder des
-            Generator-Skripts im api-Repo wird dieser Handbook-Deploy
-            automatisch angestossen (via <code>repository_dispatch</code> aus
-            <code>DFXswiss/api</code>), sodass die Vorschauen hier nie
-            asynchron zur Produktion sind.
+            Eine Änderung an Mail-Vorlage, i18n-Übersetzung oder
+            Generator-Skript im api-Repo löst hier <b>keinen</b> automatischen
+            Rebuild aus. Die neue Version wird mit dem nächsten
+            Handbook-Deploy (Push auf <code>develop</code> mit
+            handbook-relevanten Pfaden oder manueller
+            <code>workflow_dispatch</code> auf <code>handbook-deploy.yaml</code>
+            im realunit-app-Repo) reingezogen.
           </p>
         </details>
       </main>

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -488,6 +488,9 @@
             <li>
               <a href="#spec-08"><span class="spec-num">08</span>Wiederherstellung &amp; Rechtliches</a>
             </li>
+            <li>
+              <a href="#spec-mails"><span class="spec-num">M</span>E-Mails</a>
+            </li>
           </ol>
         </nav>
       </aside>
@@ -1285,6 +1288,51 @@
               </div>
             </div>
           </div>
+        </details>
+
+        <details id="spec-mails" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">M</span>E-Mails</h2>
+                <div class="file">DFXswiss/api · scripts/generate-realunit-previews.js</div>
+              </div>
+              <div class="rhs">
+                <b>Live aus api-Repo</b>
+                <div class="links">
+                  <a href="../mails/">Übersicht öffnen ↗</a>
+                </div>
+              </div>
+            </div>
+          </summary>
+          <p class="spec-intro">
+            Alle vom Backend an Endkunden versendeten E-Mails als HTML-Vorschau,
+            inkl. Beispieldaten und einer kurzen Erklärung pro Mail, wann sie
+            ausgelöst wird. Die Vorlagen leben im
+            <a href="https://github.com/DFXswiss/api">DFXswiss/api</a>-Repo
+            (<code>src/subdomains/supporting/notification/templates/realunit.hbs</code>
+            + <code>src/shared/i18n/de/mail-realunit.json</code>) und werden bei
+            jedem Handbook-Build automatisch frisch generiert und ins Image
+            gepackt — Single Source of Truth ist das api-Repo, dieses Handbook
+            spiegelt nur den aktuellen Stand.
+          </p>
+
+          <div class="callout info">
+            <p>
+              <b>Übersichts-Seite:</b> <a href="../mails/">../mails/</a> — alle
+              Vorlagen gruppiert nach Kauf / Verkauf / Ausstehend / KYC /
+              Authentifizierung / Account / Sonstiges, mit Klick-zur-Vollansicht
+              je Mail.
+            </p>
+          </div>
+
+          <p>
+            Bei Änderung einer Mail-Vorlage, einer i18n-Übersetzung oder des
+            Generator-Skripts im api-Repo wird dieser Handbook-Deploy
+            automatisch angestossen (via <code>repository_dispatch</code> aus
+            <code>DFXswiss/api</code>), sodass die Vorschauen hier nie
+            asynchron zur Produktion sind.
+          </p>
         </details>
       </main>
     </div>

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -1290,6 +1290,8 @@
           </div>
         </details>
 
+        <hr class="sep" />
+
         <details id="spec-mails" class="spec" open>
           <summary>
             <div class="spec-head">


### PR DESCRIPTION
## Summary

Beim Bau des Handbook-nginx-Containers wird `DFXswiss/api` zur Build-Zeit ausgecheckt, `scripts/generate-realunit-previews.js` lokal ausgeführt und das HTML-Output nach `docs/handbook/mails/` kopiert. Single Source of Truth = api-Repo. Kein eingecheckter Sync, kein manuelles Regenerieren.

Trigger bleibt der bestehende: `push: develop` mit handbook-relevanten Pfaden, plus `workflow_dispatch`. Wenn nur Mail-Texte im api-Repo geändert wurden, muss man im realunit-app manuell einen Push (oder `gh workflow run`) anstossen, damit der Build die neuen Mails reinzieht.

## Änderungen

- `.github/workflows/handbook.yaml` — neue Steps vor `docker build`: checkout api (public → default `GITHUB_TOKEN`, kein PAT), Handlebars isoliert via `--prefix _handlebars-only` installieren, Generator ausführen, Output verifizieren (`-ne 25` exact-match), kopieren nach `docs/handbook/mails/` plus `00_index.html → index.html` Duplikat (nginx `index` directive), Cleanup von `_api-checkout/` + `_handlebars-only/` in eigenem `if: always()` Step
- `Dockerfile.handbook` — Kommentar dass `docs/handbook/mails/` build-time generiert wird (keine COPY-Änderung nötig)
- `docs/handbook/de/index.html` — neue TOC-Eintrag + `<details id="spec-mails">` Section konsistent mit spec-01..08
- `docs/handbook/README.md` — Section "E-Mail Previews" mit lokalem Regenerieren-Snippet (mirror der CI-isolierten `--prefix`-Logik)
- `.gitignore` — `docs/handbook/mails/`, `_api-checkout/`, `_handlebars-only/`

## Fail-Fast (User-Anforderung wörtlich)

Jeder Schritt unter `set -euo pipefail`. Konkret rot bei:
- api-checkout failed (404 → Repo-Rename / unverfügbar)
- `npm install` schlägt fehl
- Generator-Script crasht
- Generator gibt `[trigger] Missing explanation` aus (workflow-side grep, weil Script in fremdem Repo)
- `OUT_DIR` nicht angelegt
- HTML-Count ≠ `EXPECTED_HTML_COUNT=25` (Drift in beide Richtungen — bei neuer Mail muss die Schwelle bewusst hochgezogen werden)
- `00_index.html` fehlt oder leer
- Copy schlägt fehl (Disk / Permissions)

## Secrets-Setup

**Kein neues Secret nötig** — `DFXswiss/api` ist public, `actions/checkout@v4` reicht der default `GITHUB_TOKEN`.

## Reviewer-Workflow

Implementer + Reviewer waren Subagenten in 3 Rounds (Implementer → Review (NEEDS_CHANGES, 3 blocking + 8 should-fix) → fixed → Re-Review (ACCEPT mit 2 should-fix) → fixed → Final-Sign-Off ACCEPT).

## Test plan

- [ ] Workflow läuft auf diesem PR grün (build only — kein deploy, der ist push-getriggert)
- [ ] Nach Merge: `develop`-Push triggert `handbook-deploy.yaml` → DEV→PRD rollout
- [ ] `dev-handbook.realunit.app/mails/` zeigt Index nach Login