### PR TITLE
docs(readme): reflect 100 % scoped coverage after the three uplift waves

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The 100% rule above is the target state. Until the items below land, it is aspir
 - [x] Floor gate lives in its own CI job (`Coverage Floor Gate`) so it is wire-up-ready as a separately required status check
 - [ ] GitHub branch protection on `develop` requiring the `Coverage Floor Gate` check (ruleset `PRs` / id `11317379`)
 - [ ] Build-time feature-flag mechanism (analogous to `EXPO_PUBLIC_ENABLE_*` in `dfx-wallet`) so non-MVP features can be gated out of the activated surface — required before the 100% rule is realistic across all feature areas
-- [ ] Inline `// coverage:ignore-*` annotations on truly unreachable paths, each with a one-line reason
+- [x] Inline `// coverage:ignore-*` annotations on truly unreachable paths, each with a one-line reason — applied to Drift schema getters across `lib/packages/storage/`, defensive `assert(false) → throw StateError` fallthroughs in `wallet.dart`, `BitboxCredentials` sync entry points that only exist to satisfy the web3dart interface, the platform-channel forwarders in `PathProviderAdapter` and `BiometricServiceAdapter`, and the `_localTesting` dev-only `Uri.http` branch in `api_config.dart`
 
 **Ratchet protocol.** The committed floor lives in two flat files at the repo root: `.coverage-floor-lines` and `.coverage-floor-functions` (integer percent, no `%` suffix). CI fails the build when scoped coverage drops below either value. Raising the floor is encouraged on every PR that raises measured coverage — bump the file in the same commit and the gate moves up. Lowering the floor requires explicit reviewer sign-off; PR convention is the `coverage:lower-floor` label so the regression is visible in the PR list rather than smuggled in. The functions floor is parked at a placeholder today because `flutter test --coverage` does not emit `FN` records — the gate warns instead of failing on that metric until upstream adds support.
 
@@ -123,14 +123,14 @@ The transport is USB on Android and Bluetooth on iOS; the original BitBox 02 has
 
 ## Triage gaps
 
-Features tagged `mvp` whose current test coverage is insufficient — these block "100% on activated features":
+The activated surface (see "Coverage scope" above) is at **100 % scoped line coverage**. Every file under `lib/packages/**`, `lib/screens/**/cubit(s)/**`, and `lib/screens/**/bloc/**` either ships with tests or carries an `// coverage:ignore-*` annotation with a documented reason. The previous bullet list of partially-covered services, KYC cubits, biometric unlock, and DFX backend services has been retired — those gaps are closed.
 
-- **Create wallet — BitBox** — covered by the integration test added in [#320](https://github.com/DFXswiss/realunit-app/pull/320); verify the spec still maps to the current `create_wallet` flow when in doubt
-- **Biometric unlock** — no test (`biometric_service.dart` has no unit spec; no widget spec asserts the unlock surface)
-- **Legal disclaimer gate** — widget exists, cubit transition not directly tested
-- **KYC cubit + sign-flow logic** — widget tests cover individual pages, but state transitions (`KycCubit`, `KycRegistrationSubmitCubit`, `Eip712Signer` guard paths) land in [#319](https://github.com/DFXswiss/realunit-app/pull/319) + [#320](https://github.com/DFXswiss/realunit-app/pull/320)
-- **DFX backend services** — `DFXAuthService`, `real_unit_registration_service`, `real_unit_pdf_service`, `dfx_kyc_service`, `dfx_price_service`, `dfx_widget_service`, `dfx_brokerbot_service`, `dfx_bank_account_service`, `dfx_blockchain_api_service`, `dfx_country_service`, `dfx_faucet_service`, `dfx_support_service`, `transaction_history_service`, `wallet_service`, `price_service`, `session_cache`, `settings_service`, `app_store`, `biometric_service`, `debug_auth_service` — partially covered after [#319](https://github.com/DFXswiss/realunit-app/pull/319) (`DFXAuthService`) and [#321](https://github.com/DFXswiss/realunit-app/pull/321) (`real_unit_buy_payment_info_service`); most other services still lack a unit spec
-- **Remaining KYC-step cubits without a spec** — `kyc/steps/ident/cubits` only (the Sumsub-SDK wrapper listed under "Surface that needs infra work" in `docs/testing.md`). `kyc/steps/2fa/cubits` and `kyc/steps/nationality/cubit` are covered at 100% line coverage by `test/screens/kyc/steps/2fa/*_cubit_test.dart` and `test/screens/kyc/steps/nationality/kyc_nationality_cubit_test.dart`.
+Out of scope of the gate and tracked elsewhere:
+
+- **Widget render paths** — measured separately via `testWidgets` specs, not in the line-coverage gate (deliberate; see `docs/testing.md` "Tier 0" rationale).
+- **Tier 2 (firmware simulator)** — runs in `bitbox-simulator.yml`, not folded into the scoped coverage number.
+- **Tier 3 (Maestro handbook flows)** — runs in `tier3-handbook.yaml`, not folded in.
+- **`lib/widgets/chain_asset_icon.dart`** and **`lib/widgets/image_picker_sheet.dart`** — `Image.asset` / `ImagePicker` platform-channel paths, see "Surface that needs infra work" in `docs/testing.md`.
 
 ## Testing tiers
 


### PR DESCRIPTION
## Summary

Mini follow-up on top of [#539](https://github.com/DFXswiss/realunit-app/pull/539). Brings the README's coverage narrative in sync with the actual state after the three uplift waves (100 % scoped line coverage on the activated surface).

## What's stale

The README's `Coverage infrastructure roadmap` (line 19+) and `Triage gaps` (line 124+) describe a 2026-Q1 state that the uplift waves have invalidated:

- The "Inline `coverage:ignore-*` annotations" roadmap item was open — it is now applied across `lib/packages/storage/`, `wallet.dart`, `BitboxCredentials`, `PathProviderAdapter` / `BiometricServiceAdapter`, and `api_config._localTesting`.
- "Triage gaps" still listed Biometric unlock, Legal disclaimer gate, KYC cubit + sign-flow logic, every DFX backend service, and the KYC 2FA / nationality cubits — every one of those has shipped via PR #539's waves 1+2+3.

## What this PR does

- ✅ Roadmap item #29 (coverage:ignore annotations) — now checked, with a concrete list of where the markers live so a reviewer can grep for them.
- Triage gaps section — retire the per-feature bullet list (the activated surface is at 100 %, the list is misleading). Replace with the actual out-of-scope items that a new contributor would otherwise expect in the gate (widget render paths, Tier 2/3 flows, two specific platform-channel widgets).

Still open and untouched: roadmap items #27 (`Coverage Floor Gate` as a required check on the `develop` branch protection — needs the GitHub repo-settings flip) and #28 (build-time feature-flag mechanism).

## Test plan

- [x] README renders correctly (markdown only, no code change)
- [ ] CI green (only the doc check)

## Merge order

Stacks on `test/coverage-uplift`. When #539 merges, GitHub will retarget this PR to `develop` — or feel free to fold this commit into #539 directly if you'd rather not have a separate merge.