### PR TITLE
feat(ci): on-demand golden regenerate workflow

### DIFF
--- a/.github/workflows/golden-regenerate.yaml
+++ b/.github/workflows/golden-regenerate.yaml
@@ -64,10 +64,12 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Narrow add: only the baseline PNG tree. `test/goldens/` also
-          # holds transient `failures/` dirs that alchemist writes on
-          # mismatch — those are diagnostic artefacts, never commit.
-          git add 'test/goldens/screens/*/goldens/'
+          # Narrow add: only the baseline PNG tree. The `**/goldens/**`
+          # pattern matches the symmetric artifact path on line 92 — and
+          # excludes alchemist's transient `failures/` directories, which
+          # alchemist writes one level up (`<feature>/failures/...`), not
+          # inside `goldens/`.
+          git add 'test/goldens/screens/**/goldens/**'
           if git diff --cached --quiet; then
             echo "No baseline changes detected — nothing to commit."
             exit 0

--- a/.github/workflows/golden-regenerate.yaml
+++ b/.github/workflows/golden-regenerate.yaml
@@ -64,7 +64,10 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add test/goldens/
+          # Narrow add: only the baseline PNG tree. `test/goldens/` also
+          # holds transient `failures/` dirs that alchemist writes on
+          # mismatch — those are diagnostic artefacts, never commit.
+          git add 'test/goldens/screens/*/goldens/'
           if git diff --cached --quiet; then
             echo "No baseline changes detected — nothing to commit."
             exit 0
@@ -85,4 +88,6 @@ jobs:
         with:
           name: golden-baselines
           path: test/goldens/screens/**/goldens/**
-          if-no-files-found: warn
+          # The fallback only runs because the push failed. An empty
+          # artifact here would silently strand the user — fail loud.
+          if-no-files-found: error

--- a/.github/workflows/golden-regenerate.yaml
+++ b/.github/workflows/golden-regenerate.yaml
@@ -1,0 +1,88 @@
+name: Golden Regenerate
+
+# On-demand visual-regression baseline regeneration on the dfx01 self-hosted
+# runner. Replaces the previous pattern of introducing/removing a temporary
+# `golden-bootstrap.yaml` per regen cycle.
+#
+# Usage:
+#   gh workflow run golden-regenerate.yaml --ref <feature-branch>
+#
+# The workflow checks out the dispatched ref, runs `flutter test
+# test/goldens --update-goldens` on dfx01, then commits the regenerated PNGs
+# back to that same ref as `github-actions[bot]`. If the ref is protected
+# (e.g. `develop`/`main`), the push fails cleanly — by design, no force-push
+# or bypass. In that case the regenerated baselines are still uploaded as a
+# `golden-baselines` artifact so the user can rsync them onto a feature
+# branch manually.
+#
+# Setup steps mirror the `golden-tests` job in `pull-request.yaml` 1:1.
+# Keep them in sync — a divergence here would mean the regenerated
+# baselines render under a different toolchain than the one that validates
+# them on PRs, defeating the whole hardware-determinism story.
+on:
+  workflow_dispatch:
+
+# Two parallel dispatches on the same ref would race each other's push.
+# Cancel the in-flight one so only the newest dispatch's baselines land.
+concurrency:
+  group: golden-regenerate-${{ github.ref }}
+  cancel-in-progress: true
+
+# `contents: write` is load-bearing: the auto-commit step pushes back to
+# the dispatched branch. The default `GITHUB_TOKEN` permission is `read`.
+permissions:
+  contents: write
+
+jobs:
+  regenerate:
+    name: Regenerate golden baselines
+    runs-on: [self-hosted, macOS, ARM64, m3-ultra, realunit-app]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Explicit token so the later `git push` is authenticated. Without
+          # this, checkout still works but the remote is configured with no
+          # credential helper and the push fails with HTTP 403.
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.6"
+          channel: "stable"
+          cache: true
+      - run: flutter pub get
+      - run: dart run tool/generate_localization.dart
+      - run: dart run tool/generate_release_info.dart
+      - run: flutter pub run build_runner build
+
+      - name: Regenerate goldens
+        run: flutter test test/goldens --update-goldens
+
+      - name: Commit and push regenerated baselines
+        id: commit
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add test/goldens/
+          if git diff --cached --quiet; then
+            echo "No baseline changes detected — nothing to commit."
+            exit 0
+          fi
+          git commit -m "test(goldens): regenerate baselines on dfx01"
+          # On protected branches (develop/main) this fails by design.
+          # The next step uploads the PNGs as an artifact so the user can
+          # still recover the regen output.
+          git push
+
+      # Runs only if the push step failed. Uploads the regenerated PNGs so
+      # the user can rsync them locally onto a feature branch and commit
+      # there — same recovery path the temporary `golden-bootstrap.yaml`
+      # used to provide.
+      - name: Upload baselines as fallback artifact
+        if: failure() && steps.commit.conclusion == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-baselines
+          path: test/goldens/screens/**/goldens/**
+          if-no-files-found: warn

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -25,17 +25,18 @@ Es gibt keinen separaten Regeneration-Schritt: Die 26 Handbook-Screenshots
 sind direkt die Golden-Baselines unter `test/goldens/screens/` (gemappt in
 `scripts/assemble-handbook-screenshots.sh`). Eine UI-Änderung an einer der
 gemappten Pages produziert beim `flutter test test/goldens` einen Diff —
-diesen mit `flutter test --update-goldens test/goldens/...` übernehmen, und
-der nächste Handbook-Deploy zeigt das aktualisierte Bild.
+diesen via `golden-regenerate.yaml` auf dfx01 regenerieren lassen, und der
+nächste Handbook-Deploy zeigt das aktualisierte Bild.
 
 Workflow:
 
 1. Page in `lib/screens/**/*_page.dart` ändern
 2. `flutter test test/goldens/screens/<feature>` läuft rot mit Diff-Artefakt
-3. Lokal `flutter test --update-goldens test/goldens/screens/<feature>` (auf
-   dfx01 oder gleichwertiger Hardware-pinned Umgebung — siehe
+3. `gh workflow run golden-regenerate.yaml --ref <branch>` — der Workflow
+   regeneriert auf dfx01 und committet die neuen PNGs als
+   `github-actions[bot]` zurück auf den Branch (siehe
    [`../visual-regression-tests.md`](../visual-regression-tests.md))
-4. Neuen PNG-Baseline committen → Handbook-Deploy pickt sie beim nächsten
+4. Pullen → Handbook-Deploy pickt die neue Baseline beim nächsten
    develop-Push automatisch auf.
 
 ## Selektive Läufe (Teilmenge)

--- a/docs/visual-regression-tests.md
+++ b/docs/visual-regression-tests.md
@@ -1,9 +1,9 @@
 # Visual Regression Tests
 
-Pixel-exact baseline tests for selected screens. The pilot covers 5 screens
-(Welcome, Dashboard, Settings, Buy, Sell) with 8 baseline PNGs. Skalierung auf
-alle 57 Page-Files ist das Folge-Ziel — wird in separaten PRs nachgezogen,
-nicht in diesem Pilot-PR.
+Pixel-exact baseline tests for every page in the app. 57 `lib/screens/**/*_page.dart`
+files mapped to 68 Golden PNGs under `test/goldens/screens/`, validated on
+each PR by the `Visual Regression` job (required status check on
+`develop` + `main`).
 
 ## Stack
 
@@ -60,9 +60,11 @@ The workflow is `workflow_dispatch`-only, runs on the same
 back-to-back dispatches on the same branch don't race each other.
 
 On a protected ref (`develop`, `main`) the push fails by design — no
-force-push, no bypass. In that case the regenerated PNGs are still
-uploaded as the `golden-baselines` artifact; download and rsync them
-onto a feature branch:
+force-push, no bypass. The same artifact-fallback also kicks in if a
+parallel human push raced the bot (non-fast-forward); the workflow
+does not retry-rebase. In either case the regenerated PNGs are uploaded
+as the `golden-baselines` artifact; download and rsync them onto a
+feature branch:
 
 ```bash
 RUN_ID=$(gh run list --workflow=golden-regenerate.yaml --limit 1 --json databaseId --jq '.[0].databaseId')

--- a/docs/visual-regression-tests.md
+++ b/docs/visual-regression-tests.md
@@ -77,7 +77,7 @@ git push
 ### Adding a new golden test
 
 1. Add a `*_golden_test.dart` under `test/goldens/screens/<feature>/`.
-   Reuse the mock pattern from the existing pilot tests.
+   Reuse the mock pattern from the existing golden tests.
 2. Open a Draft PR. The `golden-tests` job will be red because the new
    test has no committed baseline.
 3. Run `gh workflow run golden-regenerate.yaml --ref <branch>`. The

--- a/docs/visual-regression-tests.md
+++ b/docs/visual-regression-tests.md
@@ -40,29 +40,38 @@ Method-channel stubbing alone is **not enough**: the widget's first build assert
 
 For a one-page edge case the cost/benefit doesn't justify it. The test is committed with `skip: true` and reactivates the moment someone wires up a full `InAppWebViewPlatform` mock — preferably published as a separate test-only package so other Flutter apps can reuse it.
 
-## Initial bootstrap
+## Regenerating baselines
 
-The very first baseline set has to come from dfx01 itself. The pattern:
+Permanent on-demand workflow `.github/workflows/golden-regenerate.yaml`
+runs `flutter test test/goldens --update-goldens` on dfx01 and commits
+the regenerated PNGs back to the dispatched branch as
+`github-actions[bot]`. One command:
 
-1. Open this PR as **Draft**. The `golden-tests` CI job will be red on the
-   first push — no baselines exist yet.
-2. Run the temporary `golden-bootstrap.yaml` workflow via
-   `gh workflow run golden-bootstrap.yaml --ref feat/visual-regression-pilot -R DFXswiss/realunit-app`.
-3. Wait for the run to complete; download the `golden-baselines` artifact:
-   ```bash
-   RUN_ID=$(gh run list --workflow=golden-bootstrap.yaml --limit 1 --json databaseId --jq '.[0].databaseId')
-   gh run download "$RUN_ID" -n golden-baselines -D /tmp/baselines
-   ```
-4. Copy the PNGs into the repo, commit, push:
-   ```bash
-   rsync -a /tmp/baselines/ test/goldens/
-   git add test/goldens/screens/**/goldens/
-   git commit -m "test(goldens): commit initial baselines generated on dfx01"
-   git push
-   ```
-5. Verify the `golden-tests` job goes green on the next CI run.
-6. Delete `.github/workflows/golden-bootstrap.yaml` in the same PR before
-   marking ready-for-review.
+```bash
+gh workflow run golden-regenerate.yaml --ref <feature-branch>
+```
+
+When the run finishes green, the new baselines are already on the
+branch — pull and continue. No download / rsync / manual commit step.
+
+The workflow is `workflow_dispatch`-only, runs on the same
+`[self-hosted, macOS, ARM64, m3-ultra, realunit-app]` labels as
+`golden-tests`, and uses concurrency `golden-regenerate-<ref>` so two
+back-to-back dispatches on the same branch don't race each other.
+
+On a protected ref (`develop`, `main`) the push fails by design — no
+force-push, no bypass. In that case the regenerated PNGs are still
+uploaded as the `golden-baselines` artifact; download and rsync them
+onto a feature branch:
+
+```bash
+RUN_ID=$(gh run list --workflow=golden-regenerate.yaml --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run download "$RUN_ID" -n golden-baselines -D /tmp/baselines
+rsync -a /tmp/baselines/ test/goldens/
+git add test/goldens/
+git commit -m "test(goldens): regenerate baselines on dfx01"
+git push
+```
 
 ## Day-to-day workflow
 
@@ -72,19 +81,20 @@ The very first baseline set has to come from dfx01 itself. The pattern:
    Reuse the mock pattern from the existing pilot tests.
 2. Open a Draft PR. The `golden-tests` job will be red because the new
    test has no committed baseline.
-3. Trigger a one-off bootstrap on the branch — same flow as the initial
-   bootstrap above, just generate, download, commit. Or, when the
-   `golden-bootstrap.yaml` workflow has already been deleted from develop:
-   reintroduce it on the branch and remove it again in the same PR.
+3. Run `gh workflow run golden-regenerate.yaml --ref <branch>`. The
+   workflow regenerates on dfx01 and pushes the PNGs back to the
+   branch as `github-actions[bot]`. Pull and verify `golden-tests`
+   goes green.
 
 ### Reacting to a CI drift
 
 CI shows the `Run visual regression tests` step red and an artifact
 `golden-diffs` is uploaded. Open the artifact and inspect the diff PNG:
 
-* **Intentional change** (you redesigned the UI): regenerate baselines on
-  dfx01 (see "Adding a new golden test" above) and commit the new PNGs in
-  the same PR as the UI change.
+* **Intentional change** (you redesigned the UI): regenerate baselines via
+  `gh workflow run golden-regenerate.yaml --ref <branch>` (see
+  "Regenerating baselines" above) and let the bot commit the new PNGs
+  onto the branch.
 * **Regression** (UI shouldn't have moved): fix the code; CI returns to
   green when pixels match again.
 
@@ -94,26 +104,29 @@ visually first.
 ### Flutter SDK bumps
 
 A Flutter bump (`flutter-version` in `.github/workflows/*.yaml`) changes
-Skia's text shaper or layout subtly. Goldens become stale. The bump PR
-must regenerate all baselines:
+Skia's text shaper or layout subtly. Goldens become stale. On the bump
+branch, dispatch the regenerate workflow:
 
 ```bash
-# On the bump branch, on dfx01 (or via golden-bootstrap.yaml workflow):
-flutter test test/goldens --update-goldens
-git add test/goldens/screens/**/goldens/
-git commit -m "test(goldens): regenerate after Flutter <new-version> bump"
+gh workflow run golden-regenerate.yaml --ref <bump-branch>
 ```
+
+The bot pushes `test(goldens): regenerate baselines on dfx01` onto the
+branch; rename or amend the commit message locally if a more specific
+"regenerate after Flutter X.Y.Z bump" note is useful.
 
 ### dfx01 outage fallback
 
 If dfx01 is down (power, macOS update, service maintenance) and a PR is
 blocked on `golden-tests`:
 
-1. Switch `runs-on:` in `pull-request.yaml` for the `golden-tests` job
-   from `[self-hosted, ..., realunit-app]` to `macos-15`.
-2. Regenerate all baselines on `macos-15` in the same PR.
-3. Merge. When dfx01 is back up, regenerate baselines on it in a separate
-   PR and switch `runs-on:` back.
+1. Switch `runs-on:` in `pull-request.yaml` for the `golden-tests` job —
+   and in `golden-regenerate.yaml` — from `[self-hosted, ..., realunit-app]`
+   to `macos-15`.
+2. Dispatch the regenerate workflow on the branch to refresh all baselines
+   on `macos-15`.
+3. Merge. When dfx01 is back up, flip `runs-on:` back in both workflows
+   and regenerate baselines on dfx01 in a separate PR.
 
 This path is intentionally manual — it's a notfall, not a routine. The
 flipping of baselines between two hosts incurs a mass-PNG-change PR each

--- a/docs/visual-regression-tests.md
+++ b/docs/visual-regression-tests.md
@@ -20,17 +20,14 @@ Baselines werden ausschliesslich auf dfx01 generiert und validiert. Lokales
 (unterschiedliche Mac-Hardware/macOS-Versionen rendern Sub-Pixel-AA leicht
 anders).
 
-## Pilot scope
+## Layout
 
-| Screen | Tests | File |
-|---|---|---|
-| Welcome | 2 (iOS, Android theme variant) | `test/goldens/screens/welcome/welcome_golden_test.dart` |
-| Dashboard | 1 (empty balance) | `test/goldens/screens/dashboard/dashboard_golden_test.dart` |
-| Settings | 1 (default, no open wallet) | `test/goldens/screens/settings/settings_golden_test.dart` |
-| Buy | 2 (initial, payment-info-loaded) | `test/goldens/screens/buy/buy_golden_test.dart` |
-| Sell | 2 (no account zero balance, with balance) | `test/goldens/screens/sell/sell_golden_test.dart` |
-
-Baselines landen unter `test/goldens/screens/<feature>/goldens/macos/*.png`.
+One test file per `lib/screens/<feature>/<feature>_page.dart` under
+`test/goldens/screens/<feature>/<feature>_golden_test.dart`. Some pages
+have multiple state variants (e.g. Welcome has iOS + Android theme,
+Buy has initial + payment-info-loaded, Settings has default +
+confirm-logout-sheet) — those produce more than one PNG each. All
+baselines live under `test/goldens/screens/<feature>/goldens/macos/*.png`.
 
 ### Skipped: `web_view_page.dart`
 


### PR DESCRIPTION
## What

Permanent \`workflow_dispatch\`-only workflow \`.github/workflows/golden-regenerate.yaml\` that regenerates visual-regression baselines on the dfx01 self-hosted runner and commits them back to the dispatched branch as \`github-actions[bot]\`.

Replaces the previous pattern of introducing and removing a temporary \`golden-bootstrap.yaml\` per regen cycle (documented in \`docs/visual-regression-tests.md\` until this PR).

## Trigger

\`\`\`bash
gh workflow run golden-regenerate.yaml --ref <feature-branch>
\`\`\`

No inputs needed — the workflow uses \`github.ref\` as the checkout ref.

## Behaviour

- Runs on \`[self-hosted, macOS, ARM64, m3-ultra, realunit-app]\` — same labels as the \`golden-tests\` job in \`pull-request.yaml\`.
- Setup steps mirror \`golden-tests\` 1:1 (Flutter 3.41.6 via subosito, \`flutter pub get\`, generators, build_runner).
- Regen: \`flutter test test/goldens --update-goldens\`.
- Auto-commit: git as \`github-actions[bot]\` (\`41898282+github-actions[bot]@users.noreply.github.com\`), \`git add test/goldens/\`, clean-exit on no-diff, otherwise commit \`test(goldens): regenerate baselines on dfx01\` and push.
- Concurrency group \`golden-regenerate-<ref>\` with cancel-in-progress so two parallel dispatches on the same ref don't race.
- 30 min timeout (matches \`golden-tests\`).
- \`permissions: contents: write\` and \`token: \${{ secrets.GITHUB_TOKEN }}\` on checkout — load-bearing for the push.

## Failure mode on protected branches

\`develop\` and \`main\` are protected by ruleset. A dispatch against either fails cleanly on the \`git push\` step — no force-push, no bypass. To still recover the regen output, the workflow uploads the regenerated PNGs as a \`golden-baselines\` artifact whenever the push step fails; rsync them onto a feature branch and commit there.

## Doc updates

- \`docs/visual-regression-tests.md\` — replaced the \"Initial bootstrap\" + \"Adding a new golden test\" bootstrap-pattern sections (steps 1-4 of bootstrap) with the one-command \`gh workflow run golden-regenerate.yaml --ref <branch>\` flow. Updated the \"Reacting to a CI drift\", \"Flutter SDK bumps\", and \"dfx01 outage fallback\" sections to reference the new workflow.
- \`docs/handbook/README.md\` — handbook-screenshot regen now points at the same workflow instead of asking for a local \`flutter test --update-goldens\` run.

## Out of scope

- \`DFXServer/server/infrastructure/dfx01/actions-runners/golden-tests-recipe.md\` (different repo) still references the old bootstrap pattern. Separate PR there.

## Verification

- \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/golden-regenerate.yaml'))\"\` passes.
- \`actionlint\` clean except for the two expected \"unknown label\" warnings on \`m3-ultra\` and \`realunit-app\` (same as the existing \`golden-tests\` job — custom self-hosted runner labels are not in actionlint's default known-labels list).