### PR TITLE
fix(wallet): fully purge seed + key on wallet delete

### DIFF
--- a/lib/packages/repository/wallet_repository.dart
+++ b/lib/packages/repository/wallet_repository.dart
@@ -46,7 +46,7 @@ class WalletRepository {
 
   /// Full purge for the user-facing delete: removes the encrypted-seed row AND
   /// the AES-GCM mnemonic key, so no recoverable seed material remains on
-  /// device. [deleteWallet] (account-only) is preserved for onboarding regen.
+  /// device.
   Future<void> purgeWallet(int id) async {
     await _appDatabase.deleteWalletCompletely(id);
     await _secureStorage.deleteMnemonicKey();

--- a/lib/packages/repository/wallet_repository.dart
+++ b/lib/packages/repository/wallet_repository.dart
@@ -44,6 +44,14 @@ class WalletRepository {
 
   Future<void> deleteWallet(int id) => _appDatabase.deleteWallet(id);
 
+  /// Full purge for the user-facing delete: removes the encrypted-seed row AND
+  /// the AES-GCM mnemonic key, so no recoverable seed material remains on
+  /// device. [deleteWallet] (account-only) is preserved for onboarding regen.
+  Future<void> purgeWallet(int id) async {
+    await _appDatabase.deleteWalletCompletely(id);
+    await _secureStorage.deleteMnemonicKey();
+  }
+
   Future<WalletInfo> _decryptWalletInfo(WalletInfo info) async {
     final key = await _secureStorage.getOrCreateMnemonicKey();
     final decryptedSeed = SecureStorage.decryptSeed(key, info.seed);

--- a/lib/packages/service/wallet_service.dart
+++ b/lib/packages/service/wallet_service.dart
@@ -274,8 +274,8 @@ class WalletService {
 
   Future<void> deleteCurrentWallet() async {
     final id = _settingsRepository.currentWalletId!;
-    // Full purge (seed row + mnemonic key), not the account-only deleteWallet
-    // used by onboarding-regenerate — so no recoverable seed survives delete.
+    // Full purge (seed row + mnemonic key), not an account-only delete — so no
+    // recoverable seed survives delete.
     await _repository.purgeWallet(id);
     await _settingsRepository.removeCurrentWalletId();
   }

--- a/lib/packages/service/wallet_service.dart
+++ b/lib/packages/service/wallet_service.dart
@@ -274,7 +274,9 @@ class WalletService {
 
   Future<void> deleteCurrentWallet() async {
     final id = _settingsRepository.currentWalletId!;
-    await _repository.deleteWallet(id);
+    // Full purge (seed row + mnemonic key), not the account-only deleteWallet
+    // used by onboarding-regenerate — so no recoverable seed survives delete.
+    await _repository.purgeWallet(id);
     await _settingsRepository.removeCurrentWalletId();
   }
 

--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -165,6 +165,12 @@ class SecureStorage {
     return key;
   }
 
+  /// Removes the AES-GCM key that decrypts stored seeds. Call only from the
+  /// user-facing wallet delete (purge) — once gone, any surviving encrypted
+  /// seed is permanently undecryptable. The onboarding-regenerate account-only
+  /// delete must NOT call this. A fresh key is lazily minted on next creation.
+  Future<void> deleteMnemonicKey() => _secureStorage.delete(key: _mnemonicEncryptionKey);
+
   static String encryptSeed(Uint8List key, String plaintext) {
     final iv = _secureRandomBytes(12);
     final cipher = GCMBlockCipher(AESEngine())

--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -165,10 +165,9 @@ class SecureStorage {
     return key;
   }
 
-  /// Removes the AES-GCM key that decrypts stored seeds. Call only from the
-  /// user-facing wallet delete (purge) — once gone, any surviving encrypted
-  /// seed is permanently undecryptable. The onboarding-regenerate account-only
-  /// delete must NOT call this. A fresh key is lazily minted on next creation.
+  /// Removes the AES-GCM key that decrypts stored seeds. Once gone, any
+  /// surviving encrypted seed is permanently undecryptable; a fresh key is
+  /// lazily minted on next creation.
   Future<void> deleteMnemonicKey() => _secureStorage.delete(key: _mnemonicEncryptionKey);
 
   static String encryptSeed(Uint8List key, String plaintext) {

--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -168,6 +168,9 @@ class SecureStorage {
   /// Removes the AES-GCM key that decrypts stored seeds. Once gone, any
   /// surviving encrypted seed is permanently undecryptable; a fresh key is
   /// lazily minted on next creation.
+  // @no-integration-test: forwards to FlutterSecureStorage (Android Keystore /
+  // iOS Keychain) over a platform channel; real keystore removal is only
+  // verifiable on-device — the unit test mocks the plugin.
   Future<void> deleteMnemonicKey() => _secureStorage.delete(key: _mnemonicEncryptionKey);
 
   static String encryptSeed(Uint8List key, String plaintext) {

--- a/lib/packages/storage/wallet_storage.dart
+++ b/lib/packages/storage/wallet_storage.dart
@@ -28,6 +28,16 @@ extension WalletStorage on AppDatabase {
   Future<int> deleteWallet(int walletId) =>
       (delete(walletAccountInfos)..where((row) => row.wallet.equals(walletId))).go();
 
+  /// Deletes the `walletInfos` row itself (the encrypted-seed record) after
+  /// clearing its dependent `walletAccountInfos` rows (FK in
+  /// [WalletAccountInfos.wallet]). Distinct from [deleteWallet], which clears
+  /// only accounts and deliberately leaves the seed row for the
+  /// onboarding-regenerate flow.
+  Future<void> deleteWalletCompletely(int walletId) => transaction(() async {
+    await (delete(walletAccountInfos)..where((row) => row.wallet.equals(walletId))).go();
+    await (delete(walletInfos)..where((row) => row.id.equals(walletId))).go();
+  });
+
   Future<bool> get hasWallet => select(walletInfos).get().then((result) => result.isNotEmpty);
 }
 

--- a/lib/packages/storage/wallet_storage.dart
+++ b/lib/packages/storage/wallet_storage.dart
@@ -30,9 +30,7 @@ extension WalletStorage on AppDatabase {
 
   /// Deletes the `walletInfos` row itself (the encrypted-seed record) after
   /// clearing its dependent `walletAccountInfos` rows (FK in
-  /// [WalletAccountInfos.wallet]). Distinct from [deleteWallet], which clears
-  /// only accounts and deliberately leaves the seed row for the
-  /// onboarding-regenerate flow.
+  /// [WalletAccountInfos.wallet]).
   Future<void> deleteWalletCompletely(int walletId) => transaction(() async {
     await (delete(walletAccountInfos)..where((row) => row.wallet.equals(walletId))).go();
     await (delete(walletInfos)..where((row) => row.id.equals(walletId))).go();

--- a/test/packages/repository/wallet_repository_test.dart
+++ b/test/packages/repository/wallet_repository_test.dart
@@ -145,5 +145,34 @@ void main() {
       final afterAccounts = await db.getWalletAccounts(walletId);
       expect(afterAccounts, isEmpty);
     });
+
+    test('purgeWallet removes the walletInfos seed row AND the mnemonic key', () async {
+      // Regression for #612 S2: the user-facing delete must leave no
+      // recoverable seed material — neither the encrypted row nor the AES key.
+      when(() => secureStorage.deleteMnemonicKey()).thenAnswer((_) async {});
+
+      final walletId = await repo.createWallet(walletName, WalletType.software, seed, address);
+      await db.insertWalletAccount(walletId, 'acc-0', 0);
+      expect(await db.getWalletById(walletId), isNotNull);
+
+      await repo.purgeWallet(walletId);
+
+      expect(await db.getWalletById(walletId), isNull); // encrypted seed row gone
+      expect(await db.getWalletAccounts(walletId), isEmpty); // accounts gone
+      verify(() => secureStorage.deleteMnemonicKey()).called(1); // AES key removed
+    });
+
+    test('deleteWallet (account-only) leaves the seed row and mnemonic key intact', () async {
+      // Onboarding-regenerate contract: the account-only primitive must NOT
+      // wipe the seed row or the AES key.
+      final walletId = await repo.createWallet(walletName, WalletType.software, seed, address);
+      await db.insertWalletAccount(walletId, 'acc-0', 0);
+
+      await repo.deleteWallet(walletId);
+
+      expect(await db.getWalletById(walletId), isNotNull); // row survives
+      expect(await db.getWalletAccounts(walletId), isEmpty); // accounts gone
+      verifyNever(() => secureStorage.deleteMnemonicKey()); // key untouched
+    });
   });
 }

--- a/test/packages/repository/wallet_repository_test.dart
+++ b/test/packages/repository/wallet_repository_test.dart
@@ -147,8 +147,8 @@ void main() {
     });
 
     test('purgeWallet removes the walletInfos seed row AND the mnemonic key', () async {
-      // Regression for #612 S2: the user-facing delete must leave no
-      // recoverable seed material — neither the encrypted row nor the AES key.
+      // The user-facing delete must leave no recoverable seed material —
+      // neither the encrypted row nor the AES key.
       when(() => secureStorage.deleteMnemonicKey()).thenAnswer((_) async {});
 
       final walletId = await repo.createWallet(walletName, WalletType.software, seed, address);

--- a/test/packages/service/wallet_service_test.dart
+++ b/test/packages/service/wallet_service_test.dart
@@ -57,6 +57,7 @@ void main() {
     when(() => settings.saveCurrentWalletId(any())).thenAnswer((_) async => true);
     when(() => settings.removeCurrentWalletId()).thenAnswer((_) async => true);
     when(() => repo.deleteWallet(any())).thenAnswer((_) async {});
+    when(() => repo.purgeWallet(any())).thenAnswer((_) async {});
     when(() => repo.updateAddress(any(), any())).thenAnswer((_) async {});
   });
 
@@ -440,7 +441,10 @@ void main() {
 
         await service.deleteCurrentWallet();
 
-        verify(() => repo.deleteWallet(8)).called(1);
+        // User-facing delete must fully purge (seed row + mnemonic key), not the
+        // account-only deleteWallet used by onboarding-regenerate (#612 S2).
+        verify(() => repo.purgeWallet(8)).called(1);
+        verifyNever(() => repo.deleteWallet(any()));
         verify(() => settings.removeCurrentWalletId()).called(1);
       });
     });

--- a/test/packages/service/wallet_service_test.dart
+++ b/test/packages/service/wallet_service_test.dart
@@ -441,8 +441,8 @@ void main() {
 
         await service.deleteCurrentWallet();
 
-        // User-facing delete must fully purge (seed row + mnemonic key), not the
-        // account-only deleteWallet used by onboarding-regenerate (#612 S2).
+        // User-facing delete must fully purge (seed row + mnemonic key), not
+        // the account-only delete.
         verify(() => repo.purgeWallet(8)).called(1);
         verifyNever(() => repo.deleteWallet(any()));
         verify(() => settings.removeCurrentWalletId()).called(1);

--- a/test/packages/storage/secure_storage_test.dart
+++ b/test/packages/storage/secure_storage_test.dart
@@ -120,6 +120,12 @@ void main() {
       verify(() => mockStorage.delete(key: 'pin.salt')).called(1);
     });
 
+    test('deleteMnemonicKey deletes the mnemonic encryption key', () async {
+      await secureStorage.deleteMnemonicKey();
+
+      verify(() => mockStorage.delete(key: 'wallet.mnemonic.encryption.key')).called(1);
+    });
+
     test('getPinSalt returns null when no salt is stored', () async {
       when(
         () => mockStorage.read(key: 'pin.salt'),


### PR DESCRIPTION
## Summary
The user-facing **"Delete Wallet"** only cleared `walletAccountInfos` (`WalletStorage.deleteWallet`). The `walletInfos` row — which holds the **AES-GCM-encrypted seed** — and the **mnemonic encryption key** in `flutter_secure_storage` both survived. So after a user deletes their wallet, the full mnemonic remained recoverable on the device (resale / GDPR right-to-erasure risk); only the current-wallet pointer was cleared, masking the residue.

Fix (non-breaking — the account-only `deleteWallet` is preserved for the onboarding-regenerate flow, which deliberately relies on the seed row surviving):
- `WalletStorage.deleteWalletCompletely(id)` — deletes accounts **and** the `walletInfos` seed row in a transaction (FK-safe).
- `SecureStorage.deleteMnemonicKey()` — removes the AES-GCM key.
- `WalletRepository.purgeWallet(id)` = `deleteWalletCompletely` + `deleteMnemonicKey`.
- `WalletService.deleteCurrentWallet` now calls `purgeWallet`.

> Verified the onboarding-regenerate path does **not** call `deleteCurrentWallet`/`deleteWallet` at runtime (it defers the DB write), so it is unaffected.

## Test
- `purgeWallet` removes the seed row **and** the mnemonic key.
- `deleteWallet` (account-only) still leaves the row + key intact (regenerate contract guard).
- The service delete now verifies `purgeWallet` is called and `deleteWallet` is not.

## Verification (local, CI-equivalent, Flutter 3.41.6)
- `flutter analyze` on the 6 changed files: **No issues found**.
- All tests **pass with the fix**; the service test **fails when `deleteCurrentWallet` is reverted** to `deleteWallet`, confirming the regression is caught.

Fixes the S2 item of #612.
