### PR TITLE
fix(legal): show an error with retry when a legal document fails to load

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -146,6 +146,8 @@
   "legalDisclaimerTitle": "Wichtige rechtliche Hinweise für Investoren & Bestätigung des Wohnsitzes",
   "legalDisclaimerTitle2": "Weitere rechtliche Hinweise",
   "legalDisclaimerYes": "Zustimmen",
+  "legalDocumentLoadFailed": "Dokument konnte nicht geladen werden",
+  "legalDocumentLoadFailedDescription": "Beim Laden des Dokuments ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
   "legalDocuments": "Rechtsdokumente",
   "location": "Ort",
   "logout": "Abmelden",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -146,6 +146,8 @@
   "legalDisclaimerTitle": "Important legal notices for investors & confirmation of residence",
   "legalDisclaimerTitle2": "Further legal notices",
   "legalDisclaimerYes": "Agree",
+  "legalDocumentLoadFailed": "Could not load the document",
+  "legalDocumentLoadFailedDescription": "Something went wrong while loading this document. Please try again.",
   "legalDocuments": "Legal documents",
   "location": "Location",
   "logout": "Logout",

--- a/lib/screens/legal/subpages/legal_document_page.dart
+++ b/lib/screens/legal/subpages/legal_document_page.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -7,6 +9,7 @@ import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
 import 'package:realunit_wallet/screens/web_view/web_view_page.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
+import 'package:realunit_wallet/styles/colors.dart';
 import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
 
 class LegalDocumentParams {
@@ -41,6 +44,7 @@ class LegalDocumentPage extends StatefulWidget {
 
 class _LegalDocumentPageState extends State<LegalDocumentPage> {
   String? _markdownContent;
+  bool _loadFailed = false;
 
   @override
   void initState() {
@@ -54,14 +58,30 @@ class _LegalDocumentPageState extends State<LegalDocumentPage> {
 
   Future<void> _loadMarkdown() async {
     final code = context.read<SettingsBloc>().state.language.code;
+    final assetPath = 'assets/legal/${widget.params.assetBaseName}_$code.md';
     try {
-      final content = await rootBundle.loadString(
-        'assets/legal/${widget.params.assetBaseName}_$code.md',
-      );
+      // cache: false so Retry after a transient failure actually re-reads the
+      // asset instead of replaying rootBundle's cached error for this key.
+      final content = await rootBundle.loadString(assetPath, cache: false);
       if (mounted) setState(() => _markdownContent = content);
-    } catch (_) {
-      if (mounted) setState(() => _markdownContent = '');
+    } catch (e, stackTrace) {
+      developer.log(
+        'Failed to load legal document "${widget.params.assetBaseName}"',
+        name: 'realunit_wallet.legal',
+        error: e,
+        stackTrace: stackTrace,
+        level: 1000, // SEVERE
+      );
+      if (mounted) setState(() => _loadFailed = true);
     }
+  }
+
+  void _retryLoad() {
+    setState(() {
+      _loadFailed = false;
+      _markdownContent = null;
+    });
+    _loadMarkdown();
   }
 
   String? get _pdfUrl {
@@ -75,7 +95,9 @@ class _LegalDocumentPageState extends State<LegalDocumentPage> {
     appBar: AppBar(
       title: Text(widget.params.title),
     ),
-    body: _markdownContent != null
+    body: _loadFailed
+        ? _buildError(context)
+        : _markdownContent != null
         ? Column(
             children: [
               Expanded(
@@ -118,6 +140,46 @@ class _LegalDocumentPageState extends State<LegalDocumentPage> {
                 ),
             ],
           )
+        // Documents load from a bundled asset (effectively synchronous), so the
+        // brief null frame stays blank rather than flashing a spinner.
         : const SizedBox.shrink(),
+  );
+
+  // Mirrors the canonical full-page error view in
+  // settings_currencies_page.dart (`_ErrorView`); keep the two in sync.
+  Widget _buildError(BuildContext context) => Center(
+    key: const ValueKey('legalDocumentLoadError'),
+    child: Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          const Icon(
+            Icons.error_outline,
+            size: 48,
+            color: RealUnitColors.neutral500,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            S.of(context).legalDocumentLoadFailed,
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            S.of(context).legalDocumentLoadFailedDescription,
+            style: const TextStyle(color: RealUnitColors.neutral500),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          OutlinedButton(
+            key: const ValueKey('legalDocumentRetryButton'),
+            onPressed: _retryLoad,
+            child: Text(S.of(context).retry),
+          ),
+        ],
+      ),
+    ),
   );
 }

--- a/test/goldens/screens/legal/legal_document_golden_test.dart
+++ b/test/goldens/screens/legal/legal_document_golden_test.dart
@@ -27,11 +27,15 @@ void main() {
   );
 
   group('$LegalDocumentPage', () {
+    // Empty-content placeholder: renders the empty Markdown body before any
+    // document text is present. Passing an empty string via the
+    // @visibleForTesting hook keeps this deterministic (no async asset load,
+    // so it never races into the new load-error state).
     goldenTest(
-      'initial state before markdown loads',
+      'empty document placeholder',
       fileName: 'legal_document_page_default',
       constraints: const BoxConstraints.tightFor(width: 390, height: 844),
-      builder: () => wrapForGolden(buildSubject()),
+      builder: () => wrapForGolden(buildSubject(initialMarkdownContent: '')),
     );
 
     // The page reads its markdown from rootBundle in production; for the

--- a/test/screens/legal/legal_document_page_test.dart
+++ b/test/screens/legal/legal_document_page_test.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/generated/i18n.dart';
+import 'package:realunit_wallet/screens/legal/subpages/legal_document_page.dart';
+import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
+import 'package:realunit_wallet/styles/language.dart';
+
+import '../../helper/helper.dart';
+
+void main() {
+  late MockSettingsBloc settingsBloc;
+
+  setUp(() {
+    // The page loads its document from rootBundle, which caches results per
+    // asset path. Clear it between tests so a missing-asset load fails fresh
+    // each time instead of returning a sibling test's cached future.
+    rootBundle.clear();
+    settingsBloc = MockSettingsBloc();
+    when(() => settingsBloc.state).thenReturn(const SettingsState(language: Language.en));
+  });
+
+  Widget host({
+    String assetBaseName = 'terms',
+    String? initialMarkdownContent,
+  }) => BlocProvider<SettingsBloc>.value(
+    value: settingsBloc,
+    child: LegalDocumentPage(
+      params: LegalDocumentParams(
+        title: 'Terms',
+        assetBaseName: assetBaseName,
+      ),
+      initialMarkdownContent: initialMarkdownContent,
+    ),
+  );
+
+  group('$LegalDocumentPage', () {
+    testWidgets(
+      'shows an error with a retry action when the document asset fails to load '
+      '(regression for #19: silent blank page)',
+      (tester) async {
+        // No bundled asset for this base name -> rootBundle.loadString throws.
+        await tester.pumpApp(host(assetBaseName: 'missing_legal_asset_test'));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byKey(const ValueKey('legalDocumentLoadError')),
+          findsOneWidget,
+          reason: 'a failed asset load must surface an error state, not a blank page',
+        );
+        expect(
+          find.byKey(const ValueKey('legalDocumentRetryButton')),
+          findsOneWidget,
+          reason: 'the error state must offer a retry affordance',
+        );
+        expect(
+          find.byIcon(Icons.error_outline),
+          findsOneWidget,
+          reason: 'the error state should render the standard error icon',
+        );
+        expect(
+          find.text(S.current.legalDocumentLoadFailedDescription),
+          findsOneWidget,
+          reason: 'the error state should explain what went wrong',
+        );
+      },
+    );
+
+    testWidgets('renders the markdown body when content is provided', (tester) async {
+      await tester.pumpApp(host(initialMarkdownContent: '# Hello'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Markdown), findsOneWidget);
+      expect(find.byKey(const ValueKey('legalDocumentLoadError')), findsNothing);
+    });
+
+    testWidgets('retry re-runs the load and stays in the error state while the asset is missing', (
+      tester,
+    ) async {
+      await tester.pumpApp(host(assetBaseName: 'missing_legal_asset_test'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('legalDocumentRetryButton')));
+      await tester.pumpAndSettle();
+
+      // The asset is still missing, so we expect the error state to persist
+      // without throwing — exercising the retry path.
+      expect(find.byKey(const ValueKey('legalDocumentLoadError')), findsOneWidget);
+    });
+
+    testWidgets('retry recovers and renders the document once the asset loads', (
+      tester,
+    ) async {
+      const baseName = 'recoverable_legal_asset_test';
+      const assetKey = 'assets/legal/${baseName}_en.md';
+      var failNext = true;
+
+      // Mock the asset channel so the first load fails and, after retry, the
+      // second load succeeds — exercising the full error -> retry -> loaded path.
+      final messenger = tester.binding.defaultBinaryMessenger;
+      messenger.setMockMessageHandler('flutter/assets', (ByteData? message) async {
+        final key = utf8.decode(
+          message!.buffer.asUint8List(message.offsetInBytes, message.lengthInBytes),
+        );
+        if (key == assetKey && !failNext) {
+          return ByteData.sublistView(Uint8List.fromList(utf8.encode('# Recovered')));
+        }
+        return null; // missing asset -> loadString throws
+      });
+      addTearDown(() => messenger.setMockMessageHandler('flutter/assets', null));
+
+      await tester.pumpApp(host(assetBaseName: baseName));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const ValueKey('legalDocumentLoadError')), findsOneWidget);
+
+      failNext = false;
+      await tester.tap(find.byKey(const ValueKey('legalDocumentRetryButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('legalDocumentLoadError')), findsNothing);
+      expect(find.byType(Markdown), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## What

When a legal document's markdown asset fails to load, `LegalDocumentPage` caught the error and set `_markdownContent = ''`, which `build` treats as the *loaded* state → the user got a **blank page with no message and no way to retry**.

This adds an explicit error state with a localized message and a **Retry** action.

## Why

Part of #629 (audit finding **#19**). The failure was silent: `catch (_) { _markdownContent = ''; }` is indistinguishable from a successfully loaded empty document, so a missing/unreadable legal asset (e.g. a packaging slip-up or I/O error) leaves the user staring at an empty screen.

## Changes

- `legal_document_page.dart`: track `_loadFailed`; on load failure render a centered error message + `Retry` button (`_retryLoad` re-runs the load) instead of an empty `Markdown`. The load is also now logged via `developer.log`.
- New i18n key `legalDocumentLoadFailed` (EN + DE).
- `legal_document_page_test.dart` (new): regression test — asset-load failure must surface an error + retry affordance (was red before the fix), plus a control for the loaded body and a retry-path test. `rootBundle.clear()` per test keeps the asset cache from leaking between cases.
- `legal_document_golden_test.dart`: the existing default golden rendered `buildSubject()` with no content, which under the new behaviour would race into the error state. Switched it to render an empty document deterministically (`initialMarkdownContent: ''`) — same committed baseline, no async load.

## Test plan

- `flutter analyze` → **0 issues**
- `flutter test test/screens/legal/legal_document_page_test.dart` → red on `develop`, **green** with the fix
- `flutter test test/goldens/screens/legal/legal_document_golden_test.dart` → **green** (baseline unchanged)
- full `flutter test --coverage` run locally (only the known `home_golden` macOS pixel drift remains, which is green on CI)

No production behaviour changes for the loaded/loading paths — only the failure path gains an error UI.
