### PR TITLE
docs: document the staging branch flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,20 @@ flutter analyze                             # lint check
 
 After changing ARB files, always regenerate: `dart run tool/generate_localization.dart`
 
+## Branch Flow
+
+Three branches participate in the release lane:
+
+- `staging` — integration branch. **All feature PRs target `staging`**, not `develop`. Same protections as `develop`: 1 approval + `Analyze & Test` + `Visual Regression` + `Coverage Floor Gate`.
+- `develop` — pre-release. Receives changes via [`auto-staging-pr.yaml`](.github/workflows/auto-staging-pr.yaml), which opens a `staging → develop` PR on every push to `staging`.
+- `main` — production. Receives changes via [`auto-release-pr.yaml`](.github/workflows/auto-release-pr.yaml), which opens a `develop → main` PR on every push to `develop`.
+
+```
+feature/* ──(PR)──> staging ──(auto-PR)──> develop ──(auto-PR)──> main
+```
+
+The auto-opened promotion PRs are idempotent — only one is open per branch pair at any time. Each one waits for the same review + CI gates as the underlying branch. Tagged releases (`v*`) trigger after the relevant branch receives the commit; see the Release Versioning workflow table in the README for details.
+
 ## API Access — CRITICAL
 
 - The app is **only allowed to talk to the DFX API**: `api.dfx.swiss` (mainnet) and `dev.api.dfx.swiss` (testnet/Sepolia). No other hosts.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The build number is derived deterministically from the tag by `tool/generate_rel
 - The `+0` build-number sentinel is for local builds — CI always overrides `--build-name` / `--build-number` from the tag. Don't bump the `+N` part manually.
 - The `X.Y.Z` part is a **floor** for MAJOR / MINOR jumps. Patch increments come from the latest tag; pubspec is only consulted to trigger jumps. To start a new MINOR / MAJOR train (e.g. `v1.1.0`), bump pubspec on `develop` and the next auto-tag will pick it up.
 
-Typical patch flow: PR merges into `develop` → `auto-tag.yaml` creates `v1.0.X` → `release.yaml` (internal lane) ships the build to TestFlight + Play Internal.
+Typical patch flow: PR merges into `staging` → `auto-staging-pr.yaml` opens the `staging → develop` PR → after that PR merges, `auto-tag.yaml` creates `v1.0.X` on `develop` → `release.yaml` (internal lane) ships the build to TestFlight + Play Internal.
 
 ## Getting started
 


### PR DESCRIPTION
## Summary

Documents the staging branch lane that was wired up by PR #623, so contributors know where to target their PRs.

## What changes

- **`CONTRIBUTING.md`**: new "Branch Flow" section right after Build & Test Commands. Names the three branches that participate in the release lane (`staging`, `develop`, `main`), spells out that **feature PRs target `staging`**, links the two auto-promotion workflows, and shows the flow as ASCII.
- **`README.md`**: updates the "Typical patch flow" sentence so it starts from `staging` instead of `develop`.

## Note

This is the first PR opened against `staging` — it doubles as a smoke test for the new lane.

## Test plan

- [ ] After merge into `staging`, `auto-staging-pr.yaml` opens the expected `Promote: staging → develop` PR.