### PR TITLE
docs(handbook): clarify Adresse + Signatur is debug-build only

### DIFF
--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -733,10 +733,13 @@
                 />
               </div>
               <div class="desc">
-                Innerhalb des App-Wallet-Zweigs gibt es drei Optionen: <b>Neue Wallet erstellen</b>
-                (frische BIP-39-Mnemonic), <b>Wallet wiederherstellen</b> (Import einer
-                bestehenden Phrase, z.B. von Aktionariat), und <b>Adresse + Signatur</b> als
-                Debug-Pfad für die Backend-Integration.
+                Innerhalb des App-Wallet-Zweigs gibt es für End-User zwei Optionen:
+                <b>Neue Wallet erstellen</b> (frische BIP-39-Mnemonic) und
+                <b>Wallet wiederherstellen</b> (Import einer bestehenden Phrase, z.B. von
+                Aktionariat). Im Debug-Build (<code>kDebugMode</code>) erscheint zusätzlich
+                eine dritte Kachel <b>Adresse + Signatur</b> als Debug-Pfad für die
+                Backend-Integration — in Release-Builds ist diese Option für End-User
+                <em>nie</em> sichtbar.
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- `03-software-wallet-terms` listed three onboarding options without flagging that the third (**Adresse + Signatur**) is gated by `kDebugMode` (`lib/screens/welcome/welcome_page.dart:120`).
- Reword the description: end-users on release builds see two options; the debug auth tile only appears in debug builds.

## Why

The handbook is the user-facing reference at `handbook.realunit.app`. Listing the debug path alongside the two production options without qualification implies it's a normal user choice, which it isn't.

## Test plan

- [ ] Visual: open `docs/handbook/de/index.html` locally, jump to `#03-software-wallet-terms`, confirm the new wording reads cleanly and the `<code>kDebugMode</code>` tag renders.
- [ ] No screenshot/flow change — the screenshot itself is captured in debug mode and still shows three tiles, which is fine: the description now explains the gap.