### PR TITLE
fix(test): anchor flat-value 5%-floor test dates to DateTime.now()

### DIFF
--- a/test/screens/dashboard/portfolio_chart_cubit_test.dart
+++ b/test/screens/dashboard/portfolio_chart_cubit_test.dart
@@ -65,10 +65,17 @@ void main() {
       // When all values are equal, the cubit floors the padded deviation at
       // `average * 0.05` so the chart still has a visible Y-range instead of
       // collapsing to a single horizontal line.
+      //
+      // Dates are anchored to `DateTime.now()` because the cubit's default
+      // period (`TimePeriod.threeMonths`) clips the visible window relative
+      // to `DateTime.now()`; hardcoded calendar dates would silently fall
+      // outside the window once the calendar moves on and the test would
+      // start asserting on an empty series.
+      final now = DateTime.now();
       final points = [
-        _pt(DateTime.utc(2026, 1, 1), 10000),
-        _pt(DateTime.utc(2026, 2, 1), 10000),
-        _pt(DateTime.utc(2026, 3, 1), 10000),
+        _pt(now.subtract(const Duration(days: 60)), 10000),
+        _pt(now.subtract(const Duration(days: 30)), 10000),
+        _pt(now.subtract(const Duration(days: 1)), 10000),
       ];
 
       final cubit = PortfolioChartCubit(points);


### PR DESCRIPTION
## Problem

The `flat-value series still spreads lines via the 5% floor (no Y-collapse)` test in `test/screens/dashboard/portfolio_chart_cubit_test.dart:64` constructs a `PortfolioChartCubit` and asserts on `horizontalLineValues` without calling `selectPeriod`. The cubit's default period is `TimePeriod.threeMonths`, which clips `visibleSpots` to a window anchored at `DateTime.now()` (`lib/screens/dashboard/bloc/portfolio_chart/portfolio_chart_cubit.dart:51`).

The previous data points (`2026-01-01`, `2026-02-01`, `2026-03-01`) were inside that window when the test was written but fall outside as soon as the wall clock crosses three months past the last point. When that happens, `visibleSpots` is empty, `horizontalLineValues` is empty, and the `hasLength(6)` assertion at line 76 fails on every PR run until someone notices.

This surfaced on 2026-06-02. The last green CI on staging was on 2026-06-01 at 21:56 — the boundary crossed shortly after.

## Fix

Anchor the three data points to `DateTime.now()` (−60 d, −30 d, −1 d) so they stay inside the three-month window regardless of when CI runs. This mirrors the pattern the surrounding `selectPeriod to oneWeek / oneMonth / threeMonths / oneYear` tests already use (`portfolio_chart_cubit_test.dart:131+`).

The asserted line values are unchanged because the value math (`10000` → average `100` → 5 % floor `5` → nice-number interval `2` → bottom `94`) only depends on the magnitudes, not on the timestamps.

A short comment is added next to the `now` so a future reader sees why the test reaches for the wall clock.

## Validation

- `flutter test test/screens/dashboard/portfolio_chart_cubit_test.dart` — 13/13 pass locally on 2026-06-02.
- Unblocks every PR opened on or after 2026-06-02 that runs `Analyze & Test`.

## Out of scope

A more durable fix would inject a `Clock` into the cubit and pin it to a fixed instant in tests — that's a refactor of `PortfolioChartCubit` itself and properly belongs in a separate PR.