### PR TITLE
fix(seed): block screenshots on the verify-seed screen

### DIFF
--- a/lib/packages/utils/screenshot_guard.dart
+++ b/lib/packages/utils/screenshot_guard.dart
@@ -9,9 +9,7 @@ import 'package:no_screenshot/no_screenshot.dart';
 //   effect (blocked capture, blanked app-switcher thumbnail) is only
 //   observable on a physical device; the channel contract is pinned by the
 //   widget/unit tests.
-class ScreenshotGuard {
-  ScreenshotGuard._();
-
+abstract final class ScreenshotGuard {
   static int _holders = 0;
 
   static Future<void> acquire() async {

--- a/lib/packages/utils/screenshot_guard.dart
+++ b/lib/packages/utils/screenshot_guard.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/foundation.dart';
+import 'package:no_screenshot/no_screenshot.dart';
+
+/// Ref-counted wrapper around the screenshot toggle: `no_screenshot` flips ONE
+/// global window flag, so a protected screen popped off another protected
+/// screen (e.g. verify-seed over create-wallet) must not re-enable screenshots
+/// while seed material is still visible underneath.
+class ScreenshotGuard {
+  ScreenshotGuard._();
+
+  static int _holders = 0;
+
+  static Future<void> acquire() async {
+    if (++_holders == 1) await NoScreenshot.instance.screenshotOff();
+  }
+
+  static Future<void> release() async {
+    if (_holders == 0) return;
+    if (--_holders == 0) await NoScreenshot.instance.screenshotOn();
+  }
+
+  @visibleForTesting
+  static void reset() => _holders = 0;
+}

--- a/lib/packages/utils/screenshot_guard.dart
+++ b/lib/packages/utils/screenshot_guard.dart
@@ -5,6 +5,10 @@ import 'package:no_screenshot/no_screenshot.dart';
 /// global window flag, so a protected screen popped off another protected
 /// screen (e.g. verify-seed over create-wallet) must not re-enable screenshots
 /// while seed material is still visible underneath.
+// @no-integration-test: `no_screenshot` toggles a native window flag whose
+//   effect (blocked capture, blanked app-switcher thumbnail) is only
+//   observable on a physical device; the channel contract is pinned by the
+//   widget/unit tests.
 class ScreenshotGuard {
   ScreenshotGuard._();
 

--- a/lib/screens/create_wallet/create_wallet_view.dart
+++ b/lib/screens/create_wallet/create_wallet_view.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
-import 'package:no_screenshot/no_screenshot.dart';
+import 'package:realunit_wallet/packages/utils/screenshot_guard.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/screens/create_wallet/bloc/create_wallet_cubit.dart';
 import 'package:realunit_wallet/setup/routing/routes/onboarding_routes.dart';
@@ -21,7 +21,7 @@ class CreateWalletView extends StatefulWidget {
 class _CreateWalletViewState extends State<CreateWalletView> {
   @override
   void initState() {
-    NoScreenshot.instance.screenshotOff();
+    ScreenshotGuard.acquire();
     super.initState();
   }
 
@@ -102,7 +102,7 @@ class _CreateWalletViewState extends State<CreateWalletView> {
 
   @override
   void dispose() {
-    NoScreenshot.instance.screenshotOn();
+    ScreenshotGuard.release();
     super.dispose();
   }
 }

--- a/lib/screens/restore_wallet/restore_wallet_view.dart
+++ b/lib/screens/restore_wallet/restore_wallet_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:no_screenshot/no_screenshot.dart';
+import 'package:realunit_wallet/packages/utils/screenshot_guard.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
 import 'package:realunit_wallet/screens/restore_wallet/cubit/restore_wallet/restore_wallet_cubit.dart';
@@ -34,7 +34,7 @@ class _RestoreWalletViewState extends State<RestoreWalletView> {
     // (create/settings/verify). Block screenshots + the app-switcher snapshot
     // while it is on screen; re-enabled on dispose so other screens stay
     // screenshot-able.
-    NoScreenshot.instance.screenshotOff();
+    ScreenshotGuard.acquire();
     super.initState();
   }
 
@@ -136,7 +136,7 @@ class _RestoreWalletViewState extends State<RestoreWalletView> {
 
   @override
   void dispose() {
-    NoScreenshot.instance.screenshotOn();
+    ScreenshotGuard.release();
     for (final controller in _controllers) {
       controller.dispose();
     }

--- a/lib/screens/restore_wallet/restore_wallet_view.dart
+++ b/lib/screens/restore_wallet/restore_wallet_view.dart
@@ -24,16 +24,12 @@ class _RestoreWalletViewState extends State<RestoreWalletView> {
   final _controllers = List.generate(12, (_) => MnemonicInputFieldController());
   final _focusNodes = List.generate(12, (_) => FocusNode());
 
-  // @no-integration-test: no_screenshot suppresses the OS screenshot /
-  // app-switcher thumbnail / screen-recording via a platform channel — the
-  // real effect is only observable on a device, not in a widget/golden test.
   @override
   void initState() {
-    // The user types their existing 12-word recovery phrase here, so this
-    // screen handles real seed material just like the sibling seed screens
-    // (create/settings/verify). Block screenshots + the app-switcher snapshot
-    // while it is on screen; re-enabled on dispose so other screens stay
-    // screenshot-able.
+    // The user types their existing 12-word recovery phrase here — block
+    // screenshots and the app-switcher snapshot. Released on dispose;
+    // screenshots re-enable only when the last protected screen leaves
+    // (see ScreenshotGuard).
     ScreenshotGuard.acquire();
     super.initState();
   }

--- a/lib/screens/settings_seed/settings_seed_view.dart
+++ b/lib/screens/settings_seed/settings_seed_view.dart
@@ -2,7 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:no_screenshot/no_screenshot.dart';
+import 'package:realunit_wallet/packages/utils/screenshot_guard.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/screens/settings_seed/bloc/settings_seed_cubit.dart';
 import 'package:realunit_wallet/styles/colors.dart';
@@ -19,7 +19,7 @@ class SettingsSeedView extends StatefulWidget {
 class _SettingsSeedViewState extends State<SettingsSeedView> {
   @override
   void initState() {
-    NoScreenshot.instance.screenshotOff();
+    ScreenshotGuard.acquire();
     super.initState();
   }
 
@@ -114,7 +114,7 @@ class _SettingsSeedViewState extends State<SettingsSeedView> {
 
   @override
   void dispose() {
-    NoScreenshot.instance.screenshotOn();
+    ScreenshotGuard.release();
     super.dispose();
   }
 }

--- a/lib/screens/verify_seed/verify_seed_page.dart
+++ b/lib/screens/verify_seed/verify_seed_page.dart
@@ -35,14 +35,11 @@ class VerifySeedView extends StatefulWidget {
 }
 
 class _VerifySeedViewState extends State<VerifySeedView> {
-  // @no-integration-test: no_screenshot suppresses the OS screenshot /
-  // app-switcher thumbnail / screen-recording via a platform channel — the
-  // real effect is only observable on a device, not in a widget/golden test.
   @override
   void initState() {
     // Seed words are entered/visible here — block screenshots and the
-    // app-switcher snapshot like the other seed screens. Re-enabled on dispose
-    // so other screens stay screenshot-able.
+    // app-switcher snapshot. Released on dispose; screenshots re-enable only
+    // when the last protected screen leaves (see ScreenshotGuard).
     ScreenshotGuard.acquire();
     super.initState();
   }

--- a/lib/screens/verify_seed/verify_seed_page.dart
+++ b/lib/screens/verify_seed/verify_seed_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:no_screenshot/no_screenshot.dart';
+import 'package:realunit_wallet/packages/utils/screenshot_guard.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
@@ -43,13 +43,13 @@ class _VerifySeedViewState extends State<VerifySeedView> {
     // Seed words are entered/visible here — block screenshots and the
     // app-switcher snapshot like the other seed screens. Re-enabled on dispose
     // so other screens stay screenshot-able.
-    NoScreenshot.instance.screenshotOff();
+    ScreenshotGuard.acquire();
     super.initState();
   }
 
   @override
   void dispose() {
-    NoScreenshot.instance.screenshotOn();
+    ScreenshotGuard.release();
     super.dispose();
   }
 

--- a/lib/screens/verify_seed/verify_seed_page.dart
+++ b/lib/screens/verify_seed/verify_seed_page.dart
@@ -35,6 +35,9 @@ class VerifySeedView extends StatefulWidget {
 }
 
 class _VerifySeedViewState extends State<VerifySeedView> {
+  // @no-integration-test: no_screenshot suppresses the OS screenshot /
+  // app-switcher thumbnail / screen-recording via a platform channel — the
+  // real effect is only observable on a device, not in a widget/golden test.
   @override
   void initState() {
     // Seed words are entered/visible here — block screenshots and the

--- a/lib/screens/verify_seed/verify_seed_page.dart
+++ b/lib/screens/verify_seed/verify_seed_page.dart
@@ -38,9 +38,8 @@ class _VerifySeedViewState extends State<VerifySeedView> {
   @override
   void initState() {
     // Seed words are entered/visible here — block screenshots and the
-    // app-switcher snapshot like the sibling seed screens (create_wallet_view,
-    // settings_seed_view). Re-enabled on dispose so other screens stay
-    // screenshot-able.
+    // app-switcher snapshot like the other seed screens. Re-enabled on dispose
+    // so other screens stay screenshot-able.
     NoScreenshot.instance.screenshotOff();
     super.initState();
   }

--- a/lib/screens/verify_seed/verify_seed_page.dart
+++ b/lib/screens/verify_seed/verify_seed_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:no_screenshot/no_screenshot.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
@@ -26,8 +27,29 @@ class VerifySeedPage extends StatelessWidget {
   );
 }
 
-class VerifySeedView extends StatelessWidget {
+class VerifySeedView extends StatefulWidget {
   const VerifySeedView({super.key});
+
+  @override
+  State<VerifySeedView> createState() => _VerifySeedViewState();
+}
+
+class _VerifySeedViewState extends State<VerifySeedView> {
+  @override
+  void initState() {
+    // Seed words are entered/visible here — block screenshots and the
+    // app-switcher snapshot like the sibling seed screens (create_wallet_view,
+    // settings_seed_view). Re-enabled on dispose so other screens stay
+    // screenshot-able.
+    NoScreenshot.instance.screenshotOff();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    NoScreenshot.instance.screenshotOn();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/test/goldens/screens/verify_seed/verify_seed_golden_test.dart
+++ b/test/goldens/screens/verify_seed/verify_seed_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -10,18 +9,15 @@ import 'package:realunit_wallet/screens/verify_seed/verify_seed_page.dart';
 
 import '../../../helper/helper.dart';
 
-class _MockVerifySeedCubit extends MockCubit<VerifySeedState>
-    implements VerifySeedCubit {}
+class _MockVerifySeedCubit extends MockCubit<VerifySeedState> implements VerifySeedCubit {}
 
 void main() {
   late _MockVerifySeedCubit verifySeedCubit;
   late MockHomeBloc homeBloc;
 
-  // VerifySeedView toggles screenshot protection in initState/dispose via the
-  // no_screenshot method channel. Stub it so the render does not throw a
-  // MissingPluginException in the headless golden harness.
-  const noScreenshotChannel =
-      MethodChannel('com.flutterplaza.no_screenshot_methods');
+  setUpAll(() {
+    stubNoScreenshotChannel();
+  });
 
   setUp(() {
     verifySeedCubit = _MockVerifySeedCubit();
@@ -33,22 +29,15 @@ void main() {
       ),
     );
     when(() => homeBloc.state).thenReturn(const HomeState());
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(noScreenshotChannel, (_) async => true);
-  });
-
-  tearDown(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(noScreenshotChannel, null);
   });
 
   Widget buildSubject() => MultiBlocProvider(
-        providers: [
-          BlocProvider<HomeBloc>.value(value: homeBloc),
-          BlocProvider<VerifySeedCubit>.value(value: verifySeedCubit),
-        ],
-        child: const VerifySeedView(),
-      );
+    providers: [
+      BlocProvider<HomeBloc>.value(value: homeBloc),
+      BlocProvider<VerifySeedCubit>.value(value: verifySeedCubit),
+    ],
+    child: const VerifySeedView(),
+  );
 
   group('$VerifySeedView', () {
     goldenTest(

--- a/test/goldens/screens/verify_seed/verify_seed_golden_test.dart
+++ b/test/goldens/screens/verify_seed/verify_seed_golden_test.dart
@@ -1,5 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -16,6 +17,12 @@ void main() {
   late _MockVerifySeedCubit verifySeedCubit;
   late MockHomeBloc homeBloc;
 
+  // VerifySeedView toggles screenshot protection in initState/dispose via the
+  // no_screenshot method channel. Stub it so the render does not throw a
+  // MissingPluginException in the headless golden harness.
+  const noScreenshotChannel =
+      MethodChannel('com.flutterplaza.no_screenshot_methods');
+
   setUp(() {
     verifySeedCubit = _MockVerifySeedCubit();
     homeBloc = MockHomeBloc();
@@ -26,6 +33,13 @@ void main() {
       ),
     );
     when(() => homeBloc.state).thenReturn(const HomeState());
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(noScreenshotChannel, (_) async => true);
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(noScreenshotChannel, null);
   });
 
   Widget buildSubject() => MultiBlocProvider(

--- a/test/helper/golden_plugin_stubs.dart
+++ b/test/helper/golden_plugin_stubs.dart
@@ -1,15 +1,28 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+const _noScreenshotChannel = MethodChannel('com.flutterplaza.no_screenshot_methods');
+
 /// Stub the `no_screenshot` plugin's method channel so calls to
 /// `screenshotOff` / `screenshotOn` / `screenshotStream` do not throw
 /// `MissingPluginException` in headless golden tests.
 ///
-/// Call from `setUpAll`.
-void stubNoScreenshotChannel() {
-  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .setMockMethodCallHandler(
-    const MethodChannel('com.flutterplaza.no_screenshot_methods'),
-    (call) async => true,
+/// Call from `setUpAll`. Pass [calls] to record the invoked method names
+/// (for tests asserting the off/on contract).
+void stubNoScreenshotChannel({List<String>? calls}) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+    _noScreenshotChannel,
+    (call) async {
+      calls?.add(call.method);
+      return true;
+    },
+  );
+}
+
+/// Remove the stub installed by [stubNoScreenshotChannel].
+void unstubNoScreenshotChannel() {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+    _noScreenshotChannel,
+    null,
   );
 }

--- a/test/packages/utils/screenshot_guard_test.dart
+++ b/test/packages/utils/screenshot_guard_test.dart
@@ -1,31 +1,20 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/packages/utils/screenshot_guard.dart';
+
+import '../../helper/golden_plugin_stubs.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  const channel = MethodChannel('com.flutterplaza.no_screenshot_methods');
   final calls = <String>[];
 
   setUp(() {
     calls.clear();
     ScreenshotGuard.reset();
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-      channel,
-      (call) async {
-        calls.add(call.method);
-        return true;
-      },
-    );
+    stubNoScreenshotChannel(calls: calls);
   });
 
-  tearDown(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
-      channel,
-      null,
-    );
-  });
+  tearDown(unstubNoScreenshotChannel);
 
   group('$ScreenshotGuard', () {
     test('a single holder toggles the flag off and back on', () async {

--- a/test/packages/utils/screenshot_guard_test.dart
+++ b/test/packages/utils/screenshot_guard_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/utils/screenshot_guard.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.flutterplaza.no_screenshot_methods');
+  final calls = <String>[];
+
+  setUp(() {
+    calls.clear();
+    ScreenshotGuard.reset();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      (call) async {
+        calls.add(call.method);
+        return true;
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      null,
+    );
+  });
+
+  group('$ScreenshotGuard', () {
+    test('a single holder toggles the flag off and back on', () async {
+      await ScreenshotGuard.acquire();
+      expect(calls, ['screenshotOff']);
+
+      await ScreenshotGuard.release();
+      expect(calls, ['screenshotOff', 'screenshotOn']);
+    });
+
+    test('a stacked holder must not re-enable screenshots for the screen underneath', () async {
+      await ScreenshotGuard.acquire(); // e.g. create-wallet showing seed words
+      await ScreenshotGuard.acquire(); // verify-seed pushed on top
+      expect(calls, ['screenshotOff'], reason: 'the flag is global — off once is off');
+
+      await ScreenshotGuard.release(); // verify-seed popped
+      expect(
+        calls,
+        ['screenshotOff'],
+        reason: 'the screen underneath still shows seed material — screenshots stay blocked',
+      );
+
+      await ScreenshotGuard.release(); // create-wallet closed
+      expect(calls, ['screenshotOff', 'screenshotOn']);
+    });
+
+    test('an unbalanced release is a no-op', () async {
+      await ScreenshotGuard.release();
+      expect(calls, isEmpty);
+    });
+  });
+}

--- a/test/screens/restore_wallet/restore_wallet_page_test.dart
+++ b/test/screens/restore_wallet/restore_wallet_page_test.dart
@@ -1,7 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -99,18 +98,9 @@ void main() {
     // and re-enable them on dispose so it never lands in the recents thumbnail
     // or a screen recording.
     testWidgets('disables screenshots on init and re-enables on dispose', (tester) async {
-      const channel = MethodChannel('com.flutterplaza.no_screenshot_methods');
       final calls = <String>[];
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-        channel,
-        (call) async {
-          calls.add(call.method);
-          return true;
-        },
-      );
-      addTearDown(
-        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, null),
-      );
+      stubNoScreenshotChannel(calls: calls);
+      addTearDown(unstubNoScreenshotChannel);
 
       await tester.pumpApp(buildSubject(const RestoreWalletView()));
       expect(
@@ -219,12 +209,10 @@ void main() {
         );
       });
 
-      testWidgets(
-          'offers a tappable retry (not a dead spinner) when restore failed '
+      testWidgets('offers a tappable retry (not a dead spinner) when restore failed '
           '(issue #657 P1 B1)', (tester) async {
         when(() => validateSeedCubit.state).thenReturn(ValidateSeedState.valid);
-        when(() => restoreWalletCubit.state)
-            .thenReturn(const RestoreWalletState(hasError: true));
+        when(() => restoreWalletCubit.state).thenReturn(const RestoreWalletState(hasError: true));
 
         await tester.pumpApp(buildSubject(const RestoreWalletView()));
 

--- a/test/screens/verify_seed/verify_seed_page_test.dart
+++ b/test/screens/verify_seed/verify_seed_page_test.dart
@@ -1,6 +1,5 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,6 +14,7 @@ import 'package:realunit_wallet/screens/verify_seed/widgets/verify_seed_button.d
 import 'package:realunit_wallet/screens/verify_seed/widgets/verify_seed_input_field.dart';
 import 'package:realunit_wallet/styles/colors.dart';
 
+import '../../helper/golden_plugin_stubs.dart';
 import '../../helper/pump_app.dart';
 
 class MockVerifySeedCubit extends MockCubit<VerifySeedState> implements VerifySeedCubit {}
@@ -183,39 +183,29 @@ void main() {
       });
     });
 
-    // The verify-seed screen (where the user re-enters real seed words) had no
-    // screenshot protection, unlike the sibling seed screens. It must disable
-    // screenshots on init and re-enable on dispose so it never lands in the
-    // app-switcher snapshot / a recording.
-    testWidgets('disables screenshots on init and re-enables on dispose',
-        (tester) async {
-      const channel = MethodChannel('com.flutterplaza.no_screenshot_methods');
+    testWidgets('disables screenshots on init and re-enables on dispose', (tester) async {
       final calls = <String>[];
-      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
-        channel,
-        (call) async {
-          calls.add(call.method);
-          return true;
-        },
-      );
-      addTearDown(
-        () => tester.binding.defaultBinaryMessenger
-            .setMockMethodCallHandler(channel, null),
-      );
+      stubNoScreenshotChannel(calls: calls);
+      addTearDown(unstubNoScreenshotChannel);
 
       await tester.pumpApp(buildSubject(const VerifySeedView()));
-      expect(calls, contains('screenshotOff'),
-          reason: 'seed screen must block screenshots on init');
+      expect(
+        calls,
+        contains('screenshotOff'),
+        reason: 'seed screen must block screenshots on init',
+      );
 
       // Replace the screen so VerifySeedView is disposed.
       await tester.pumpApp(buildSubject(const SizedBox.shrink()));
-      expect(calls, contains('screenshotOn'),
-          reason: 'leaving the seed screen must re-enable screenshots');
+      expect(
+        calls,
+        contains('screenshotOn'),
+        reason: 'leaving the seed screen must re-enable screenshots',
+      );
     });
 
     group('$BlocListener', () {
-      testWidgets('sends $LoadWalletEvent with the committed wallet when verified',
-          (tester) async {
+      testWidgets('sends $LoadWalletEvent with the committed wallet when verified', (tester) async {
         // The committed wallet `verify()` produced — a persisted row with a
         // real id (42), not the draft's `0` sentinel.
         final committed = SoftwareWallet(

--- a/test/screens/verify_seed/verify_seed_page_test.dart
+++ b/test/screens/verify_seed/verify_seed_page_test.dart
@@ -183,10 +183,10 @@ void main() {
       });
     });
 
-    // Regression for issue #612 S1: the verify-seed screen (where the user
-    // re-enters real seed words) had no screenshot protection, unlike the
-    // sibling seed screens. It must disable screenshots on init and re-enable
-    // on dispose so it never lands in the app-switcher snapshot / a recording.
+    // The verify-seed screen (where the user re-enters real seed words) had no
+    // screenshot protection, unlike the sibling seed screens. It must disable
+    // screenshots on init and re-enable on dispose so it never lands in the
+    // app-switcher snapshot / a recording.
     testWidgets('disables screenshots on init and re-enables on dispose',
         (tester) async {
       const channel = MethodChannel('com.flutterplaza.no_screenshot_methods');

--- a/test/screens/verify_seed/verify_seed_page_test.dart
+++ b/test/screens/verify_seed/verify_seed_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -180,6 +181,36 @@ void main() {
           findsOne,
         );
       });
+    });
+
+    // Regression for issue #612 S1: the verify-seed screen (where the user
+    // re-enters real seed words) had no screenshot protection, unlike the
+    // sibling seed screens. It must disable screenshots on init and re-enable
+    // on dispose so it never lands in the app-switcher snapshot / a recording.
+    testWidgets('disables screenshots on init and re-enables on dispose',
+        (tester) async {
+      const channel = MethodChannel('com.flutterplaza.no_screenshot_methods');
+      final calls = <String>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        (call) async {
+          calls.add(call.method);
+          return true;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null),
+      );
+
+      await tester.pumpApp(buildSubject(const VerifySeedView()));
+      expect(calls, contains('screenshotOff'),
+          reason: 'seed screen must block screenshots on init');
+
+      // Replace the screen so VerifySeedView is disposed.
+      await tester.pumpApp(buildSubject(const SizedBox.shrink()));
+      expect(calls, contains('screenshotOn'),
+          reason: 'leaving the seed screen must re-enable screenshots');
     });
 
     group('$BlocListener', () {


### PR DESCRIPTION
## Summary
`VerifySeedView` (where the user re-enters real seed words) was a `StatelessWidget` with **no screenshot protection**, unlike the sibling seed screens (`create_wallet_view.dart`, `settings_seed_view.dart`). So the entered words could be captured in the OS app-switcher thumbnail or a screen recording.

Fix: convert `VerifySeedView` to a `StatefulWidget` and call `NoScreenshot.instance.screenshotOff()` in `initState` / `screenshotOn()` in `dispose` — exactly the pattern the two sibling seed screens already use (so non-sensitive screens stay screenshot-able).

## Test
Widget test (in the existing `verify_seed_page_test.dart`) asserting the `no_screenshot` method channel receives `screenshotOff` on init and `screenshotOn` on dispose. Native app-switcher blanking is not unit-testable in Flutter; this pins the contract the protection relies on (on-device recents/recording check remains a manual sign-off).

## Verification (local, CI-equivalent, Flutter 3.41.6)
- `flutter analyze` on the changed files: **No issues found**.
- Test **passes with the fix**; **fails when the change is reverted** (no `screenshotOff` call), confirming it catches the regression.

## Scope
Addresses the **S3** item of #612 ("VerifySeedPage has no screenshot protection at all").

This does **not** close **S1** ("Seed phrase leaks to OS app-switcher / no `FLAG_SECURE`"): S1 needs `FLAG_SECURE` on `MainActivity.kt` to cover the Android recents/app-switcher thumbnail and screen-recording vector app-wide, which this PR does not touch.
