### PR TITLE
fix(tests): settings golden renders software wallet path

### DIFF
--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -1085,6 +1085,9 @@
                 Nutzerdaten, Rechtsdokumente, Kontakt, Wallet-Adresse, Wallet-Sicherung,
                 Geschäftsbeziehung beenden. Aktive Auswahlen (Sprache, Währung, Netzwerk)
                 werden inline als trailing Text rechts angezeigt.
+                Die Kachel <b>Wallet-Sicherung</b> erscheint nur bei einer Software-Wallet
+                (Re-Display der BIP-39-Recovery-Phrase) — bei einer BitBox ist sie
+                ausgeblendet, weil dort das Backup auf dem Hardware-Device selbst liegt.
               </div>
             </div>
             <div class="test" id="13-settings-languages">

--- a/test/goldens/screens/settings/settings_golden_test.dart
+++ b/test/goldens/screens/settings/settings_golden_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
 import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
 import 'package:realunit_wallet/screens/settings/settings_page.dart';
@@ -12,13 +13,16 @@ import '../../../helper/helper.dart';
 void main() {
   late MockSettingsBloc settingsBloc;
   late MockHomeBloc homeBloc;
+  late MockSoftwareWallet wallet;
 
   setUp(() {
     settingsBloc = MockSettingsBloc();
     homeBloc = MockHomeBloc();
+    wallet = MockSoftwareWallet();
 
+    when(() => wallet.walletType).thenReturn(WalletType.software);
     when(() => settingsBloc.state).thenReturn(const SettingsState());
-    when(() => homeBloc.state).thenReturn(const HomeState());
+    when(() => homeBloc.state).thenReturn(HomeState(openWallet: wallet));
   });
 
   setUpAll(() {
@@ -31,7 +35,7 @@ void main() {
 
   group('$SettingsPage', () {
     goldenTest(
-      'default state, no open wallet',
+      'default state, software wallet open',
       fileName: 'settings_page_default',
       constraints: const BoxConstraints.tightFor(width: 390, height: 844),
       builder: () {


### PR DESCRIPTION
## Summary

- `settings_page.dart:100` only renders the **Wallet-Sicherung** tile when `openWallet?.walletType == WalletType.software`.
- The existing golden test (`settings_golden_test.dart`) used `const HomeState()` — `openWallet` defaulted to `null`, so the tile never appeared in `settings_page_default.png`.
- Handbook entry [`#12-settings`](https://handbook.realunit.app/de/#12-settings) lists Wallet-Sicherung in its description but the PNG never showed it — visible mismatch.
- Stub the HomeBloc state with a `MockSoftwareWallet` so the golden matches the actual production state of users navigating to Settings.

## Why

The handbook documents the software-wallet user journey end-to-end (BitBox is only a branch on screen #02). Any conditionally-rendered tile gated by `walletType == WalletType.software` must appear in the handbook PNG.

## Follow-up

- Trigger `golden-regenerate.yaml` on this branch — the bot will commit the regenerated `settings_page_default.png` showing the Wallet-Sicherung tile.
- After regenerate lands, this PR is ready for review (still Draft until then).

## Test plan

- [ ] `gh workflow run golden-regenerate.yaml --ref fix/settings-golden-software-wallet`
- [ ] Verify regenerated PNG shows: Sprachen, Währung, Netzwerk, Steuerbericht, Nutzerdaten, Rechtsdokumente, Kontakt, **Wallet-Adresse, Wallet-Sicherung**, ─, Geschäftsbeziehung beenden.
- [ ] CI `Visual Regression` job green on the regenerated baseline.