### PR TITLE
fix(ci): pin Tier-3 iOS cache key to Xcode version

### DIFF
--- a/.github/workflows/tier3-handbook.yaml
+++ b/.github/workflows/tier3-handbook.yaml
@@ -151,22 +151,35 @@ jobs:
       - run: dart run tool/generate_release_info.dart
       - run: flutter pub run build_runner build
 
+      # Bind the iOS cache key to the active Xcode / iOS-SDK version so
+      # cached `.pcm` module files are not reused across an SDK rev. Without
+      # this, the cache key matched on `runner.os + lock files` only and
+      # restored a cached `SwiftShims-*.pcm` whose `module.modulemap` mtime
+      # no longer matched the SDK on disk — Swift then rejected the cached
+      # module and the build failed with "module file ... was built: mtime
+      # changed". Pinning the cache to `xcodebuild -version` invalidates the
+      # cache the moment the runner image upgrades Xcode.
+      - name: Resolve Xcode version
+        id: xcode
+        run: echo "version=$(xcodebuild -version | tr '\n' '-' | sed 's/[^A-Za-z0-9.-]//g; s/-$//')" >> "$GITHUB_OUTPUT"
+
       # Cache iOS DerivedData (compiled Flutter modules) + Pods (Cocoapods
       # dependencies). On a cache hit, `flutter build ios --simulator
       # --debug` reuses the cached objects and the build time drops from
       # ~5-6 min to ~2-3 min. Cache-Key invalidates on pubspec.lock or
       # Podfile.lock changes — i.e. any dependency bump forces a clean
-      # build. The restore-keys fallback allows partial cache reuse if
-      # the lock files moved but the SDK is unchanged.
+      # build — and additionally on Xcode version (see step above). The
+      # restore-keys fallback allows partial cache reuse if the lock files
+      # moved but the SDK is unchanged.
       - name: Cache iOS DerivedData + Pods
         uses: actions/cache@v4
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData
             ios/Pods
-          key: ios-derived-data-${{ runner.os }}-${{ hashFiles('pubspec.lock', 'ios/Podfile.lock') }}
+          key: ios-derived-data-${{ runner.os }}-${{ steps.xcode.outputs.version }}-${{ hashFiles('pubspec.lock', 'ios/Podfile.lock') }}
           restore-keys: |
-            ios-derived-data-${{ runner.os }}-
+            ios-derived-data-${{ runner.os }}-${{ steps.xcode.outputs.version }}-
 
       - name: Build iOS simulator app
         run: flutter build ios --simulator --debug


### PR DESCRIPTION
## Problem

The Tier-3 \`Build iOS simulator app\` step failed on PR #626 with:

\`\`\`
Swift Compiler Error (Xcode): File '/Applications/Xcode_16.4.app/.../iPhoneSimulator18.5.sdk/usr/lib/swift/shims/module.modulemap'
has been modified since the module file '.../ModuleCache.noindex/.../SwiftShims-2ZSRUUIS75TOI.pcm' was built:
mtime changed (was 1779274009, now 1779861061)
\`\`\`

The cached \`SwiftShims-*.pcm\` referenced a previous SDK's \`module.modulemap\` mtime — its own \`module.modulemap\` had been rewritten by the runner image's Xcode upgrade between two macOS-latest runs.

## Root cause

\`Cache iOS DerivedData + Pods\` keyed only on \`runner.os + lock files\`. \`runner.os\` is just \`"macOS"\` regardless of the runtime Xcode/SDK version, so a cache restored across an Xcode bump produces \`.pcm\` files that point at SDK file mtimes from the **previous** toolchain. Swift refuses to use them and the build fails.

## Fix

Resolve \`xcodebuild -version\` at runtime and inject it into both the cache key and the restore-keys fallback. The cache now invalidates exactly when the active Xcode rolls, so a hit can only restore objects that were built against the current toolchain.

The version string is normalised (\`tr '\n' '-' | sed 's/[^A-Za-z0-9.-]//g; s/-\$//'\`) so \`Xcode 16.4 / Build version 16F6\` becomes a safe cache-key fragment like \`Xcode-16.4-Build-version-16F6\`.

## Validation plan

- [ ] On first run after merge, cache misses (new key includes Xcode version that didn't exist in the old cache namespace) → clean build, populates a fresh cache.
- [ ] Subsequent runs hit the cache as before, but only across the same Xcode version.
- [ ] When the runner image upgrades Xcode next, the cache misses again instead of restoring stale modules — same one-time clean-build cost, no \`mtime changed\` failure.