### PR TITLE
fix(ios): point Match at RealUnitCH/fastlane-certificates

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -65,7 +65,7 @@ platform :ios do
       type: "appstore",
       app_identifier: "swiss.realunit.app",
       api_key: get_api_key,
-      git_url: "git@github.com:DFXswiss/fastlane-certificates.git"
+      git_url: "git@github.com:RealUnitCH/fastlane-certificates.git"
     )
 
     # CFBundleShortVersionString must be three integers (App Store ITMS-90060).

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -1,4 +1,4 @@
-git_url("git@github.com:DFXswiss/fastlane-certificates.git")
+git_url("git@github.com:RealUnitCH/fastlane-certificates.git")
 
 storage_mode("git")
 


### PR DESCRIPTION
## Problem

After today's `DFXswiss/realunit-app → RealUnitCH/app` org transfer, the iOS release lane on `v1.0.72` failed in Fastlane Match:

```
git@github.com: Permission denied (publickey).
Error cloning certificates repo, please make sure you have read access to the repository you want to use
Called from Fastfile at line 64 (sync_code_signing)
```

The previous certificates repo `DFXswiss/fastlane-certificates` had zero registered deploy keys (the trust was lost during the wider DFXswiss → RealUnitCH cleanup).

## Fix

The Match storage was migrated to `RealUnitCH/fastlane-certificates` — same encrypted content (so `MATCH_PASSWORD` and the existing distribution cert / appstore provisioning profile remain unchanged). This PR updates both call sites that hardcode the storage URL:

- `ios/fastlane/Matchfile:1` — the default `git_url` consulted when Match runs without an explicit override
- `ios/fastlane/Fastfile:68` — the explicit `git_url:` override inside the `sync_code_signing` call in the `:release` lane (CI uses this path)

Both now point at `git@github.com:RealUnitCH/fastlane-certificates.git`.

## Credential rotation (done out-of-band)

The `MATCH_SSH_KEY` Actions secret on `RealUnitCH/app` has been rotated against a fresh ED25519 deploy key on `RealUnitCH/fastlane-certificates` (key ID `153227247`, write access for sync). Private key + metadata backed up to Vaultwarden under `dfx01/Services` as `RealUnitCH/app MATCH_SSH_KEY`.

## Test plan

- [ ] Merge through `staging → develop → main`
- [ ] `Auto Tag on Merge` produces `v1.0.73`
- [ ] `release.yaml` ios-deploy succeeds (Match clones from new repo, sync_code_signing passes, build uploads to TestFlight)
- [ ] android-deploy continues unaffected

`v1.0.72` is being skipped — no app-facing changes were in it (only doc + cache-key-fix), so the next tag from the natural release flow is the first successful build.