### PR TITLE
docs(testing): correct `disconnect` exception in FakeBitboxBehavior table

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -277,7 +277,7 @@ Tier 1 reuses the same `flutter_test` runner but swaps in [`FakeBitboxCredential
 |---|---|---|
 | `success` | Deterministic EIP-712 / personal-message signature from an embedded test private key | User confirms on device |
 | `cancel` | Returns `'0x'` | iOS bridge cancel signal |
-| `disconnect` | Throws `SigningCancelledException`; `isConnected == false` | BLE link drop |
+| `disconnect` | Throws `BitboxNotConnectedException`; `isConnected == false` | BLE link drop |
 | `timeout` | Never resolves; caller imposes its own outer timeout | Device hangs |
 | `malformed` | Returns non-hex data | Frame-desync regression (`bitbox_flutter` PR #11) |
 


### PR DESCRIPTION
## Summary

`docs/testing.md:280` claimed `FakeBitboxBehavior.disconnect` throws `SigningCancelledException`. The fake actually throws `BitboxNotConnectedException` at `test/helper/fake_bitbox_credentials.dart:89`.

Both are distinct exception classes serving distinct intents:

| Class | Defined at | Used for |
|---|---|---|
| `SigningCancelledException` | `lib/packages/wallet/exceptions/signing_cancelled_exception.dart` | User-cancel mid-sign |
| `BitboxNotConnectedException` | `lib/packages/service/dfx/exceptions/bitbox_exception.dart` | Disconnect / not-paired |

The cancel-flow code example immediately below the table (lines 284-295) is correct and stays unchanged — it tests the `cancel` behavior, which legitimately surfaces as `SigningCancelledException` through `Eip712Signer.signRegistration` when the fake returns `'0x'`.

## Discovered during

Deep audit of issue #542 (Tier 1 integration tests) — verifying the cited Tier-1 doc references against the actual fake implementation.

## Test plan

- [x] `grep -n SigningCancelledException docs/testing.md` and `BitboxNotConnectedException` — confirmed only the one drifted line touched
- [x] `dart analyze` — markdown change, no Dart impact
- [ ] CI green