### PR TITLE
fix(settings): hide Network-mode row from production builds

### DIFF
--- a/lib/screens/settings/settings_page.dart
+++ b/lib/screens/settings/settings_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -53,13 +54,14 @@ class SettingsPage extends StatelessWidget {
                   selectedOption: state.currency.code,
                   onTap: () => context.pushNamed(SettingsRoutes.currencies),
                 ),
-                SettingOption(
-                  title: S.of(context).settingsNetwork,
-                  leading: const NodesIcon(size: 24),
-                  trailing: _forwardIcon,
-                  selectedOption: state.networkMode.localizedName(context),
-                  onTap: () => context.pushNamed(SettingsRoutes.network),
-                ),
+                if (kDebugMode)
+                  SettingOption(
+                    title: S.of(context).settingsNetwork,
+                    leading: const NodesIcon(size: 24),
+                    trailing: _forwardIcon,
+                    selectedOption: state.networkMode.localizedName(context),
+                    onTap: () => context.pushNamed(SettingsRoutes.network),
+                  ),
                 SettingOption(
                   title: S.of(context).settingsTaxReport,
                   leading: const DocumentReportIcon(size: 24),


### PR DESCRIPTION
## Summary

Hides the Settings → Network row (Mainnet/Testnet toggle) from production builds.

The toggle is a developer affordance — an end-user has no legitimate reason to switch networks, and an accidental tap drops them onto Testnet with broken liquidity and a forced reauth on every subsequent network round-trip.

## Change

Wraps the `SettingOption` that opens `SettingsNetworkPage` in a `if (kDebugMode)` collection-if. This mirrors the existing pattern in `lib/screens/welcome/welcome_page.dart:125`, where the **Address + Signature** debug entry is hidden the same way.

What stays:
- `SettingsNetworkPage`, `SettingsRoutes.network`, `SettingsBloc` network-mode state, `SettingsRepository.networkMode` — all untouched.
- Default Mainnet mode stays active for every user.
- Debug builds still expose the toggle for internal use.

## Test plan

- [ ] `flutter analyze` clean on the touched file.
- [ ] Production build of the Settings page no longer lists the Network row.
- [ ] Debug build still shows it.
- [ ] Visual Regression: the `settings_page` golden will drift; regenerate via `golden-regenerate.yaml` after merge to refresh the handbook screenshot (§12-settings).