### PR TITLE
fix(support): hide TransactionIssue + LimitRequest from ticket menu

### DIFF
--- a/lib/screens/support/subpages/support_create_ticket_page.dart
+++ b/lib/screens/support/subpages/support_create_ticket_page.dart
@@ -94,19 +94,9 @@ class SupportCreateTicketView extends StatelessWidget {
                                       Icons.bug_report_outlined,
                                     ),
                                     (
-                                      SupportIssueType.transactionIssue,
-                                      S.of(context).supportTransactionIssue,
-                                      Icons.swap_horiz,
-                                    ),
-                                    (
                                       SupportIssueType.kycIssue,
                                       S.of(context).supportKycIssue,
                                       Icons.verified_user_outlined,
-                                    ),
-                                    (
-                                      SupportIssueType.limitRequest,
-                                      S.of(context).supportLimitRequest,
-                                      Icons.trending_up,
                                     ),
                                   ],
                                   selected: state.selectedType,


### PR DESCRIPTION
## Summary

Both `TransactionIssue` and `LimitRequest` options in the in-app support ticket type picker silently fail with HTTP 400 on submit because the app never sends the API-required nested DTOs (`transaction` / `limitRequest`). The reproduction in the field is `RealUnitApiException: limitRequest should not be empty (statusCode: 400)` for LimitRequest; the TransactionIssue equivalent has not surfaced because realunit-app users typically file transaction issues via services.dfx.swiss instead.

This PR hides both options from the picker until the proper forms are implemented. The enum values, i18n keys (`supportTransactionIssue`, `supportLimitRequest`), icons, and the cubit's `_getTicketName` mapping are intentionally left in place so re-enabling is a one-tuple revert per type once the structured input UI (dropdowns, transaction picker, document upload) lands.

## Why not implement the forms now

- `LimitRequest` needs three dropdowns (`limit` / `investmentDate` / `fundOrigin`), an optional `fundOriginText` field mapped from message, a KYC ≥ 50 gate, and a mandatory document upload (PNG / JPEG / PDF). Requires a new `file_picker` dependency for PDF support.
- `TransactionIssue` needs a transaction picker (list of the user's recent transactions via `GET /v1/transactions`) plus a reason dropdown filtered to `[FundsNotReceived, TransactionMissing, Other]`.
- Both are independent feature PRs of meaningful scope; hiding now removes the user-facing failure immediately.

## Scope

- `lib/screens/support/subpages/support_create_ticket_page.dart` — remove two tuples from the `items:` array of `TagSelection<SupportIssueType>`.
- No API, model, cubit, service, or i18n changes.

## Test plan

- [x] `flutter analyze` → `No issues found! (ran in 4.7s)`
- [x] `flutter test test/screens/support/` → 62 / 62 passed
- [ ] Manual smoke: open `Neues Ticket erstellen`, confirm only `Allgemeines Anliegen`, `Fehlerbericht`, `KYC-Problem` are selectable.
- [ ] Manual smoke: submit each of the three remaining types with a short message and verify a ticket is created (no 400).