### PR TITLE
feat(kyc): validate name and address against Swiss payment character set

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -300,6 +300,7 @@
   "supportTicketCreated": "Ticket erstellt",
   "supportTransactionIssue": "Transaktionsproblem",
   "supportTypeMessage": "Beschreiben Sie Ihr Anliegen",
+  "swissPaymentTextInvalid": "Nur in der Schweiz gültige Buchstaben und Zeichen sind erlaubt",
   "tapHereToView": "Hier tippen, um anzuzeigen",
   "taxReport": "Steuerbericht",
   "taxReportDescription": "Hier können Sie Ihren Steuerbericht für ein spezifisches Datum generieren.",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -300,6 +300,7 @@
   "supportTicketCreated": "Ticket created",
   "supportTransactionIssue": "Transaction issue",
   "supportTypeMessage": "Describe your issue",
+  "swissPaymentTextInvalid": "Only letters and characters valid in Switzerland are allowed",
   "tapHereToView": "Tap here to view",
   "taxReport": "Tax report",
   "taxReportDescription": "Here you can generate your tax report for a specific date.",

--- a/lib/packages/utils/swiss_payment_text.dart
+++ b/lib/packages/utils/swiss_payment_text.dart
@@ -1,0 +1,30 @@
+/// Validator for user-supplied name and address fields that mirror the
+/// SIX SIG IG QR-Bill v2.3 permitted character set — printable ASCII plus
+/// the Latin diacritics required for the four Swiss national languages.
+///
+/// Kept byte-for-byte aligned with the API-side
+/// `Config.formats.swissPaymentText` regex
+/// (`api/src/config/config.ts`) so client-side validation matches what the
+/// backend's `@IsSwissPaymentText()` decorator accepts. Without this,
+/// non-Latin input would only fail server-side with a generic 400.
+library;
+
+final RegExp _swissPaymentText = RegExp(
+  r'^[\x20-\x7E'
+  'ÀÁÂÄÇÈÉÊË'
+  'ÌÍÎÏÑÒÓÔÖ'
+  'ÙÚÛÜÝß'
+  'àáâäçèéêë'
+  'ìíîïñòóôö'
+  'ùúûüý'
+  r'\n]*$',
+  unicode: true,
+);
+
+/// Returns `true` if [value] contains only characters permitted in Swiss
+/// payment systems. Empty/null values are considered valid (callers should
+/// chain a non-empty check separately).
+bool isSwissPaymentText(String? value) {
+  if (value == null || value.isEmpty) return true;
+  return _swissPaymentText.hasMatch(value);
+}

--- a/lib/screens/kyc/steps/registration/steps/kyc_registration_address_step.dart
+++ b/lib/screens/kyc/steps/registration/steps/kyc_registration_address_step.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/country/country.dart';
+import 'package:realunit_wallet/packages/utils/swiss_payment_text.dart';
 import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
 import 'package:realunit_wallet/widgets/form/country_field.dart';
 import 'package:realunit_wallet/widgets/form/labeled_text_field.dart';
@@ -51,6 +52,7 @@ class KycRegistrationAddressStep extends StatelessWidget {
                         textCapitalization: TextCapitalization.words,
                         validator: (value) {
                           if (value == null || value.isEmpty) return '';
+                          if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
                           return null;
                         },
                       ),
@@ -63,6 +65,7 @@ class KycRegistrationAddressStep extends StatelessWidget {
                         keyboardType: TextInputType.streetAddress,
                         validator: (value) {
                           if (value == null || value.isEmpty) return '';
+                          if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
                           return null;
                         },
                       ),
@@ -82,6 +85,7 @@ class KycRegistrationAddressStep extends StatelessWidget {
                         keyboardType: TextInputType.number,
                         validator: (value) {
                           if (value == null || value.isEmpty) return '';
+                          if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
                           return null;
                         },
                       ),
@@ -96,6 +100,7 @@ class KycRegistrationAddressStep extends StatelessWidget {
                         textCapitalization: TextCapitalization.words,
                         validator: (value) {
                           if (value == null || value.isEmpty) return '';
+                          if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
                           return null;
                         },
                       ),

--- a/lib/screens/kyc/steps/registration/steps/kyc_registration_personal_step.dart
+++ b/lib/screens/kyc/steps/registration/steps/kyc_registration_personal_step.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/country/country.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/registration_user_type.dart';
+import 'package:realunit_wallet/packages/utils/swiss_payment_text.dart';
 import 'package:realunit_wallet/screens/kyc/steps/registration/cubits/registration_step/kyc_registration_step_cubit.dart';
 import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
 import 'package:realunit_wallet/widgets/form/birthday_field.dart';
@@ -69,6 +70,7 @@ class KycRegistrationPersonalStep extends StatelessWidget {
                         textCapitalization: TextCapitalization.words,
                         validator: (value) {
                           if (value == null || value.isEmpty) return '';
+                          if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
                           return null;
                         },
                       ),
@@ -82,6 +84,7 @@ class KycRegistrationPersonalStep extends StatelessWidget {
                         textCapitalization: TextCapitalization.words,
                         validator: (value) {
                           if (value == null || value.isEmpty) return '';
+                          if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
                           return null;
                         },
                       ),

--- a/lib/screens/settings_user_data/subpages/edit_address/settings_edit_address_page.dart
+++ b/lib/screens/settings_user_data/subpages/edit_address/settings_edit_address_page.dart
@@ -5,6 +5,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/country/country.dart';
+import 'package:realunit_wallet/packages/utils/swiss_payment_text.dart';
 import 'package:realunit_wallet/packages/utils/xfile_extension.dart';
 import 'package:realunit_wallet/screens/settings_user_data/subpages/edit_address/cubit/settings_edit_address_cubit.dart';
 import 'package:realunit_wallet/screens/settings_user_data/subpages/others/settings_edit_failure_page.dart';
@@ -111,6 +112,7 @@ class _SettingsEditAddressViewState extends State<SettingsEditAddressView> {
                                         textCapitalization: .words,
                                         validator: (value) {
                                           if (value == null || value.isEmpty) return '';
+                                          if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
                                           return null;
                                         },
                                       ),
@@ -121,6 +123,11 @@ class _SettingsEditAddressViewState extends State<SettingsEditAddressView> {
                                         controller: _numberCtrl,
                                         label: S.of(context).number,
                                         keyboardType: .streetAddress,
+                                        validator: (value) {
+                                          if (value == null || value.isEmpty) return null;
+                                          if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
+                                          return null;
+                                        },
                                       ),
                                     ),
                                   ],
@@ -138,6 +145,7 @@ class _SettingsEditAddressViewState extends State<SettingsEditAddressView> {
                                         keyboardType: .number,
                                         validator: (value) {
                                           if (value == null || value.isEmpty) return '';
+                                          if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
                                           return null;
                                         },
                                       ),
@@ -152,6 +160,7 @@ class _SettingsEditAddressViewState extends State<SettingsEditAddressView> {
                                         textCapitalization: .words,
                                         validator: (value) {
                                           if (value == null || value.isEmpty) return '';
+                                          if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
                                           return null;
                                         },
                                       ),

--- a/lib/screens/settings_user_data/subpages/edit_name/settings_edit_name_page.dart
+++ b/lib/screens/settings_user_data/subpages/edit_name/settings_edit_name_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
+import 'package:realunit_wallet/packages/utils/swiss_payment_text.dart';
 import 'package:realunit_wallet/packages/utils/xfile_extension.dart';
 import 'package:realunit_wallet/screens/settings_user_data/subpages/edit_name/cubit/settings_edit_name_cubit.dart';
 import 'package:realunit_wallet/screens/settings_user_data/subpages/others/settings_edit_failure_page.dart';
@@ -98,6 +99,7 @@ class _SettingsEditNameViewState extends State<SettingsEditNameView> {
                                   textCapitalization: .words,
                                   validator: (value) {
                                     if (value == null || value.isEmpty) return '';
+                                    if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
                                     return null;
                                   },
                                 ),
@@ -108,6 +110,7 @@ class _SettingsEditNameViewState extends State<SettingsEditNameView> {
                                   textCapitalization: .words,
                                   validator: (value) {
                                     if (value == null || value.isEmpty) return '';
+                                    if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;
                                     return null;
                                   },
                                 ),


### PR DESCRIPTION
## Summary

Mirror the API-side `@IsSwissPaymentText()` validator (DFXswiss/api#3766) in the four user flows that write into `user_data`:

- KYC registration — personal step (`firstName`, `lastName`)
- KYC registration — address step (`street`, `houseNumber`, `postalCode`, `city`)
- Settings → edit name (`firstName`, `lastName`)
- Settings → edit address (`street`, `houseNumber`, `postalCode`, `city`)

Users now get immediate field-level feedback in the form if they enter a character outside the SIX SIG IG QR-Bill v2.3 permitted character set, instead of submitting and waiting for a generic 400 from the backend.

## Why

DFX business decision: only characters valid in Swiss payment systems are supported end-to-end. Pairs with the umlaut-preservation fix in DFXswiss/api#3766 — now that diacritics survive storage and PDF rendering, we also lock the input surface so CJK / Cyrillic / Arabic / emoji never enter the system.

## Character set

```
[\x20-\x7E] (printable ASCII)
+ À Á Â Ä Ç È É Ê Ë Ì Í Î Ï Ñ Ò Ó Ô Ö Ù Ú Û Ü Ý ß
+ à á â ä ç è é ê ë ì í î ï ñ ò ó ô ö ù ú û ü ý
+ \n (line feed)
```

Covers German, French, Italian, Romansh. Regex is byte-for-byte aligned with the API regex (`Config.formats.swissPaymentText`) so any input the client accepts the backend also accepts.

## Changes

- `lib/packages/utils/swiss_payment_text.dart`: new `isSwissPaymentText(String?)` helper (empty/null = valid).
- Four screen files: add the helper call to existing `validator:` callbacks; missing validator on house-number in settings edit-address page added.
- `assets/languages/strings_en.arb`, `strings_de.arb`: new `swissPaymentTextInvalid` translation key, inserted in alphabetical order.
- Generated `lib/generated/i18n.dart` is gitignored — built by `dart run tool/generate_localization.dart` after pulling.

## Test plan

- [ ] `dart run tool/generate_localization.dart` runs without errors after checkout
- [ ] `flutter analyze` — passes (verified locally, no new issues)
- [ ] Type `Rüttimann` / `Münchwilen` / `Genève` / `Saint-Légier` in any of the four flows → no error, form accepts
- [ ] Type `王小明` / `Иван` / `日本語` / an emoji → field shows the Swiss-payment-text error message
- [ ] Submit a valid form → API call succeeds (i.e. client and server regex match)
- [ ] German UI shows German error message; English UI shows English message
- [ ] `flutter test` — pre-existing golden failures unchanged (verified locally — same 88 failures on clean develop)