### PR TITLE
fix(handbook): store-listing source links point at develop, not main

### DIFF
--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2280,9 +2280,9 @@
       <div class="rhs">
         <b>Live aus Repo</b>
         <div class="links">
-          <a href="https://github.com/RealUnitCH/app/tree/main/ios/fastlane/metadata">iOS metadata ↗</a>
+          <a href="https://github.com/RealUnitCH/app/tree/develop/ios/fastlane/metadata">iOS metadata ↗</a>
           ·
-          <a href="https://github.com/RealUnitCH/app/tree/main/android/fastlane/metadata/android">Android metadata ↗</a>
+          <a href="https://github.com/RealUnitCH/app/tree/develop/android/fastlane/metadata/android">Android metadata ↗</a>
         </div>
       </div>
     </div>
@@ -2301,9 +2301,9 @@
   <!-- iOS section -->
   <h3>Apple App Store (de-DE)</h3>
   <dl class="store-listing">
-    <dt>App-Name (max 30)</dt><dd><code>RealUnit Wallet</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/name.txt" title="Quelle: name.txt">↗</a></dd>
-    <dt>Untertitel (max 30)</dt><dd><code>Sicher. Einfach. Unabhängig.</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/subtitle.txt" title="Quelle: subtitle.txt">↗</a></dd>
-    <dt>Beschreibung (max 4000) <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/description.txt" title="Quelle: description.txt">↗</a></dt><dd><pre>Die offizielle App der RealUnit Schweiz AG – für den einfachen, sicheren Kauf und die Verwahrung der RealUnit Aktientoken. Ohne Bank. Ohne Gebühren. Direkt in Ihrer Hand.
+    <dt>App-Name (max 30)</dt><dd><code>RealUnit Wallet</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/name.txt" title="Quelle: name.txt">↗</a></dd>
+    <dt>Untertitel (max 30)</dt><dd><code>Sicher. Einfach. Unabhängig.</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/subtitle.txt" title="Quelle: subtitle.txt">↗</a></dd>
+    <dt>Beschreibung (max 4000) <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/description.txt" title="Quelle: description.txt">↗</a></dt><dd><pre>Die offizielle App der RealUnit Schweiz AG – für den einfachen, sicheren Kauf und die Verwahrung der RealUnit Aktientoken. Ohne Bank. Ohne Gebühren. Direkt in Ihrer Hand.
 
 IHRE VORTEILE AUF EINEN BLICK
 
@@ -2320,38 +2320,38 @@ Die RealUnit App richtet sich an Anlegerinnen und Anleger, die ihr Vermögen aus
 Die RealUnit Schweiz AG ist eine börsenkotierte Investmentgesellschaft, welche breit diversifiziert in Realwerte investiert. Wir verfolgen das Ziel, das uns anvertraute Vermögen bestmöglich vor Krisen und Kaufkraftverlust zu schützen und das Privateigentum zu sichern.
 
 Jetzt herunterladen und Ihre finanzielle Souveränität zurückgewinnen.</pre></dd>
-    <dt>Schlagwörter (max 100, kommasepariert)</dt><dd><code>RealUnit,Wallet,Token,Aktien,Vermögen,Schweiz,Bitbox,Krypto,Investment,bankenunabhängig</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/keywords.txt" title="Quelle: keywords.txt">↗</a></dd>
-    <dt>Marketing-URL</dt><dd><a href="https://realunit.ch">https://realunit.ch</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/marketing_url.txt" title="Quelle: marketing_url.txt">↗</a></dd>
-    <dt>Privacy-URL</dt><dd><a href="https://realunit.ch/datenschutz/">https://realunit.ch/datenschutz/</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/privacy_url.txt" title="Quelle: privacy_url.txt">↗</a></dd>
-    <dt>Support-URL</dt><dd><a href="https://realunit.ch/kontakt/">https://realunit.ch/kontakt/</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/support_url.txt" title="Quelle: support_url.txt">↗</a></dd>
-    <dt>Copyright</dt><dd>© 2026 RealUnit Schweiz AG <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/copyright.txt" title="Quelle: copyright.txt">↗</a></dd>
-    <dt>Release-Notes</dt><dd>Erste Veröffentlichung der RealUnit Wallet App. <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/release_notes.txt" title="Quelle: release_notes.txt">↗</a></dd>
+    <dt>Schlagwörter (max 100, kommasepariert)</dt><dd><code>RealUnit,Wallet,Token,Aktien,Vermögen,Schweiz,Bitbox,Krypto,Investment,bankenunabhängig</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/keywords.txt" title="Quelle: keywords.txt">↗</a></dd>
+    <dt>Marketing-URL</dt><dd><a href="https://realunit.ch">https://realunit.ch</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/marketing_url.txt" title="Quelle: marketing_url.txt">↗</a></dd>
+    <dt>Privacy-URL</dt><dd><a href="https://realunit.ch/datenschutz/">https://realunit.ch/datenschutz/</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/privacy_url.txt" title="Quelle: privacy_url.txt">↗</a></dd>
+    <dt>Support-URL</dt><dd><a href="https://realunit.ch/kontakt/">https://realunit.ch/kontakt/</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/support_url.txt" title="Quelle: support_url.txt">↗</a></dd>
+    <dt>Copyright</dt><dd>© 2026 RealUnit Schweiz AG <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/copyright.txt" title="Quelle: copyright.txt">↗</a></dd>
+    <dt>Release-Notes</dt><dd>Erste Veröffentlichung der RealUnit Wallet App. <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/release_notes.txt" title="Quelle: release_notes.txt">↗</a></dd>
   </dl>
 
   <h4>Screenshots — iPhone 6.9 Display (1320×2868)</h4>
   <div class="store-screenshots">
-    <figure><img src="../store/ios/iphone-69/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/iphone-69/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/iphone-69/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/03_security.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/iphone-69/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/04_buy.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/iphone-69/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/05_tax.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/iphone-69/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/iphone-69/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/iphone-69/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/03_security.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/iphone-69/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/04_buy.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/iphone-69/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/05_tax.png" title="Quelle">↗</a></figcaption></figure>
   </div>
 
   <h4>Screenshots — iPad Pro 13" Display (2752×2064)</h4>
   <div class="store-screenshots">
-    <figure><img src="../store/ios/ipad-13/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/ipad-13/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/ipad-13/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/03_security.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/ipad-13/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/04_buy.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/ipad-13/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/05_tax.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/ipad-13/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/ipad-13/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/ipad-13/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/03_security.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/ipad-13/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/04_buy.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/ipad-13/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/05_tax.png" title="Quelle">↗</a></figcaption></figure>
   </div>
 
   <!-- Android section -->
   <h3>Google Play Store (de-DE)</h3>
   <dl class="store-listing">
-    <dt>Titel (max 50)</dt><dd><code>RealUnit Wallet</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/title.txt" title="Quelle: title.txt">↗</a></dd>
-    <dt>Kurzbeschreibung (max 80)</dt><dd>RealUnit Token kaufen, verwahren &amp; verwalten – sicher und bankenunabhängig. <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/short_description.txt" title="Quelle: short_description.txt">↗</a></dd>
-    <dt>Lang-Beschreibung (max 4000, HTML) <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/full_description.txt" title="Quelle: full_description.txt">↗</a></dt><dd><div class="rendered-html">Die offizielle App der RealUnit Schweiz AG – für den einfachen, gebührenfreien Kauf und die sichere Verwahrung der RealUnit Aktientoken. Ohne Bank. Ohne Gebühren. Direkt in Ihrer Hand.
+    <dt>Titel (max 50)</dt><dd><code>RealUnit Wallet</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/title.txt" title="Quelle: title.txt">↗</a></dd>
+    <dt>Kurzbeschreibung (max 80)</dt><dd>RealUnit Token kaufen, verwahren &amp; verwalten – sicher und bankenunabhängig. <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/short_description.txt" title="Quelle: short_description.txt">↗</a></dd>
+    <dt>Lang-Beschreibung (max 4000, HTML) <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/full_description.txt" title="Quelle: full_description.txt">↗</a></dt><dd><div class="rendered-html">Die offizielle App der RealUnit Schweiz AG – für den einfachen, gebührenfreien Kauf und die sichere Verwahrung der RealUnit Aktientoken. Ohne Bank. Ohne Gebühren. Direkt in Ihrer Hand.
 
 <b>Ihre Vorteile</b>
 
@@ -2374,40 +2374,40 @@ Die RealUnit App richtet sich an Anlegerinnen und Anleger, die ihr Vermögen aus
 Die RealUnit Schweiz AG ist eine börsenkotierte Investmentgesellschaft, welche breit diversifiziert in Realwerte investiert. Wir verfolgen das Ziel, das uns anvertraute Vermögen bestmöglich vor Krisen und Kaufkraftverlust zu schützen und das Privateigentum zu sichern.
 
 Jetzt herunterladen und Ihre finanzielle Souveränität zurückgewinnen.</div></dd>
-    <dt>Changelog</dt><dd>Erste Veröffentlichung der RealUnit Wallet App. <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/changelogs/default.txt" title="Quelle: changelogs/default.txt">↗</a></dd>
+    <dt>Changelog</dt><dd>Erste Veröffentlichung der RealUnit Wallet App. <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/changelogs/default.txt" title="Quelle: changelogs/default.txt">↗</a></dd>
   </dl>
 
   <h4>Feature Graphic (1024×500)</h4>
-  <figure class="store-graphic"><img src="../store/android/featureGraphic.png" alt="Feature Graphic"/><figcaption>featureGraphic <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/featureGraphic.png" title="Quelle">↗</a></figcaption></figure>
+  <figure class="store-graphic"><img src="../store/android/featureGraphic.png" alt="Feature Graphic"/><figcaption>featureGraphic <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/featureGraphic.png" title="Quelle">↗</a></figcaption></figure>
 
   <h4>Icon (512×512)</h4>
-  <figure class="store-icon"><img src="../store/android/icon.png" alt="App Icon"/><figcaption>icon <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/icon.png" title="Quelle">↗</a></figcaption></figure>
+  <figure class="store-icon"><img src="../store/android/icon.png" alt="App Icon"/><figcaption>icon <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/icon.png" title="Quelle">↗</a></figcaption></figure>
 
   <h4>Phone Screenshots (1350×2400)</h4>
   <div class="store-screenshots">
-    <figure><img src="../store/android/phone/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/phone/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/phone/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/phone/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/phone/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/phone/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/phone/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/phone/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/phone/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/phone/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
   </div>
 
   <h4>7" Tablet (1920×1200)</h4>
   <div class="store-screenshots">
-    <figure><img src="../store/android/seven-inch/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/seven-inch/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/seven-inch/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/seven-inch/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/seven-inch/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/seven-inch/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/seven-inch/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/seven-inch/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/seven-inch/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/seven-inch/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
   </div>
 
   <h4>10" Tablet (2560×1440)</h4>
   <div class="store-screenshots">
-    <figure><img src="../store/android/ten-inch/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/ten-inch/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/ten-inch/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/ten-inch/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/ten-inch/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/ten-inch/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/ten-inch/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/ten-inch/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/ten-inch/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/ten-inch/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
   </div>
 </details>
 <!-- END:store-listing -->

--- a/scripts/templates/store-listing.html.tmpl
+++ b/scripts/templates/store-listing.html.tmpl
@@ -8,9 +8,9 @@
       <div class="rhs">
         <b>Live aus Repo</b>
         <div class="links">
-          <a href="https://github.com/RealUnitCH/app/tree/main/ios/fastlane/metadata">iOS metadata ↗</a>
+          <a href="https://github.com/RealUnitCH/app/tree/develop/ios/fastlane/metadata">iOS metadata ↗</a>
           ·
-          <a href="https://github.com/RealUnitCH/app/tree/main/android/fastlane/metadata/android">Android metadata ↗</a>
+          <a href="https://github.com/RealUnitCH/app/tree/develop/android/fastlane/metadata/android">Android metadata ↗</a>
         </div>
       </div>
     </div>
@@ -29,74 +29,74 @@
   <!-- iOS section -->
   <h3>Apple App Store (de-DE)</h3>
   <dl class="store-listing">
-    <dt>App-Name (max 30)</dt><dd><code>{{ ios_name }}</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/name.txt" title="Quelle: name.txt">↗</a></dd>
-    <dt>Untertitel (max 30)</dt><dd><code>{{ ios_subtitle }}</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/subtitle.txt" title="Quelle: subtitle.txt">↗</a></dd>
-    <dt>Beschreibung (max 4000) <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/description.txt" title="Quelle: description.txt">↗</a></dt><dd><pre>{{ ios_description }}</pre></dd>
-    <dt>Schlagwörter (max 100, kommasepariert)</dt><dd><code>{{ ios_keywords }}</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/keywords.txt" title="Quelle: keywords.txt">↗</a></dd>
-    <dt>Marketing-URL</dt><dd><a href="{{ ios_marketing_url }}">{{ ios_marketing_url }}</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/marketing_url.txt" title="Quelle: marketing_url.txt">↗</a></dd>
-    <dt>Privacy-URL</dt><dd><a href="{{ ios_privacy_url }}">{{ ios_privacy_url }}</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/privacy_url.txt" title="Quelle: privacy_url.txt">↗</a></dd>
-    <dt>Support-URL</dt><dd><a href="{{ ios_support_url }}">{{ ios_support_url }}</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/support_url.txt" title="Quelle: support_url.txt">↗</a></dd>
-    <dt>Copyright</dt><dd>{{ ios_copyright }} <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/copyright.txt" title="Quelle: copyright.txt">↗</a></dd>
-    <dt>Release-Notes</dt><dd>{{ ios_release_notes }} <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/metadata/de-DE/release_notes.txt" title="Quelle: release_notes.txt">↗</a></dd>
+    <dt>App-Name (max 30)</dt><dd><code>{{ ios_name }}</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/name.txt" title="Quelle: name.txt">↗</a></dd>
+    <dt>Untertitel (max 30)</dt><dd><code>{{ ios_subtitle }}</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/subtitle.txt" title="Quelle: subtitle.txt">↗</a></dd>
+    <dt>Beschreibung (max 4000) <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/description.txt" title="Quelle: description.txt">↗</a></dt><dd><pre>{{ ios_description }}</pre></dd>
+    <dt>Schlagwörter (max 100, kommasepariert)</dt><dd><code>{{ ios_keywords }}</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/keywords.txt" title="Quelle: keywords.txt">↗</a></dd>
+    <dt>Marketing-URL</dt><dd><a href="{{ ios_marketing_url }}">{{ ios_marketing_url }}</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/marketing_url.txt" title="Quelle: marketing_url.txt">↗</a></dd>
+    <dt>Privacy-URL</dt><dd><a href="{{ ios_privacy_url }}">{{ ios_privacy_url }}</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/privacy_url.txt" title="Quelle: privacy_url.txt">↗</a></dd>
+    <dt>Support-URL</dt><dd><a href="{{ ios_support_url }}">{{ ios_support_url }}</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/support_url.txt" title="Quelle: support_url.txt">↗</a></dd>
+    <dt>Copyright</dt><dd>{{ ios_copyright }} <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/copyright.txt" title="Quelle: copyright.txt">↗</a></dd>
+    <dt>Release-Notes</dt><dd>{{ ios_release_notes }} <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/release_notes.txt" title="Quelle: release_notes.txt">↗</a></dd>
   </dl>
 
   <h4>Screenshots — iPhone 6.9 Display (1320×2868)</h4>
   <div class="store-screenshots">
-    <figure><img src="../store/ios/iphone-69/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/iphone-69/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/iphone-69/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/03_security.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/iphone-69/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/04_buy.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/iphone-69/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/05_tax.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/iphone-69/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/iphone-69/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/iphone-69/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/03_security.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/iphone-69/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/04_buy.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/iphone-69/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPhone%206.9%20Display/05_tax.png" title="Quelle">↗</a></figcaption></figure>
   </div>
 
   <h4>Screenshots — iPad Pro 13" Display (2752×2064)</h4>
   <div class="store-screenshots">
-    <figure><img src="../store/ios/ipad-13/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/ipad-13/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/ipad-13/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/03_security.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/ipad-13/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/04_buy.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/ios/ipad-13/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/main/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/05_tax.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/ipad-13/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/ipad-13/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/ipad-13/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/03_security.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/ipad-13/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/04_buy.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/ios/ipad-13/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/screenshots/de-DE/iPad%20Pro%20(13%20inch)%20Display/05_tax.png" title="Quelle">↗</a></figcaption></figure>
   </div>
 
   <!-- Android section -->
   <h3>Google Play Store (de-DE)</h3>
   <dl class="store-listing">
-    <dt>Titel (max 50)</dt><dd><code>{{ android_title }}</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/title.txt" title="Quelle: title.txt">↗</a></dd>
-    <dt>Kurzbeschreibung (max 80)</dt><dd>{{ android_short }} <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/short_description.txt" title="Quelle: short_description.txt">↗</a></dd>
-    <dt>Lang-Beschreibung (max 4000, HTML) <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/full_description.txt" title="Quelle: full_description.txt">↗</a></dt><dd><div class="rendered-html">{{ android_full_html }}</div></dd>
-    <dt>Changelog</dt><dd>{{ android_changelog }} <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/changelogs/default.txt" title="Quelle: changelogs/default.txt">↗</a></dd>
+    <dt>Titel (max 50)</dt><dd><code>{{ android_title }}</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/title.txt" title="Quelle: title.txt">↗</a></dd>
+    <dt>Kurzbeschreibung (max 80)</dt><dd>{{ android_short }} <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/short_description.txt" title="Quelle: short_description.txt">↗</a></dd>
+    <dt>Lang-Beschreibung (max 4000, HTML) <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/full_description.txt" title="Quelle: full_description.txt">↗</a></dt><dd><div class="rendered-html">{{ android_full_html }}</div></dd>
+    <dt>Changelog</dt><dd>{{ android_changelog }} <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/changelogs/default.txt" title="Quelle: changelogs/default.txt">↗</a></dd>
   </dl>
 
   <h4>Feature Graphic (1024×500)</h4>
-  <figure class="store-graphic"><img src="../store/android/featureGraphic.png" alt="Feature Graphic"/><figcaption>featureGraphic <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/featureGraphic.png" title="Quelle">↗</a></figcaption></figure>
+  <figure class="store-graphic"><img src="../store/android/featureGraphic.png" alt="Feature Graphic"/><figcaption>featureGraphic <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/featureGraphic.png" title="Quelle">↗</a></figcaption></figure>
 
   <h4>Icon (512×512)</h4>
-  <figure class="store-icon"><img src="../store/android/icon.png" alt="App Icon"/><figcaption>icon <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/icon.png" title="Quelle">↗</a></figcaption></figure>
+  <figure class="store-icon"><img src="../store/android/icon.png" alt="App Icon"/><figcaption>icon <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/icon.png" title="Quelle">↗</a></figcaption></figure>
 
   <h4>Phone Screenshots (1350×2400)</h4>
   <div class="store-screenshots">
-    <figure><img src="../store/android/phone/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/phone/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/phone/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/phone/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/phone/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/phone/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/phone/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/phone/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/phone/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/phone/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/phoneScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
   </div>
 
   <h4>7" Tablet (1920×1200)</h4>
   <div class="store-screenshots">
-    <figure><img src="../store/android/seven-inch/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/seven-inch/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/seven-inch/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/seven-inch/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/seven-inch/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/seven-inch/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/seven-inch/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/seven-inch/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/seven-inch/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/seven-inch/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/sevenInchScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
   </div>
 
   <h4>10" Tablet (2560×1440)</h4>
   <div class="store-screenshots">
-    <figure><img src="../store/android/ten-inch/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/ten-inch/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/ten-inch/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/ten-inch/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
-    <figure><img src="../store/android/ten-inch/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/main/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/ten-inch/01_welcome.png"   alt="Welcome"/><figcaption>01_welcome <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/01_welcome.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/ten-inch/02_dashboard.png" alt="Dashboard"/><figcaption>02_dashboard <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/02_dashboard.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/ten-inch/03_security.png"  alt="Security"/><figcaption>03_security <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/03_security.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/ten-inch/04_buy.png"       alt="Buy"/><figcaption>04_buy <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/04_buy.png" title="Quelle">↗</a></figcaption></figure>
+    <figure><img src="../store/android/ten-inch/05_tax.png"       alt="Tax"/><figcaption>05_tax <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/images/tenInchScreenshots/05_tax.png" title="Quelle">↗</a></figcaption></figure>
   </div>
 </details>


### PR DESCRIPTION
## Problem

The rendered handbook at `handbook.realunit.app/de/#spec-store-listing` linked every per-element source — and the two section-header links (`iOS metadata ↗` / `Android metadata ↗`) — at `github.com/RealUnitCH/app/blob/main/…` and `…/tree/main/…`.

`develop` is the source of truth for the listing (it lands there first via the promotion chain; `main` lags behind until the next `develop → main` promotion), so the links pointed at stale content.

## Fix

In `scripts/templates/store-listing.html.tmpl` (where the GitHub URLs are hardcoded): repoint **all** `blob/main → blob/develop` and `tree/main → tree/develop`, including the two header links. The generator (`scripts/assemble-handbook-store-listing.py`) does not build URLs, so re-running it regenerates `docs/handbook/de/index.html` with the corrected links.

- Template + generated `index.html`: **0** remaining `blob/main` / `tree/main`; **42** `…/develop` links (2 header `tree/develop` + 40 per-element `blob/develop` = 13 metadata fields + 27 images).
- Generator remains **idempotent** (re-run leaves `index.html` byte-identical) → the `handbook-build-check.yaml` sync gate stays green.
- Diff is exactly 42 link lines in `index.html` + the template; nothing else touched.

## Validation
- Ran the generator: 0 `main` remnants anywhere, 42 develop links, idempotent re-run (no diff).
- `git diff docs/handbook/de/index.html` = only the 42 `main → develop` link lines.

Base branch: **`staging`** (per `CONTRIBUTING.md`).

Refs #634
