### PR TITLE
fix(ci): make auto-tag remote portable across renames/transfers

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -29,7 +29,10 @@ jobs:
           ssh-private-key: ${{ secrets.TAG_DEPLOY_KEY }}
 
       - name: Configure Git for SSH
-        run: git remote set-url origin git@github.com:DFXswiss/realunit-app.git
+        # `${{ github.repository }}` resolves to `<owner>/<repo>` for the
+        # currently running workflow — keeps the remote correct if the repo
+        # is renamed or transferred between orgs, without a follow-up edit.
+        run: git remote set-url origin git@github.com:${{ github.repository }}.git
 
       - name: Get latest tag
         id: get-tag


### PR DESCRIPTION
## Summary

`auto-tag.yaml` set the SSH remote to a hardcoded `git@github.com:DFXswiss/realunit-app.git`. After the recent transfer to `RealUnitCH/app`, the next tag push would either rely on GitHub's 301 redirect (which `git push` over SSH does not follow reliably) or fail outright.

Switching to `${{ github.repository }}` resolves to the current `<owner>/<repo>` of the workflow run, so the remote tracks the repo automatically across future renames and transfers.

## Verification

- [ ] Workflow YAML still parses (no shell quoting issues with the `${{ }}` substitution).
- [ ] Next push to develop triggers `auto-tag.yaml` and the tag lands cleanly on the new origin.