### PR TITLE
refactor(goldens): shared mocks, constants and plugin stubs

### DIFF
--- a/test/goldens/screens/create_wallet/create_wallet_golden_test.dart
+++ b/test/goldens/screens/create_wallet/create_wallet_golden_test.dart
@@ -1,11 +1,9 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/screens/create_wallet/bloc/create_wallet_cubit.dart';
 import 'package:realunit_wallet/screens/create_wallet/create_wallet_view.dart';
 
@@ -14,24 +12,16 @@ import '../../../helper/helper.dart';
 class _MockCreateWalletCubit extends MockCubit<CreateWalletState>
     implements CreateWalletCubit {}
 
-class _MockWallet extends Mock implements SoftwareWallet {}
-
 void main() {
   late _MockCreateWalletCubit cubit;
 
   setUpAll(() {
-    // Stub the no_screenshot plugin's MethodChannel so screenshotOff/On calls
-    // do not throw MissingPluginException in headless tests.
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-      const MethodChannel('com.flutterplaza.no_screenshot_methods'),
-      (call) async => true,
-    );
+    stubNoScreenshotChannel();
   });
 
   setUp(() {
     cubit = _MockCreateWalletCubit();
-    final wallet = _MockWallet();
+    final wallet = MockSoftwareWallet();
     when(() => wallet.seed).thenReturn(
       'cheese trigger cannon mention judge hire snack sustain annual predict illness celery',
     );

--- a/test/goldens/screens/dashboard/dashboard_golden_test.dart
+++ b/test/goldens/screens/dashboard/dashboard_golden_test.dart
@@ -24,14 +24,11 @@ class _MockBalanceCubit extends MockCubit<Balance> implements BalanceCubit {}
 class _MockPendingTransactionsCubit extends MockCubit<List<TransactionDto>>
     implements PendingTransactionsCubit {}
 
-class _MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
-    implements SettingsBloc {}
-
 void main() {
   late _MockDashboardBloc dashboardBloc;
   late _MockBalanceCubit balanceCubit;
   late _MockPendingTransactionsCubit pendingTxCubit;
-  late _MockSettingsBloc settingsBloc;
+  late MockSettingsBloc settingsBloc;
 
   Balance zeroBalance() => Balance(
         chainId: realUnitAsset.chainId,
@@ -52,7 +49,7 @@ void main() {
     dashboardBloc = _MockDashboardBloc();
     balanceCubit = _MockBalanceCubit();
     pendingTxCubit = _MockPendingTransactionsCubit();
-    settingsBloc = _MockSettingsBloc();
+    settingsBloc = MockSettingsBloc();
 
     when(() => dashboardBloc.state).thenReturn(emptyDashboardState());
     when(() => balanceCubit.state).thenReturn(zeroBalance());

--- a/test/goldens/screens/home/home_golden_test.dart
+++ b/test/goldens/screens/home/home_golden_test.dart
@@ -1,5 +1,4 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -9,13 +8,11 @@ import 'package:realunit_wallet/screens/home/home_page.dart';
 
 import '../../../helper/helper.dart';
 
-class _MockHomeBloc extends MockBloc<HomeEvent, HomeState> implements HomeBloc {}
-
 void main() {
-  late _MockHomeBloc homeBloc;
+  late MockHomeBloc homeBloc;
 
   setUp(() {
-    homeBloc = _MockHomeBloc();
+    homeBloc = MockHomeBloc();
     when(() => homeBloc.state).thenReturn(const HomeState());
   });
 

--- a/test/goldens/screens/kyc/kyc_2fa_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_2fa_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -19,7 +18,6 @@ class _MockKyc2FaVerifyCubit extends MockCubit<Kyc2FaVerifyState>
 class _MockKycCubit extends MockCubit<KycState> implements KycCubit {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockKyc2FaCubit kyc2FaCubit;
   late _MockKyc2FaVerifyCubit kyc2FaVerifyCubit;

--- a/test/goldens/screens/kyc/kyc_account_merge_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_account_merge_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -12,7 +11,6 @@ import '../../../helper/helper.dart';
 class _MockKycCubit extends MockCubit<KycState> implements KycCubit {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockKycCubit kycCubit;
 

--- a/test/goldens/screens/kyc/kyc_completed_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_completed_golden_test.dart
@@ -1,12 +1,10 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/kyc/subpages/kyc_completed_page.dart';
 
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$KycCompletedPage', () {
     goldenTest(

--- a/test/goldens/screens/kyc/kyc_email_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_email_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -16,7 +15,6 @@ class _MockKycEmailStepCubit extends MockCubit<KycEmailStepState>
 class _MockKycCubit extends MockCubit<KycState> implements KycCubit {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockKycEmailStepCubit emailStepCubit;
   late _MockKycCubit kycCubit;

--- a/test/goldens/screens/kyc/kyc_email_verification_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_email_verification_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -13,17 +12,14 @@ import '../../../helper/helper.dart';
 class _MockKycEmailVerificationCubit extends MockCubit<KycEmailVerificationState>
     implements KycEmailVerificationCubit {}
 
-class _MockHomeBloc extends MockBloc<HomeEvent, HomeState> implements HomeBloc {}
-
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockKycEmailVerificationCubit verificationCubit;
-  late _MockHomeBloc homeBloc;
+  late MockHomeBloc homeBloc;
 
   setUp(() {
     verificationCubit = _MockKycEmailVerificationCubit();
-    homeBloc = _MockHomeBloc();
+    homeBloc = MockHomeBloc();
 
     when(() => verificationCubit.state).thenReturn(
       const KycEmailVerificationInitial(),

--- a/test/goldens/screens/kyc/kyc_failure_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_failure_golden_test.dart
@@ -1,12 +1,10 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/kyc/subpages/kyc_failure_page.dart';
 
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$KycFailurePage', () {
     goldenTest(

--- a/test/goldens/screens/kyc/kyc_financial_data_failure_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_financial_data_failure_golden_test.dart
@@ -1,12 +1,10 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/kyc/steps/financial_data/subpages/kyc_financial_data_failure_page.dart';
 
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$KycFinancialDataFailurePage', () {
     goldenTest(

--- a/test/goldens/screens/kyc/kyc_financial_data_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_financial_data_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -16,7 +15,6 @@ class _MockKycFinancialDataCubit extends MockCubit<KycFinancialDataState>
 class _MockKycCubit extends MockCubit<KycState> implements KycCubit {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockKycFinancialDataCubit financialDataCubit;
   late _MockKycCubit kycCubit;

--- a/test/goldens/screens/kyc/kyc_financial_data_loading_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_financial_data_loading_golden_test.dart
@@ -1,12 +1,10 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/kyc/steps/financial_data/subpages/kyc_financial_data_loading_page.dart';
 
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$KycFinancialDataLoadingPage', () {
     goldenTest(

--- a/test/goldens/screens/kyc/kyc_financial_data_questions_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_financial_data_questions_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -14,7 +13,6 @@ class _MockKycFinancialDataCubit extends MockCubit<KycFinancialDataState>
     implements KycFinancialDataCubit {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockKycFinancialDataCubit financialDataCubit;
 

--- a/test/goldens/screens/kyc/kyc_ident_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_ident_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -16,20 +15,16 @@ class _MockKycIdentCubit extends MockCubit<KycIdentState>
 
 class _MockKycCubit extends MockCubit<KycState> implements KycCubit {}
 
-class _MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
-    implements SettingsBloc {}
-
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockKycIdentCubit kycIdentCubit;
   late _MockKycCubit kycCubit;
-  late _MockSettingsBloc settingsBloc;
+  late MockSettingsBloc settingsBloc;
 
   setUp(() {
     kycIdentCubit = _MockKycIdentCubit();
     kycCubit = _MockKycCubit();
-    settingsBloc = _MockSettingsBloc();
+    settingsBloc = MockSettingsBloc();
 
     when(() => kycIdentCubit.state).thenReturn(const KycIdentInitial());
     when(() => kycCubit.state).thenReturn(const KycInitial());

--- a/test/goldens/screens/kyc/kyc_loading_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_loading_golden_test.dart
@@ -1,12 +1,10 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/kyc/subpages/kyc_loading_page.dart';
 
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$KycLoadingPage', () {
     goldenTest(

--- a/test/goldens/screens/kyc/kyc_nationality_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_nationality_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
@@ -18,14 +17,11 @@ class _MockKycNationalityCubit extends MockCubit<KycNationalityState>
 
 class _MockKycCubit extends MockCubit<KycState> implements KycCubit {}
 
-class _MockDfxCountryService extends Mock implements DfxCountryService {}
-
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockKycNationalityCubit kycNationalityCubit;
   late _MockKycCubit kycCubit;
-  late _MockDfxCountryService countryService;
+  late MockDfxCountryService countryService;
 
   const country = Country(
     id: 41,
@@ -44,7 +40,7 @@ void main() {
   });
 
   setUpAll(() {
-    countryService = _MockDfxCountryService();
+    countryService = MockDfxCountryService();
     when(() => countryService.getAllCountries())
         .thenAnswer((_) async => const [country]);
     GetIt.instance.registerSingleton<DfxCountryService>(countryService);

--- a/test/goldens/screens/kyc/kyc_pending_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_pending_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -12,7 +11,6 @@ import '../../../helper/helper.dart';
 class _MockKycCubit extends MockCubit<KycState> implements KycCubit {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockKycCubit kycCubit;
 

--- a/test/goldens/screens/kyc/kyc_registration_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_registration_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
@@ -22,10 +21,7 @@ class _MockKycRegistrationSubmitCubit
 
 class _MockKycCubit extends MockCubit<KycState> implements KycCubit {}
 
-class _MockDfxCountryService extends Mock implements DfxCountryService {}
-
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockKycRegistrationStepCubit registrationStepCubit;
   late _MockKycRegistrationSubmitCubit registrationSubmitCubit;
@@ -51,7 +47,7 @@ void main() {
   });
 
   setUpAll(() {
-    final countryService = _MockDfxCountryService();
+    final countryService = MockDfxCountryService();
     when(() => countryService.getAllCountries()).thenAnswer((_) async => const []);
     GetIt.instance.registerSingleton<DfxCountryService>(countryService);
   });

--- a/test/goldens/screens/legal/legal_document_golden_test.dart
+++ b/test/goldens/screens/legal/legal_document_golden_test.dart
@@ -1,5 +1,4 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -9,14 +8,11 @@ import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
 
 import '../../../helper/helper.dart';
 
-class _MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
-    implements SettingsBloc {}
-
 void main() {
-  late _MockSettingsBloc settingsBloc;
+  late MockSettingsBloc settingsBloc;
 
   setUp(() {
-    settingsBloc = _MockSettingsBloc();
+    settingsBloc = MockSettingsBloc();
     when(() => settingsBloc.state).thenReturn(const SettingsState());
   });
 

--- a/test/goldens/screens/receive/receive_golden_test.dart
+++ b/test/goldens/screens/receive/receive_golden_test.dart
@@ -8,12 +8,10 @@ import 'package:realunit_wallet/screens/receive/receive_page.dart';
 
 import '../../../helper/helper.dart';
 
-class _MockAppStore extends Mock implements AppStore {}
-
 void main() {
   setUpAll(() {
     final getIt = GetIt.instance;
-    final appStore = _MockAppStore();
+    final appStore = MockAppStore();
     when(() => appStore.primaryAddress)
         .thenReturn('0xcabd3f4b10a7089986e708d19140bfc98e5880c0');
     getIt.registerSingleton<AppStore>(appStore);

--- a/test/goldens/screens/restore_wallet/restore_wallet_golden_test.dart
+++ b/test/goldens/screens/restore_wallet/restore_wallet_golden_test.dart
@@ -17,17 +17,15 @@ class _MockRestoreWalletCubit extends MockCubit<RestoreWalletState>
 class _MockValidateSeedCubit extends MockCubit<ValidateSeedState>
     implements ValidateSeedCubit {}
 
-class _MockHomeBloc extends MockBloc<HomeEvent, HomeState> implements HomeBloc {}
-
 void main() {
   late _MockRestoreWalletCubit restoreWalletCubit;
   late _MockValidateSeedCubit validateSeedCubit;
-  late _MockHomeBloc homeBloc;
+  late MockHomeBloc homeBloc;
 
   setUp(() {
     restoreWalletCubit = _MockRestoreWalletCubit();
     validateSeedCubit = _MockValidateSeedCubit();
-    homeBloc = _MockHomeBloc();
+    homeBloc = MockHomeBloc();
     when(() => restoreWalletCubit.state).thenReturn(const RestoreWalletState());
     when(() => validateSeedCubit.state).thenReturn(ValidateSeedState.uncomplete);
     when(() => homeBloc.state).thenReturn(const HomeState());

--- a/test/goldens/screens/sell/sell_golden_test.dart
+++ b/test/goldens/screens/sell/sell_golden_test.dart
@@ -16,7 +16,6 @@ import 'package:realunit_wallet/packages/service/dfx/dfx_price_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/bank_account/bank_account.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_sell_payment_info_service.dart';
 import 'package:realunit_wallet/packages/utils/default_assets.dart';
-import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/screens/sell/cubits/sell_balance/sell_balance_cubit.dart';
 import 'package:realunit_wallet/screens/sell/cubits/sell_converter/sell_converter_cubit.dart';
 import 'package:realunit_wallet/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart';
@@ -53,10 +52,6 @@ class _MockSupportedFiatRepository extends Mock implements SupportedFiatReposito
 
 class _MockApiConfig extends Mock implements ApiConfig {}
 
-class _MockAppStore extends Mock implements AppStore {}
-
-class _MockWallet extends Mock implements SoftwareWallet {}
-
 void main() {
   late _MockSellConverterCubit converterCubit;
   late _MockSellPaymentInfoCubit paymentInfoCubit;
@@ -78,9 +73,9 @@ void main() {
     final getIt = GetIt.instance;
     final apiConfig = _MockApiConfig();
     when(() => apiConfig.asset).thenReturn(realUnitAsset);
-    final appStore = _MockAppStore();
+    final appStore = MockAppStore();
     when(() => appStore.apiConfig).thenReturn(apiConfig);
-    when(() => appStore.wallet).thenReturn(_MockWallet());
+    when(() => appStore.wallet).thenReturn(MockSoftwareWallet());
     when(() => appStore.primaryAddress).thenReturn(
       '0x0000000000000000000000000000000000000000',
     );

--- a/test/goldens/screens/settings/settings_golden_test.dart
+++ b/test/goldens/screens/settings/settings_golden_test.dart
@@ -1,5 +1,4 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,25 +10,20 @@ import 'package:realunit_wallet/screens/settings/settings_page.dart';
 
 import '../../../helper/helper.dart';
 
-class _MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
-    implements SettingsBloc {}
-
-class _MockHomeBloc extends MockBloc<HomeEvent, HomeState> implements HomeBloc {}
-
 void main() {
-  late _MockSettingsBloc settingsBloc;
-  late _MockHomeBloc homeBloc;
+  late MockSettingsBloc settingsBloc;
+  late MockHomeBloc homeBloc;
 
   setUp(() {
-    settingsBloc = _MockSettingsBloc();
-    homeBloc = _MockHomeBloc();
+    settingsBloc = MockSettingsBloc();
+    homeBloc = MockHomeBloc();
 
     when(() => settingsBloc.state).thenReturn(const SettingsState());
     when(() => homeBloc.state).thenReturn(const HomeState());
   });
 
   setUpAll(() {
-    GetIt.instance.registerSingleton<SettingsBloc>(_MockSettingsBloc());
+    GetIt.instance.registerSingleton<SettingsBloc>(MockSettingsBloc());
   });
 
   tearDownAll(() async {

--- a/test/goldens/screens/settings_contact/settings_contact_golden_test.dart
+++ b/test/goldens/screens/settings_contact/settings_contact_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
@@ -17,7 +16,6 @@ class _MockSettingsContactCubit extends MockCubit<SettingsContactState>
 class _MockDfxKycService extends Mock implements DfxKycService {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockSettingsContactCubit contactCubit;
 

--- a/test/goldens/screens/settings_currencies/settings_currencies_golden_test.dart
+++ b/test/goldens/screens/settings_currencies/settings_currencies_golden_test.dart
@@ -1,5 +1,4 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
@@ -17,7 +16,6 @@ class _MockSupportedFiatRepository extends Mock implements SupportedFiatReposito
 class _MockSettingsRepository extends Mock implements SettingsRepository {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockSupportedFiatRepository fiatRepo;
   late _MockSettingsRepository settingsRepo;

--- a/test/goldens/screens/settings_languages/settings_languages_golden_test.dart
+++ b/test/goldens/screens/settings_languages/settings_languages_golden_test.dart
@@ -1,5 +1,4 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
@@ -18,7 +17,6 @@ class _MockSupportedLanguageRepository extends Mock
 class _MockSettingsRepository extends Mock implements SettingsRepository {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockSupportedLanguageRepository langRepo;
   late _MockSettingsRepository settingsRepo;

--- a/test/goldens/screens/settings_legal_documents/settings_aktionariat_documents_golden_test.dart
+++ b/test/goldens/screens/settings_legal_documents/settings_aktionariat_documents_golden_test.dart
@@ -1,12 +1,10 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/settings_legal_documents/subpages/settings_aktionariat_documents_page.dart';
 
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$SettingsAktionariatDocumentsPage', () {
     goldenTest(

--- a/test/goldens/screens/settings_legal_documents/settings_dfx_documents_golden_test.dart
+++ b/test/goldens/screens/settings_legal_documents/settings_dfx_documents_golden_test.dart
@@ -1,12 +1,10 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/settings_legal_documents/subpages/settings_dfx_documents_page.dart';
 
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$SettingsDfxDocumentsPage', () {
     goldenTest(

--- a/test/goldens/screens/settings_legal_documents/settings_legal_documents_golden_test.dart
+++ b/test/goldens/screens/settings_legal_documents/settings_legal_documents_golden_test.dart
@@ -1,12 +1,10 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/settings_legal_documents/settings_legal_documents_page.dart';
 
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$SettingsLegalDocumentsPage', () {
     goldenTest(

--- a/test/goldens/screens/settings_network/settings_network_golden_test.dart
+++ b/test/goldens/screens/settings_network/settings_network_golden_test.dart
@@ -1,6 +1,4 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
@@ -10,16 +8,12 @@ import 'package:realunit_wallet/screens/settings_network/settings_network_page.d
 
 import '../../../helper/helper.dart';
 
-class _MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
-    implements SettingsBloc {}
-
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
-  late _MockSettingsBloc settingsBloc;
+  late MockSettingsBloc settingsBloc;
 
   setUp(() {
-    settingsBloc = _MockSettingsBloc();
+    settingsBloc = MockSettingsBloc();
     when(() => settingsBloc.state).thenReturn(const SettingsState());
 
     final getIt = GetIt.instance;

--- a/test/goldens/screens/settings_seed/settings_seed_golden_test.dart
+++ b/test/goldens/screens/settings_seed/settings_seed_golden_test.dart
@@ -1,14 +1,11 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
-import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/screens/settings_seed/bloc/settings_seed_cubit.dart';
 import 'package:realunit_wallet/screens/settings_seed/settings_seed_page.dart';
 import 'package:realunit_wallet/screens/settings_seed/settings_seed_view.dart';
@@ -18,21 +15,16 @@ import '../../../helper/helper.dart';
 class _MockSettingsSeedCubit extends MockCubit<SettingsSeedState>
     implements SettingsSeedCubit {}
 
-class _MockAppStore extends Mock implements AppStore {}
-
 class _MockWalletService extends Mock implements WalletService {}
 
-class _MockWallet extends Mock implements SoftwareWallet {}
-
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
   const seed =
       'cheese trigger cannon mention judge hire snack sustain annual predict illness celery';
 
   late _MockSettingsSeedCubit settingsSeedCubit;
-  final _MockAppStore appStore = _MockAppStore();
+  final MockAppStore appStore = MockAppStore();
   final _MockWalletService walletService = _MockWalletService();
-  final _MockWallet wallet = _MockWallet();
+  final MockSoftwareWallet wallet = MockSoftwareWallet();
 
   setUp(() {
     settingsSeedCubit = _MockSettingsSeedCubit();
@@ -44,13 +36,7 @@ void main() {
   });
 
   setUpAll(() {
-    // Stub the no_screenshot plugin's MethodChannel so screenshotOff/On calls
-    // do not throw MissingPluginException in headless tests.
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-      const MethodChannel('com.flutterplaza.no_screenshot_methods'),
-      (call) async => true,
-    );
+    stubNoScreenshotChannel();
 
     final getIt = GetIt.instance;
     getIt.registerSingleton<AppStore>(appStore);

--- a/test/goldens/screens/settings_tax_report/settings_tax_report_golden_test.dart
+++ b/test/goldens/screens/settings_tax_report/settings_tax_report_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
@@ -12,22 +11,18 @@ import 'package:realunit_wallet/screens/settings_tax_report/settings_tax_report_
 
 import '../../../helper/helper.dart';
 
-class _MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
-    implements SettingsBloc {}
-
 class _MockSettingsTaxReportCubit extends MockCubit<SettingsTaxReportState>
     implements SettingsTaxReportCubit {}
 
 class _MockRealUnitPdfService extends Mock implements RealUnitPdfService {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
-  late _MockSettingsBloc settingsBloc;
+  late MockSettingsBloc settingsBloc;
   late _MockSettingsTaxReportCubit taxReportCubit;
 
   setUp(() {
-    settingsBloc = _MockSettingsBloc();
+    settingsBloc = MockSettingsBloc();
     taxReportCubit = _MockSettingsTaxReportCubit();
     when(() => settingsBloc.state).thenReturn(const SettingsState());
     when(() => taxReportCubit.state).thenReturn(const SettingsTaxReportInitial());

--- a/test/goldens/screens/settings_user_data/settings_edit_address_golden_test.dart
+++ b/test/goldens/screens/settings_user_data/settings_edit_address_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
@@ -16,12 +15,9 @@ import '../../../helper/helper.dart';
 class _MockSettingsEditAddressCubit extends MockCubit<SettingsEditAddressState>
     implements SettingsEditAddressCubit {}
 
-class _MockDfxCountryService extends Mock implements DfxCountryService {}
-
 class _MockDfxKycService extends Mock implements DfxKycService {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
   const country = Country(
     id: 41,
     symbol: 'CH',
@@ -30,11 +26,11 @@ void main() {
   );
 
   late _MockSettingsEditAddressCubit cubit;
-  late _MockDfxCountryService countryService;
+  late MockDfxCountryService countryService;
 
   setUp(() {
     cubit = _MockSettingsEditAddressCubit();
-    countryService = _MockDfxCountryService();
+    countryService = MockDfxCountryService();
     when(() => cubit.state).thenReturn(const SettingsEditAddressReady('url'));
     when(() => countryService.getAllCountries())
         .thenAnswer((_) async => const [country]);

--- a/test/goldens/screens/settings_user_data/settings_edit_failure_golden_test.dart
+++ b/test/goldens/screens/settings_user_data/settings_edit_failure_golden_test.dart
@@ -1,12 +1,10 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/settings_user_data/subpages/others/settings_edit_failure_page.dart';
 
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$SettingsEditFailurePage', () {
     goldenTest(

--- a/test/goldens/screens/settings_user_data/settings_edit_loading_golden_test.dart
+++ b/test/goldens/screens/settings_user_data/settings_edit_loading_golden_test.dart
@@ -1,12 +1,10 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/settings_user_data/subpages/others/settings_edit_loading_page.dart';
 
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$SettingsEditLoadingPage', () {
     goldenTest(

--- a/test/goldens/screens/settings_user_data/settings_edit_name_golden_test.dart
+++ b/test/goldens/screens/settings_user_data/settings_edit_name_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
@@ -17,7 +16,6 @@ class _MockSettingsEditNameCubit extends MockCubit<SettingsEditNameState>
 class _MockDfxKycService extends Mock implements DfxKycService {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockSettingsEditNameCubit cubit;
 

--- a/test/goldens/screens/settings_user_data/settings_edit_pending_golden_test.dart
+++ b/test/goldens/screens/settings_user_data/settings_edit_pending_golden_test.dart
@@ -1,12 +1,10 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/settings_user_data/subpages/others/settings_edit_pending_page.dart';
 
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$SettingsEditPendingPage', () {
     goldenTest(

--- a/test/goldens/screens/settings_user_data/settings_edit_phone_number_golden_test.dart
+++ b/test/goldens/screens/settings_user_data/settings_edit_phone_number_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
@@ -18,7 +17,6 @@ class _MockSettingsEditPhoneNumberCubit
 class _MockDfxKycService extends Mock implements DfxKycService {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockSettingsEditPhoneNumberCubit cubit;
 

--- a/test/goldens/screens/settings_user_data/settings_user_data_golden_test.dart
+++ b/test/goldens/screens/settings_user_data/settings_user_data_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:alchemist/alchemist.dart';
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
@@ -21,12 +20,9 @@ class _MockSettingsUserDataCubit extends MockCubit<SettingsUserDataState>
 
 class _MockRealUnitWalletService extends Mock implements RealUnitWalletService {}
 
-class _MockDfxCountryService extends Mock implements DfxCountryService {}
-
 class _MockDfxKycService extends Mock implements DfxKycService {}
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   late _MockSettingsUserDataCubit cubit;
 
@@ -65,7 +61,7 @@ void main() {
   setUpAll(() {
     final getIt = GetIt.instance;
     getIt.registerSingleton<RealUnitWalletService>(_MockRealUnitWalletService());
-    getIt.registerSingleton<DfxCountryService>(_MockDfxCountryService());
+    getIt.registerSingleton<DfxCountryService>(MockDfxCountryService());
     getIt.registerSingleton<DfxKycService>(_MockDfxKycService());
   });
 

--- a/test/goldens/screens/settings_wallet_address/settings_wallet_address_golden_test.dart
+++ b/test/goldens/screens/settings_wallet_address/settings_wallet_address_golden_test.dart
@@ -1,5 +1,4 @@
 import 'package:alchemist/alchemist.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
@@ -8,12 +7,9 @@ import 'package:realunit_wallet/screens/settings_wallet_address/settings_wallet_
 
 import '../../../helper/helper.dart';
 
-class _MockAppStore extends Mock implements AppStore {}
-
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
-  final _MockAppStore appStore = _MockAppStore();
+  final MockAppStore appStore = MockAppStore();
 
   setUp(() {
     when(() => appStore.primaryAddress)

--- a/test/goldens/screens/transaction_history/transaction_history_golden_test.dart
+++ b/test/goldens/screens/transaction_history/transaction_history_golden_test.dart
@@ -18,9 +18,6 @@ import 'package:realunit_wallet/screens/transaction_history/transaction_history_
 
 import '../../../helper/helper.dart';
 
-class _MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
-    implements SettingsBloc {}
-
 class _MockTransactionHistoryFilterCubit
     extends MockCubit<TransactionHistoryFilterState>
     implements TransactionHistoryFilterCubit {}
@@ -33,16 +30,14 @@ class _MockTransactionRepository extends Mock implements TransactionRepository {
 
 class _MockRealUnitPdfService extends Mock implements RealUnitPdfService {}
 
-class _MockAppStore extends Mock implements AppStore {}
-
 class _MockApiConfig extends Mock implements ApiConfig {}
 
 void main() {
-  late _MockSettingsBloc settingsBloc;
+  late MockSettingsBloc settingsBloc;
   late _MockTransactionHistoryFilterCubit filterCubit;
   late _MockTransactionHistoryReceiptCubit receiptCubit;
   final transactionRepository = _MockTransactionRepository();
-  final appStore = _MockAppStore();
+  final appStore = MockAppStore();
   final apiConfig = _MockApiConfig();
   const walletAddress = '0xcabd3f4b10a7089986e708d19140bfc98e5880c0';
 
@@ -59,7 +54,7 @@ void main() {
   });
 
   setUp(() {
-    settingsBloc = _MockSettingsBloc();
+    settingsBloc = MockSettingsBloc();
     filterCubit = _MockTransactionHistoryFilterCubit();
     receiptCubit = _MockTransactionHistoryReceiptCubit();
     when(() => settingsBloc.state).thenReturn(const SettingsState());

--- a/test/goldens/screens/verify_seed/verify_seed_golden_test.dart
+++ b/test/goldens/screens/verify_seed/verify_seed_golden_test.dart
@@ -13,15 +13,13 @@ import '../../../helper/helper.dart';
 class _MockVerifySeedCubit extends MockCubit<VerifySeedState>
     implements VerifySeedCubit {}
 
-class _MockHomeBloc extends MockBloc<HomeEvent, HomeState> implements HomeBloc {}
-
 void main() {
   late _MockVerifySeedCubit verifySeedCubit;
-  late _MockHomeBloc homeBloc;
+  late MockHomeBloc homeBloc;
 
   setUp(() {
     verifySeedCubit = _MockVerifySeedCubit();
-    homeBloc = _MockHomeBloc();
+    homeBloc = MockHomeBloc();
     when(() => verifySeedCubit.state).thenReturn(
       const VerifySeedState(
         wordIndices: [1, 3, 5, 7],

--- a/test/goldens/screens/welcome/welcome_golden_test.dart
+++ b/test/goldens/screens/welcome/welcome_golden_test.dart
@@ -7,7 +7,6 @@ import 'package:realunit_wallet/styles/themes.dart';
 import '../../../helper/helper.dart';
 
 void main() {
-  const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);
 
   group('$WelcomePage', () {
     goldenTest(

--- a/test/helper/golden_constants.dart
+++ b/test/helper/golden_constants.dart
@@ -1,0 +1,3 @@
+import 'package:flutter/widgets.dart';
+
+const phoneConstraints = BoxConstraints.tightFor(width: 390, height: 844);

--- a/test/helper/golden_mocks.dart
+++ b/test/helper/golden_mocks.dart
@@ -1,0 +1,18 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_country_service.dart';
+import 'package:realunit_wallet/packages/wallet/wallet.dart';
+import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
+import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
+
+class MockHomeBloc extends MockBloc<HomeEvent, HomeState> implements HomeBloc {}
+
+class MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
+    implements SettingsBloc {}
+
+class MockAppStore extends Mock implements AppStore {}
+
+class MockDfxCountryService extends Mock implements DfxCountryService {}
+
+class MockSoftwareWallet extends Mock implements SoftwareWallet {}

--- a/test/helper/golden_plugin_stubs.dart
+++ b/test/helper/golden_plugin_stubs.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Stub the `no_screenshot` plugin's method channel so calls to
+/// `screenshotOff` / `screenshotOn` / `screenshotStream` do not throw
+/// `MissingPluginException` in headless golden tests.
+///
+/// Call from `setUpAll`.
+void stubNoScreenshotChannel() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+    const MethodChannel('com.flutterplaza.no_screenshot_methods'),
+    (call) async => true,
+  );
+}

--- a/test/helper/helper.dart
+++ b/test/helper/helper.dart
@@ -1,2 +1,5 @@
+export 'golden_constants.dart';
+export 'golden_mocks.dart';
+export 'golden_plugin_stubs.dart';
 export 'pump_app.dart';
 export 'pump_golden_app.dart';


### PR DESCRIPTION
Stacked on top of #541. Pure refactor — no functional change, no baseline touched.

## What changed

Five duplicated patterns across 35+ golden test files moved behind 3 new helper files re-exported from \`test/helper/helper.dart\`:

| Helper | Symbol(s) | Was inline in |
|---|---|---|
| \`golden_constants.dart\` | \`phoneConstraints\` | 33 files |
| \`golden_mocks.dart\` | \`MockHomeBloc\` | 5 |
| | \`MockSettingsBloc\` | 7 |
| | \`MockAppStore\` | 5 |
| | \`MockDfxCountryService\` | 4 |
| | \`MockSoftwareWallet\` | 3 |
| \`golden_plugin_stubs.dart\` | \`stubNoScreenshotChannel()\` | 2 |

Plus 32 unused \`package:flutter/material.dart\` imports removed (collateral of the phoneConstraints extraction).

**Net diff:** 44 insertions / 182 deletions across 44 files. Every new golden test from here saves ~10-15 lines of boilerplate.

## Verified

- \`flutter analyze\` clean
- \`flutter test --exclude-tags golden\`: 2148/2148 green
- \`golden-tests\` CI will run on this branch once #541 lands on develop (stacked PR limitation — \`pull_request.yaml\` triggers only on PRs targeting develop)

## After merge follow-up

After #541 lands on develop, this PR's base auto-rebases to develop and the \`golden-tests\` job validates that the refactor didn't break the committed baselines on dfx01.