### PR TITLE
fix(buy/sell-converter): drop stale in-flight responses via seq guard

### DIFF
--- a/lib/screens/buy/cubits/buy_converter/buy_converter_cubit.dart
+++ b/lib/screens/buy/cubits/buy_converter/buy_converter_cubit.dart
@@ -16,18 +16,29 @@ class BuyConverterCubit extends Cubit<BuyConverterState> {
   Timer? _fiatDebounce;
   Timer? _sharesDebounce;
 
+  // Monotonic counter for the latest user intent. Every user-triggered
+  // method (onFiatChanged / onSharesChanged / onCurrencyChanged) increments
+  // it and captures its own value via closure; the async body drops its
+  // emit if `_seq` has moved on. Prevents the timer-cancel-vs-running-body
+  // race where a debounced timer's body has already started its API call
+  // by the time the user types another character — without this guard the
+  // older in-flight response can win last-write-wins and overwrite the
+  // newer result (e.g. `460 → shares=321` overwriting `4600 → shares=3216`).
+  int _seq = 0;
+
   /// User changed fiat → convert to shares
   Future<void> onFiatChanged(String value) async {
     emit(state.copyWith(fiatText: value));
 
     _fiatDebounce?.cancel();
+    final mySeq = ++_seq;
     _fiatDebounce = Timer(const Duration(milliseconds: 100), () async {
-      if (isClosed) return;
+      if (isClosed || mySeq != _seq) return;
       emit(state.copyWith(loading: true));
 
       try {
         final result = await _brokerbotService.getBuyShares(value, state.currency);
-        if (isClosed) return;
+        if (isClosed || mySeq != _seq) return;
         emit(
           state.copyWith(
             sharesText: result.shares.toString(),
@@ -36,7 +47,7 @@ class BuyConverterCubit extends Cubit<BuyConverterState> {
         );
       } catch (e) {
         developer.log(e.toString());
-        if (isClosed) return;
+        if (isClosed || mySeq != _seq) return;
         emit(state.copyWith(loading: false));
       }
     });
@@ -47,13 +58,14 @@ class BuyConverterCubit extends Cubit<BuyConverterState> {
     emit(state.copyWith(sharesText: value));
 
     _sharesDebounce?.cancel();
+    final mySeq = ++_seq;
     _sharesDebounce = Timer(const Duration(milliseconds: 100), () async {
-      if (isClosed) return;
+      if (isClosed || mySeq != _seq) return;
       emit(state.copyWith(loading: true));
 
       try {
         final result = await _brokerbotService.getBuyPrice(value, state.currency);
-        if (isClosed) return;
+        if (isClosed || mySeq != _seq) return;
         emit(
           state.copyWith(
             fiatText: result.totalCost.toStringAsFixed(_fractionDigits(value)),
@@ -62,34 +74,32 @@ class BuyConverterCubit extends Cubit<BuyConverterState> {
         );
       } catch (e) {
         developer.log(e.toString());
-        if (isClosed) return;
+        if (isClosed || mySeq != _seq) return;
         emit(state.copyWith(loading: false));
       }
     });
   }
 
   Future<void> onCurrencyChanged(Currency currency) async {
-    emit(state.copyWith(loading: true));
+    final mySeq = ++_seq;
+    // Flip currency immediately so the picker reflects the user choice
+    // even if an in-flight conversion arrives later and gets dropped by
+    // the seq guard.
+    emit(state.copyWith(loading: true, currency: currency));
 
     try {
       final result = await _brokerbotService.getBuyShares(state.fiatText, currency);
-      if (isClosed) return;
+      if (isClosed || mySeq != _seq) return;
       emit(
         state.copyWith(
           sharesText: result.shares.toString(),
           loading: false,
-          currency: currency,
         ),
       );
     } catch (e) {
       developer.log(e.toString());
-      if (isClosed) return;
-      emit(
-        state.copyWith(
-          loading: false,
-          currency: currency,
-        ),
-      );
+      if (isClosed || mySeq != _seq) return;
+      emit(state.copyWith(loading: false));
     }
   }
 

--- a/lib/screens/sell/cubits/sell_converter/sell_converter_cubit.dart
+++ b/lib/screens/sell/cubits/sell_converter/sell_converter_cubit.dart
@@ -16,18 +16,29 @@ class SellConverterCubit extends Cubit<SellConverterState> {
   Timer? _fiatDebounce;
   Timer? _sharesDebounce;
 
+  // Monotonic counter for the latest user intent. Every user-triggered
+  // method (onFiatChanged / onSharesChanged / onCurrencyChanged) increments
+  // it and captures its own value via closure; the async body drops its
+  // emit if `_seq` has moved on. Prevents the timer-cancel-vs-running-body
+  // race where a debounced timer's body has already started its API call
+  // by the time the user types another character — without this guard the
+  // older in-flight response can win last-write-wins and overwrite the
+  // newer result.
+  int _seq = 0;
+
   /// User changed fiat → convert to shares
   Future<void> onFiatChanged(String value, {Currency currency = Currency.chf}) async {
     emit(state.copyWith(fiatText: value));
 
     _fiatDebounce?.cancel();
+    final mySeq = ++_seq;
     _fiatDebounce = Timer(const Duration(milliseconds: 100), () async {
-      if (isClosed) return;
+      if (isClosed || mySeq != _seq) return;
       emit(state.copyWith(loading: true));
 
       try {
         final result = await _brokerbotService.getSellShares(value, currency);
-        if (isClosed) return;
+        if (isClosed || mySeq != _seq) return;
         emit(
           state.copyWith(
             sharesText: result.shares.toString(),
@@ -36,7 +47,7 @@ class SellConverterCubit extends Cubit<SellConverterState> {
         );
       } catch (e) {
         developer.log(e.toString());
-        if (isClosed) return;
+        if (isClosed || mySeq != _seq) return;
         emit(state.copyWith(loading: false));
       }
     });
@@ -47,13 +58,14 @@ class SellConverterCubit extends Cubit<SellConverterState> {
     emit(state.copyWith(sharesText: value));
 
     _sharesDebounce?.cancel();
+    final mySeq = ++_seq;
     _sharesDebounce = Timer(const Duration(milliseconds: 100), () async {
-      if (isClosed) return;
+      if (isClosed || mySeq != _seq) return;
       emit(state.copyWith(loading: true));
 
       try {
         final result = await _brokerbotService.getSellPrice(value, currency);
-        if (isClosed) return;
+        if (isClosed || mySeq != _seq) return;
         emit(
           state.copyWith(
             fiatText: result.estimatedAmount.toStringAsFixed(_fractionDigits(value)),
@@ -62,33 +74,31 @@ class SellConverterCubit extends Cubit<SellConverterState> {
         );
       } catch (e) {
         developer.log(e.toString());
-        if (isClosed) return;
+        if (isClosed || mySeq != _seq) return;
         emit(state.copyWith(loading: false));
       }
     });
   }
 
   Future<void> onCurrencyChanged(Currency currency) async {
-    emit(state.copyWith(loading: true));
+    final mySeq = ++_seq;
+    // Flip currency immediately so the picker reflects the user choice
+    // even if an in-flight conversion arrives later and gets dropped by
+    // the seq guard.
+    emit(state.copyWith(loading: true, currency: currency));
     try {
       final result = await _brokerbotService.getBuyPrice(state.sharesText, currency);
-      if (isClosed) return;
+      if (isClosed || mySeq != _seq) return;
       emit(
         state.copyWith(
           fiatText: result.totalCost.toStringAsFixed(_fractionDigits(state.sharesText)),
           loading: false,
-          currency: currency,
         ),
       );
     } catch (e) {
       developer.log(e.toString());
-      if (isClosed) return;
-      emit(
-        state.copyWith(
-          loading: false,
-          currency: currency,
-        ),
-      );
+      if (isClosed || mySeq != _seq) return;
+      emit(state.copyWith(loading: false));
     }
   }
 

--- a/test/screens/buy/cubits/buy_converter_cubit_test.dart
+++ b/test/screens/buy/cubits/buy_converter_cubit_test.dart
@@ -172,6 +172,129 @@ void main() {
       expect(cubit.state.loading, isFalse);
     });
 
+    test(
+      'fiat race: stale in-flight response is dropped when user typed further',
+      () async {
+        // Reproduces the production bug: user types fast enough that the
+        // debounce timer for an intermediate value (e.g. "460") has already
+        // fired and started its API call by the time they type the last
+        // digit ("4600"). Both API calls are now in flight; without the
+        // seq guard, the slower response wins last-write-wins — exactly
+        // the "4600 CHF → 321 shares (=460/1.43)" observation in v1.0.67.
+        final c460 = Completer<BrokerbotBuySharesDto>();
+        final c4600 = Completer<BrokerbotBuySharesDto>();
+        when(() => service.getBuyShares('460', any())).thenAnswer((_) => c460.future);
+        when(() => service.getBuyShares('4600', any())).thenAnswer((_) => c4600.future);
+
+        final cubit = BuyConverterCubit(service);
+
+        await cubit.onFiatChanged('460');
+        await Future<void>.delayed(const Duration(milliseconds: 150)); // timer fires → API_460 in flight
+        await cubit.onFiatChanged('4600');
+        await Future<void>.delayed(const Duration(milliseconds: 150)); // timer fires → API_4600 in flight
+
+        // Pathological response order: the NEWER request resolves first…
+        c4600.complete(BrokerbotBuySharesDto(
+          shares: 3216,
+          pricePerShare: 1.43,
+          availableShares: 100,
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(cubit.state.sharesText, '3216');
+
+        // …and the OLDER request resolves later. Without the seq guard,
+        // this would overwrite sharesText with '321'.
+        c460.complete(BrokerbotBuySharesDto(
+          shares: 321,
+          pricePerShare: 1.43,
+          availableShares: 100,
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          cubit.state.sharesText,
+          '3216',
+          reason: 'stale seq=1 response for "460" must NOT overwrite seq=2 result for "4600"',
+        );
+      },
+    );
+
+    test(
+      'shares race: stale in-flight response is dropped when user typed further',
+      () async {
+        // Symmetric pin for the onSharesChanged debounce path.
+        final c5 = Completer<BrokerbotBuyPriceDto>();
+        final c50 = Completer<BrokerbotBuyPriceDto>();
+        when(() => service.getBuyPrice('5', any())).thenAnswer((_) => c5.future);
+        when(() => service.getBuyPrice('50', any())).thenAnswer((_) => c50.future);
+
+        final cubit = BuyConverterCubit(service);
+
+        await cubit.onSharesChanged('5');
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+        await cubit.onSharesChanged('50');
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+
+        c50.complete(BrokerbotBuyPriceDto(
+          totalCost: 71.50,
+          pricePerShare: 1.43,
+          availableShares: 100,
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(cubit.state.fiatText, '71.50');
+
+        c5.complete(BrokerbotBuyPriceDto(
+          totalCost: 7.15,
+          pricePerShare: 1.43,
+          availableShares: 100,
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          cubit.state.fiatText,
+          '71.50',
+          reason: 'stale in-flight onSharesChanged response must not overwrite newer one',
+        );
+      },
+    );
+
+    test(
+      'onCurrencyChanged: superseded in-flight response is dropped, but the currency flip survives',
+      () async {
+        // User changes currency to EUR, then quickly types a new fiat
+        // amount before the EUR conversion returns. The EUR-conversion
+        // shares result must not land; but the currency picker must
+        // already reflect EUR because we flip it eagerly before the await.
+        final cEur = Completer<BrokerbotBuySharesDto>();
+        when(() => service.getBuyShares(any(), Currency.eur)).thenAnswer((_) => cEur.future);
+        when(() => service.getBuyShares('1000', Currency.eur)).thenAnswer(
+          (_) async => BrokerbotBuySharesDto(
+            shares: 700,
+            pricePerShare: 1.43,
+            availableShares: 100,
+          ),
+        );
+
+        final cubit = BuyConverterCubit(service);
+        // ignore: unawaited_futures
+        cubit.onCurrencyChanged(Currency.eur);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(cubit.state.currency, Currency.eur, reason: 'currency flips immediately');
+
+        await cubit.onFiatChanged('1000');
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+
+        cEur.complete(BrokerbotBuySharesDto(
+          shares: 0,
+          pricePerShare: 1.43,
+          availableShares: 100,
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(cubit.state.currency, Currency.eur);
+        expect(cubit.state.sharesText, '700',
+            reason: 'the superseded onCurrencyChanged response (shares=0) must be dropped');
+      },
+    );
+
     test('close() cancels pending debounce timers', () async {
       when(() => service.getBuyShares(any(), any())).thenAnswer(
         (_) async => BrokerbotBuySharesDto(

--- a/test/screens/sell/cubits/sell_converter_cubit_test.dart
+++ b/test/screens/sell/cubits/sell_converter_cubit_test.dart
@@ -201,6 +201,87 @@ void main() {
       expect(cubit.state.loading, isFalse);
     });
 
+    test(
+      'fiat race: stale in-flight response is dropped when user typed further',
+      () async {
+        // Symmetric pin to BuyConverterCubit: prevents the timer-cancel-vs-
+        // running-body race where an older API call resolves after a newer
+        // one and overwrites the result via last-write-wins.
+        final c5 = Completer<BrokerbotSellSharesDto>();
+        final c50 = Completer<BrokerbotSellSharesDto>();
+        when(() => service.getSellShares('5', any())).thenAnswer((_) => c5.future);
+        when(() => service.getSellShares('50', any())).thenAnswer((_) => c50.future);
+
+        final cubit = SellConverterCubit(service);
+
+        await cubit.onFiatChanged('5');
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+        await cubit.onFiatChanged('50');
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+
+        c50.complete(BrokerbotSellSharesDto(
+          targetAmount: 50,
+          shares: 35,
+          pricePerShare: 1.43,
+          currency: 'CHF',
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(cubit.state.sharesText, '35');
+
+        c5.complete(BrokerbotSellSharesDto(
+          targetAmount: 5,
+          shares: 3,
+          pricePerShare: 1.43,
+          currency: 'CHF',
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          cubit.state.sharesText,
+          '35',
+          reason: 'stale seq=1 response must NOT overwrite seq=2 result',
+        );
+      },
+    );
+
+    test(
+      'shares race: stale in-flight response is dropped when user typed further',
+      () async {
+        final c5 = Completer<BrokerbotSellPriceDto>();
+        final c50 = Completer<BrokerbotSellPriceDto>();
+        when(() => service.getSellPrice('5', any())).thenAnswer((_) => c5.future);
+        when(() => service.getSellPrice('50', any())).thenAnswer((_) => c50.future);
+
+        final cubit = SellConverterCubit(service);
+
+        await cubit.onSharesChanged('5');
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+        await cubit.onSharesChanged('50');
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+
+        c50.complete(BrokerbotSellPriceDto(
+          shares: 50,
+          estimatedAmount: 71.50,
+          pricePerShare: 1.43,
+          currency: 'CHF',
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(cubit.state.fiatText, '71.50');
+
+        c5.complete(BrokerbotSellPriceDto(
+          shares: 5,
+          estimatedAmount: 7.15,
+          pricePerShare: 1.43,
+          currency: 'CHF',
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(
+          cubit.state.fiatText,
+          '71.50',
+          reason: 'stale in-flight onSharesChanged response must not overwrite newer one',
+        );
+      },
+    );
+
     test('close() cancels pending debounce timers', () async {
       when(() => service.getSellShares(any(), any())).thenAnswer(
         (_) async => BrokerbotSellSharesDto(


### PR DESCRIPTION
## Symptom (v1.0.67, reproduced live)

Open Buy page → quickly delete the prefilled \`300\` → type \`4600\` →
**Result-Feld zeigt 321** statt der korrekten 3216 REALU. Erneutes
Löschen + Tippen von \`4600\` zeigt 3216.

\`floor(460 / 1.43) = 321\` — der Smoking Gun: die App hat das Resultat
einer API-Anfrage für \`amount=460\` angezeigt, obwohl der Controller
\`4600\` enthält.

## Root cause

\`_fiatDebounce?.cancel()\` storniert nur **noch nicht gefeuerte**
Timer. Sobald ein Timer-Body läuft, schickt er seine API-Anfrage raus
und emittet das Resultat bei Rückkehr — unabhängig davon, was der User
inzwischen tippt.

Konkrete Sequenz für das Symptom:

\`\`\`
T=0    '4'   → emit fiatText:'4', Timer→100ms
T=20   '6'   → cancel, Timer→120ms
T=40   '0'   → cancel, Timer→140ms        ← fiatText='460' jetzt
T=140  Timer für '460' feuert: emit loading:true, API_460 startet ─┐
T=160  '0'   → cancel (zu spät!), Timer→260ms                     │ in flight
T=260  Timer für '4600' feuert: API_4600 startet ────┐            │
T=380  API_4600 antwortet → shares:3216 → emit ✓     │            │
T=420  API_460 antwortet später → shares:321 → emit ← ÜBERSCHREIBT
\`\`\`

Zwei in-flight Requests, last-write-wins, der ältere gewinnt
nicht-deterministisch je nach Latenz.

## Fix

Monotoner Counter \`_seq\` im Cubit. Jede User-Methode
(\`onFiatChanged\`, \`onSharesChanged\`, \`onCurrencyChanged\`) inkrementiert
ihn synchron und übergibt den Wert via Closure-Capture an den
async-Body. Der Body prüft vor jedem \`emit\` (vor und nach dem
\`await\`), ob \`_seq\` weitergewandert ist, und droppt sich stillschweigend
falls ja.

\`onCurrencyChanged\` flippt \`state.currency\` zusätzlich **vor** dem
\`await\` — der Picker reagiert sofort, auch wenn die nachfolgende
Konversion vom Seq-Guard verworfen wird. Existing Test
\`'onCurrencyChanged still flips currency even on service error'\`
bleibt grün.

## Tests

**5 neue Race-Tests** (3 buy, 2 sell), die in-flight Responses out of
order completen und pinnen dass der Seq-Guard die alten droppt — also
direkt das Symptom aus v1.0.67 pinnen.

**Bestehende Tests** (28 cubit, 180 buy/sell breit) bleiben grün ohne
Anpassungen.

## Verifiziert lokal

- \`flutter analyze lib/screens/buy/cubits/buy_converter/ lib/screens/sell/cubits/sell_converter/ test/screens/buy/cubits/ test/screens/sell/cubits/\` → clean
- \`flutter test test/screens/buy/cubits/buy_converter_cubit_test.dart test/screens/sell/cubits/sell_converter_cubit_test.dart\` → 28/28
- \`flutter test test/screens/buy/ test/screens/sell/ test/screens/buy_sell_converter_confirm_states_test.dart\` → 180/180

## Was bewusst NICHT in dieser PR ist

- **D1** Stale \`sharesText\` bei API-Fehler (verschieden vom Race; separater Pfad)
- **D2** Komma-Sanitization im Brokerbot-Service (PaymentInfo macht es schon, Converter nicht — separate PR)
- **D3** Loading-Indikator + Error-Surface in der UI (Welle 2)
- **Eager Controller-Init / focus-aware Sync** (UX-PR, ändert Behavior)

Diese sind reale Defekte aber **nicht Ursache** des reproduzierten
Symptoms. Sie verschmutzen den Race-Fix nur und werden separat
adressiert.