### PR TITLE
Split PR 578: BitBox connection lifecycle

### DIFF
--- a/docs/adr/0001-bitbox-connection-lifecycle.md
+++ b/docs/adr/0001-bitbox-connection-lifecycle.md
@@ -1,0 +1,231 @@
+# ADR 0001 — BitBox Connection Lifecycle
+
+Status: Proposed
+Date: 2026-05-23
+Initiative: I — BitBox Connection Lifecycle
+Reviewers: @TaprootFreak (mandatory)
+
+## Context
+
+Three concurrent sources of truth currently model the BitBox connection state:
+
+1. `BitboxService._isConnected` — a private boolean, written from `init()` and the
+   periodic observer.
+2. `BitboxCredentials.isConnected` — derived from a nullable `bitboxManager` per
+   address, mutated by `setBitbox`/`clearBitbox` from both the service and the
+   sign-queue timeout.
+3. `ConnectBitboxCubit.state` — emitted from the connect-bitbox cubit, which
+   makes its own decisions based on what `BitboxService` reports.
+
+The three drift on every important event:
+
+- F-032 — `init()` sets `_isConnected = true` BEFORE the credentials fan-out
+  completes; a sign racing through `getCredentials()` on another isolate can
+  observe "connected" while the credentials are still detached.
+- F-009 — `_synchronizeBoundedSign` on timeout calls `clearBitbox()` on the
+  credentials and frees the queue slot, but never tells `BitboxService` that
+  the device is gone. The observer keeps thinking we are connected; the next
+  reconnect must come from the user manually unplugging.
+- F-045 — `_connectionStatusObserver` only inspects the `devices.isEmpty` branch
+  and ignores any non-empty list. A user who unplugs their BitBox and plugs in a
+  different one is reported "still connected".
+- F-005 / F-024 — `_credentialsByAddress` is never cleared on wallet-delete;
+  `_onDeleteCurrentWallet` only stops the observer. A subsequent "restore from
+  different seed → pair same physical device at a different account index"
+  silently re-attaches the OLD derivation path.
+- F-007 — `init()` is not serialised against concurrent invocation; two
+  rapid-fire `connectToBitbox` calls can race two `bitboxManager.connect()` calls
+  on the same manager, with undefined behaviour for the noise channel.
+- F-033 / F-034 — no `dispose()` on the singleton; hot-restart leaves the
+  prior `BitboxManager` claimed natively.
+
+The worst case is: user deletes wallet A, factory-resets the BitBox, restores
+wallet B from a different seed. Stale credentials bind wallet B's derivation
+path to the device's new static pubkey without prompting re-pair; the observer
+reports "still connected"; the next sign flows to a device the user no longer
+owns.
+
+## Decision
+
+Adopt a single source of truth for the BitBox connection state, owned by
+`BitboxService`. Every other consumer — `BitboxCredentials`,
+`ConnectBitboxCubit`, `HomeBloc`, `WalletService`, future cubits — subscribes
+to a broadcast stream of typed state transitions and holds no parallel
+connected-flag of its own.
+
+### State machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Disconnected
+    Disconnected --> Connecting: init(device)
+    Connecting --> Paired: bitboxManager.initBitBox() == true
+    Connecting --> Disconnected: init() throws or returns false
+    Paired --> InUse: credentials.setBitbox(...) + sign in flight
+    InUse --> Paired: sign completes
+    Paired --> Lost: signalDeviceLost(reason) / observer reports device gone
+    InUse --> Lost: sign-queue timeout / static-pubkey mismatch
+    Lost --> Disconnecting: clear() / dispose()
+    Paired --> Disconnecting: clear() / dispose()
+    Disconnecting --> Disconnected: bitboxManager.disconnect() completes
+    Disconnected --> [*]: dispose()
+```
+
+`Lost` is a terminal sub-state for the current pairing session — the consumer
+must call `clear()` to transition to `Disconnecting` and then `Disconnected`
+before another `init()` can succeed.
+
+### Stream contract
+
+`BitboxConnectionStatus` is a Dart sealed class hierarchy:
+
+```dart
+sealed class BitboxConnectionStatus {}
+final class Disconnected extends BitboxConnectionStatus {}
+final class Connecting extends BitboxConnectionStatus { final BitboxDevice device; }
+final class Paired extends BitboxConnectionStatus { final BitboxDevice device; }
+final class InUse extends BitboxConnectionStatus { final BitboxDevice device; final SignContext context; }
+final class Lost extends BitboxConnectionStatus { final LostReason reason; }
+final class Disconnecting extends BitboxConnectionStatus {}
+
+enum LostReason {
+  signQueueTimeout,
+  staticPubkeyMismatch,
+  manualDisconnect,
+  deviceUnreachable,
+  factoryResetDetected,
+}
+```
+
+All variants are immutable. Equality is value-based (Equatable). The stream is
+broadcast and replay-last-value — late subscribers receive the current state
+synchronously on subscription.
+
+### Ownership rules
+
+- `BitboxService` is the **sole writer** to the stream.
+- `BitboxCredentials` does NOT mutate `BitboxService` state directly. When
+  `_synchronizeBoundedSign` hits a timeout it calls
+  `_bitboxService.signalDeviceLost(LostReason.signQueueTimeout)` and lets the
+  service decide the transition.
+- `ConnectBitboxCubit` does NOT keep its own `isConnected` field. Its state is
+  derived from the stream + its own UX-only states
+  (`BitboxCheckHash`, `BitboxCapturingSignature`, etc.). The pairing flow is
+  still cubit-driven; the new contract is that whenever the cubit needs to
+  know "are we still connected?", it asks `BitboxService.currentStatus`.
+- `HomeBloc._onDeleteCurrentWallet` calls `BitboxService.clear()` — which
+  empties the credentials map, tears down the observer, disconnects, and
+  emits `Disconnected` — in addition to the existing
+  `stopConnectionStatusObserver` (kept for backward compatibility; `clear()`
+  invokes it internally).
+- `WalletService` does not subscribe — it consumes `BitboxService` only
+  through explicit method calls. The lifecycle hook is the `clear()` call
+  on wallet delete (mediated by `HomeBloc`).
+- Stream subscriptions in cubits are mandatory-cancelled in `close()`.
+
+### Init concurrency guard
+
+`init()` is guarded by a `Future<BitboxConnectionStatus>? _pendingInit`.
+Concurrent callers `await` the same future. Result:
+
+- One physical `bitboxManager.connect(device)` per concurrent batch.
+- Property-test pinned: for any N concurrent `init()` calls, exactly one
+  `connect()` invocation.
+
+### Lifecycle methods
+
+- `Future<BitboxConnectionStatus> init(BitboxDevice)` — guarded; emits
+  `Connecting(device)` then `Paired(device)` on success, `Disconnected` on
+  failure.
+- `Future<void> clear()` — disconnects, cancels observer, empties
+  `_credentialsByAddress`, emits `Disconnecting → Disconnected`. Idempotent.
+- `void signalDeviceLost(LostReason)` — only valid from `Paired` / `InUse`;
+  emits `Lost(reason)`, tears down observer, clears each credentials' manager.
+  Idempotent — repeated calls from the same state are no-ops.
+- `Future<void> dispose()` — emits final `Disconnected`, closes the stream
+  controller. Used for hot-restart and end-of-app. Post-`dispose()` calls to
+  `init()` throw `StateError`.
+
+## Alternatives considered
+
+1. **Enum instead of sealed class.** Rejected. The `Paired(device)` and
+   `Lost(reason)` variants carry data that consumers need (which physical
+   device is paired, why the device was lost). An enum would force a separate
+   "current device" field on the service, recreating the parallel-state-of-truth
+   problem.
+
+2. **`ValueNotifier<BitboxConnectionStatus>` instead of `Stream`.** Rejected.
+   `ValueNotifier` is a Flutter framework type and would couple `BitboxService`
+   (a service-layer construct, tested without `flutter_test`) to widget tree
+   lifecycles. A `Stream` carries no framework dependency, integrates with
+   `bloc`'s `emit`/`listen` patterns, and supports backpressure semantics if
+   we ever need them.
+
+3. **Plain `StreamController<BitboxConnectionStatus>.broadcast()` without
+   replay.** Rejected. Late subscribers (e.g. a fresh `ConnectBitboxCubit` after
+   the service has already paired) would not see the current state until the
+   next transition. The Stream-with-replay-last-value pattern (hand-rolled
+   inside `BitboxService` via a `_lastStatus` field exposed as `currentStatus`
+   + an immediate replay in the stream getter) preserves the "subscribe and
+   know" property without dragging in `rxdart`'s `BehaviorSubject`. `rxdart`
+   is not in `pubspec.yaml` today; adding it just for one type would violate
+   Mandate §1 Law 15.
+
+4. **Per-credentials connection state instead of service-level.** Rejected.
+   The audit (F-005, F-024) shows that any per-instance flag desyncs from
+   the physical-device truth and from sibling credentials sharing the same
+   noise cipher. Single SoT at the service is the only invariant that
+   survives the multi-credential-fan-out lifecycle.
+
+5. **No replay at all; consumers cache the latest state themselves.**
+   Rejected — it reintroduces the parallel-state-of-truth problem this ADR
+   exists to solve.
+
+## Consequences
+
+### Positive
+
+- Single source of truth for connect-state — F-005, F-007, F-009, F-024,
+  F-032, F-033, F-034, F-045 close as one architectural unit.
+- Property-pinnable invariant: any sequence of `init`/`clear`/`signalDeviceLost`
+  emits a valid state-machine traversal.
+- Sign-queue timeout no longer silently desyncs the service from the
+  credentials.
+- `_onDeleteCurrentWallet` cleanup actually clears the credentials map —
+  closes the "delete wallet, restore different seed, sign against wrong
+  derivation path" worst-case in the Context section.
+- Stream model integrates cleanly with the `bloc` package and with future
+  Initiative III FakeBitboxCredentials inject-points
+  (`injectDisconnectAtPage`, etc.).
+- `dispose()` makes hot-restart and tests deterministic.
+
+### Negative
+
+- The pre-existing `bool isConnected` on `BitboxCredentials` becomes a derived
+  view, not a writeable flag. Tests that asserted on it still work but should
+  be migrated to assert on `service.currentStatus` for clarity. Migration in
+  Initiative I commits.
+- Every consuming cubit gains a stream subscription that must be cancelled
+  in `close()`. Lint-enforceable if we add the lint; in the interim, the
+  cubit close path is asserted by unit test.
+
+### Neutral
+
+- The pre-existing `startConnectionStatusObserver()` / `stopConnectionStatusObserver()`
+  callers (`ConnectBitboxCubit`, `HomeBloc`) keep their direct API for now;
+  the observer is an internal driver of the stream rather than a parallel
+  signal. A follow-up ADR may collapse those callers into pure stream
+  subscribers.
+
+## References
+
+- Backlog items: BL-014, BL-015, BL-016, BL-019, BL-040, BL-041, BL-042,
+  BL-044, BL-078, BL-079.
+- Audit findings (`audit-bitbox-2026-05-23/realunit-app-bitbox-findings.md`):
+  F-005, F-007, F-009, F-024, F-032, F-033, F-034, F-045.
+- TF cluster: Cluster B (Channel-Hash Race / Re-Pair Stale Hash) in
+  `audit-bitbox-2026-05-23/taprootfreak-crawl.md`.
+- TF tracking: realunit-app#468 (BitBox lifecycle 17-item tracking).
+- Initiative III co-design (BL-008) — factory-reset / device-replaced
+  scenarios will land Tier-2 verifiers for `LostReason.staticPubkeyMismatch`
+  and `LostReason.factoryResetDetected`.

--- a/lib/packages/hardware_wallet/bitbox.dart
+++ b/lib/packages/hardware_wallet/bitbox.dart
@@ -2,8 +2,37 @@ import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:bitbox_flutter/bitbox_flutter.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_connection_status.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
 
+// MIGRATION NOTE — Initiative I, ADR 0001 (docs/adr/0001-bitbox-connection-lifecycle.md)
+//
+// _isConnected removed; subscribe to status stream (or read currentStatus
+// for the latest replayed value). The Stream<BitboxConnectionStatus> owned
+// by BitboxService is the sole source of truth for the connect-state. Every
+// other consumer — BitboxCredentials, ConnectBitboxCubit, HomeBloc — must
+// derive its view of "are we connected?" from currentStatus or from a
+// subscription. The pre-existing bool getter on BitboxCredentials is now a
+// derived view (delegates to `bitboxManager != null`) and is preserved only
+// for backward compatibility with sign-path call sites that already snapshot
+// it.
+
+/// Owns the lifecycle of the paired BitBox device.
+///
+/// ADR 0001 declares this service as the single source of truth for the
+/// BitBox connect-state. Every transition flows through [status] — a
+/// broadcast stream with replay-last-value semantics. Consumers subscribe
+/// and receive the current state synchronously, plus every subsequent
+/// transition.
+///
+/// Internal contract:
+///   - [_lastStatus] is the canonical "where are we now". Mutated only by
+///     [_emit], which also writes to [_statusController].
+///   - [init], [clear], [signalDeviceLost], [dispose] are the only public
+///     transition triggers.
+///   - The periodic observer is an internal driver of [status]; it never
+///     mutates [_lastStatus] directly — it routes through [_emit] like
+///     every other transition source.
 class BitboxService {
   // Observer poll period is widened in production and tightened in tests so
   // device-loss-recovery behaviour can be exercised in real time without
@@ -13,20 +42,80 @@ class BitboxService {
 
   final BitboxManager bitboxManager = BitboxManager();
   final Duration _connectionStatusInterval;
-  bool _isConnected = false;
   // Keyed by the lowercased address so multi-wallet (future) reconnect
   // re-attaches every active set of credentials, not just the most recently
   // handed out. Lowercase invariant: callers may hand in EIP-55-mixed or raw
   // hex — we normalise via [_key] on every read/write so a checksum-flip
   // can't fork the map.
   final Map<String, BitboxCredentials> _credentialsByAddress = {};
+
+  /// Broadcast controller for the lifecycle stream. Late subscribers replay
+  /// the cached [_lastStatus] synchronously via [status] before joining the
+  /// live broadcast.
+  final StreamController<BitboxConnectionStatus> _statusController =
+      StreamController<BitboxConnectionStatus>.broadcast();
+
+  /// Canonical "where are we now" — every emission to [_statusController]
+  /// also writes here so [currentStatus] and the replay-on-subscribe path
+  /// stay in sync.
+  BitboxConnectionStatus _lastStatus = const Disconnected();
+
+  /// Shared future for an in-flight [init] so concurrent callers receive the
+  /// same result without racing a second `bitboxManager.connect()`. Property
+  /// test pinned: for any N concurrent [init] calls, exactly one underlying
+  /// `initBitBox()` invocation.
+  Future<BitboxConnectionStatus>? _pendingInit;
+
   Timer? _connectionStatusObserver;
   Future<void>? _pendingDisconnect;
+  bool _disposed = false;
 
   /// Normalises an address into the form used as the map key. Lowercase is
   /// the cheapest robust choice — EIP-55 checksum differs in casing only, so
   /// `0xAbC` and `0xabc` collapse to the same entry.
   String _key(String address) => address.toLowerCase();
+
+  /// Latest broadcast value (replay-last semantics). Cheap to read; no
+  /// allocation.
+  BitboxConnectionStatus get currentStatus => _lastStatus;
+
+  /// Broadcast lifecycle stream. Late subscribers receive the latest cached
+  /// status synchronously as their first event (replay-last-value), then
+  /// follow every transition until the controller is closed by [dispose].
+  Stream<BitboxConnectionStatus> get status {
+    // Replay-last pattern hand-rolled (rxdart not in pubspec). We wire the
+    // per-subscriber controller eagerly to the broadcast stream BEFORE
+    // delivering the replayed value — an `async*` generator that does
+    // `yield initial; yield* upstream;` would subscribe to upstream only
+    // after the first yield was consumed, so any transition emitted between
+    // the test's `service.status.listen(...)` and the next microtask hop
+    // would be dropped by the broadcast controller (no listener yet). The
+    // listener-attached-then-replay order below preserves every transition.
+    final controller = StreamController<BitboxConnectionStatus>();
+    late StreamSubscription<BitboxConnectionStatus> upstreamSub;
+    controller.onListen = () {
+      upstreamSub = _statusController.stream.listen(
+        controller.add,
+        onError: controller.addError,
+        onDone: controller.close,
+      );
+      // Replay the latest cached value AFTER the upstream subscription is
+      // installed. If an `_emit` ran synchronously between this getter
+      // returning and the consumer's `.listen` call, it lands inside the
+      // broadcast stream's pending queue and will surface to upstreamSub
+      // on the next microtask hop — never silently dropped.
+      controller.add(_lastStatus);
+    };
+    controller.onCancel = () => upstreamSub.cancel();
+    return controller.stream;
+  }
+
+  void _emit(BitboxConnectionStatus next) {
+    if (_disposed) return;
+    if (_lastStatus == next) return; // de-dup identical consecutive states.
+    _lastStatus = next;
+    _statusController.add(next);
+  }
 
   Future<List<BitboxDevice>> getAllUsbDevices() => bitboxManager.devices;
 
@@ -35,34 +124,157 @@ class BitboxService {
   BitboxCredentials getCredentials(String address) {
     final credentials = _credentialsByAddress.putIfAbsent(
       _key(address),
-      () => BitboxCredentials(address),
+      () => BitboxCredentials(address, _onCredentialsSignQueueTimeout),
     );
-    if (_isConnected) {
+    final live = _lastStatus is Paired || _lastStatus is InUse;
+    if (live) {
       credentials.setBitbox(bitboxManager);
     }
     return credentials;
   }
 
-  Future<bool> init(BitboxDevice device) async {
-    // The disconnect observer fires .disconnect() asynchronously when the
-    // device drops. If the user re-plugs immediately we'd race two ops on the
-    // same SDK manager and the result is undefined. Wait for any in-flight
-    // disconnect to finish first.
-    await _pendingDisconnect;
-    await bitboxManager.connect(device);
-    final didInit = await bitboxManager.initBitBox();
-    if (!didInit) throw Exception('Failed to init');
-    _isConnected = true;
-    // Re-attach the manager to every active credentials instance so existing
-    // wallets heal automatically on reconnect. The previous derivationPath is
-    // preserved inside setBitbox().
-    for (final credentials in _credentialsByAddress.values) {
-      credentials.setBitbox(bitboxManager);
+  /// Pairs the given device.
+  ///
+  /// Concurrent callers share a single in-flight future via [_pendingInit] —
+  /// the SDK sees exactly one `bitboxManager.connect()` + `initBitBox()` per
+  /// concurrent batch. A redundant [init] against an already-paired device
+  /// short-circuits to the current [Paired] status without re-issuing any
+  /// native call.
+  Future<BitboxConnectionStatus> init(BitboxDevice device) async {
+    if (_disposed) {
+      throw StateError(
+        'BitboxService.init called after dispose; create a new service.',
+      );
     }
-    return didInit;
+    // Idempotent fast-path: if we already reached Paired for the same
+    // session, just return it. Prevents a redundant init() (e.g. a fast
+    // `checkForBitbox` tick re-entering during a stable pair) from kicking
+    // a second handshake on the live noise channel.
+    if (_lastStatus is Paired || _lastStatus is InUse) {
+      return _lastStatus;
+    }
+    // Coalesce concurrent callers onto the single in-flight future.
+    final pending = _pendingInit;
+    if (pending != null) return pending;
+    final future = _runInit(device);
+    _pendingInit = future;
+    try {
+      return await future;
+    } finally {
+      // Only the caller that started the init clears the slot; later joiners
+      // observe the field already nulled and skip the clear.
+      if (identical(_pendingInit, future)) _pendingInit = null;
+    }
+  }
+
+  Future<BitboxConnectionStatus> _runInit(BitboxDevice device) async {
+    // The disconnect observer fires .disconnect() asynchronously when the
+    // device drops. If the user re-plugs immediately we'd race two ops on
+    // the same SDK manager and the result is undefined. Wait for any
+    // in-flight disconnect to finish first.
+    await _pendingDisconnect;
+    _emit(Connecting(device));
+    try {
+      await bitboxManager.connect(device);
+      final didInit = await bitboxManager.initBitBox();
+      if (!didInit) {
+        // Failure walks back to Disconnected so the cubit can decide to
+        // retry; we deliberately surface the typed status BEFORE rethrowing
+        // so a subscriber that only listens for state transitions sees the
+        // bounce without depending on the throw site.
+        _emit(const Disconnected());
+        throw Exception('Failed to init');
+      }
+      // Re-attach the manager to every active credentials instance so
+      // existing wallets heal automatically on reconnect. The previous
+      // derivationPath is preserved inside setBitbox().
+      for (final credentials in _credentialsByAddress.values) {
+        credentials.setBitbox(bitboxManager);
+      }
+      // Paired emitted ONLY after the credentials fan-out completes —
+      // closes F-032: a sign racing through getCredentials() on another
+      // isolate can no longer observe "connected" while credentials are
+      // detached.
+      _emit(Paired(device));
+      return _lastStatus;
+    } catch (e) {
+      if (_lastStatus is Connecting) {
+        _emit(const Disconnected());
+      }
+      rethrow;
+    }
+  }
+
+  /// Tears down the active pairing (if any), empties the credentials map,
+  /// stops the observer, and walks Paired/Lost → Disconnecting → Disconnected.
+  /// Idempotent: clearing from Disconnected is a no-op.
+  Future<void> clear() async {
+    if (_disposed) return;
+    if (_lastStatus is Disconnected) return;
+    _emit(const Disconnecting());
+    stopConnectionStatusObserver();
+    for (final credentials in _credentialsByAddress.values) {
+      credentials.clearBitbox();
+    }
+    _credentialsByAddress.clear();
+    _pendingDisconnect = _disconnectAndForget();
+    await _pendingDisconnect;
+    _pendingDisconnect = null;
+    _emit(const Disconnected());
+  }
+
+  /// Signals that the previously-paired device has been lost mid-session
+  /// for the given [reason]. Only valid from [Paired] / [InUse] — from any
+  /// other state this is a no-op (a stale credentials reference firing
+  /// after clear() must NOT emit a synthetic Lost).
+  ///
+  /// Emits [Lost], detaches every credentials in the map, and tears down
+  /// the observer. The consumer must call [clear] to walk to [Disconnected]
+  /// before a fresh [init] can succeed.
+  void signalDeviceLost(LostReason reason) {
+    if (_disposed) return;
+    final current = _lastStatus;
+    if (current is! Paired && current is! InUse) return;
+    for (final credentials in _credentialsByAddress.values) {
+      credentials.clearBitbox();
+    }
+    stopConnectionStatusObserver();
+    _emit(Lost(reason));
+  }
+
+  /// Hot-restart and end-of-app cleanup. Closes the broadcast controller so
+  /// every active subscription's `onDone` fires; rejects subsequent [init]
+  /// with a [StateError]. Idempotent.
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    stopConnectionStatusObserver();
+    for (final credentials in _credentialsByAddress.values) {
+      credentials.clearBitbox();
+    }
+    _credentialsByAddress.clear();
+    // Terminal emission must happen BEFORE the controller is closed so
+    // late subscribers replay the final Disconnected and onDone-listeners
+    // see the closing event. _emit short-circuits on _disposed — write
+    // directly here.
+    if (_lastStatus is! Disconnected) {
+      _lastStatus = const Disconnected();
+      _statusController.add(const Disconnected());
+    }
+    await _statusController.close();
+  }
+
+  /// Internal callback wired into every [BitboxCredentials] instance so the
+  /// sign-queue timeout propagates back to the service without the
+  /// credentials having to reach back through a singleton getter. Closure-
+  /// based to keep the dependency uni-directional (service owns credentials,
+  /// never the other way round).
+  void _onCredentialsSignQueueTimeout() {
+    signalDeviceLost(LostReason.signQueueTimeout);
   }
 
   void startConnectionStatusObserver() {
+    if (_disposed) return;
     _connectionStatusObserver?.cancel();
     _connectionStatusObserver = Timer.periodic(_connectionStatusInterval, (_) async {
       final List<BitboxDevice> devices;
@@ -78,15 +290,19 @@ class BitboxService {
       }
       if (devices.isEmpty) {
         // Two ticks can fire back-to-back if the body's awaits straddle the
-        // next interval — bail if the previous tick already entered the
-        // device-loss path. _isConnected acts as the single-writer flag
-        // because we set it to false before any further work.
-        if (!_isConnected) return;
-        _isConnected = false;
+        // next interval — bail unless we're still in the live state.
+        // currentStatus acts as the single-writer guard because we emit Lost
+        // (which also stops the observer) before any further work.
+        final current = _lastStatus;
+        if (current is! Paired && current is! InUse) return;
+        // Detach credentials and stop the observer BEFORE issuing the
+        // disconnect so any callback racing on the manager sees a clean
+        // detach.
         for (final credentials in _credentialsByAddress.values) {
           credentials.clearBitbox();
         }
         stopConnectionStatusObserver();
+        _emit(const Lost(LostReason.deviceUnreachable));
         // Close the underlying transport. Required on Android so the USB
         // file-descriptor is released — otherwise the next connect() can
         // fail because the OS still considers the device claimed. Safe on

--- a/lib/packages/hardware_wallet/bitbox_connection_status.dart
+++ b/lib/packages/hardware_wallet/bitbox_connection_status.dart
@@ -1,0 +1,170 @@
+import 'package:bitbox_flutter/bitbox_flutter.dart';
+import 'package:equatable/equatable.dart';
+
+/// Reasons the connection transitioned to [Lost].
+///
+/// Each value names a distinct trust-boundary event so the consumer can decide
+/// whether to silently re-pair, show the reconnect sheet, or refuse to sign
+/// without a fresh channel hash. The set is closed by design — adding a new
+/// value is a deliberate API extension and forces an exhaustiveness review at
+/// every switch site.
+enum LostReason {
+  /// `_synchronizeBoundedSign` fired its `signQueueTimeout`. The native sign
+  /// is still in flight against the (now-desynced) noise cipher; the next
+  /// sign would either decrypt garbage or hang. The recovery is a full
+  /// re-pair so the host obtains a fresh ephemeral noise channel.
+  signQueueTimeout,
+
+  /// The observer compared the currently-paired device's static pubkey with
+  /// the device-list entry's pubkey and found a mismatch. Either the user
+  /// swapped a different BitBox in, or the device was factory-reset and a
+  /// new static pubkey was generated. Either case requires explicit
+  /// re-pairing rather than silent reconnect.
+  staticPubkeyMismatch,
+
+  /// The user (or a higher-level lifecycle hook) explicitly asked the
+  /// service to drop the pairing — e.g. `_onDeleteCurrentWallet` invoking
+  /// `BitboxService.clear()` while a session is live.
+  manualDisconnect,
+
+  /// The periodic observer's `getDevices()` probe returned an empty list and
+  /// the host-side transport was torn down. The device is physically gone
+  /// (unplugged, BLE link silent, USB FD released).
+  deviceUnreachable,
+
+  /// Co-design with Initiative III simulator scenarios — the device was
+  /// detected to have been factory-reset between sessions (new static
+  /// pubkey on second connect). Distinct from [staticPubkeyMismatch] only
+  /// in observability semantics; both refuse silent reconnect.
+  factoryResetDetected,
+}
+
+/// Sealed view of the BitBox connection lifecycle owned by `BitboxService`.
+///
+/// State-machine traversal (see ADR 0001):
+///
+/// ```
+/// Disconnected → Connecting → Paired → InUse → Lost → Disconnecting → Disconnected
+/// ```
+///
+/// All variants are immutable and use value equality so identical states can
+/// be deduplicated by the broadcast controller and asserted on with
+/// `equals(...)` instead of `same(...)`.
+sealed class BitboxConnectionStatus extends Equatable {
+  const BitboxConnectionStatus();
+}
+
+/// No device is paired. Initial state at service construction; terminal
+/// state after [Disconnecting] resolves.
+final class Disconnected extends BitboxConnectionStatus {
+  const Disconnected();
+
+  @override
+  List<Object?> get props => const <Object?>[];
+
+  @override
+  String toString() => 'Disconnected()';
+}
+
+/// A connect is in flight. The service is awaiting `bitboxManager.connect()`
+/// + `initBitBox()`. The user has NOT yet seen a channel hash.
+final class Connecting extends BitboxConnectionStatus {
+  const Connecting(this.device);
+
+  final BitboxDevice device;
+
+  @override
+  List<Object?> get props => <Object?>[device.identifier];
+
+  @override
+  String toString() => 'Connecting(${device.identifier})';
+}
+
+/// Pairing complete; credentials are attached; the channel hash has been
+/// verified by the user. No sign is currently in flight.
+final class Paired extends BitboxConnectionStatus {
+  const Paired(this.device);
+
+  final BitboxDevice device;
+
+  @override
+  List<Object?> get props => <Object?>[device.identifier];
+
+  @override
+  String toString() => 'Paired(${device.identifier})';
+}
+
+/// A sign-shaped operation is in flight against the paired device. Distinct
+/// from [Paired] so a UI layer can choose a different "busy" affordance and
+/// so observers can pin "InUse only ever follows Paired" as an invariant.
+final class InUse extends BitboxConnectionStatus {
+  const InUse(this.device, this.context);
+
+  final BitboxDevice device;
+  final SignContext context;
+
+  @override
+  List<Object?> get props => <Object?>[device.identifier, context];
+
+  @override
+  String toString() => 'InUse(${device.identifier}, $context)';
+}
+
+/// The pairing was lost mid-session. Terminal for this pairing — the
+/// consumer must call `clear()` to transition to [Disconnecting] and then
+/// [Disconnected] before another `init()` can succeed.
+final class Lost extends BitboxConnectionStatus {
+  const Lost(this.reason);
+
+  final LostReason reason;
+
+  @override
+  List<Object?> get props => <Object?>[reason];
+
+  @override
+  String toString() => 'Lost(${reason.name})';
+}
+
+/// Disconnect is in flight — `bitboxManager.disconnect()` is awaiting. The
+/// service may briefly stay in this state on Android where releasing the USB
+/// FD takes a few ms. From here the only legal next state is [Disconnected].
+final class Disconnecting extends BitboxConnectionStatus {
+  const Disconnecting();
+
+  @override
+  List<Object?> get props => const <Object?>[];
+
+  @override
+  String toString() => 'Disconnecting()';
+}
+
+/// Describes which sign operation is currently in flight on the device.
+///
+/// Carried inside [InUse] so future Tier-1 / Tier-2 tests can assert "we
+/// only ever signed payload X exactly once" without depending on cubit-level
+/// state shape. Initiative II's `SignPipeline` will own the canonical
+/// construction of these.
+class SignContext extends Equatable {
+  const SignContext({
+    required this.address,
+    required this.derivationPath,
+    required this.kind,
+  });
+
+  /// EIP-55-or-lowercase hex address of the credentials handling the sign.
+  final String address;
+
+  /// BIP-32 derivation path the sign is performed against.
+  final String derivationPath;
+
+  /// Discriminator for the sign shape. Kept open as a String so Initiative
+  /// II can extend it (`eip712`, `eip7702`, `btcPsbt`, `personalMessage`,
+  /// `rlpTransaction`, ...) without forcing a coordinated change here.
+  final String kind;
+
+  @override
+  List<Object?> get props => <Object?>[address, derivationPath, kind];
+
+  @override
+  String toString() => 'SignContext($kind on $address @ $derivationPath)';
+}

--- a/lib/packages/hardware_wallet/bitbox_credentials.dart
+++ b/lib/packages/hardware_wallet/bitbox_credentials.dart
@@ -28,10 +28,18 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
 
   final String _address;
 
+  /// Optional callback the service wires up in [BitboxService.getCredentials]
+  /// so a sign-queue timeout in this credentials instance can flip the
+  /// service-level state to `Lost(signQueueTimeout)`. Stored as a closure to
+  /// keep the dependency uni-directional — credentials never reach back
+  /// through a singleton getter.
+  // ignore: unused_field
+  final void Function()? _onSignQueueTimeout;
+
   BitboxManager? bitboxManager;
   String? derivationPath;
 
-  BitboxCredentials(this._address);
+  BitboxCredentials(this._address, [this._onSignQueueTimeout]);
 
   /// Re-seeds the static sign queue with a freshly-completed future.
   ///

--- a/lib/packages/hardware_wallet/bitbox_credentials.dart
+++ b/lib/packages/hardware_wallet/bitbox_credentials.dart
@@ -33,7 +33,6 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
   /// service-level state to `Lost(signQueueTimeout)`. Stored as a closure to
   /// keep the dependency uni-directional — credentials never reach back
   /// through a singleton getter.
-  // ignore: unused_field
   final void Function()? _onSignQueueTimeout;
 
   BitboxManager? bitboxManager;
@@ -81,7 +80,16 @@ class BitboxCredentials extends CredentialsWithKnownAddress {
       try {
         return await sign().timeout(signQueueTimeout);
       } on TimeoutException {
+        // F-009 closure (Initiative I, ADR 0001): the queue-timeout used to
+        // clear local credentials but leave BitboxService thinking we were
+        // still connected — the observer kept polling and the consuming cubit
+        // had no way to learn the device was lost without polling
+        // currentStatus. Propagating via the closure-wired callback flips the
+        // service-level Stream to Lost(signQueueTimeout) so the observer
+        // tears down and the consuming cubit can route to the reconnect sheet
+        // off a state transition instead of a poll.
         clearBitbox();
+        _onSignQueueTimeout?.call();
         throw const BitboxNotConnectedException();
       }
     });

--- a/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
+++ b/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
@@ -4,6 +4,7 @@ import 'dart:developer' as developer;
 import 'package:bitbox_flutter/bitbox_flutter.dart' as sdk;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_connection_status.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/utils/device_info.dart';
@@ -35,6 +36,12 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
        _createWalletTimeout = createWalletTimeout,
        _pairingPinTimeout = pairingPinTimeout,
        super(BitboxNotConnected()) {
+    // Subscribe to the lifecycle Stream so a mid-session Lost (e.g. observer
+    // device-vanish, sign-queue timeout) bounces the cubit to
+    // BitboxNotConnected without forcing every internal try/catch to also
+    // poll currentStatus. The subscription is cancelled in [close] to
+    // prevent the stream from holding a reference to the closed cubit.
+    _statusSub = _service.status.listen(_onServiceStatus);
     _startScanning();
   }
 
@@ -51,7 +58,29 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
   final WalletService _walletService;
   final DFXAuthService _authService;
   Timer? _checkForTimer;
-  Future<bool>? _pendingInit;
+  Future<BitboxConnectionStatus>? _pendingInit;
+  StreamSubscription<BitboxConnectionStatus>? _statusSub;
+
+  /// Routes service-level transitions into the cubit's UX state machine. The
+  /// only mid-flow transition the cubit cares about is `Lost` — the
+  /// service-level signal that the paired device is gone before the cubit
+  /// has reached `BitboxConnected` is the channel the timeout / observer
+  /// paths feed (see `_synchronizeBoundedSign` propagation in
+  /// `BitboxCredentials` and the periodic observer in `BitboxService`).
+  void _onServiceStatus(BitboxConnectionStatus status) {
+    if (isClosed) return;
+    if (status is Lost) {
+      developer.log('service emitted Lost(${status.reason.name})',
+          name: '$ConnectBitboxCubit');
+      _pendingInit = null;
+      _checkForTimer?.cancel();
+      emit(BitboxNotConnected());
+      _checkForTimer = Timer.periodic(
+        const Duration(milliseconds: 500),
+        (_) => checkForBitbox(),
+      );
+    }
+  }
 
   Future<void> checkForBitbox() async {
     final devices = await _service.getAllUsbDevices();
@@ -79,17 +108,14 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
       if (isClosed) return;
 
       var initFailed = false;
-      _pendingInit = _service
-          .init(device)
-          .then((success) {
-            if (!success) initFailed = true;
-            return success;
-          })
-          .catchError((Object e) {
-            developer.log('init error: $e', name: '$ConnectBitboxCubit');
-            initFailed = true;
-            return false;
-          });
+      _pendingInit = _service.init(device).then((status) {
+        if (status is! Paired && status is! InUse) initFailed = true;
+        return status;
+      }).catchError((Object e) {
+        developer.log('init error: $e', name: '$ConnectBitboxCubit');
+        initFailed = true;
+        return const Disconnected() as BitboxConnectionStatus;
+      });
 
       String channelHash = '';
       final deadline = DateTime.now().add(const Duration(seconds: 90));
@@ -130,11 +156,18 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
 
     try {
       emit(BitboxPairing(currentState.device));
-      final initOk = await _pendingInit!.timeout(
+      // _pendingInit now resolves to a BitboxConnectionStatus — only Paired
+      // (or the transient InUse) counts as a successful init. Anything else
+      // (Connecting still pending, Disconnected, Lost, Disconnecting) means
+      // the device-side confirmation never landed and the cubit must bounce
+      // back to BitboxNotConnected.
+      final initStatus = await _pendingInit!.timeout(
         _pairingPinTimeout,
-        onTimeout: () => false,
+        onTimeout: () => const Disconnected() as BitboxConnectionStatus,
       );
-      if (!initOk) throw Exception('pairing not confirmed on device');
+      if (initStatus is! Paired && initStatus is! InUse) {
+        throw Exception('pairing not confirmed on device');
+      }
       await _service.confirmPairing().timeout(
         _confirmPairingTimeout,
         onTimeout: () => throw TimeoutException(
@@ -216,6 +249,15 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
     // as an unhandled exception after the cubit is gone.
     _pendingInit?.ignore();
     _pendingInit = null;
+    // Cancel the lifecycle subscription so the broadcast Stream stops
+    // holding a reference to this cubit (prevents subscription-leak; pinned
+    // by the "cancelled subscriptions stop receiving transitions" test in
+    // bitbox_service_lifecycle_test.dart). The await is fire-and-forget
+    // chained off super.close() so a hot-restart with many cubits doesn't
+    // serialise on the cancellation.
+    final sub = _statusSub;
+    _statusSub = null;
+    sub?.cancel();
     return super.close();
   }
 }

--- a/lib/screens/home/bloc/home_bloc.dart
+++ b/lib/screens/home/bloc/home_bloc.dart
@@ -84,7 +84,18 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
   ) async {
     emit(state.copyWith(isLoadingWallet: true));
 
+    // Initiative I (ADR 0001) — F-024 closure. `stopConnectionStatusObserver`
+    // only cancels the periodic; `clear()` ALSO empties the credentials map,
+    // disconnects the underlying BitboxManager, and walks the lifecycle
+    // Stream to Disconnected. Without the `clear()` a "delete wallet,
+    // restore different seed, re-pair the same device" flow could silently
+    // re-attach the old derivation path against the device's new static
+    // pubkey. `clear()` invokes `stopConnectionStatusObserver` internally;
+    // calling both is intentional (the explicit `stop` call is kept so a
+    // refactor that drops the implicit one inside `clear()` does not
+    // regress the wallet-delete teardown).
     _bitboxService.stopConnectionStatusObserver();
+    await _bitboxService.clear();
     await _appStore.sessionCache.clear();
     if (_walletService.hasWallet()) {
       await _walletService.deleteCurrentWallet();

--- a/test/integration/bitbox_lifecycle_test.dart
+++ b/test/integration/bitbox_lifecycle_test.dart
@@ -15,10 +15,12 @@
 // refactor of the Stream contract must keep these traversals legal.
 
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:bitbox_flutter/bitbox_flutter.dart';
 import 'package:bitbox_flutter/testing.dart';
 import 'package:bitbox_flutter/usb/bitbox_usb_platform_interface.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox_connection_status.dart';
@@ -317,5 +319,158 @@ void main() {
       reason: 'init() after dispose() must throw',
     );
   });
+
+  // ---------------------------------------------------------------------
+  // Coverage-gap fillers — exercise the remaining surface that the higher
+  // level integration tests don't naturally touch but that ADR 0001 still
+  // requires to be observable from the test boundary.
+  // ---------------------------------------------------------------------
+
+  test('startScan delegates to BitboxManager and surfaces its boolean', () async {
+    final service = BitboxService(connectionStatusInterval: interval);
+    addTearDown(service.dispose);
+    final ok = await service.startScan();
+    expect(ok, isTrue,
+        reason: 'simulated platform reports scan success by default');
+    expect(platform.count(SimulatedBitboxMethod.startScan), 1);
+  });
+
+  test('init() failure inside `connect` walks Connecting → Disconnected via the catch arm',
+      () async {
+    // Drives the catch-arm inside `_runInit` that re-emits Disconnected
+    // when an exception escapes the connect path. Achieved by making the
+    // simulator's `open` throw (the SDK call site rethrows the original).
+    platform.throwOn(SimulatedBitboxMethod.open, Exception('USB busy'));
+
+    final service = BitboxService(connectionStatusInterval: interval);
+    addTearDown(service.dispose);
+    final observed = <BitboxConnectionStatus>[];
+    final sub = service.status.listen(observed.add);
+    addTearDown(sub.cancel);
+
+    final devices = await service.getAllUsbDevices();
+    await expectLater(
+      () => service.init(devices.single),
+      throwsA(isA<Exception>()),
+    );
+    // Drain any pending broadcast events so the post-throw Disconnected
+    // lands in `observed` before we assert.
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    // Drop the replayed initial Disconnected so the assertion describes
+    // only the transitions caused by init().
+    final transitions = observed
+        .skipWhile((s) => s is Disconnected)
+        .toList(growable: false);
+    expect(
+      transitions.map((s) => s.runtimeType).toList(),
+      containsAllInOrder(<Type>[Connecting, Disconnected]),
+      reason: 'failure in connect must walk Connecting → Disconnected',
+    );
+  });
+
+  test('getChannelHash and confirmPairing delegate to the SDK', () async {
+    final service = await pair();
+    addTearDown(service.dispose);
+
+    final hash = await service.getChannelHash();
+    expect(hash, isNotEmpty,
+        reason: 'simulator returns its default channel hash');
+
+    await service.confirmPairing();
+    expect(platform.count(SimulatedBitboxMethod.channelHashVerify), 1);
+  });
+
+  test('confirmPairing throws when the SDK reports verify failure', () async {
+    // Drives the !didVerify branch.
+    platform.when(
+      SimulatedBitboxMethod.channelHashVerify,
+      (_) async => false,
+    );
+
+    final service = await pair();
+    addTearDown(service.dispose);
+
+    await expectLater(
+      service.confirmPairing(),
+      throwsA(isA<Exception>()),
+    );
+  });
+
+  test(
+    '_onCredentialsSignQueueTimeout: a hung credentials sign routes to service-Lost via the wired closure',
+    () {
+      // End-to-end pin of the wired closure inside BitboxService.
+      // `getCredentials` injects `_onCredentialsSignQueueTimeout` into every
+      // BitboxCredentials it constructs, and a `_synchronizeBoundedSign`
+      // timeout calls the closure. The closure forwards to
+      // `signalDeviceLost(LostReason.signQueueTimeout)`. We drive the
+      // production timeout inside fakeAsync so the 5-minute wall-clock wait
+      // collapses to virtual time, AND we assert the post-condition on the
+      // service stream — proving the closure was actually wired (a missing
+      // wire would surface as an absent Lost emission).
+      fakeAsync((async) {
+        // Seed the sign queue inside this zone.
+        BitboxCredentials.resetSignQueue();
+        async.flushMicrotasks();
+
+        // Native sign hangs — exactly the failure mode the bounded queue
+        // exists to bound. `setDelay` would re-arm wall-clock; instead we
+        // stub the simulator to return a never-completing future for the
+        // native call.
+        platform.when(
+          SimulatedBitboxMethod.signETHTypedMessage,
+          (_) => Completer<Uint8List>().future,
+        );
+
+        final service = BitboxService(connectionStatusInterval: interval);
+        late List<BitboxDevice> devices;
+        service.getAllUsbDevices().then((d) => devices = d);
+        async.flushMicrotasks();
+        BitboxConnectionStatus? initStatus;
+        service.init(devices.single).then((s) => initStatus = s);
+        async.flushMicrotasks();
+        expect(initStatus, isA<Paired>(),
+            reason: 'fakeAsync init must reach Paired');
+
+        final observed = <BitboxConnectionStatus>[];
+        final sub = service.status.listen(observed.add);
+
+        // Issue a sign through the service-handed credentials. The native
+        // call hangs; the queue-bound timeout fires after `signQueueTimeout`
+        // and the closure inside the credentials calls back into the
+        // service.
+        final credentials = service.getCredentials(knownAddress);
+        Object? thrown;
+        credentials.signTypedDataV4(1, '{"primaryType":"Hang"}').catchError(
+          (Object e) {
+            thrown = e;
+            return '';
+          },
+        );
+
+        // Drain past the queue-bound timeout.
+        async.elapse(
+          BitboxCredentials.signQueueTimeout + const Duration(seconds: 2),
+        );
+        async.flushMicrotasks();
+
+        expect(thrown, isA<BitboxNotConnectedException>(),
+            reason: 'queue-bound timeout must surface the typed exception');
+
+        // The closure fired Lost(signQueueTimeout) on the stream BEFORE the
+        // exception reached the caller.
+        final losts = observed.whereType<Lost>().toList();
+        expect(losts, isNotEmpty,
+            reason: 'sign-queue timeout must reach the service-level stream');
+        expect(losts.last.reason, equals(LostReason.signQueueTimeout));
+
+        sub.cancel();
+      });
+    },
+  );
 }
+
+// fakeAsync requires Uint8List for the typed-data return; pulled in via
+// bitbox_flutter export above. Keep the test file dependency-clean.
 

--- a/test/integration/bitbox_lifecycle_test.dart
+++ b/test/integration/bitbox_lifecycle_test.dart
@@ -48,8 +48,7 @@ void main() {
     final service = BitboxService(connectionStatusInterval: interval);
     final devices = await service.getAllUsbDevices();
     final status = await service.init(devices.single);
-    expect(status, isA<Paired>(),
-        reason: 'integration setup requires a successful pair');
+    expect(status, isA<Paired>(), reason: 'integration setup requires a successful pair');
     return service;
   }
 
@@ -60,8 +59,7 @@ void main() {
       addTearDown(service.dispose);
 
       final credentials = service.getCredentials(knownAddress);
-      expect(credentials.isConnected, isTrue,
-          reason: 'credentials must be live after pair');
+      expect(credentials.isConnected, isTrue, reason: 'credentials must be live after pair');
 
       // sign via the typed-message path so the credentials hit
       // signETHTypedMessage on the simulator and we observe the full
@@ -158,8 +156,11 @@ void main() {
       expect(status, isA<Paired>(), reason: 're-init must succeed');
 
       final reAcquired = service.getCredentials(knownAddress);
-      expect(reAcquired.isConnected, isTrue,
-          reason: 're-acquired credentials are attached to the new pairing');
+      expect(
+        reAcquired.isConnected,
+        isTrue,
+        reason: 're-acquired credentials are attached to the new pairing',
+      );
       // The signature must succeed via the re-attached manager.
       final sig = await reAcquired.signTypedDataV4(
         1,
@@ -214,11 +215,13 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
       final losts = transitions.whereType<Lost>().toList();
-      expect(losts, isNotEmpty,
-          reason: 'sign-queue propagation must emit Lost on the stream');
+      expect(losts, isNotEmpty, reason: 'sign-queue propagation must emit Lost on the stream');
       expect(losts.last.reason, equals(LostReason.signQueueTimeout));
-      expect(credentials.isConnected, isFalse,
-          reason: 'signalDeviceLost must detach every credentials');
+      expect(
+        credentials.isConnected,
+        isFalse,
+        reason: 'signalDeviceLost must detach every credentials',
+      );
     },
   );
 
@@ -246,10 +249,16 @@ void main() {
         expect(sig, isNotEmpty);
 
         await service.clear();
-        expect(service.currentStatus, equals(const Disconnected()),
-            reason: 'cycle $i: clear must terminate at Disconnected');
-        expect(credentials.isConnected, isFalse,
-            reason: 'cycle $i: clear must detach the credentials');
+        expect(
+          service.currentStatus,
+          equals(const Disconnected()),
+          reason: 'cycle $i: clear must terminate at Disconnected',
+        );
+        expect(
+          credentials.isConnected,
+          isFalse,
+          reason: 'cycle $i: clear must detach the credentials',
+        );
       }
 
       expect(
@@ -330,52 +339,50 @@ void main() {
     final service = BitboxService(connectionStatusInterval: interval);
     addTearDown(service.dispose);
     final ok = await service.startScan();
-    expect(ok, isTrue,
-        reason: 'simulated platform reports scan success by default');
+    expect(ok, isTrue, reason: 'simulated platform reports scan success by default');
     expect(platform.count(SimulatedBitboxMethod.startScan), 1);
   });
 
-  test('init() failure inside `connect` walks Connecting → Disconnected via the catch arm',
-      () async {
-    // Drives the catch-arm inside `_runInit` that re-emits Disconnected
-    // when an exception escapes the connect path. Achieved by making the
-    // simulator's `open` throw (the SDK call site rethrows the original).
-    platform.throwOn(SimulatedBitboxMethod.open, Exception('USB busy'));
+  test(
+    'init() failure inside `connect` walks Connecting → Disconnected via the catch arm',
+    () async {
+      // Drives the catch-arm inside `_runInit` that re-emits Disconnected
+      // when an exception escapes the connect path. Achieved by making the
+      // simulator's `open` throw (the SDK call site rethrows the original).
+      platform.throwOn(SimulatedBitboxMethod.open, Exception('USB busy'));
 
-    final service = BitboxService(connectionStatusInterval: interval);
-    addTearDown(service.dispose);
-    final observed = <BitboxConnectionStatus>[];
-    final sub = service.status.listen(observed.add);
-    addTearDown(sub.cancel);
+      final service = BitboxService(connectionStatusInterval: interval);
+      addTearDown(service.dispose);
+      final observed = <BitboxConnectionStatus>[];
+      final sub = service.status.listen(observed.add);
+      addTearDown(sub.cancel);
 
-    final devices = await service.getAllUsbDevices();
-    await expectLater(
-      () => service.init(devices.single),
-      throwsA(isA<Exception>()),
-    );
-    // Drain any pending broadcast events so the post-throw Disconnected
-    // lands in `observed` before we assert.
-    await Future<void>.delayed(const Duration(milliseconds: 10));
+      final devices = await service.getAllUsbDevices();
+      await expectLater(
+        () => service.init(devices.single),
+        throwsA(isA<Exception>()),
+      );
+      // Drain any pending broadcast events so the post-throw Disconnected
+      // lands in `observed` before we assert.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
 
-    // Drop the replayed initial Disconnected so the assertion describes
-    // only the transitions caused by init().
-    final transitions = observed
-        .skipWhile((s) => s is Disconnected)
-        .toList(growable: false);
-    expect(
-      transitions.map((s) => s.runtimeType).toList(),
-      containsAllInOrder(<Type>[Connecting, Disconnected]),
-      reason: 'failure in connect must walk Connecting → Disconnected',
-    );
-  });
+      // Drop the replayed initial Disconnected so the assertion describes
+      // only the transitions caused by init().
+      final transitions = observed.skipWhile((s) => s is Disconnected).toList(growable: false);
+      expect(
+        transitions.map((s) => s.runtimeType).toList(),
+        containsAllInOrder(<Type>[Connecting, Disconnected]),
+        reason: 'failure in connect must walk Connecting → Disconnected',
+      );
+    },
+  );
 
   test('getChannelHash and confirmPairing delegate to the SDK', () async {
     final service = await pair();
     addTearDown(service.dispose);
 
     final hash = await service.getChannelHash();
-    expect(hash, isNotEmpty,
-        reason: 'simulator returns its default channel hash');
+    expect(hash, isNotEmpty, reason: 'simulator returns its default channel hash');
 
     await service.confirmPairing();
     expect(platform.count(SimulatedBitboxMethod.channelHashVerify), 1);
@@ -430,8 +437,7 @@ void main() {
         BitboxConnectionStatus? initStatus;
         service.init(devices.single).then((s) => initStatus = s);
         async.flushMicrotasks();
-        expect(initStatus, isA<Paired>(),
-            reason: 'fakeAsync init must reach Paired');
+        expect(initStatus, isA<Paired>(), reason: 'fakeAsync init must reach Paired');
 
         final observed = <BitboxConnectionStatus>[];
         final sub = service.status.listen(observed.add);
@@ -455,14 +461,16 @@ void main() {
         );
         async.flushMicrotasks();
 
-        expect(thrown, isA<BitboxNotConnectedException>(),
-            reason: 'queue-bound timeout must surface the typed exception');
+        expect(
+          thrown,
+          isA<BitboxNotConnectedException>(),
+          reason: 'queue-bound timeout must surface the typed exception',
+        );
 
         // The closure fired Lost(signQueueTimeout) on the stream BEFORE the
         // exception reached the caller.
         final losts = observed.whereType<Lost>().toList();
-        expect(losts, isNotEmpty,
-            reason: 'sign-queue timeout must reach the service-level stream');
+        expect(losts, isNotEmpty, reason: 'sign-queue timeout must reach the service-level stream');
         expect(losts.last.reason, equals(LostReason.signQueueTimeout));
 
         sub.cancel();
@@ -473,4 +481,3 @@ void main() {
 
 // fakeAsync requires Uint8List for the typed-data return; pulled in via
 // bitbox_flutter export above. Keep the test file dependency-clean.
-

--- a/test/integration/bitbox_lifecycle_test.dart
+++ b/test/integration/bitbox_lifecycle_test.dart
@@ -1,0 +1,321 @@
+// Cross-layer integration test for the Initiative I BitBox connection
+// lifecycle. The suite stitches the real `BitboxService` against the in-tree
+// `SimulatedBitboxPlatform` (the same testkit `bitbox_service_lifecycle_test`
+// uses) and exercises the end-to-end traversal that PR #468's 17-item
+// tracking issue cares about:
+//
+//   init → pair → sign → disconnect-mid-sign → reconnect → re-init
+//
+// No mocks above the service surface: real BitboxService, real
+// BitboxCredentials, real broadcast Stream<BitboxConnectionStatus>. The
+// simulated platform is the load-bearing seam — every call site that would
+// reach the BitBox firmware in production lands here instead.
+//
+// This is the Tier-1 conformance pin for ADR 0001's state machine: any
+// refactor of the Stream contract must keep these traversals legal.
+
+import 'dart:async';
+
+import 'package:bitbox_flutter/bitbox_flutter.dart';
+import 'package:bitbox_flutter/testing.dart';
+import 'package:bitbox_flutter/usb/bitbox_usb_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_connection_status.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
+
+void main() {
+  late BitboxUsbPlatform previousPlatform;
+  late SimulatedBitboxPlatform platform;
+
+  const interval = Duration(milliseconds: 25);
+  const settle = Duration(milliseconds: 80);
+  const knownAddress = '0x000000000000000000000000000000000000dead';
+
+  setUp(() {
+    previousPlatform = BitboxUsbPlatform.instance;
+    platform = installSimulatedBitboxPlatform();
+  });
+
+  tearDown(() {
+    BitboxUsbPlatform.instance = previousPlatform;
+  });
+
+  Future<BitboxService> pair() async {
+    final service = BitboxService(connectionStatusInterval: interval);
+    final devices = await service.getAllUsbDevices();
+    final status = await service.init(devices.single);
+    expect(status, isA<Paired>(),
+        reason: 'integration setup requires a successful pair');
+    return service;
+  }
+
+  test(
+    'happy path: init → pair → sign (signTypedDataV4) → clear',
+    () async {
+      final service = await pair();
+      addTearDown(service.dispose);
+
+      final credentials = service.getCredentials(knownAddress);
+      expect(credentials.isConnected, isTrue,
+          reason: 'credentials must be live after pair');
+
+      // sign via the typed-message path so the credentials hit
+      // signETHTypedMessage on the simulator and we observe the full
+      // credentials → manager → platform chain.
+      final signature = await credentials.signTypedDataV4(
+        1,
+        '{"primaryType":"Mail"}',
+      );
+      expect(signature, isNotEmpty);
+      expect(
+        platform.count(SimulatedBitboxMethod.signETHTypedMessage),
+        1,
+        reason: 'sign must reach the platform exactly once',
+      );
+
+      await service.clear();
+      expect(service.currentStatus, equals(const Disconnected()));
+      expect(credentials.isConnected, isFalse);
+    },
+  );
+
+  test(
+    'disconnect-mid-sign: observer flips service to Lost(deviceUnreachable)',
+    () async {
+      final service = await pair();
+      addTearDown(service.dispose);
+
+      final credentials = service.getCredentials(knownAddress);
+      expect(credentials.isConnected, isTrue);
+
+      final transitions = <BitboxConnectionStatus>[];
+      final sub = service.status.listen(transitions.add);
+      addTearDown(sub.cancel);
+
+      // Simulate the device vanishing on the BLE link. The next observer
+      // tick must detect the empty device list and flip Lost.
+      platform.when(
+        SimulatedBitboxMethod.getDevices,
+        (_) async => const <BitboxDevice>[],
+      );
+      service.startConnectionStatusObserver();
+
+      // Wait long enough for at least 2 ticks (the observer's await-chain
+      // takes one tick to inspect the device list and a follow-up microtask
+      // hop to emit Lost).
+      await Future<void>.delayed(settle);
+
+      expect(
+        transitions.whereType<Lost>().toList(),
+        isNotEmpty,
+        reason: 'observer must emit Lost on device vanish',
+      );
+      expect(
+        transitions.whereType<Lost>().last.reason,
+        equals(LostReason.deviceUnreachable),
+      );
+      expect(credentials.isConnected, isFalse);
+    },
+  );
+
+  test(
+    'reconnect after Lost: a fresh init() heals the previously-detached credentials',
+    () async {
+      final service = await pair();
+      addTearDown(service.dispose);
+
+      final credentials = service.getCredentials(knownAddress);
+      expect(credentials.isConnected, isTrue);
+
+      // Vanish then come back.
+      platform.when(
+        SimulatedBitboxMethod.getDevices,
+        (_) async => const <BitboxDevice>[],
+      );
+      service.startConnectionStatusObserver();
+      await Future<void>.delayed(settle);
+      expect(credentials.isConnected, isFalse);
+
+      // Device reappears. clear() is required to walk Lost → Disconnected
+      // before re-init can succeed (per ADR 0001's state machine — Lost is
+      // terminal for the pairing session).
+      await service.clear();
+      expect(service.currentStatus, equals(const Disconnected()));
+
+      platform.when(
+        SimulatedBitboxMethod.getDevices,
+        (_) async => platform.devices,
+      );
+      final devices = await service.getAllUsbDevices();
+      // After clear() the credentials cache was dropped, so re-init does
+      // not re-attach the SAME credentials instance. The consumer must
+      // re-acquire credentials via getCredentials AFTER init.
+      final status = await service.init(devices.single);
+      expect(status, isA<Paired>(), reason: 're-init must succeed');
+
+      final reAcquired = service.getCredentials(knownAddress);
+      expect(reAcquired.isConnected, isTrue,
+          reason: 're-acquired credentials are attached to the new pairing');
+      // The signature must succeed via the re-attached manager.
+      final sig = await reAcquired.signTypedDataV4(
+        1,
+        '{"primaryType":"Mail"}',
+      );
+      expect(sig, isNotEmpty);
+    },
+  );
+
+  test(
+    'sign-queue timeout (mid-sign) routes through service-level Lost(signQueueTimeout)',
+    () async {
+      // End-to-end pin of the F-009 closure: a hung native sign times out,
+      // BitboxCredentials clears local state AND calls the closure the
+      // service wired up — service emits Lost(signQueueTimeout) on the
+      // lifecycle stream BEFORE the credentials' BitboxNotConnectedException
+      // reaches the caller.
+      //
+      // Use the production sign-queue timeout to avoid coupling to internal
+      // duration constants; the timeout is shortened by issuing the sign
+      // against a platform that hangs the native method indefinitely. Real
+      // wait time = signQueueTimeout (5 minutes). Drive the wait via a
+      // bounded test-side timer so the suite stays fast: we stub the native
+      // method to throw immediately as if the bounded sign already gave up.
+      //
+      // For the integration boundary, we rely on the existing unit-test
+      // pinning of the closure invocation (bitbox_credentials_test.dart) and
+      // here only assert the SERVICE-LEVEL post-condition: an immediate
+      // `signalDeviceLost(signQueueTimeout)` from the credentials surfaces
+      // through the stream.
+      BitboxCredentials.resetSignQueue();
+
+      final service = await pair();
+      addTearDown(service.dispose);
+
+      final transitions = <BitboxConnectionStatus>[];
+      final sub = service.status.listen(transitions.add);
+      addTearDown(sub.cancel);
+
+      final credentials = service.getCredentials(knownAddress);
+
+      // Drive the propagation deterministically by triggering it through the
+      // public surface — the service exposes the closure via getCredentials,
+      // so we exercise the equivalent failure path by calling
+      // `signalDeviceLost(signQueueTimeout)` directly. The exact wire from
+      // _synchronizeBoundedSign → closure is unit-tested in
+      // bitbox_credentials_test.dart with fakeAsync.
+      service.signalDeviceLost(LostReason.signQueueTimeout);
+
+      // Lost emission lands synchronously on the broadcast queue and arrives
+      // to subscribers on the next microtask hop.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final losts = transitions.whereType<Lost>().toList();
+      expect(losts, isNotEmpty,
+          reason: 'sign-queue propagation must emit Lost on the stream');
+      expect(losts.last.reason, equals(LostReason.signQueueTimeout));
+      expect(credentials.isConnected, isFalse,
+          reason: 'signalDeviceLost must detach every credentials');
+    },
+  );
+
+  test(
+    'cycle: pair → sign → clear → pair → sign stays legal across iterations',
+    () async {
+      // Stress pin: the state machine has to survive arbitrary pair/clear
+      // cycles without leaking observer timers or wedging the
+      // _pendingDisconnect future. Three full cycles is enough to catch a
+      // missed reset of _pendingInit or _credentialsByAddress.
+      final service = BitboxService(connectionStatusInterval: interval);
+      addTearDown(service.dispose);
+
+      for (var i = 0; i < 3; i++) {
+        final devices = await service.getAllUsbDevices();
+        expect(devices, isNotEmpty);
+        final status = await service.init(devices.single);
+        expect(status, isA<Paired>(), reason: 'cycle $i: init must Pair');
+
+        final credentials = service.getCredentials(knownAddress);
+        final sig = await credentials.signTypedDataV4(
+          1,
+          '{"primaryType":"Iter-$i"}',
+        );
+        expect(sig, isNotEmpty);
+
+        await service.clear();
+        expect(service.currentStatus, equals(const Disconnected()),
+            reason: 'cycle $i: clear must terminate at Disconnected');
+        expect(credentials.isConnected, isFalse,
+            reason: 'cycle $i: clear must detach the credentials');
+      }
+
+      expect(
+        platform.count(SimulatedBitboxMethod.signETHTypedMessage),
+        3,
+        reason: 'every cycle must reach the device exactly once',
+      );
+    },
+  );
+
+  test(
+    'signalDeviceLost from a non-Paired state is a no-op (no spurious Lost emission)',
+    () async {
+      // Defensive: a stale credentials reference firing the closure after
+      // the service has already cleared must NOT emit Lost — the consumer
+      // would otherwise see "lost while never connected" and the state
+      // machine would walk Disconnected → Lost which is illegal.
+      final service = BitboxService(connectionStatusInterval: interval);
+      addTearDown(service.dispose);
+
+      final transitions = <BitboxConnectionStatus>[];
+      final sub = service.status.listen(transitions.add);
+      addTearDown(sub.cancel);
+
+      service.signalDeviceLost(LostReason.signQueueTimeout);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(
+        transitions.whereType<Lost>(),
+        isEmpty,
+        reason: 'signalDeviceLost from Disconnected must be a no-op',
+      );
+    },
+  );
+
+  test(
+    'sign on a cleared service throws BitboxNotConnectedException',
+    () async {
+      // Cleared service => credentials cache empty AND manager detached.
+      // The next sign must fail fast with the typed exception instead of
+      // racing the (now-disconnected) device.
+      final service = await pair();
+      addTearDown(service.dispose);
+
+      final credentials = service.getCredentials(knownAddress);
+      await service.clear();
+
+      await expectLater(
+        credentials.signTypedDataV4(1, '{"primaryType":"X"}'),
+        throwsA(isA<BitboxNotConnectedException>()),
+      );
+    },
+  );
+
+  test('dispose() closes the stream and rejects subsequent init()', () async {
+    final service = await pair();
+    final done = Completer<void>();
+    service.status.listen((_) {}, onDone: done.complete);
+
+    final devices = await service.getAllUsbDevices();
+    await service.dispose();
+    await done.future.timeout(const Duration(seconds: 1));
+
+    expect(
+      () => service.init(devices.single),
+      throwsA(isA<StateError>()),
+      reason: 'init() after dispose() must throw',
+    );
+  });
+}
+

--- a/test/integration/connect_bitbox_flow_test.dart
+++ b/test/integration/connect_bitbox_flow_test.dart
@@ -22,6 +22,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_connection_status.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
@@ -299,8 +300,8 @@ void main() {
         );
         final devices = await service.getAllUsbDevices();
         expect(devices, hasLength(1));
-        final initOk = await service.init(devices.single);
-        expect(initOk, isTrue);
+        final status = await service.init(devices.single);
+        expect(status, isA<Paired>());
 
         expect(
           credentials.isConnected,

--- a/test/packages/hardware_wallet/bitbox_connection_status_test.dart
+++ b/test/packages/hardware_wallet/bitbox_connection_status_test.dart
@@ -1,0 +1,228 @@
+import 'package:bitbox_flutter/bitbox_flutter.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_connection_status.dart';
+
+// Pins the sealed-class equality + immutability contract that ADR 0001
+// promises consumers. If a refactor breaks value equality on any variant the
+// broadcast controller's de-dup logic + bloc-test assertions silently slip,
+// so the test surface is deliberately exhaustive — every variant gets an
+// equality, an inequality, and a toString debug-print pin.
+void main() {
+  BitboxDevice device(String id) =>
+      BitboxDevice.fromIdentifier(id);
+
+  group('$BitboxConnectionStatus equality', () {
+    test('Disconnected instances are equal', () {
+      expect(const Disconnected(), equals(const Disconnected()));
+      // Distinct identities deliberately — the controller must dedupe on
+      // value, not on reference, when a transient transition lands back on
+      // the same terminal status.
+      expect(identical(const Disconnected(), const Disconnected()), isTrue,
+          reason: 'const Disconnected() is canonicalised');
+    });
+
+    test('Disconnecting instances are equal', () {
+      expect(const Disconnecting(), equals(const Disconnecting()));
+    });
+
+    test('Connecting equality keys on device identifier', () {
+      expect(
+        Connecting(device('bitbox-A')),
+        equals(Connecting(device('bitbox-A'))),
+      );
+      expect(
+        Connecting(device('bitbox-A')),
+        isNot(equals(Connecting(device('bitbox-B')))),
+        reason: 'distinct devices must compare unequal',
+      );
+    });
+
+    test('Paired equality keys on device identifier', () {
+      expect(
+        Paired(device('bitbox-A')),
+        equals(Paired(device('bitbox-A'))),
+      );
+      expect(
+        Paired(device('bitbox-A')),
+        isNot(equals(Paired(device('bitbox-B')))),
+      );
+    });
+
+    test('Connecting and Paired are not equal even with the same device', () {
+      // Belt-and-braces: if a future refactor mistakenly hashes on `props`
+      // alone without considering the runtime type, this catches it.
+      expect(
+        Connecting(device('bitbox-A')),
+        isNot(equals(Paired(device('bitbox-A')))),
+      );
+    });
+
+    test('InUse equality keys on (device, context)', () {
+      final ctxA = const SignContext(
+        address: '0xdead',
+        derivationPath: "m/44'/60'/0'/0/0",
+        kind: 'eip712',
+      );
+      final ctxB = const SignContext(
+        address: '0xdead',
+        derivationPath: "m/44'/60'/0'/0/1",
+        kind: 'eip712',
+      );
+      expect(
+        InUse(device('bitbox-A'), ctxA),
+        equals(InUse(device('bitbox-A'), ctxA)),
+      );
+      expect(
+        InUse(device('bitbox-A'), ctxA),
+        isNot(equals(InUse(device('bitbox-A'), ctxB))),
+        reason: 'different derivation paths must compare unequal',
+      );
+      expect(
+        InUse(device('bitbox-A'), ctxA),
+        isNot(equals(InUse(device('bitbox-B'), ctxA))),
+        reason: 'different devices must compare unequal',
+      );
+    });
+
+    test('Lost equality keys on reason', () {
+      expect(
+        const Lost(LostReason.signQueueTimeout),
+        equals(const Lost(LostReason.signQueueTimeout)),
+      );
+      expect(
+        const Lost(LostReason.signQueueTimeout),
+        isNot(equals(const Lost(LostReason.staticPubkeyMismatch))),
+      );
+      expect(
+        const Lost(LostReason.deviceUnreachable),
+        isNot(equals(const Lost(LostReason.factoryResetDetected))),
+      );
+    });
+
+    test('Disconnected and Lost are never equal even with no payload-difference', () {
+      expect(
+        const Disconnected(),
+        isNot(equals(const Lost(LostReason.manualDisconnect))),
+      );
+    });
+  });
+
+  group('$BitboxConnectionStatus debug surface', () {
+    test('toString names the runtime type for each variant', () {
+      expect(const Disconnected().toString(), equals('Disconnected()'));
+      expect(const Disconnecting().toString(), equals('Disconnecting()'));
+      expect(
+        Connecting(device('bitbox-A')).toString(),
+        equals('Connecting(bitbox-A)'),
+      );
+      expect(
+        Paired(device('bitbox-A')).toString(),
+        equals('Paired(bitbox-A)'),
+      );
+      expect(
+        const Lost(LostReason.signQueueTimeout).toString(),
+        equals('Lost(signQueueTimeout)'),
+      );
+    });
+
+    test('InUse.toString includes both device identifier and sign context', () {
+      final ctx = const SignContext(
+        address: '0xdead',
+        derivationPath: "m/44'/60'/0'/0/0",
+        kind: 'eip712',
+      );
+      expect(
+        InUse(device('bitbox-A'), ctx).toString(),
+        contains('bitbox-A'),
+      );
+      expect(
+        InUse(device('bitbox-A'), ctx).toString(),
+        contains('eip712'),
+      );
+    });
+  });
+
+  group('$LostReason enum surface', () {
+    test('every reason has a stable name (sealed-set contract)', () {
+      // The set is closed by design — adding a new value forces a
+      // coordinated update everywhere this enum is switched on. The test
+      // pins the current set so an accidental rename or removal is caught
+      // before it ships.
+      expect(LostReason.values.map((r) => r.name).toSet(), equals({
+        'signQueueTimeout',
+        'staticPubkeyMismatch',
+        'manualDisconnect',
+        'deviceUnreachable',
+        'factoryResetDetected',
+      }));
+    });
+  });
+
+  group('exhaustiveness — sealed switch', () {
+    // Compile-time pin: a sealed-class switch over BitboxConnectionStatus
+    // must compile to a complete `T Function(...)` without a default arm.
+    // If a future PR adds a new subtype without updating the switch this
+    // test stops compiling — the canonical Dart 3 sealed-class enforcement
+    // the consumer surface depends on.
+    String nameOf(BitboxConnectionStatus status) {
+      return switch (status) {
+        Disconnected() => 'disconnected',
+        Connecting() => 'connecting',
+        Paired() => 'paired',
+        InUse() => 'inUse',
+        Lost() => 'lost',
+        Disconnecting() => 'disconnecting',
+      };
+    }
+
+    test('switch covers every variant exhaustively at compile time', () {
+      expect(nameOf(const Disconnected()), 'disconnected');
+      expect(nameOf(Connecting(device('x'))), 'connecting');
+      expect(nameOf(Paired(device('x'))), 'paired');
+      expect(
+        nameOf(InUse(
+          device('x'),
+          const SignContext(
+            address: '0xdead',
+            derivationPath: "m/44'/60'/0'/0/0",
+            kind: 'eip712',
+          ),
+        )),
+        'inUse',
+      );
+      expect(nameOf(const Lost(LostReason.signQueueTimeout)), 'lost');
+      expect(nameOf(const Disconnecting()), 'disconnecting');
+    });
+  });
+
+  group('$SignContext equality', () {
+    test('same (address, path, kind) compares equal', () {
+      const a = SignContext(
+        address: '0xdead',
+        derivationPath: "m/44'/60'/0'/0/0",
+        kind: 'eip712',
+      );
+      const b = SignContext(
+        address: '0xdead',
+        derivationPath: "m/44'/60'/0'/0/0",
+        kind: 'eip712',
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('different kind compares unequal', () {
+      const a = SignContext(
+        address: '0xdead',
+        derivationPath: "m/44'/60'/0'/0/0",
+        kind: 'eip712',
+      );
+      const b = SignContext(
+        address: '0xdead',
+        derivationPath: "m/44'/60'/0'/0/0",
+        kind: 'eip7702',
+      );
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/test/packages/hardware_wallet/bitbox_connection_status_test.dart
+++ b/test/packages/hardware_wallet/bitbox_connection_status_test.dart
@@ -8,8 +8,7 @@ import 'package:realunit_wallet/packages/hardware_wallet/bitbox_connection_statu
 // so the test surface is deliberately exhaustive — every variant gets an
 // equality, an inequality, and a toString debug-print pin.
 void main() {
-  BitboxDevice device(String id) =>
-      BitboxDevice.fromIdentifier(id);
+  BitboxDevice device(String id) => BitboxDevice.fromIdentifier(id);
 
   group('$BitboxConnectionStatus equality', () {
     test('Disconnected instances are equal', () {
@@ -17,12 +16,17 @@ void main() {
       // Distinct identities deliberately — the controller must dedupe on
       // value, not on reference, when a transient transition lands back on
       // the same terminal status.
-      expect(identical(const Disconnected(), const Disconnected()), isTrue,
-          reason: 'const Disconnected() is canonicalised');
+      expect(
+        identical(const Disconnected(), const Disconnected()),
+        isTrue,
+        reason: 'const Disconnected() is canonicalised',
+      );
+      expect(const Disconnected().props, isEmpty);
     });
 
     test('Disconnecting instances are equal', () {
       expect(const Disconnecting(), equals(const Disconnecting()));
+      expect(const Disconnecting().props, isEmpty);
     });
 
     test('Connecting equality keys on device identifier', () {
@@ -148,13 +152,16 @@ void main() {
       // coordinated update everywhere this enum is switched on. The test
       // pins the current set so an accidental rename or removal is caught
       // before it ships.
-      expect(LostReason.values.map((r) => r.name).toSet(), equals({
-        'signQueueTimeout',
-        'staticPubkeyMismatch',
-        'manualDisconnect',
-        'deviceUnreachable',
-        'factoryResetDetected',
-      }));
+      expect(
+        LostReason.values.map((r) => r.name).toSet(),
+        equals({
+          'signQueueTimeout',
+          'staticPubkeyMismatch',
+          'manualDisconnect',
+          'deviceUnreachable',
+          'factoryResetDetected',
+        }),
+      );
     });
   });
 
@@ -180,14 +187,16 @@ void main() {
       expect(nameOf(Connecting(device('x'))), 'connecting');
       expect(nameOf(Paired(device('x'))), 'paired');
       expect(
-        nameOf(InUse(
-          device('x'),
-          const SignContext(
-            address: '0xdead',
-            derivationPath: "m/44'/60'/0'/0/0",
-            kind: 'eip712',
+        nameOf(
+          InUse(
+            device('x'),
+            const SignContext(
+              address: '0xdead',
+              derivationPath: "m/44'/60'/0'/0/0",
+              kind: 'eip712',
+            ),
           ),
-        )),
+        ),
         'inUse',
       );
       expect(nameOf(const Lost(LostReason.signQueueTimeout)), 'lost');
@@ -197,8 +206,9 @@ void main() {
 
   group('$SignContext equality', () {
     test('same (address, path, kind) compares equal', () {
-      const a = SignContext(
-        address: '0xdead',
+      final address = '0xdead';
+      final a = SignContext(
+        address: address,
         derivationPath: "m/44'/60'/0'/0/0",
         kind: 'eip712',
       );

--- a/test/packages/hardware_wallet/bitbox_credentials_test.dart
+++ b/test/packages/hardware_wallet/bitbox_credentials_test.dart
@@ -431,5 +431,204 @@ void main() {
         throwsA(isA<BitboxNotConnectedException>()),
       );
     });
+
+    // -----------------------------------------------------------------------
+    // Initiative I (ADR 0001) — sign-queue timeout propagation.
+    //
+    // Pre-Initiative-I, a timed-out sign cleared credentials but left
+    // BitboxService thinking we were still Paired. The consuming cubit had to
+    // poll currentStatus to discover the loss. The fix wires an
+    // `_onSignQueueTimeout` closure that the service installs via
+    // `getCredentials`, and the timeout branch calls it before throwing
+    // BitboxNotConnectedException.
+    //
+    // The tests below pin BOTH effects (clearBitbox AND the closure call) so
+    // a future refactor that drops one half flips the assertion immediately.
+    // -----------------------------------------------------------------------
+
+    test(
+      'a hung sign fires the _onSignQueueTimeout callback once AND clears credentials',
+      () {
+        fakeAsync((async) {
+          BitboxCredentials.resetSignQueue();
+          async.flushMicrotasks();
+
+          when(() => manager.signETHTypedMessage(any(), any(), any()))
+              .thenAnswer((_) => Completer<Uint8List>().future);
+
+          var timeoutCalls = 0;
+          final c = BitboxCredentials(
+            '0x000000000000000000000000000000000000dead',
+            () => timeoutCalls++,
+          )..setBitbox(manager);
+
+          c.signTypedDataV4(1, '{"primaryType":"A"}').catchError(
+            (Object _) => '',
+          );
+
+          // Before the bound the callback has NOT fired.
+          async.elapse(
+            BitboxCredentials.signQueueTimeout - const Duration(seconds: 1),
+          );
+          async.flushMicrotasks();
+          expect(timeoutCalls, 0, reason: 'callback must not fire pre-timeout');
+
+          // Past the bound the callback fires exactly once, and credentials
+          // are cleared.
+          async.elapse(const Duration(seconds: 2));
+          async.flushMicrotasks();
+          expect(timeoutCalls, 1,
+              reason: 'sign-queue timeout must invoke the closure exactly once');
+          expect(c.isConnected, isFalse,
+              reason: 'sign-queue timeout must clear local credentials');
+        });
+      },
+    );
+
+    test(
+      'a successful sign does NOT invoke the _onSignQueueTimeout callback',
+      () async {
+        // Negative pin: the callback is strictly a timeout signal; a normal
+        // sign-success path must not flip the service to Lost.
+        var timeoutCalls = 0;
+        when(() => manager.signETHTypedMessage(any(), any(), any()))
+            .thenAnswer((_) async => Uint8List.fromList([0x42]));
+
+        final c = BitboxCredentials(
+          '0x000000000000000000000000000000000000dead',
+          () => timeoutCalls++,
+        )..setBitbox(manager);
+
+        await c.signTypedDataV4(1, '{"primaryType":"OK"}');
+        expect(timeoutCalls, 0);
+        expect(c.isConnected, isTrue,
+            reason: 'a successful sign keeps the credentials attached');
+      },
+    );
+
+    test(
+      'a sign that throws (non-timeout) does NOT invoke _onSignQueueTimeout',
+      () async {
+        // Distinguish the timeout path from generic native-error paths.
+        // A native sign-error must surface as its own exception; only the
+        // queue-timeout flips the service-level state to Lost.
+        var timeoutCalls = 0;
+        when(() => manager.signETHTypedMessage(any(), any(), any()))
+            .thenThrow(_ParseError());
+
+        final c = BitboxCredentials(
+          '0x000000000000000000000000000000000000dead',
+          () => timeoutCalls++,
+        )..setBitbox(manager);
+
+        await expectLater(
+          c.signTypedDataV4(1, '{"primaryType":"A"}'),
+          throwsA(isA<_ParseError>()),
+        );
+        expect(timeoutCalls, 0,
+            reason: 'native-error path must not trigger the service-Lost flow');
+      },
+    );
+
+    test(
+      'omitting the callback keeps the timeout path safe (no NPE)',
+      () {
+        // Defensive guard: the callback parameter is optional. A test or
+        // construction-site that never wires the closure must still see the
+        // timeout path complete — the closure call is null-aware.
+        fakeAsync((async) {
+          BitboxCredentials.resetSignQueue();
+          async.flushMicrotasks();
+
+          when(() => manager.signETHTypedMessage(any(), any(), any()))
+              .thenAnswer((_) => Completer<Uint8List>().future);
+
+          final c = BitboxCredentials(
+            '0x000000000000000000000000000000000000dead',
+          )..setBitbox(manager);
+
+          Object? thrown;
+          c.signTypedDataV4(1, '{"primaryType":"A"}').catchError(
+            (Object e) {
+              thrown = e;
+              return '';
+            },
+          );
+          async.elapse(
+            BitboxCredentials.signQueueTimeout + const Duration(seconds: 1),
+          );
+          async.flushMicrotasks();
+
+          expect(thrown, isA<BitboxNotConnectedException>(),
+              reason: 'no callback wired still surfaces the typed exception');
+        });
+      },
+    );
+
+    test(
+      'property: across a sequence with mid-timeout, callback fires exactly once before any subsequent sign',
+      () {
+        // Property pin (hand-rolled loop): for every mid-sign timeout in a
+        // sequence of K signs, the callback must fire exactly once and the
+        // remaining signs must observe `isConnected == false` (post-timeout)
+        // BEFORE they reach the device. Iterates over K in [1..6] so an
+        // off-by-one in the queue-slot release surfaces.
+        for (var totalSigns = 1; totalSigns <= 6; totalSigns++) {
+          fakeAsync((async) {
+            BitboxCredentials.resetSignQueue();
+            async.flushMicrotasks();
+
+            var nativeCalls = 0;
+            when(() => manager.signETHTypedMessage(any(), any(), any()))
+                .thenAnswer((_) {
+              nativeCalls++;
+              // Every native call hangs; the queue-timeout must clean up.
+              return Completer<Uint8List>().future;
+            });
+
+            var timeoutCalls = 0;
+            final c = BitboxCredentials(
+              '0x000000000000000000000000000000000000dead',
+              () => timeoutCalls++,
+            )..setBitbox(manager);
+
+            // Issue K signs. After the first one hits the timeout, every
+            // subsequent sign must fail fast (manager == null guard) without
+            // ever reaching the native mock.
+            final thrown = <Object?>[];
+            for (var i = 0; i < totalSigns; i++) {
+              c.signTypedDataV4(1, '{"primaryType":"P$i"}').catchError(
+                (Object e) {
+                  thrown.add(e);
+                  return '';
+                },
+              );
+            }
+
+            async.elapse(
+              BitboxCredentials.signQueueTimeout +
+                  const Duration(seconds: 2),
+            );
+            async.flushMicrotasks();
+
+            expect(timeoutCalls, 1,
+                reason: 'totalSigns=$totalSigns: callback must fire exactly once');
+            expect(c.isConnected, isFalse);
+            // Native mock must have been called exactly once — the first
+            // sign — and never again because subsequent signs see the
+            // detached manager and fail fast at the snapshot null-check.
+            expect(nativeCalls, 1,
+                reason:
+                    'totalSigns=$totalSigns: post-timeout signs must NOT reach the device');
+            // Every sign in the batch must observe the typed exception.
+            for (final t in thrown) {
+              expect(t, isA<BitboxNotConnectedException>());
+            }
+            expect(thrown.length, totalSigns,
+                reason: 'all signs must terminate with a typed exception');
+          });
+        }
+      },
+    );
   });
 }

--- a/test/packages/hardware_wallet/bitbox_credentials_test.dart
+++ b/test/packages/hardware_wallet/bitbox_credentials_test.dart
@@ -433,6 +433,66 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
+    // Defensive pins for the pre-existing surface (kept covered so a future
+    // refactor that ports these to real implementations also lands its tests).
+    // -----------------------------------------------------------------------
+
+    test('address derives from the constructor-supplied hex', () {
+      final c = BitboxCredentials('0x000000000000000000000000000000000000dead');
+      expect(
+        c.address.hexEip55,
+        equals('0x000000000000000000000000000000000000dEaD'),
+      );
+    });
+
+    test('signToEcSignature throws UnimplementedError (intentionally unsupported)', () {
+      final c = connected();
+      expect(
+        () => c.signToEcSignature(Uint8List(32)),
+        throwsA(isA<UnimplementedError>()),
+      );
+    });
+
+    test(
+      'signPersonalMessageToUint8List throws UnimplementedError (intentionally unsupported)',
+      () {
+        final c = connected();
+        expect(
+          () => c.signPersonalMessageToUint8List(Uint8List(32)),
+          throwsA(isA<UnimplementedError>()),
+        );
+      },
+    );
+
+    test('signToSignature truncates a >32-bit chainId before EIP-155 parity match', () async {
+      // chainId well past 2^32 forces the truncation while-loop to iterate.
+      // The truncated chainId then becomes the EIP-155 target; we mock a
+      // matching v so the parity-0 branch resolves.
+      final hugeChainId = 0x1234567890; // 41 bits
+      // After truncation by `>>= 8` repeated while bitLength > 32, the
+      // result fits in 32 bits and produces a deterministic truncTarget.
+      var trunc = hugeChainId;
+      while (trunc.bitLength > 32) {
+        trunc >>= 8;
+      }
+      final truncTarget = trunc * 2 + 35; // EIP-155 parity-0
+      final fakeSig = Uint8List.fromList(
+        List<int>.filled(32, 0x11) + List<int>.filled(32, 0x22) + [truncTarget & 0xff],
+      );
+      when(
+        () => manager.signETHRLPTransaction(any(), any(), any(), any()),
+      ).thenAnswer((_) async => fakeSig);
+
+      final sig = await connected().signToSignature(
+        Uint8List.fromList([0xDE]),
+        chainId: hugeChainId,
+      );
+      // chainIdV = parity + (chainId * 2 + 35). Parity must be 0 because we
+      // crafted truncTarget to match v exactly.
+      expect(sig.v, 0 + (hugeChainId * 2 + 35));
+    });
+
+    // -----------------------------------------------------------------------
     // Initiative I (ADR 0001) — sign-queue timeout propagation.
     //
     // Pre-Initiative-I, a timed-out sign cleared credentials but left

--- a/test/packages/hardware_wallet/bitbox_service_lifecycle_test.dart
+++ b/test/packages/hardware_wallet/bitbox_service_lifecycle_test.dart
@@ -567,4 +567,118 @@ void main() {
       });
     });
   });
+
+  group('multi-subscriber + cancel semantics', () {
+    test('two simultaneous subscribers receive the same traversal', () {
+      // Broadcast contract: every active subscription sees every transition
+      // in the same order. Without this, a sub-Cubit could miss a Lost the
+      // parent Cubit observed and continue to treat the device as live.
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        final a = observe(service);
+        final b = observe(service);
+        pairServiceSync(async, service);
+        service.signalDeviceLost(LostReason.signQueueTimeout);
+        async.flushMicrotasks();
+        service.clear();
+        async.flushMicrotasks();
+
+        final aTypes = a.map((s) => s.runtimeType).toList();
+        final bTypes = b.map((s) => s.runtimeType).toList();
+        expect(aTypes, equals(bTypes),
+            reason: 'broadcast subscribers must observe identical traversals');
+        expect(aTypes, containsAllInOrder(<Type>[
+          Paired,
+          Lost,
+          Disconnecting,
+          Disconnected,
+        ]));
+      });
+    });
+
+    test('cancelled subscriptions stop receiving transitions', () {
+      // Subscription leak guard: a cubit's `close()` must let go of its
+      // status subscription. After `cancel()` no further events should
+      // reach the closed-over collector.
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+
+        final received = <BitboxConnectionStatus>[];
+        final sub = service.status.listen(received.add);
+        async.flushMicrotasks();
+        final countBeforeCancel = received.length;
+
+        sub.cancel();
+        pairServiceSync(async, service);
+        service.clear();
+        async.flushMicrotasks();
+
+        expect(received.length, countBeforeCancel,
+            reason: 'cancelled subscriptions must not accrue events');
+      });
+    });
+  });
+
+  group('clear() observable post-conditions', () {
+    test('clear() empties _credentialsByAddress (next getCredentials is fresh)', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        pairServiceSync(async, service);
+
+        final original = service.getCredentials(
+          '0x000000000000000000000000000000000000dead',
+        );
+        expect(original.isConnected, isTrue);
+
+        service.clear();
+        async.flushMicrotasks();
+
+        final after = service.getCredentials(
+          '0x000000000000000000000000000000000000dead',
+        );
+        expect(identical(after, original), isFalse,
+            reason: 'clear() drops cached credentials');
+        expect(after.isConnected, isFalse,
+            reason: 'fresh credentials before re-init are detached');
+      });
+    });
+
+    test('clear() detaches the BitboxManager from every credentials in the map', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        pairServiceSync(async, service);
+
+        final a = service.getCredentials(
+          '0x000000000000000000000000000000000000dead',
+        );
+        final b = service.getCredentials(
+          '0x000000000000000000000000000000000000beef',
+        );
+        expect(a.isConnected, isTrue);
+        expect(b.isConnected, isTrue);
+
+        service.clear();
+        async.flushMicrotasks();
+
+        expect(a.isConnected, isFalse,
+            reason: 'clear() must null-out the manager on every credentials');
+        expect(b.isConnected, isFalse);
+      });
+    });
+
+    test('clear() final status is Disconnected (terminal of the walk)', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        pairServiceSync(async, service);
+        service.clear();
+        async.flushMicrotasks();
+        expect(service.currentStatus, equals(const Disconnected()));
+      });
+    });
+  });
 }

--- a/test/packages/hardware_wallet/bitbox_service_lifecycle_test.dart
+++ b/test/packages/hardware_wallet/bitbox_service_lifecycle_test.dart
@@ -193,19 +193,16 @@ void main() {
             .then(results.add)
             .catchError((Object e) {
           firstError = e;
-          return const Disconnected() as BitboxConnectionStatus;
         });
         service.init(devices.single)
             .then(results.add)
             .catchError((Object e) {
           secondError = e;
-          return const Disconnected() as BitboxConnectionStatus;
         });
         service.init(devices.single)
             .then(results.add)
             .catchError((Object e) {
           thirdError = e;
-          return const Disconnected() as BitboxConnectionStatus;
         });
         async.flushMicrotasks();
 

--- a/test/packages/hardware_wallet/bitbox_service_lifecycle_test.dart
+++ b/test/packages/hardware_wallet/bitbox_service_lifecycle_test.dart
@@ -1,0 +1,573 @@
+import 'dart:async';
+
+import 'package:bitbox_flutter/bitbox_flutter.dart';
+import 'package:bitbox_flutter/testing.dart';
+import 'package:bitbox_flutter/usb/bitbox_usb_platform_interface.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_connection_status.dart';
+
+// Lifecycle conformance suite — pins the Initiative I contract: a single
+// Stream<BitboxConnectionStatus> owned by BitboxService is the only truth
+// for connect-state, and the state-machine traversal is exactly the one
+// declared in ADR 0001.
+//
+// Property-style coverage:
+//   - For any sequence of init/clear/signalDeviceLost, observed Stream is a
+//     valid traversal (no Disconnected→InUse without Paired, etc.).
+//   - For any concurrent init() calls, exactly one bitboxManager.connect()
+//     is invoked.
+//   - dispose() rejects subsequent init() with StateError; no Stream
+//     emissions after dispose().
+//
+// All time-sensitive cases drive the periodic observer inside fakeAsync so
+// virtual time replaces wall-clock Future.delayed — keeps the suite under
+// 200ms total even though the observer interval is artificially fast (50ms).
+void main() {
+  late BitboxUsbPlatform previousPlatform;
+  late SimulatedBitboxPlatform platform;
+
+  const fastInterval = Duration(milliseconds: 50);
+  const observerSettleTime = Duration(milliseconds: 150);
+
+  setUp(() {
+    previousPlatform = BitboxUsbPlatform.instance;
+    platform = installSimulatedBitboxPlatform();
+  });
+
+  tearDown(() {
+    BitboxUsbPlatform.instance = previousPlatform;
+  });
+
+  /// Pair the service inside an existing fakeAsync zone. Returns the device
+  /// the service is now paired to. Must NOT be called outside fakeAsync.
+  BitboxDevice pairServiceSync(FakeAsync async, BitboxService service) {
+    late List<BitboxDevice> devices;
+    service.getAllUsbDevices().then((d) => devices = d);
+    async.flushMicrotasks();
+    service.init(devices.single);
+    async.flushMicrotasks();
+    return devices.single;
+  }
+
+  /// Collect every status emission until the disposable subscription is
+  /// cancelled by [addTearDown]. Sized to be appendable across fakeAsync
+  /// boundaries.
+  List<BitboxConnectionStatus> observe(BitboxService service) {
+    final emitted = <BitboxConnectionStatus>[];
+    final sub = service.status.listen(emitted.add);
+    addTearDown(sub.cancel);
+    return emitted;
+  }
+
+  group('Stream replay-last semantics', () {
+    test('a fresh subscriber synchronously receives Disconnected as initial state', () {
+      // Replay-last contract: subscribing late must NOT leave the consumer
+      // blind to the current state until the next transition. Without this,
+      // a cubit constructed after the service has paired would render
+      // "BitboxNotConnected" until something happened to bump the stream.
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+
+        final observed = observe(service);
+        async.flushMicrotasks();
+
+        expect(observed, isNotEmpty,
+            reason: 'late subscriber must receive replayed status');
+        expect(observed.first, equals(const Disconnected()));
+      });
+    });
+
+    test('the latest status is replayed even after multiple transitions', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+
+        pairServiceSync(async, service);
+        async.flushMicrotasks();
+
+        // Subscribe AFTER the Paired transition.
+        final observed = observe(service);
+        async.flushMicrotasks();
+
+        expect(observed.last, isA<Paired>(),
+            reason: 'replay-last must surface the post-transition state');
+      });
+    });
+
+    test('currentStatus exposes the most recent emission without subscribing', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+
+        expect(service.currentStatus, equals(const Disconnected()),
+            reason: 'pre-init currentStatus is Disconnected');
+
+        pairServiceSync(async, service);
+        async.flushMicrotasks();
+
+        expect(service.currentStatus, isA<Paired>(),
+            reason: 'post-init currentStatus follows the stream');
+      });
+    });
+  });
+
+  group('init() lifecycle', () {
+    test('init() emits Connecting then Paired on success', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+
+        final observed = observe(service);
+        pairServiceSync(async, service);
+        async.flushMicrotasks();
+
+        // Drop the replayed Disconnected so the trail describes only
+        // the transitions caused by init().
+        final transitions = observed
+            .skipWhile((s) => s is Disconnected)
+            .toList(growable: false);
+        expect(
+          transitions.map((s) => s.runtimeType).toList(),
+          containsAllInOrder(<Type>[Connecting, Paired]),
+          reason: 'init() must walk Connecting → Paired',
+        );
+      });
+    });
+
+    test('init() emits Connecting then Disconnected when initBitBox returns false', () {
+      // Failure path: the SDK returned `false`. The service must NOT promote
+      // any credentials and must NOT linger in Connecting — it has to walk
+      // back to Disconnected so the cubit can decide to retry.
+      fakeAsync((async) {
+        platform.when(SimulatedBitboxMethod.initBitBox, (_) async => false);
+
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+
+        final observed = observe(service);
+        late List<BitboxDevice> devices;
+        service.getAllUsbDevices().then((d) => devices = d);
+        async.flushMicrotasks();
+
+        Object? caught;
+        service.init(devices.single).catchError((Object e) {
+          caught = e;
+          return const Disconnected() as BitboxConnectionStatus;
+        });
+        async.flushMicrotasks();
+
+        expect(caught, isA<Exception>(),
+            reason: 'init() must throw when initBitBox returns false');
+
+        final transitions = observed
+            .skipWhile((s) => s is Disconnected)
+            .toList(growable: false);
+        expect(
+          transitions.map((s) => s.runtimeType).toList(),
+          containsAllInOrder(<Type>[Connecting, Disconnected]),
+        );
+        expect(service.currentStatus, equals(const Disconnected()));
+      });
+    });
+
+    test('concurrent init() calls share a single bitboxManager.connect()', () {
+      // Property: for any N concurrent init() invocations the underlying SDK
+      // must see exactly one connect(). The shared-future guard is the only
+      // defence against two BLE handshakes racing on the same noise channel.
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+
+        late List<BitboxDevice> devices;
+        service.getAllUsbDevices().then((d) => devices = d);
+        async.flushMicrotasks();
+
+        final results = <BitboxConnectionStatus>[];
+        Object? firstError;
+        Object? secondError;
+        Object? thirdError;
+        service.init(devices.single)
+            .then(results.add)
+            .catchError((Object e) {
+          firstError = e;
+          return const Disconnected() as BitboxConnectionStatus;
+        });
+        service.init(devices.single)
+            .then(results.add)
+            .catchError((Object e) {
+          secondError = e;
+          return const Disconnected() as BitboxConnectionStatus;
+        });
+        service.init(devices.single)
+            .then(results.add)
+            .catchError((Object e) {
+          thirdError = e;
+          return const Disconnected() as BitboxConnectionStatus;
+        });
+        async.flushMicrotasks();
+
+        expect(firstError, isNull);
+        expect(secondError, isNull);
+        expect(thirdError, isNull);
+        expect(results.length, 3,
+            reason: 'every caller receives the shared result');
+        expect(
+          platform.count(SimulatedBitboxMethod.initBitBox),
+          1,
+          reason:
+              'exactly one initBitBox per concurrent init() batch (property pin)',
+        );
+      });
+    });
+
+    test('init() after a successful pair is a no-op when re-driven by checkForBitbox', () {
+      // Defensive pin: the service already exposes a connected manager. A
+      // second init() with the same device must short-circuit (return the
+      // current Paired status) without re-issuing connect/initBitBox.
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        final device = pairServiceSync(async, service);
+        final initsAfterPair = platform.count(SimulatedBitboxMethod.initBitBox);
+
+        BitboxConnectionStatus? result;
+        service.init(device).then((s) => result = s);
+        async.flushMicrotasks();
+
+        expect(result, isA<Paired>(),
+            reason: 'redundant init() resolves to the live Paired status');
+        expect(
+          platform.count(SimulatedBitboxMethod.initBitBox),
+          initsAfterPair,
+          reason: 'redundant init() must not re-call initBitBox',
+        );
+      });
+    });
+  });
+
+  group('clear() semantics', () {
+    test('clear() emits Disconnecting → Disconnected and empties the credentials map', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        pairServiceSync(async, service);
+
+        // Hand out one credential so the cleanup path has something to
+        // empty — pinned via isConnected before vs. after.
+        final credentials =
+            service.getCredentials('0x000000000000000000000000000000000000dead');
+        expect(credentials.isConnected, isTrue);
+
+        final observed = observe(service);
+        service.clear();
+        async.flushMicrotasks();
+
+        final trail = observed
+            .skipWhile((s) => s is! Paired)
+            .skip(1)
+            .toList(growable: false);
+        expect(
+          trail.map((s) => s.runtimeType).toList(),
+          equals(<Type>[Disconnecting, Disconnected]),
+          reason: 'clear() walks Paired → Disconnecting → Disconnected',
+        );
+        expect(credentials.isConnected, isFalse,
+            reason: 'clear() must detach every credentials in the map');
+      });
+    });
+
+    test('clear() on Disconnected is a no-op (idempotent)', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+
+        final observed = observe(service);
+        service.clear();
+        async.flushMicrotasks();
+        service.clear();
+        async.flushMicrotasks();
+
+        // Only the replayed initial Disconnected — no Disconnecting → Disconnected
+        // round-trip should fire from a state where there's nothing to clear.
+        expect(observed.whereType<Disconnecting>(), isEmpty,
+            reason: 'clear() from Disconnected must not emit Disconnecting');
+      });
+    });
+
+    test('clear() drops the credentials map so a re-paired session starts fresh', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        pairServiceSync(async, service);
+
+        final beforeClear =
+            service.getCredentials('0x000000000000000000000000000000000000dead');
+        expect(beforeClear.isConnected, isTrue);
+
+        service.clear();
+        async.flushMicrotasks();
+
+        // After clear() the map is empty — same address must hand out a
+        // DIFFERENT BitboxCredentials instance, not the cleared one.
+        final afterClear =
+            service.getCredentials('0x000000000000000000000000000000000000dead');
+        expect(identical(beforeClear, afterClear), isFalse,
+            reason: 'clear() must drop the credentials map');
+        expect(afterClear.isConnected, isFalse,
+            reason: 'fresh credentials handed out before re-init are detached');
+      });
+    });
+  });
+
+  group('signalDeviceLost()', () {
+    test('emits Lost(reason) with the supplied reason and tears down the observer', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        pairServiceSync(async, service);
+        final credentials =
+            service.getCredentials('0x000000000000000000000000000000000000dead');
+        expect(credentials.isConnected, isTrue);
+
+        service.startConnectionStatusObserver();
+        final observed = observe(service);
+
+        service.signalDeviceLost(LostReason.signQueueTimeout);
+        async.flushMicrotasks();
+
+        expect(observed.last, equals(const Lost(LostReason.signQueueTimeout)));
+        expect(credentials.isConnected, isFalse,
+            reason: 'signalDeviceLost must detach every credentials');
+
+        // Observer ticks must stop firing after Lost — the next tick would
+        // otherwise duplicate the lost transition with deviceUnreachable.
+        final ticksBefore = platform.count(SimulatedBitboxMethod.getDevices);
+        async.elapse(observerSettleTime * 2);
+        expect(
+          platform.count(SimulatedBitboxMethod.getDevices),
+          ticksBefore,
+          reason: 'observer must be cancelled by signalDeviceLost',
+        );
+      });
+    });
+
+    test('signalDeviceLost() from Disconnected is a no-op', () {
+      // Defensive: a stale credentials reference firing signalDeviceLost
+      // after the service has already cleared must NOT emit a Lost — the
+      // consumer would see "lost while never connected" which violates the
+      // state machine.
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+
+        final observed = observe(service);
+        service.signalDeviceLost(LostReason.signQueueTimeout);
+        async.flushMicrotasks();
+
+        expect(observed.whereType<Lost>(), isEmpty,
+            reason: 'signalDeviceLost from Disconnected must be a no-op');
+      });
+    });
+
+    test('signalDeviceLost() carries every documented reason verbatim', () {
+      // Exhaustive: every LostReason value must traverse through the
+      // controller — proves the service doesn't silently drop unfamiliar
+      // values via a switch-default arm.
+      for (final reason in LostReason.values) {
+        fakeAsync((async) {
+          final service = BitboxService(connectionStatusInterval: fastInterval);
+          addTearDown(service.dispose);
+          pairServiceSync(async, service);
+
+          final observed = observe(service);
+          service.signalDeviceLost(reason);
+          async.flushMicrotasks();
+
+          expect(observed.last, equals(Lost(reason)),
+              reason: 'reason $reason must reach the stream untranslated');
+        });
+      }
+    });
+
+    test('signalDeviceLost() then clear() walks Lost → Disconnecting → Disconnected', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        pairServiceSync(async, service);
+
+        final observed = observe(service);
+        service.signalDeviceLost(LostReason.signQueueTimeout);
+        async.flushMicrotasks();
+        service.clear();
+        async.flushMicrotasks();
+
+        final trail = observed.map((s) => s.runtimeType).toList();
+        // Order: ... Paired Lost Disconnecting Disconnected
+        expect(trail, containsAllInOrder(<Type>[
+          Paired,
+          Lost,
+          Disconnecting,
+          Disconnected,
+        ]));
+      });
+    });
+  });
+
+  group('observer-driven device loss', () {
+    test('observer emits Lost(deviceUnreachable) when devices vanish', () {
+      // The observer used to silently flip _isConnected and clear credentials
+      // without surfacing the transition. Stream model promotes that into a
+      // visible Lost(deviceUnreachable) so the cubit can route to the
+      // reconnect sheet without polling currentStatus.
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        pairServiceSync(async, service);
+        final credentials =
+            service.getCredentials('0x000000000000000000000000000000000000dead');
+
+        platform.when(
+          SimulatedBitboxMethod.getDevices,
+          (_) async => const <BitboxDevice>[],
+        );
+        final observed = observe(service);
+        service.startConnectionStatusObserver();
+        async.elapse(observerSettleTime);
+
+        expect(observed.whereType<Lost>(), isNotEmpty,
+            reason: 'observer must emit Lost on device vanish');
+        expect(
+          observed.whereType<Lost>().last.reason,
+          equals(LostReason.deviceUnreachable),
+        );
+        expect(credentials.isConnected, isFalse);
+      });
+    });
+  });
+
+  group('dispose()', () {
+    test('dispose() emits a final Disconnected and closes the stream', () async {
+      final service = BitboxService(connectionStatusInterval: fastInterval);
+
+      final observed = <BitboxConnectionStatus>[];
+      final done = Completer<void>();
+      service.status.listen(observed.add, onDone: done.complete);
+
+      await service.dispose();
+      // The broadcast controller must close so onDone fires for the
+      // subscriber, which is how cubits know to drop their subscription
+      // on hot-restart.
+      await done.future.timeout(const Duration(seconds: 1));
+      expect(observed.last, equals(const Disconnected()));
+    });
+
+    test('init() after dispose() throws StateError', () async {
+      final service = BitboxService(connectionStatusInterval: fastInterval);
+      final devices = await service.getAllUsbDevices();
+      await service.dispose();
+
+      expect(
+        () => service.init(devices.single),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('dispose() is idempotent', () async {
+      final service = BitboxService(connectionStatusInterval: fastInterval);
+      await service.dispose();
+      await service.dispose();
+      // No assertion beyond "no throw" — the contract is "safe to call
+      // multiple times" so hot-restart code paths can be defensive.
+    });
+  });
+
+  group('state-machine property — every observed traversal is valid', () {
+    // Exhaustively pin "no impossible transition" for the canonical
+    // operating sequences. The property is: for any sequence of
+    // init/clear/signalDeviceLost, two consecutive emissions on the stream
+    // must be a legal edge in the state machine declared in ADR 0001.
+    final legalEdges = <Type, Set<Type>>{
+      Disconnected: <Type>{Connecting, Disconnecting},
+      Connecting: <Type>{Paired, Disconnected},
+      Paired: <Type>{InUse, Lost, Disconnecting},
+      InUse: <Type>{Paired, Lost, Disconnecting},
+      Lost: <Type>{Disconnecting},
+      Disconnecting: <Type>{Disconnected},
+    };
+
+    bool isValid(List<BitboxConnectionStatus> trail) {
+      for (var i = 1; i < trail.length; i++) {
+        final prev = trail[i - 1].runtimeType;
+        final next = trail[i].runtimeType;
+        if (prev == next) continue; // de-dup or replay-last; trivially valid.
+        final allowed = legalEdges[prev];
+        if (allowed == null || !allowed.contains(next)) return false;
+      }
+      return true;
+    }
+
+    test('init → clear', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        final observed = observe(service);
+        pairServiceSync(async, service);
+        service.clear();
+        async.flushMicrotasks();
+        expect(isValid(observed), isTrue,
+            reason: 'observed: ${observed.map((s) => s.runtimeType).toList()}');
+      });
+    });
+
+    test('init → signalDeviceLost → clear', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        final observed = observe(service);
+        pairServiceSync(async, service);
+        service.signalDeviceLost(LostReason.signQueueTimeout);
+        async.flushMicrotasks();
+        service.clear();
+        async.flushMicrotasks();
+        expect(isValid(observed), isTrue,
+            reason: 'observed: ${observed.map((s) => s.runtimeType).toList()}');
+      });
+    });
+
+    test('init → clear → init → clear (cycle stays legal)', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        final observed = observe(service);
+        pairServiceSync(async, service);
+        service.clear();
+        async.flushMicrotasks();
+        pairServiceSync(async, service);
+        service.clear();
+        async.flushMicrotasks();
+        expect(isValid(observed), isTrue,
+            reason: 'observed: ${observed.map((s) => s.runtimeType).toList()}');
+      });
+    });
+
+    test('observer-driven device vanish keeps the traversal legal', () {
+      fakeAsync((async) {
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        addTearDown(service.dispose);
+        final observed = observe(service);
+        pairServiceSync(async, service);
+        platform.when(
+          SimulatedBitboxMethod.getDevices,
+          (_) async => const <BitboxDevice>[],
+        );
+        service.startConnectionStatusObserver();
+        async.elapse(observerSettleTime);
+        expect(isValid(observed), isTrue,
+            reason: 'observed: ${observed.map((s) => s.runtimeType).toList()}');
+      });
+    });
+  });
+}

--- a/test/packages/hardware_wallet/bitbox_service_test.dart
+++ b/test/packages/hardware_wallet/bitbox_service_test.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:bitbox_flutter/bitbox_flutter.dart';
 import 'package:bitbox_flutter/testing.dart';
 import 'package:bitbox_flutter/usb/bitbox_usb_platform_interface.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_connection_status.dart';
 
 // Service-lifecycle suite. Drives the official bitbox_flutter simulator
 // (installed at the BitboxUsbPlatform.instance seam) so the tests exercise
@@ -313,7 +316,10 @@ void main() {
         Object? caught;
         service.init(devices.single).catchError((Object e) {
           caught = e;
-          return false;
+          // init() returns BitboxConnectionStatus post-Initiative-I; surface
+          // a typed Disconnected as the fallback so the catchError contract
+          // is honoured without leaking a bool into the FutureOr<T> signature.
+          return const Disconnected() as BitboxConnectionStatus;
         });
         async.flushMicrotasks();
 
@@ -328,7 +334,7 @@ void main() {
         expect(
           postInit.isConnected,
           isFalse,
-          reason: 'failed init must leave _isConnected false for future hand-outs',
+          reason: 'failed init must leave the service in Disconnected for future hand-outs',
         );
       });
     });
@@ -494,39 +500,32 @@ void main() {
           final firstInit = service.init(devices.single);
           final secondInit = service.init(devices.single);
 
-          firstInit.catchError((_) => false);
-          secondInit.catchError((_) => false);
+          firstInit.catchError(
+            (_) => const Disconnected() as BitboxConnectionStatus,
+          );
+          secondInit.catchError(
+            (_) => const Disconnected() as BitboxConnectionStatus,
+          );
 
           // Drain past the 20ms `open` delay AND the post-open hops.
           async.elapse(const Duration(milliseconds: 100));
           async.flushMicrotasks();
 
           final openCount = platform.count(SimulatedBitboxMethod.open);
+          // POST-INITIATIVE-I CONTRACT (BL-014 landed): the `_pendingInit`
+          // shared-future guard funnels every concurrent init() onto a single
+          // bitboxManager.connect() — exactly one `open` per concurrent
+          // batch. A future refactor that splits the funnel is a NEW
+          // regression and must be caught here.
           expect(
             openCount,
-            greaterThanOrEqualTo(1),
-            reason: 'at least one open() must reach the platform',
-          );
-          // POST-INITIATIVE-I CONTRACT (flip-to-pass marker):
-          // expect(openCount, 1, reason: 'concurrent init() must funnel through one connect()');
-          // The expectation above is the post-Initiative-I invariant; today
-          // the second concurrent init() can still issue a parallel open()
-          // (F-007). The assertion below documents the CURRENT bound so a
-          // refactor that worsens it (e.g. one-open-per-caller fan-out
-          // beyond two) trips immediately.
-          expect(
-            openCount,
-            lessThanOrEqualTo(2),
+            1,
             reason:
-                'pre-Initiative-I: concurrent init() may issue parallel open(); '
-                'a fan-out beyond 2 is a NEW regression and must be caught here',
+                'Initiative I post-condition: concurrent init() must funnel '
+                'through one connect() (property pin)',
           );
         });
       },
-      // Skip the strict 1-invocation assertion until BL-014 lands the
-      // `_pendingInit` guard described in OPUS_BITBOX_MANDATE.md §5.1
-      // Deliverable 3. The bounded-to-2 sub-assertion above runs today.
-      skip: false,
     );
 
     test(
@@ -559,11 +558,12 @@ void main() {
           service.getAllUsbDevices().then((d) => devices = d);
           async.flushMicrotasks();
 
-          bool? initResolved;
+          BitboxConnectionStatus? initResolved;
           service.init(devices.single).then((v) => initResolved = v);
           async.flushMicrotasks();
 
-          expect(initResolved, isTrue, reason: 'init() must have resolved within microtasks');
+          expect(initResolved, isA<Paired>(),
+              reason: 'init() must resolve to Paired within microtasks');
           expect(
             preInitA.isConnected,
             isTrue,
@@ -750,28 +750,28 @@ void main() {
     );
 
     test(
-      'BitboxService has no dispose() today; this pin will flip after Initiative I (F-033)',
-      () {
-        // F-033 / OPUS_BITBOX_MANDATE.md §5.1 Deliverable 3.5:
-        // `Future<void> dispose()` is to be added so test-bleed and
-        // hot-restart leave a clean state. Today the call does not exist.
-        // We pin the ABSENCE of dispose via a runtime-introspection check
-        // so the refactor must explicitly remove THIS test (or flip it)
-        // when adding the API.
+      'BitboxService.dispose() emits a final Disconnected and rejects post-dispose init() (F-033)',
+      () async {
+        // F-033 / OPUS_BITBOX_MANDATE.md §5.1 Deliverable 3.5: `dispose()` is
+        // the hot-restart / end-of-app cleanup. Post-`dispose()` calls to
+        // `init()` throw StateError; subscribers receive the final
+        // Disconnected and an `onDone` signal. The test below pins all three.
         final service = BitboxService(connectionStatusInterval: fastInterval);
-        expect(service, isA<BitboxService>(), reason: 'sanity: the service exists');
-        // If a `dispose` getter or method is ever added, this will throw
-        // NoSuchMethodError and the test will fail — at which point the
-        // Initiative-I implementer flips this to a real lifecycle test.
-        //
-        // dynamic dispatch is intentional: we are probing for the ABSENCE
-        // of a method, not type-checking against the static surface.
-        final dynamic d = service;
+
+        final observed = <BitboxConnectionStatus>[];
+        final done = Completer<void>();
+        service.status.listen(observed.add, onDone: done.complete);
+
+        final devices = await service.getAllUsbDevices();
+        await service.dispose();
+        await done.future.timeout(const Duration(seconds: 1));
+
+        expect(observed.last, equals(const Disconnected()),
+            reason: 'dispose() must surface a final Disconnected emission');
         expect(
-          () => d.dispose(),
-          throwsA(isA<NoSuchMethodError>()),
-          reason: 'pre-Initiative-I: dispose() is intentionally absent. '
-              'Flip this to a real lifecycle assertion when BL-014 lands.',
+          () => service.init(devices.single),
+          throwsA(isA<StateError>()),
+          reason: 'init() after dispose() must throw StateError',
         );
       },
     );

--- a/test/packages/hardware_wallet/bitbox_service_test.dart
+++ b/test/packages/hardware_wallet/bitbox_service_test.dart
@@ -453,5 +453,359 @@ void main() {
         });
       },
     );
+
+    // ---------------------------------------------------------------------
+    // Audit gap deepening — Initiative I scope
+    //
+    // The block below pins behaviour the audit calls out as worst-case
+    // failure modes (F-005, F-007, F-011, F-024, F-032, F-033, F-034,
+    // F-045). Each test states the current (sometimes buggy) invariant
+    // verbatim. Tests that will only PASS after Initiative I lands the
+    // refactor described in OPUS_BITBOX_MANDATE.md §5.1 are gated via
+    // `skip:` with a `blocks-on: BL-NNN` marker — they exist now so the
+    // refactor cannot silently land without flipping the assertion.
+    // ---------------------------------------------------------------------
+
+    test(
+      'init() is serialised against concurrent invocation (F-007)',
+      () {
+        // F-007: two parallel init() calls today both reach
+        // bitboxManager.connect() because there is no _pendingInit guard.
+        // Initiative I (BL-014) adds the serialisation. Pin both halves:
+        //
+        //   - current behaviour: the simulator's `open` is invoked at most
+        //     twice (one per init call) — already strictly bounded by the
+        //     SDK fix #1, but the host does NOT funnel concurrent callers.
+        //   - post-Initiative-I behaviour: exactly ONE `open` per device.
+        //
+        // The first expectation is the regression guard the refactor must
+        // not loosen; the second is the contract Initiative I must add.
+        fakeAsync((async) {
+          // Tighten the simulator's `open` so two parallel inits actually
+          // overlap on the wire. Without a delay both inits would resolve
+          // microtask-back-to-back and look serial by accident.
+          platform.setDelay(SimulatedBitboxMethod.open, const Duration(milliseconds: 20));
+
+          final service = BitboxService(connectionStatusInterval: fastInterval);
+          late List<BitboxDevice> devices;
+          service.getAllUsbDevices().then((d) => devices = d);
+          async.flushMicrotasks();
+
+          final firstInit = service.init(devices.single);
+          final secondInit = service.init(devices.single);
+
+          firstInit.catchError((_) => false);
+          secondInit.catchError((_) => false);
+
+          // Drain past the 20ms `open` delay AND the post-open hops.
+          async.elapse(const Duration(milliseconds: 100));
+          async.flushMicrotasks();
+
+          final openCount = platform.count(SimulatedBitboxMethod.open);
+          expect(
+            openCount,
+            greaterThanOrEqualTo(1),
+            reason: 'at least one open() must reach the platform',
+          );
+          // POST-INITIATIVE-I CONTRACT (flip-to-pass marker):
+          // expect(openCount, 1, reason: 'concurrent init() must funnel through one connect()');
+          // The expectation above is the post-Initiative-I invariant; today
+          // the second concurrent init() can still issue a parallel open()
+          // (F-007). The assertion below documents the CURRENT bound so a
+          // refactor that worsens it (e.g. one-open-per-caller fan-out
+          // beyond two) trips immediately.
+          expect(
+            openCount,
+            lessThanOrEqualTo(2),
+            reason:
+                'pre-Initiative-I: concurrent init() may issue parallel open(); '
+                'a fan-out beyond 2 is a NEW regression and must be caught here',
+          );
+        });
+      },
+      // Skip the strict 1-invocation assertion until BL-014 lands the
+      // `_pendingInit` guard described in OPUS_BITBOX_MANDATE.md §5.1
+      // Deliverable 3. The bounded-to-2 sub-assertion above runs today.
+      skip: false,
+    );
+
+    test(
+      'init() sets _isConnected AFTER credentials fan-out completes (F-032)',
+      () {
+        // F-032: _isConnected = true is set BEFORE the setBitbox-loop runs.
+        // A concurrent observer tick (or another caller reading the public
+        // surface) could see `connected==true` while credentials still
+        // report `isConnected==false`. The credentials-attach loop must be
+        // observed as a SINGLE atomic transition from the caller's POV.
+        //
+        // We pin the observable contract: when init() resolves, every
+        // pre-existing credentials instance reports `isConnected == true`.
+        // The reverse — that during the init() Future the credentials are
+        // still untouched — is the property the refactor (Initiative I)
+        // strengthens by removing the boolean entirely. We pin the
+        // post-condition because it survives the refactor.
+        fakeAsync((async) {
+          final service = BitboxService(connectionStatusInterval: fastInterval);
+
+          // Hand out two credentials BEFORE init so the fan-out has work.
+          final preInitA = service.getCredentials(knownAddress);
+          final preInitB = service.getCredentials(
+            '0x000000000000000000000000000000000000beef',
+          );
+          expect(preInitA.isConnected, isFalse);
+          expect(preInitB.isConnected, isFalse);
+
+          late List<BitboxDevice> devices;
+          service.getAllUsbDevices().then((d) => devices = d);
+          async.flushMicrotasks();
+
+          bool? initResolved;
+          service.init(devices.single).then((v) => initResolved = v);
+          async.flushMicrotasks();
+
+          expect(initResolved, isTrue, reason: 'init() must have resolved within microtasks');
+          expect(
+            preInitA.isConnected,
+            isTrue,
+            reason: 'every pre-existing credentials must be attached when init() resolves',
+          );
+          expect(
+            preInitB.isConnected,
+            isTrue,
+            reason: 'all entries of _credentialsByAddress are fanned out, not just one',
+          );
+        });
+      },
+    );
+
+    test(
+      'observer detects an empty device list within one tick interval (F-011)',
+      () {
+        // F-011: startConnectionStatusObserver cancels any prior periodic
+        // and installs a NEW one, but does NOT perform an eager probe.
+        // Worst case the device-loss latency is up to one full interval.
+        //
+        // This test pins the CURRENT behaviour: device-loss is detected
+        // within ONE interval-plus-microtask budget after arm. Initiative I
+        // is expected to add an eager probe (`unawaited(checkDevices())`)
+        // — that would let the assertion below tighten to "within one
+        // microtask". The current bound is `fastInterval`; the refactor
+        // can only tighten, never loosen.
+        fakeAsync((async) {
+          final service = pairedServiceSync(async);
+          final credentials = service.getCredentials(knownAddress);
+          expect(credentials.isConnected, isTrue);
+
+          platform.when(
+            SimulatedBitboxMethod.getDevices,
+            (_) async => const <BitboxDevice>[],
+          );
+
+          service.startConnectionStatusObserver();
+          // Exactly one interval — the periodic must have fired AT LEAST
+          // once by now. Plus a microtask drain for the await chain inside
+          // the periodic callback.
+          async.elapse(fastInterval);
+          async.flushMicrotasks();
+          async.elapse(const Duration(milliseconds: 5));
+          async.flushMicrotasks();
+
+          expect(
+            credentials.isConnected,
+            isFalse,
+            reason: 'device-loss must surface within one tick of arm; '
+                'a slower observer is a NEW regression vs the current cap',
+          );
+        });
+      },
+    );
+
+    test(
+      'observer does NOT yet treat a different-static-device list as Lost (F-045)',
+      () {
+        // F-045: the observer's callback ignores device-list CONTENTS past
+        // the `isEmpty` branch. A user could unplug their BitBox and plug
+        // in a different one — the observer would silently treat it as
+        // "still connected". This is the worst-case in §5.1's Context.
+        //
+        // Initiative I (Deliverable 5) adds the static-pubkey-mismatch
+        // check. We pin the CURRENT incorrect behaviour so the
+        // implementer cannot silently land "Disconnected on any non-empty
+        // mismatch" without flipping this assertion (which is what BL-014
+        // / §5.1 Deliverable 5 demands).
+        fakeAsync((async) {
+          final service = pairedServiceSync(async);
+          final credentials = service.getCredentials(knownAddress);
+          expect(credentials.isConnected, isTrue);
+
+          // Simulator hands out a DIFFERENT device than the one paired
+          // with. Pre-Initiative-I the observer does not look at identity.
+          final differentDevice = BitboxDevice(
+            identifier: 'simulated-bitbox-02-OTHER',
+            vendorId: 0x03eb,
+            productId: 0x2403,
+            productName: 'BitBox02 Simulator',
+            deviceId: 99,
+            deviceName: 'Different BitBox02',
+            manufacturerName: 'Shift Crypto',
+            configurationCount: 1,
+          );
+          platform.when(
+            SimulatedBitboxMethod.getDevices,
+            (_) async => <BitboxDevice>[differentDevice],
+          );
+
+          service.startConnectionStatusObserver();
+          async.elapse(observerSettleTime);
+
+          // CURRENT behaviour: list non-empty → observer stays quiet, even
+          // though the connected device is no longer the paired one.
+          expect(
+            credentials.isConnected,
+            isTrue,
+            reason: 'pre-Initiative-I the observer does NOT detect device-replacement '
+                '(F-045); a refactor that flips this MUST also emit Lost(staticPubkeyMismatch) '
+                'and update the post-Initiative-I assertion below',
+          );
+
+          // POST-INITIATIVE-I CONTRACT (flip-to-fail marker):
+          // expect(credentials.isConnected, isFalse,
+          //     reason: 'Initiative I Deliverable 5: device-replaced detection');
+        });
+      },
+    );
+
+    test(
+      '_credentialsByAddress is NOT cleared on transient device-loss (F-005, current behaviour)',
+      () {
+        // F-005: the entries in _credentialsByAddress are kept across a
+        // transient device-loss so a reconnect can re-attach the SAME
+        // credentials instance. That's load-bearing behaviour — the
+        // observer test above relies on it ("preserves the credentials
+        // reference so reconnect can heal them").
+        //
+        // What is NOT acceptable per the audit: on a wallet-delete the
+        // map STAYS populated forever (covered in the home_bloc test in
+        // F-024 below). This test pins the half that must survive
+        // Initiative I unchanged.
+        fakeAsync((async) {
+          final service = pairedServiceSync(async);
+          final credentials = service.getCredentials(knownAddress);
+          expect(credentials.isConnected, isTrue);
+
+          platform.when(
+            SimulatedBitboxMethod.getDevices,
+            (_) async => const <BitboxDevice>[],
+          );
+          service.startConnectionStatusObserver();
+          async.elapse(observerSettleTime);
+
+          // Device gone, but the cached entry survives so a reconnect can
+          // heal it without forcing the caller to re-acquire credentials.
+          expect(credentials.isConnected, isFalse);
+
+          final sameAfterLoss = service.getCredentials(knownAddress);
+          expect(
+            sameAfterLoss,
+            same(credentials),
+            reason: 'device-loss must NOT evict the cached credentials — '
+                'reconnect re-attaches the same instance (load-bearing for P461 #1)',
+          );
+        });
+      },
+    );
+
+    test(
+      '_checkForTimer-style observer re-arm cannot leak parallel timers (F-034 sibling)',
+      () {
+        // F-034 lives on the cubit side, but the BitboxService surface it
+        // exercises is identical: an observer re-arm must cancel before
+        // installing the new periodic. We already have a "replaces any
+        // prior periodic" test; this one pins the BOUNDED behaviour under
+        // a re-arm storm (10 calls in tight succession).
+        //
+        // Without the cancel, 10 parallel timers would fire ~10× per
+        // interval. We assert a strict cap.
+        fakeAsync((async) {
+          final service = pairedServiceSync(async);
+          final ticksBefore = platform.count(SimulatedBitboxMethod.getDevices);
+
+          for (var i = 0; i < 10; i++) {
+            service.startConnectionStatusObserver();
+          }
+          async.elapse(fastInterval * 3);
+          async.flushMicrotasks();
+
+          final probes = platform.count(SimulatedBitboxMethod.getDevices) - ticksBefore;
+          expect(
+            probes,
+            lessThanOrEqualTo(3),
+            reason: 'a 10x re-arm must NOT result in 30 probes per 3 intervals — '
+                'cap is <=3 (one per interval). Higher count = leaked timer.',
+          );
+
+          service.stopConnectionStatusObserver();
+        });
+      },
+    );
+
+    test(
+      'BitboxService has no dispose() today; this pin will flip after Initiative I (F-033)',
+      () {
+        // F-033 / OPUS_BITBOX_MANDATE.md §5.1 Deliverable 3.5:
+        // `Future<void> dispose()` is to be added so test-bleed and
+        // hot-restart leave a clean state. Today the call does not exist.
+        // We pin the ABSENCE of dispose via a runtime-introspection check
+        // so the refactor must explicitly remove THIS test (or flip it)
+        // when adding the API.
+        final service = BitboxService(connectionStatusInterval: fastInterval);
+        expect(service, isA<BitboxService>(), reason: 'sanity: the service exists');
+        // If a `dispose` getter or method is ever added, this will throw
+        // NoSuchMethodError and the test will fail — at which point the
+        // Initiative-I implementer flips this to a real lifecycle test.
+        //
+        // dynamic dispatch is intentional: we are probing for the ABSENCE
+        // of a method, not type-checking against the static surface.
+        final dynamic d = service;
+        expect(
+          () => d.dispose(),
+          throwsA(isA<NoSuchMethodError>()),
+          reason: 'pre-Initiative-I: dispose() is intentionally absent. '
+              'Flip this to a real lifecycle assertion when BL-014 lands.',
+        );
+      },
+    );
+
+    test(
+      'observer DOES NOT call disconnect() on stop alone (F-024 boundary)',
+      () {
+        // F-024: stopConnectionStatusObserver only cancels the periodic;
+        // it intentionally does NOT call bitboxManager.disconnect(). The
+        // home_bloc on wallet-delete calls JUST stop(), so the BitBox
+        // stays paired to the host (USB-FD claim on Android, BLE
+        // peripheral connected on iOS). Initiative I (Deliverable 6) adds
+        // a service-level clear() call from home_bloc on delete.
+        //
+        // Pin the current contract: stop alone is observer-only. The
+        // Initiative-I refactor will add `BitboxService.clear()` that
+        // DOES tear down the transport; that's a NEW method, not a
+        // behavioural change of stop().
+        fakeAsync((async) {
+          final service = pairedServiceSync(async);
+          final closeCallsBefore = platform.count(SimulatedBitboxMethod.close);
+
+          service.startConnectionStatusObserver();
+          service.stopConnectionStatusObserver();
+          async.flushMicrotasks();
+
+          expect(
+            platform.count(SimulatedBitboxMethod.close),
+            closeCallsBefore,
+            reason: 'stopConnectionStatusObserver MUST NOT close the transport — '
+                'the host_bloc.delete path expects a separate clear() call (BL-014).',
+          );
+        });
+      },
+    );
   });
 }

--- a/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
+++ b/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
@@ -299,7 +299,11 @@ void main() {
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
       when(
         () => service.init(any()),
-      ).thenAnswer((_) => Future<bool>.error(Exception('async init boom')));
+      ).thenAnswer(
+        (_) => Future<BitboxConnectionStatus>.error(
+          Exception('async init boom'),
+        ),
+      );
       when(() => service.getChannelHash()).thenAnswer((_) async => '');
 
       final cubit = makeCubit();
@@ -340,8 +344,7 @@ void main() {
       // failure path back to BitboxNotConnected.
       var pollCount = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
-      when(() => service.init(any()))
-          .thenAnswer((_) => Completer<BitboxConnectionStatus>().future);
+      when(() => service.init(any())).thenAnswer((_) => Completer<BitboxConnectionStatus>().future);
       when(() => service.getChannelHash()).thenAnswer((_) async {
         pollCount++;
         return pollCount < 3 ? '' : 'HASH-ok';
@@ -431,12 +434,14 @@ void main() {
       addTearDown(cubit.close);
 
       verify(() => service.status).called(1);
-      expect(statusController.hasListener, isTrue,
-          reason: 'cubit must hold a live subscription after construction');
+      expect(
+        statusController.hasListener,
+        isTrue,
+        reason: 'cubit must hold a live subscription after construction',
+      );
     });
 
-    test('service-emitted Lost bounces an in-progress pairing back to NotConnected',
-        () async {
+    test('service-emitted Lost bounces an in-progress pairing back to NotConnected', () async {
       // Mid-flow scenario: cubit has reached BitboxCheckHash, sign-queue
       // timeout fires on the service side and emits Lost. The cubit must
       // bounce to BitboxNotConnected and re-arm the scan timer without
@@ -462,8 +467,7 @@ void main() {
       expect(cubit.state, isA<BitboxNotConnected>());
     });
 
-    test('non-Lost transitions on the status stream do NOT spuriously bounce',
-        () async {
+    test('non-Lost transitions on the status stream do NOT spuriously bounce', () async {
       // Defensive: emitting Paired or Connecting from the service must not
       // flip the cubit's UX state. Only Lost is load-bearing.
       final cubit = makeCubit();
@@ -484,8 +488,7 @@ void main() {
       );
     });
 
-    test('close() cancels the status subscription (no leak after close)',
-        () async {
+    test('close() cancels the status subscription (no leak after close)', () async {
       final cubit = makeCubit();
       expect(statusController.hasListener, isTrue);
       await cubit.close();

--- a/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
+++ b/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
@@ -457,6 +457,7 @@ void main() {
       final cubit = makeCubit();
       addTearDown(cubit.close);
       await waitForState<BitboxCheckHash>(cubit);
+      clearInteractions(service);
 
       // Service flips to Lost mid-flow. Cubit must observe the transition
       // and route back to BitboxNotConnected.
@@ -465,6 +466,10 @@ void main() {
           .firstWhere((s) => s is BitboxNotConnected)
           .timeout(const Duration(seconds: 2));
       expect(cubit.state, isA<BitboxNotConnected>());
+      await Future<void>.delayed(const Duration(milliseconds: 650));
+      verify(
+        () => service.getAllUsbDevices(),
+      ).called(greaterThanOrEqualTo(1));
     });
 
     test('non-Lost transitions on the status stream do NOT spuriously bounce', () async {

--- a/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
+++ b/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox.dart';
+import 'package:realunit_wallet/packages/hardware_wallet/bitbox_connection_status.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
@@ -19,7 +20,10 @@ class _MockBitboxWallet extends Mock implements BitboxWallet {}
 
 class _MockAuthService extends Mock implements DFXAuthService {}
 
-class _FakeBitboxDevice extends Fake implements sdk.BitboxDevice {}
+class _FakeBitboxDevice extends Fake implements sdk.BitboxDevice {
+  @override
+  String get identifier => 'fake-device';
+}
 
 class _FakeBitboxWalletAccount extends Fake implements BitboxWalletAccount {}
 
@@ -29,6 +33,7 @@ void main() {
   late _MockAuthService authService;
   late _FakeBitboxDevice device;
   late _MockBitboxWallet wallet;
+  late StreamController<BitboxConnectionStatus> statusController;
 
   setUpAll(() {
     debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
@@ -46,13 +51,19 @@ void main() {
     authService = _MockAuthService();
     device = _FakeBitboxDevice();
     wallet = _MockBitboxWallet();
+    statusController = StreamController<BitboxConnectionStatus>.broadcast();
 
     when(() => service.startScan()).thenAnswer((_) async => true);
     when(() => service.getAllUsbDevices()).thenAnswer((_) async => []);
     when(() => service.startConnectionStatusObserver()).thenReturn(null);
+    when(() => service.status).thenAnswer((_) => statusController.stream);
     when(() => walletService.createBitboxWallet(any())).thenAnswer((_) async => wallet);
     when(() => wallet.currentAccount).thenReturn(_FakeBitboxWalletAccount());
     when(() => authService.ensureSignatureFor(any())).thenAnswer((_) async {});
+  });
+
+  tearDown(() async {
+    await statusController.close();
   });
 
   // Tests pass in short timeouts so the bounce-back path can be exercised in
@@ -80,7 +91,7 @@ void main() {
 
   group('$ConnectBitboxCubit', () {
     test('reaches BitboxConnected via BitboxCapturingSignature when all succeed', () async {
-      final initCompleter = Completer<bool>();
+      final initCompleter = Completer<BitboxConnectionStatus>();
       var pollCount = 0;
 
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
@@ -105,7 +116,7 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 10));
       expect(cubit.state, isA<BitboxPairing>());
 
-      initCompleter.complete(true);
+      initCompleter.complete(Paired(device));
       await confirmFut;
 
       expect(cubit.state, isA<BitboxConnected>());
@@ -119,7 +130,7 @@ void main() {
     test('emits BitboxSignatureFailed when the signature capture throws', () async {
       var pollCount = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
-      when(() => service.init(any())).thenAnswer((_) async => true);
+      when(() => service.init(any())).thenAnswer((_) async => Paired(device));
       when(() => service.getChannelHash()).thenAnswer((_) async {
         pollCount++;
         return pollCount < 3 ? '' : 'HASH-ok';
@@ -145,7 +156,7 @@ void main() {
       var pollCount = 0;
       var signCalls = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
-      when(() => service.init(any())).thenAnswer((_) async => true);
+      when(() => service.init(any())).thenAnswer((_) async => Paired(device));
       when(() => service.getChannelHash()).thenAnswer((_) async {
         pollCount++;
         return pollCount < 3 ? '' : 'HASH-ok';
@@ -179,7 +190,7 @@ void main() {
     test('continueWithoutSignature transitions BitboxSignatureFailed to BitboxConnected', () async {
       var pollCount = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
-      when(() => service.init(any())).thenAnswer((_) async => true);
+      when(() => service.init(any())).thenAnswer((_) async => Paired(device));
       when(() => service.getChannelHash()).thenAnswer((_) async {
         pollCount++;
         return pollCount < 3 ? '' : 'HASH-ok';
@@ -209,7 +220,7 @@ void main() {
     test('finishSetup transitions BitboxConnected to BitboxFinishSetup', () async {
       var pollCount = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
-      when(() => service.init(any())).thenAnswer((_) async => true);
+      when(() => service.init(any())).thenAnswer((_) async => Paired(device));
       when(() => service.getChannelHash()).thenAnswer((_) async {
         pollCount++;
         return pollCount < 3 ? '' : 'HASH-ok';
@@ -235,7 +246,7 @@ void main() {
         'FRESH-NEW',
       ];
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
-      when(() => service.init(any())).thenAnswer((_) async => true);
+      when(() => service.init(any())).thenAnswer((_) async => Paired(device));
       when(() => service.getChannelHash()).thenAnswer(
         (_) async => responses.isEmpty ? 'FRESH-NEW' : responses.removeAt(0),
       );
@@ -248,9 +259,12 @@ void main() {
       expect((cubit.state as BitboxCheckHash).channelHash, 'FRESH-NEW');
     });
 
-    test('falls back to NotConnected when init returns false', () async {
+    test('falls back to NotConnected when init resolves to Disconnected', () async {
+      // Post-Initiative-I: init() now returns a BitboxConnectionStatus. A
+      // resolution that is NOT Paired/InUse means pairing did not land, so
+      // the cubit must bounce to BitboxNotConnected.
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
-      when(() => service.init(any())).thenAnswer((_) async => false);
+      when(() => service.init(any())).thenAnswer((_) async => const Disconnected());
       when(() => service.getChannelHash()).thenAnswer((_) async => '');
 
       final cubit = makeCubit();
@@ -300,7 +314,7 @@ void main() {
     test('bounces to NotConnected when confirmPairing hangs past the timeout', () async {
       var pollCount = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
-      when(() => service.init(any())).thenAnswer((_) async => true);
+      when(() => service.init(any())).thenAnswer((_) async => Paired(device));
       when(() => service.getChannelHash()).thenAnswer((_) async {
         pollCount++;
         return pollCount < 3 ? '' : 'HASH-ok';
@@ -326,7 +340,8 @@ void main() {
       // failure path back to BitboxNotConnected.
       var pollCount = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
-      when(() => service.init(any())).thenAnswer((_) => Completer<bool>().future);
+      when(() => service.init(any()))
+          .thenAnswer((_) => Completer<BitboxConnectionStatus>().future);
       when(() => service.getChannelHash()).thenAnswer((_) async {
         pollCount++;
         return pollCount < 3 ? '' : 'HASH-ok';
@@ -353,7 +368,7 @@ void main() {
     test('emits BitboxCheckHash before service.confirmPairing is called (P1)', () async {
       var pollCount = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
-      when(() => service.init(any())).thenAnswer((_) async => true);
+      when(() => service.init(any())).thenAnswer((_) async => Paired(device));
       when(() => service.getChannelHash()).thenAnswer((_) async {
         pollCount++;
         return pollCount < 3 ? '' : 'HASH-VISIBLE-TO-USER';
@@ -377,7 +392,7 @@ void main() {
     test('bounces to NotConnected when createBitboxWallet hangs past the timeout', () async {
       var pollCount = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
-      when(() => service.init(any())).thenAnswer((_) async => true);
+      when(() => service.init(any())).thenAnswer((_) async => Paired(device));
       when(() => service.getChannelHash()).thenAnswer((_) async {
         pollCount++;
         return pollCount < 3 ? '' : 'HASH-ok';
@@ -397,6 +412,104 @@ void main() {
           .firstWhere((s) => s is BitboxNotConnected)
           .timeout(const Duration(seconds: 2));
       expect(cubit.state, isA<BitboxNotConnected>());
+    });
+
+    // -----------------------------------------------------------------------
+    // Initiative I — BitboxService.status stream subscription
+    //
+    // Post-ADR-0001 the cubit subscribes to the service's lifecycle stream
+    // so a service-side Lost (e.g. sign-queue timeout, observer device
+    // vanish) bounces the cubit back to BitboxNotConnected without forcing
+    // each individual try/catch to also poll currentStatus.
+    // -----------------------------------------------------------------------
+
+    test('subscribes to BitboxService.status on construction', () {
+      // The cubit's construction must register exactly one stream
+      // subscription. Without it the Lost-routing below would silently
+      // no-op.
+      final cubit = makeCubit();
+      addTearDown(cubit.close);
+
+      verify(() => service.status).called(1);
+      expect(statusController.hasListener, isTrue,
+          reason: 'cubit must hold a live subscription after construction');
+    });
+
+    test('service-emitted Lost bounces an in-progress pairing back to NotConnected',
+        () async {
+      // Mid-flow scenario: cubit has reached BitboxCheckHash, sign-queue
+      // timeout fires on the service side and emits Lost. The cubit must
+      // bounce to BitboxNotConnected and re-arm the scan timer without
+      // requiring the user to manually unplug.
+      var pollCount = 0;
+      when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
+      when(() => service.init(any())).thenAnswer((_) async => Paired(device));
+      when(() => service.getChannelHash()).thenAnswer((_) async {
+        pollCount++;
+        return pollCount < 3 ? '' : 'HASH-ok';
+      });
+
+      final cubit = makeCubit();
+      addTearDown(cubit.close);
+      await waitForState<BitboxCheckHash>(cubit);
+
+      // Service flips to Lost mid-flow. Cubit must observe the transition
+      // and route back to BitboxNotConnected.
+      statusController.add(const Lost(LostReason.signQueueTimeout));
+      await cubit.stream
+          .firstWhere((s) => s is BitboxNotConnected)
+          .timeout(const Duration(seconds: 2));
+      expect(cubit.state, isA<BitboxNotConnected>());
+    });
+
+    test('non-Lost transitions on the status stream do NOT spuriously bounce',
+        () async {
+      // Defensive: emitting Paired or Connecting from the service must not
+      // flip the cubit's UX state. Only Lost is load-bearing.
+      final cubit = makeCubit();
+      addTearDown(cubit.close);
+      final emitted = <BitboxConnectionState>[];
+      final sub = cubit.stream.listen(emitted.add);
+      addTearDown(sub.cancel);
+
+      statusController.add(const Disconnected());
+      statusController.add(Connecting(device));
+      statusController.add(Paired(device));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(
+        emitted.whereType<BitboxNotConnected>().toList(),
+        isEmpty,
+        reason: 'non-Lost transitions must not perturb the cubit state',
+      );
+    });
+
+    test('close() cancels the status subscription (no leak after close)',
+        () async {
+      final cubit = makeCubit();
+      expect(statusController.hasListener, isTrue);
+      await cubit.close();
+      expect(
+        statusController.hasListener,
+        isFalse,
+        reason: 'close() must cancel the cubit\'s status subscription',
+      );
+    });
+
+    test('Lost emitted after close() does NOT throw or emit', () async {
+      // Defensive: a Lost arriving after `close()` (e.g. service emitting
+      // during cubit teardown) must be ignored without throwing.
+      final cubit = makeCubit();
+      final emitted = <BitboxConnectionState>[];
+      final sub = cubit.stream.listen(emitted.add);
+      await cubit.close();
+      await sub.cancel();
+
+      statusController.add(const Lost(LostReason.deviceUnreachable));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      // No assertion beyond "no throw" — the cancel above must have
+      // detached, so no further state-emission is even possible.
+      expect(emitted.whereType<BitboxNotConnected>(), isEmpty);
     });
   });
 }

--- a/test/screens/home/home_bloc_test.dart
+++ b/test/screens/home/home_bloc_test.dart
@@ -29,6 +29,7 @@ class _FakeWallet extends Fake implements AWallet {}
 const _debugAddress = '0x0000000000000000000000000000000000000001';
 const _primary = '0x00000000000000000000000000000000deadbeef';
 
+
 void main() {
   late _MockWalletService walletService;
   late _MockBalanceService balanceService;
@@ -378,6 +379,59 @@ void main() {
           verifyNever(() => transactionHistoryService.apiBasedSync());
         },
       );
+    });
+
+    group('DeleteCurrentWalletEvent (Initiative I, ADR 0001)', () {
+      // F-024 closure: `_onDeleteCurrentWallet` MUST call
+      // `BitboxService.clear()` in addition to `stopConnectionStatusObserver`,
+      // so a subsequent "restore different seed, re-pair the same device"
+      // can no longer silently re-attach the old derivation path against the
+      // device's new static pubkey.
+
+      late _MockSessionCache sessionCache;
+
+      setUp(() {
+        sessionCache = _MockSessionCache();
+        when(() => sessionCache.clear()).thenAnswer((_) async {});
+        when(() => bitboxService.stopConnectionStatusObserver()).thenReturn(null);
+        when(() => bitboxService.clear()).thenAnswer((_) async {});
+        when(
+          () => walletService.deleteCurrentWallet(),
+        ).thenAnswer((_) async {});
+        when(() => appStore.sessionCache).thenReturn(sessionCache);
+      });
+
+      test('calls BitboxService.clear() in addition to stopConnectionStatusObserver',
+          () async {
+        when(() => walletService.hasWallet()).thenReturn(true);
+        when(() => settingsService.isTermsAccepted).thenReturn(true);
+
+        final bloc = build();
+        await bloc.stream.firstWhere((s) => s.hasWallet);
+
+        bloc.add(const DeleteCurrentWalletEvent());
+        await bloc.stream.firstWhere((s) => s.hasWallet == false);
+
+        verify(() => bitboxService.stopConnectionStatusObserver()).called(1);
+        verify(() => bitboxService.clear()).called(1);
+        verify(() => walletService.deleteCurrentWallet()).called(1);
+      });
+
+      test('still calls clear() even when no wallet is present', () async {
+        // Defensive: clear() must run before the hasWallet branch so a
+        // pre-pair "delete" still releases any in-flight BitBox session.
+        when(() => walletService.hasWallet()).thenReturn(false);
+
+        final bloc = build();
+        await bloc.stream.firstWhere((s) => s.hasWallet == false);
+
+        bloc.add(const DeleteCurrentWalletEvent());
+        // Stream emits the cleared state (isLoadingWallet flips back to false).
+        await bloc.stream.firstWhere((s) => s.isLoadingWallet == false);
+
+        verify(() => bitboxService.clear()).called(1);
+        verifyNever(() => walletService.deleteCurrentWallet());
+      });
     });
   });
 

--- a/test/screens/home/home_bloc_test.dart
+++ b/test/screens/home/home_bloc_test.dart
@@ -29,7 +29,6 @@ class _FakeWallet extends Fake implements AWallet {}
 const _debugAddress = '0x0000000000000000000000000000000000000001';
 const _primary = '0x00000000000000000000000000000000deadbeef';
 
-
 void main() {
   late _MockWalletService walletService;
   late _MockBalanceService balanceService;
@@ -67,6 +66,7 @@ void main() {
     when(() => balanceService.startSync(any())).thenReturn(null);
     when(() => transactionHistoryService.apiBasedSync()).thenAnswer((_) async {});
     when(() => bitboxService.stopConnectionStatusObserver()).thenReturn(null);
+    when(() => bitboxService.clear()).thenAnswer((_) async {});
   });
 
   HomeBloc build() => HomeBloc(
@@ -401,8 +401,7 @@ void main() {
         when(() => appStore.sessionCache).thenReturn(sessionCache);
       });
 
-      test('calls BitboxService.clear() in addition to stopConnectionStatusObserver',
-          () async {
+      test('calls BitboxService.clear() in addition to stopConnectionStatusObserver', () async {
         when(() => walletService.hasWallet()).thenReturn(true);
         when(() => settingsService.isTermsAccepted).thenReturn(true);
 


### PR DESCRIPTION
Draft split from #578 after TaprootFreak review.

Scope:
- ADR 0001 BitBox connection lifecycle
- BitBox service/status lifecycle changes
- connect-flow/home-bloc integration
- focused lifecycle tests

Validation:
- flutter pub get
- dart run tool/generate_localization.dart
- dart run tool/generate_release_info.dart
- flutter pub run build_runner build --delete-conflicting-outputs
- flutter analyze --no-pub
- flutter test --reporter compact test/packages/hardware_wallet test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart test/screens/home/home_bloc_test.dart test/integration/bitbox_lifecycle_test.dart