### PR TITLE
test(dashboard): fix time-dependent portfolio chart test (repo-wide CI red since 2026-06-02)

### DIFF
--- a/test/screens/dashboard/portfolio_chart_cubit_test.dart
+++ b/test/screens/dashboard/portfolio_chart_cubit_test.dart
@@ -79,6 +79,12 @@ void main() {
       ];
 
       final cubit = PortfolioChartCubit(points);
+      // Select the all-time window so these fixed-date points are always inside
+      // the visible range. The default `threeMonths` period filters relative to
+      // DateTime.now(), which silently emptied the series once wall-clock time
+      // moved more than three months past the points (time-dependent failure);
+      // the 5%-floor behaviour under test is period-independent.
+      cubit.selectPeriod(TimePeriod.all);
 
       expect(cubit.state.horizontalLineValues, hasLength(6));
       // average 100 → floor 5 → rawInterval 2 → niceNumber 2 → bottom 94.


### PR DESCRIPTION
## Problem
`PortfolioChartCubit` defaults to the `threeMonths` period, which filters price points relative to `DateTime.now()`. The test **`flat-value series still spreads lines via the 5% floor (no Y-collapse)`** pinned its points to fixed 2026-Q1 dates (`DateTime.utc(2026, 1/2/3, 1)`) **without selecting a period**.

Once wall-clock time moved >3 months past those points, the default window filtered **every** point out → empty series → `horizontalLineValues == []` → the `hasLength(6)` assertion fails.

This is a **deterministic, calendar-triggered** failure that flips on **2026-06-02** (cutoff `DateTime(2026, 3, 2)` excludes all three Q1 points) and reddens **Analyze & Test on every branch** carrying this test — not specific to any feature PR. staging's last green run was 2026-06-01; the next run on/after today fails.

## Fix
Select `TimePeriod.all` (all-time window, `minX = first price time`, no `now` dependency) so the fixed-date points are always visible — mirroring the sibling flat-series tests (`all-period…`, `zero-average…`, `large-magnitude…` all already use `.all`). The 5%-floor behaviour under test is period-independent, so the assertions are unchanged.

## Verify (Flutter 3.41.6, CI sequence)
- `flutter analyze`: No issues found.
- Target test: **13/13 green, run 3× (deterministic)**.
- Full `flutter test --exclude-tags golden`: **2279/2279 green**.

Commits as Joshua Krüger.