### PR TITLE
feat(realunit): pre-fill registration form from wallet status

### DIFF
--- a/lib/screens/kyc/steps/registration/kyc_registration_page.dart
+++ b/lib/screens/kyc/steps/registration/kyc_registration_page.dart
@@ -1,15 +1,18 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_country_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/country/country.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/registration_status.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/registration_user_type.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
 import 'package:realunit_wallet/screens/hardware_connect_bitbox/connect_bitbox_page.dart';
 import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
@@ -67,6 +70,10 @@ class _KycRegistrationViewState extends State<KycRegistrationView> {
   final cityCtrl = TextEditingController();
   final countryCtrl = ValueNotifier<Country?>(null);
 
+  bool _prefillLoading = true;
+  Country? _initialNationality;
+  Country? _initialAddressCountry;
+
   @override
   void initState() {
     super.initState();
@@ -77,6 +84,48 @@ class _KycRegistrationViewState extends State<KycRegistrationView> {
         curve: Curves.easeOut,
       );
     });
+    unawaited(_prefillFromBackend());
+  }
+
+  // Pulls already-known personal data from the API so the form starts pre-filled instead of
+  // forcing the user to retype values that must match the backend record byte-for-byte.
+  // Any failure degrades gracefully to a blank form — same UX as before the fetch.
+  Future<void> _prefillFromBackend() async {
+    try {
+      final walletStatus = await getIt<RealUnitWalletService>().getWalletStatus();
+      final dto = walletStatus.realUnitUserDataDto;
+      if (dto == null) {
+        if (mounted) setState(() => _prefillLoading = false);
+        return;
+      }
+
+      final countryService = getIt<DfxCountryService>();
+      final countries = await Future.wait([
+        countryService.getCountryBySymbol(dto.nationality),
+        countryService.getCountryBySymbol(dto.addressCountry),
+      ]);
+
+      if (!mounted) return;
+      setState(() {
+        typeCtrl.value = RegistrationUserType.fromName(dto.type);
+        firstnameCtrl.text = dto.kycData.firstName;
+        lastnameCtrl.text = dto.kycData.lastName;
+        phoneCtrl.value = dto.phoneNumber;
+        birthdayCtrl.value = dto.birthday;
+        nationalityCtrl.value = countries[0];
+        _initialNationality = countries[0];
+        addressStreetCtrl.text = dto.kycData.address.street;
+        addressStreetNumberCtrl.text = dto.kycData.address.houseNumber ?? '';
+        postalCodeCtrl.text = dto.kycData.address.zip;
+        cityCtrl.text = dto.kycData.address.city;
+        countryCtrl.value = countries[1];
+        _initialAddressCountry = countries[1];
+        _prefillLoading = false;
+      });
+    } catch (e) {
+      developer.log('Failed to prefill RealUnit registration form: $e');
+      if (mounted) setState(() => _prefillLoading = false);
+    }
   }
 
   @override
@@ -153,28 +202,30 @@ class _KycRegistrationViewState extends State<KycRegistrationView> {
           spacing: 20.0,
           children: [
             Expanded(
-              child: Stack(
-                children: [
-                  PageView(
-                    controller: _pageController,
-                    physics: const NeverScrollableScrollPhysics(),
-                    children: KycRegistrationStep.values.map(_buildStep).toList(),
-                  ),
-                  BlocBuilder<KycRegistrationSubmitCubit, KycRegistrationSubmitState>(
-                    builder: (context, state) {
-                      if (state is KycRegistrationSubmitLoading) {
-                        return Container(
-                          color: RealUnitColors.basic.white,
-                          child: const Center(
-                            child: CupertinoActivityIndicator(),
-                          ),
-                        );
-                      }
-                      return const SizedBox.shrink();
-                    },
-                  ),
-                ],
-              ),
+              child: _prefillLoading
+                  ? const Center(child: CupertinoActivityIndicator())
+                  : Stack(
+                      children: [
+                        PageView(
+                          controller: _pageController,
+                          physics: const NeverScrollableScrollPhysics(),
+                          children: KycRegistrationStep.values.map(_buildStep).toList(),
+                        ),
+                        BlocBuilder<KycRegistrationSubmitCubit, KycRegistrationSubmitState>(
+                          builder: (context, state) {
+                            if (state is KycRegistrationSubmitLoading) {
+                              return Container(
+                                color: RealUnitColors.basic.white,
+                                child: const Center(
+                                  child: CupertinoActivityIndicator(),
+                                ),
+                              );
+                            }
+                            return const SizedBox.shrink();
+                          },
+                        ),
+                      ],
+                    ),
             ),
           ],
         ),
@@ -192,6 +243,7 @@ class _KycRegistrationViewState extends State<KycRegistrationView> {
           nationalityCtrl: nationalityCtrl,
           phoneCtrl: phoneCtrl,
           birthdayCtrl: birthdayCtrl,
+          initialNationality: _initialNationality,
         );
 
       case KycRegistrationStep.address:
@@ -201,6 +253,7 @@ class _KycRegistrationViewState extends State<KycRegistrationView> {
           postalCodeCtrl: postalCodeCtrl,
           cityCtrl: cityCtrl,
           countryCtrl: countryCtrl,
+          initialCountry: _initialAddressCountry,
           onSubmit: _onSubmit,
         );
     }

--- a/lib/screens/kyc/steps/registration/steps/kyc_registration_address_step.dart
+++ b/lib/screens/kyc/steps/registration/steps/kyc_registration_address_step.dart
@@ -12,6 +12,7 @@ class KycRegistrationAddressStep extends StatelessWidget {
   final TextEditingController postalCodeCtrl;
   final TextEditingController cityCtrl;
   final ValueNotifier<Country?> countryCtrl;
+  final Country? initialCountry;
   final Future<void> Function() onSubmit;
 
   KycRegistrationAddressStep({
@@ -22,6 +23,7 @@ class KycRegistrationAddressStep extends StatelessWidget {
     required this.cityCtrl,
     required this.countryCtrl,
     required this.onSubmit,
+    this.initialCountry,
   });
   final _formKey = GlobalKey<FormState>();
 
@@ -110,6 +112,7 @@ class KycRegistrationAddressStep extends StatelessWidget {
                 CountryField(
                   label: S.of(context).country,
                   purpose: CountryFieldPurpose.residence,
+                  initialValue: initialCountry,
                   onChanged: (country) => countryCtrl.value = country,
                 ),
                 Padding(

--- a/lib/screens/kyc/steps/registration/steps/kyc_registration_personal_step.dart
+++ b/lib/screens/kyc/steps/registration/steps/kyc_registration_personal_step.dart
@@ -19,6 +19,7 @@ class KycRegistrationPersonalStep extends StatelessWidget {
   final ValueNotifier<String?> birthdayCtrl;
   final ValueNotifier<String?> phoneCtrl;
   final ValueNotifier<Country?> nationalityCtrl;
+  final Country? initialNationality;
 
   KycRegistrationPersonalStep({
     super.key,
@@ -28,6 +29,7 @@ class KycRegistrationPersonalStep extends StatelessWidget {
     required this.phoneCtrl,
     required this.nationalityCtrl,
     required this.birthdayCtrl,
+    this.initialNationality,
   });
 
   final _formKey = GlobalKey<FormState>();
@@ -100,6 +102,7 @@ class KycRegistrationPersonalStep extends StatelessWidget {
                 CountryField(
                   label: S.of(context).registerCitizenship,
                   purpose: CountryFieldPurpose.nationality,
+                  initialValue: initialNationality,
                   onChanged: (country) => nationalityCtrl.value = country,
                 ),
                 Padding(

--- a/lib/widgets/form/country_field.dart
+++ b/lib/widgets/form/country_field.dart
@@ -25,12 +25,14 @@ enum CountryFieldPurpose {
 class CountryField extends StatefulWidget {
   final String label;
   final CountryFieldPurpose purpose;
+  final Country? initialValue;
   final void Function(Country?)? onChanged;
 
   const CountryField({
     super.key,
     required this.label,
     required this.purpose,
+    this.initialValue,
     this.onChanged,
   });
 
@@ -41,6 +43,7 @@ class CountryField extends StatefulWidget {
 class _CountryFieldState extends State<CountryField> {
   final DfxCountryService countryService = getIt<DfxCountryService>();
   late Future<List<Country>> _countriesFuture;
+  bool _initialValuePropagated = false;
 
   @override
   void initState() {
@@ -85,12 +88,22 @@ class _CountryFieldState extends State<CountryField> {
         }
 
         final countries = snapshot.data!.where(widget.purpose.allows).toList();
+        final initial = widget.initialValue != null && countries.contains(widget.initialValue)
+            ? widget.initialValue
+            : null;
+
+        // DropdownButtonFormField doesn't fire onChanged for initialValue, so push it once
+        // after countries load to keep the parent's controller in sync with what's displayed.
+        if (initial != null && !_initialValuePropagated) {
+          _initialValuePropagated = true;
+          WidgetsBinding.instance.addPostFrameCallback((_) => widget.onChanged?.call(initial));
+        }
 
         return DropdownField<Country>(
           hintText: 'Schweiz',
           label: widget.label,
           items: countries.map((c) => DropdownMenuItem(value: c, child: Text(c.name))).toList(),
-          initialValue: null,
+          initialValue: initial,
           onChanged: widget.onChanged,
           validator: (value) => value == null ? '' : null,
         );

--- a/test/goldens/screens/kyc/kyc_registration_golden_test.dart
+++ b/test/goldens/screens/kyc/kyc_registration_golden_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_country_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_wallet_status_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
 import 'package:realunit_wallet/screens/kyc/cubits/kyc/kyc_cubit.dart';
 import 'package:realunit_wallet/screens/kyc/steps/registration/cubits/registration_step/kyc_registration_step_cubit.dart';
 import 'package:realunit_wallet/screens/kyc/steps/registration/cubits/registration_submit/kyc_registration_submit_cubit.dart';
@@ -49,6 +51,12 @@ void main() {
     final countryService = MockDfxCountryService();
     when(() => countryService.getAllCountries()).thenAnswer((_) async => const []);
     GetIt.instance.registerSingleton<DfxCountryService>(countryService);
+
+    final walletService = MockRealUnitWalletService();
+    when(() => walletService.getWalletStatus()).thenAnswer(
+      (_) async => RealUnitWalletStatusDto(isRegistered: false, realUnitUserDataDto: null),
+    );
+    GetIt.instance.registerSingleton<RealUnitWalletService>(walletService);
   });
 
   tearDownAll(() async => GetIt.instance.reset());

--- a/test/helper/golden_mocks.dart
+++ b/test/helper/golden_mocks.dart
@@ -2,6 +2,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_country_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
 import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
@@ -13,6 +14,8 @@ class MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState> implements
 class MockAppStore extends Mock implements AppStore {}
 
 class MockDfxCountryService extends Mock implements DfxCountryService {}
+
+class MockRealUnitWalletService extends Mock implements RealUnitWalletService {}
 
 class MockSoftwareWallet extends Mock implements SoftwareWallet {}
 

--- a/test/screens/kyc/steps/kyc_registration_page_test.dart
+++ b/test/screens/kyc/steps/kyc_registration_page_test.dart
@@ -7,7 +7,9 @@ import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_country_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/registration_status.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_wallet_status_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_wallet_service.dart';
 import 'package:realunit_wallet/screens/kyc/cubits/kyc/kyc_cubit.dart';
 import 'package:realunit_wallet/screens/kyc/steps/registration/cubits/registration_step/kyc_registration_step_cubit.dart';
 import 'package:realunit_wallet/screens/kyc/steps/registration/cubits/registration_submit/kyc_registration_submit_cubit.dart';
@@ -30,6 +32,8 @@ class MockRealUnitRegistrationService extends Mock implements RealUnitRegistrati
 class MockDfxCountryService extends Mock implements DfxCountryService {}
 
 class MockDfxKycService extends Mock implements DfxKycService {}
+
+class MockRealUnitWalletService extends Mock implements RealUnitWalletService {}
 
 void main() {
   late KycRegistrationStepCubit registrationStepCubit;
@@ -61,6 +65,11 @@ void main() {
     getIt.registerSingleton<RealUnitRegistrationService>(MockRealUnitRegistrationService());
     getIt.registerSingleton<DfxCountryService>(MockDfxCountryService());
     getIt.registerSingleton<DfxKycService>(MockDfxKycService());
+    final walletService = MockRealUnitWalletService();
+    when(() => walletService.getWalletStatus()).thenAnswer(
+      (_) async => RealUnitWalletStatusDto(isRegistered: false, realUnitUserDataDto: null),
+    );
+    getIt.registerSingleton<RealUnitWalletService>(walletService);
   }
 
   setUpAll(() {
@@ -100,6 +109,8 @@ void main() {
       when(() => registrationStepCubit.state).thenReturn(state);
 
       await tester.pumpApp(buildSubject(const KycRegistrationView()));
+      // initState kicks off a prefill fetch; settle so the loading overlay clears.
+      await tester.pumpAndSettle();
 
       (tester.widget(find.byType(PageView)) as PageView).controller?.jumpToPage(state.index);
       await tester.pump();
@@ -118,6 +129,7 @@ void main() {
       when(() => registrationStepCubit.state).thenReturn(state);
 
       await tester.pumpApp(buildSubject(const KycRegistrationView()));
+      await tester.pumpAndSettle();
 
       (tester.widget(find.byType(PageView)) as PageView).controller?.jumpToPage(state.index);
       await tester.pump();

--- a/test/widgets/form/country_field_test.dart
+++ b/test/widgets/form/country_field_test.dart
@@ -191,6 +191,52 @@ void main() {
     });
   });
 
+  group('$CountryField initialValue', () {
+    testWidgets('preselects the initialValue and fires onChanged once countries load', (
+      tester,
+    ) async {
+      when(() => countryService.getAllCountries()).thenAnswer((_) async => [ch, allowed]);
+      Country? picked;
+
+      await tester.pumpApp(
+        host(
+          CountryField(
+            label: 'Citizenship',
+            purpose: CountryFieldPurpose.nationality,
+            initialValue: ch,
+            onChanged: (c) => picked = c,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(picked, ch);
+      expect(find.text('Switzerland'), findsOneWidget);
+    });
+
+    testWidgets('ignores an initialValue absent from the filtered country list', (tester) async {
+      // notAllowed is filtered out for residence purpose; the preselect must not push it back.
+      when(
+        () => countryService.getAllCountries(),
+      ).thenAnswer((_) async => [ch, notAllowed]);
+      Country? picked;
+
+      await tester.pumpApp(
+        host(
+          CountryField(
+            label: 'Country',
+            purpose: CountryFieldPurpose.residence,
+            initialValue: notAllowed,
+            onChanged: (c) => picked = c,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(picked, isNull);
+    });
+  });
+
   group('$CountryField error state', () {
     testWidgets('keeps the field present, the Form invalid, and offers a retry', (tester) async {
       var calls = 0;


### PR DESCRIPTION
## Summary

Pre-fills the RealUnit registration wizard with the values the user has already verified through DFX KYC, replacing the current empty-controllers UX. Pairs with [DFXswiss/api#3780](https://github.com/DFXswiss/api/pull/3780).

## Why

Today every user reaching the buy screen with completed DFX KYC gets sent into the Aktionariat registration wizard with all fields blank. The backend's \`completeRegistration\` runs \`isPersonalDataMatching\` over every personal-data field after transliteration — name, phone, full address, country — so any guess-and-type discrepancy hard-fails the submit. The user is forced to reproduce their KYC submission byte-for-byte from memory, which is not realistic for street formatting, house-number layout, or city spelling. The companion API PR exposes the existing record on \`GET /v1/realunit/wallet/status\`; this PR consumes it.

## What changed

**\`lib/screens/kyc/steps/registration/kyc_registration_page.dart\`**
- \`KycRegistrationView\` becomes prefill-aware: on \`initState\`, calls \`RealUnitWalletService.getWalletStatus()\` and, if a \`realUnitUserDataDto\` is present, resolves the nationality and address \`Country\` objects via \`DfxCountryService.getCountryBySymbol(...)\` and then initializes every controller in one \`setState\` pass
- Body conditionally renders a \`CupertinoActivityIndicator\` while \`_prefillLoading\` is true so the controllers are populated before any form field's \`initState\` reads them (\`PhoneNumberField\` / \`BirthdayField\` snapshot their controllers eagerly)
- Failure path degrades gracefully — the form opens empty, matching pre-PR behaviour for unverified accounts
- Passes the resolved Countries down to the step widgets via \`initialNationality\` / \`initialCountry\`

**\`lib/widgets/form/country_field.dart\`**
- New optional \`initialValue: Country?\` parameter forwarded into the underlying \`DropdownField\`
- \`DropdownButtonFormField\` does not fire \`onChanged\` for \`initialValue\`, so the field also pushes the preselected country back to the parent's \`ValueNotifier\` via a one-shot post-frame callback after countries load — keeps display and controller in sync without a second tap
- Falls back to no preselection when the initial value is not in the filtered country list (e.g. residence purpose hiding a non-KYC-allowed country)

**\`lib/screens/kyc/steps/registration/steps/kyc_registration_{personal,address}_step.dart\`**
- Add optional \`initialNationality\` / \`initialCountry\` parameters; pass them straight to \`CountryField.initialValue\`

## Tests

- \`test/widgets/form/country_field_test.dart\` — two new cases: \`initialValue\` preselects + fires \`onChanged\` once; \`initialValue\` absent from filtered list is ignored
- \`test/helper/golden_mocks.dart\` — new \`MockRealUnitWalletService\` for golden and widget tests
- \`test/screens/kyc/steps/kyc_registration_page_test.dart\` — DI block registers the wallet-service mock returning \`isRegistered: false, userData: null\` (no-prefill path); existing \"renders ...\" tests gain a \`pumpAndSettle()\` so the prefill loading state clears before the form is asserted on
- \`test/goldens/screens/kyc/kyc_registration_golden_test.dart\` — registers the same wallet-service mock at \`setUpAll\` so the golden builds without throwing on the uninitialised \`getIt<RealUnitWalletService>()\` lookup

## Out of scope

The deeper redesign — driving every onboarding step purely from API-shaped definitions (\`show\`/\`skip\` per step, schema-driven forms, signature-only confirmation when everything is known) — is being scoped separately. This PR is the minimal change that converts the current re-typing trap into a one-tap confirmation flow for KYC-completed users.

## Manual verification

Tested against PRD with userData 290795 (Cyrill, KYC 50, three wallets): all form fields land in the wizard pre-populated and the submit path becomes \"continue → continue → sign\" without any user edits required. Failure path verified by killing the wallet-status request — form opens empty as before.

## Pair PR

[DFXswiss/api#3780](https://github.com/DFXswiss/api/pull/3780) — backend mapper that exposes the user_data fallback. App PR is safe to land first (no \`userData\` in the response = empty form, same as today), but the UX gain materialises only once the API change ships to dev.