### PR TITLE
fix(deps): bump sqlite3 3.3.0 → 3.3.1 (libsqlite3mc hash mismatch)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1360,10 +1360,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3
-      sha256: b3fe250b4ebd681a8ba20b12794c42b00c1375e5b51005568f0b8731265beb03
+      sha256: "56da3e13ed7d28a66f930aa2b2b29db6736a233f08283326e96321dd812030f5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.1"
   sqlparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,7 +72,7 @@ dependencies:
   pointycastle: ^3.9.1
   qr_flutter: ^4.1.0
   shared_preferences: ^2.5.2
-  sqlite3: ^3.3.0
+  sqlite3: ^3.3.1
   url_launcher: ^6.3.1
   web3dart: ^2.7.1
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
## Problem

The `Release` workflow's `android-deploy` job has been failing since develop@42f4cc2 (run [26394143332](https://github.com/DFXswiss/realunit-app/actions/runs/26394143332)):

```
Bad state: Hash of downloaded file libsqlite3mc.arm.android.so is
ec426ba2…a4a708, expected 92ec0a14…ae9c7d1b.
Building assets for package:sqlite3 failed.
Target dart_build failed: Error: Building native assets failed.
Execution failed for task ':app:compileFlutterBuildRelease'.
```

The previous release on develop@eaac473 still passed with the same `sqlite3 3.3.0` pin — the failure was triggered by an **upstream binary update on the SQLite3 Multiple Ciphers CDN**, not by anything in the #541 stack. The 3.3.0 package has a hardcoded SHA-256 for the downloaded `libsqlite3mc.*.so` artifacts; once the served binary changed, every fresh build aborts at the hash check.

## Fix

`sqlite3 3.3.1` (released 2026-04) bumps the bundled SQLite3 Multiple Ciphers binary to 2.3.3 and re-pins the matching hashes ([changelog](https://pub.dev/packages/sqlite3/changelog)). Bumping the constraint + re-resolving `pubspec.lock` realigns our build with what the CDN now serves.

## Diff

Exactly 2 files, 3 lines each:

- `pubspec.yaml`: `sqlite3: ^3.3.0` → `^3.3.1`
- `pubspec.lock`: regenerated sqlite3 entry (version + sha256)

No other dependency moved (verified with `flutter pub get` on dfx01, no transitive churn).

## Test plan

- [ ] CI on this PR is green (incl. `RealUnit Build` which exercises `flutter pub get` and analyze)
- [ ] After merge: next `Release` run on develop succeeds at `android-deploy`