### PR TITLE
feat(handbook): downloadable legal documents (PDF + DOCX) as derived export

### DIFF
--- a/.github/workflows/handbook-build-check.yaml
+++ b/.github/workflows/handbook-build-check.yaml
@@ -23,12 +23,20 @@ on:
       - "scripts/assemble-handbook-screenshots.sh"
       - "scripts/assemble-handbook-store-listing.py"
       - "scripts/templates/store-listing.html.tmpl"
+      - "scripts/assemble-handbook-legal.py"
+      - "scripts/build-legal-downloads.sh"
+      - "scripts/templates/legal-downloads.html.tmpl"
       - "test/goldens/**"
       # Store-listing section is a derived export of the Fastlane metadata —
       # changing it must re-run the generator and re-commit the handbook.
       - "ios/fastlane/metadata/**"
       - "ios/fastlane/screenshots/**"
       - "android/fastlane/metadata/**"
+      # Legal-downloads section is a derived export of the in-app legal Markdown
+      # (and the ARB titles) — changing either must re-run the generator and
+      # re-commit the handbook HTML block.
+      - "assets/legal/**"
+      - "assets/languages/**"
       - "Dockerfile.handbook"
       - "handbook.nginx.conf"
       - "handbook.htpasswd"
@@ -99,6 +107,23 @@ jobs:
             exit 1
           fi
 
+      - name: Verify handbook legal-downloads section is in sync with assets/legal
+        # The legal-downloads block in docs/handbook/de/index.html is a derived
+        # export of assets/legal/*.md + the ARB titles. Re-run the (pure-stdlib,
+        # deterministic) generator; if the working tree changes, the committed
+        # handbook is stale — someone edited a legal .md or its ARB title without
+        # re-running the generator. Only the HTML block is gated here; the
+        # pandoc-produced PDF/DOCX are non-deterministic and intentionally
+        # git-ignored, so build-legal-downloads.sh is NOT run in this gate.
+        run: |
+          set -euo pipefail
+          python3 scripts/assemble-handbook-legal.py /tmp/legal-out
+          if ! git diff --quiet docs/handbook/de/index.html; then
+            echo "::error::docs/handbook/de/index.html legal-downloads block is stale — re-run scripts/assemble-handbook-legal.py and commit."
+            git diff docs/handbook/de/index.html
+            exit 1
+          fi
+
       - name: Build handbook image (no push)
         run: docker build -f Dockerfile.handbook -t realunit-handbook:pr-check .
 
@@ -134,6 +159,18 @@ jobs:
             # both prove the file is on disk. 404 means it was not assembled.
             if [ "$code" = "404" ]; then
               echo "screenshot ${name}.png missing from /usr/share/nginx/html/screenshots/" >&2
+              docker logs handbook
+              exit 1
+            fi
+          done
+
+          # Legal downloads must be present (built by the legal-docs-builder
+          # stage via pandoc). Same 200/401-vs-404 logic: 404 means the PDF/DOCX
+          # was not produced. Covers PDF + DOCX and both languages.
+          for f in legal/privacy_policy_de.pdf legal/privacy_policy_de.docx legal/terms_of_use_en.pdf legal/registration_agreement_de.docx; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' -u "${HANDBOOK_USER:-x}:${HANDBOOK_PASS:-x}" "http://127.0.0.1:8080/${f}")
+            if [ "$code" = "404" ]; then
+              echo "legal download ${f} missing from /usr/share/nginx/html/legal/" >&2
               docker logs handbook
               exit 1
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,14 @@ docs/handbook/mails/
 # directory is only populated transiently for local previews.
 docs/handbook/screenshots/
 
+# Built at handbook build time from assets/legal/*.md via pandoc
+# (scripts/build-legal-downloads.sh, see Dockerfile.handbook). The PDF/DOCX are
+# NON-deterministic (pandoc embeds timestamps/metadata), so — unlike the
+# committed legal-downloads HTML block in de/index.html — they are never
+# committed and never sync-gated; they exist only inside the image. This
+# directory holds the assembly output for local previews only.
+docs/handbook/legal/
+
 # Scratch directories produced when reproducing the handbook CI's
 # mail-preview generation locally (see docs/handbook/README.md → "E-Mail
 # Previews → Lokal regenerieren"). Mirrors the names the CI uses so a

--- a/Dockerfile.handbook
+++ b/Dockerfile.handbook
@@ -53,6 +53,32 @@ COPY android/fastlane/metadata/ ./android/fastlane/metadata/
 COPY docs/handbook/de/index.html ./docs/handbook/de/index.html
 RUN python3 ./scripts/assemble-handbook-store-listing.py /out && cp ./docs/handbook/de/index.html /out/index.html
 
+# Legal-downloads section: derived export of the in-app legal Markdown
+# (assets/legal/*.md). Two separate concerns, by design:
+#   - assemble-handbook-legal.py rewrites the deterministic <!-- BEGIN/END:
+#     legal-downloads --> block in index.html (committed + sync-gated upstream).
+#   - build-legal-downloads.sh renders the NON-deterministic PDF/DOCX via pandoc
+#     (weasyprint PDF engine — no TeX), git-ignored like the screenshots.
+# This stage takes the store-listing-rewritten index.html as input so BOTH the
+# store-listing and the legal-downloads blocks survive into the final image.
+FROM alpine:3.20 AS legal-docs-builder
+WORKDIR /work
+# font-dejavu (+ a rebuilt fontconfig cache) is required: weasyprint renders via
+# Pango, which aborts ("No fonts configured in FontConfig" → "Error producing
+# PDF") on a bare Alpine that ships no font files. DejaVu covers the Latin/German
+# glyphs the legal texts use.
+RUN apk add --no-cache python3 pandoc weasyprint bash font-dejavu \
+ && fc-cache -f
+COPY scripts/assemble-handbook-legal.py ./scripts/
+COPY scripts/build-legal-downloads.sh ./scripts/
+COPY scripts/templates/legal-downloads.html.tmpl ./scripts/templates/
+COPY assets/legal/ ./assets/legal/
+COPY assets/languages/ ./assets/languages/
+COPY --from=store-listing-builder /out/index.html ./docs/handbook/de/index.html
+RUN python3 ./scripts/assemble-handbook-legal.py /out \
+ && bash ./scripts/build-legal-downloads.sh /out \
+ && cp ./docs/handbook/de/index.html /out/index.html
+
 FROM nginx:1.27.5-alpine
 
 COPY docs/handbook/ /usr/share/nginx/html/
@@ -62,6 +88,11 @@ COPY --from=screenshots-builder /out/ /usr/share/nginx/html/screenshots/
 COPY --from=store-listing-builder /out/ios/ /usr/share/nginx/html/store/ios/
 COPY --from=store-listing-builder /out/android/ /usr/share/nginx/html/store/android/
 COPY --from=store-listing-builder /out/index.html /usr/share/nginx/html/de/index.html
+# Legal-downloads PDFs/DOCX + the index.html with BOTH the store-listing and the
+# legal-downloads blocks rewritten (this copy overwrites the store-listing one
+# above, so the legal stage's index.html is the authoritative final version).
+COPY --from=legal-docs-builder /out/legal/ /usr/share/nginx/html/legal/
+COPY --from=legal-docs-builder /out/index.html /usr/share/nginx/html/de/index.html
 COPY handbook.nginx.conf /etc/nginx/conf.d/default.conf
 COPY handbook.htpasswd /etc/nginx/handbook.htpasswd
 

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -608,6 +608,40 @@
       .store-screenshots .src {
         font-size: 0.85em;
       }
+      /* Legal-downloads section (#spec-legal-downloads) — see
+         scripts/assemble-handbook-legal.py. Reuses the .test card chrome
+         (border + :target highlight) so each (document, language) entry has the
+         same direct-link affordance as the screenshot cards. */
+      .test.legal-doc .downloads {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 10px;
+        padding: 12px 14px;
+      }
+      .test.legal-doc .doc-title {
+        flex-basis: 100%;
+        font-size: 13px;
+        color: var(--ink-2);
+      }
+      a.dl-btn {
+        text-decoration: none;
+        font-size: 12.5px;
+        font-weight: 600;
+        color: var(--brand);
+        background: var(--surface-2);
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        padding: 5px 12px;
+        transition:
+          background 0.15s,
+          border-color 0.15s,
+          color 0.15s;
+      }
+      a.dl-btn:hover {
+        background: var(--surface);
+        border-color: var(--brand);
+      }
     </style>
   </head>
   <body>
@@ -688,6 +722,9 @@
             </li>
             <li>
               <a href="#spec-store-listing"><span class="spec-num">S</span>Store-Listing</a>
+            </li>
+            <li>
+              <a href="#spec-legal-downloads"><span class="spec-num">L</span>Rechtsdokumente</a>
             </li>
           </ol>
         </nav>
@@ -2411,6 +2448,126 @@ Jetzt herunterladen und Ihre finanzielle Souveränität zurückgewinnen.</div></
   </div>
 </details>
 <!-- END:store-listing -->
+
+        <!-- BEGIN:legal-downloads -->
+<details id="spec-legal-downloads" class="spec" open>
+  <summary>
+    <div class="spec-head">
+      <div class="lhs">
+        <h2><span class="num">L</span>Rechtsdokumente — Downloads</h2>
+        <div class="file">assets/legal/*.md</div>
+      </div>
+      <div class="rhs">
+        <b>Live aus Repo</b>
+        <div class="links">
+          <a href="https://github.com/RealUnitCH/app/tree/develop/assets/legal">assets/legal ↗</a>
+        </div>
+      </div>
+    </div>
+  </summary>
+
+  <p class="spec-intro">
+    Single source of truth für die App-eigenen Rechtstexte sind die Markdown-Dateien
+    unter <code>assets/legal/*.md</code>. Die In-App-Ansicht (<code>LegalDocumentPage</code>)
+    und die Downloads hier rendern aus denselben Dateien; jede Änderung am Text geht
+    ausschliesslich über einen PR auf diese Markdown-Quellen. Pro Dokument und Sprache
+    gibt es einen <b>PDF</b>- und <b>DOCX</b>-Download (im Handbook-Image via
+    <code>pandoc</code> erzeugt) sowie einen Direkt-Link (🔗) auf den jeweiligen Eintrag
+    und einen <span class="src">↗</span>-Link auf die Markdown-Quelldatei.
+    DFX- und Aktionariat-Dokumente sowie die extern gehosteten Unternehmensdokumente
+    (Prospekte, Statuten) sind <em>nicht</em> Teil dieses Exports — sie haben keine
+    Markdown-Quelle im Repo.
+  </p>
+
+  <h3>Datenschutzbestimmungen <a class="src" href="https://github.com/RealUnitCH/app/tree/develop/assets/legal" title="Quelle: assets/legal/">↗</a></h3>
+  <div class="tests cols-2">
+    <div class="test legal-doc" id="legal-privacy_policy-de">
+      <div class="head">
+        <a class="name permalink" href="#legal-privacy_policy-de">privacy_policy_de</a>
+        <button class="copy-link" type="button" data-target="legal-privacy_policy-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+        <span class="src">de</span>
+      </div>
+      <div class="downloads">
+        <span class="doc-title">Datenschutzbestimmungen</span>
+        <a class="dl-btn" href="../legal/privacy_policy_de.pdf" download>PDF</a>
+        <a class="dl-btn" href="../legal/privacy_policy_de.docx" download>DOCX</a>
+        <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/assets/legal/privacy_policy_de.md" title="Quelle: privacy_policy_de.md">Markdown ↗</a>
+      </div>
+    </div>
+    <div class="test legal-doc" id="legal-privacy_policy-en">
+      <div class="head">
+        <a class="name permalink" href="#legal-privacy_policy-en">privacy_policy_en</a>
+        <button class="copy-link" type="button" data-target="legal-privacy_policy-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+        <span class="src">en</span>
+      </div>
+      <div class="downloads">
+        <span class="doc-title">Privacy Policy</span>
+        <a class="dl-btn" href="../legal/privacy_policy_en.pdf" download>PDF</a>
+        <a class="dl-btn" href="../legal/privacy_policy_en.docx" download>DOCX</a>
+        <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/assets/legal/privacy_policy_en.md" title="Quelle: privacy_policy_en.md">Markdown ↗</a>
+      </div>
+    </div>
+  </div>
+  <h3>Nutzungsbedingungen <a class="src" href="https://github.com/RealUnitCH/app/tree/develop/assets/legal" title="Quelle: assets/legal/">↗</a></h3>
+  <div class="tests cols-2">
+    <div class="test legal-doc" id="legal-terms_of_use-de">
+      <div class="head">
+        <a class="name permalink" href="#legal-terms_of_use-de">terms_of_use_de</a>
+        <button class="copy-link" type="button" data-target="legal-terms_of_use-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+        <span class="src">de</span>
+      </div>
+      <div class="downloads">
+        <span class="doc-title">Nutzungsbedingungen</span>
+        <a class="dl-btn" href="../legal/terms_of_use_de.pdf" download>PDF</a>
+        <a class="dl-btn" href="../legal/terms_of_use_de.docx" download>DOCX</a>
+        <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/assets/legal/terms_of_use_de.md" title="Quelle: terms_of_use_de.md">Markdown ↗</a>
+      </div>
+    </div>
+    <div class="test legal-doc" id="legal-terms_of_use-en">
+      <div class="head">
+        <a class="name permalink" href="#legal-terms_of_use-en">terms_of_use_en</a>
+        <button class="copy-link" type="button" data-target="legal-terms_of_use-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+        <span class="src">en</span>
+      </div>
+      <div class="downloads">
+        <span class="doc-title">Terms of use</span>
+        <a class="dl-btn" href="../legal/terms_of_use_en.pdf" download>PDF</a>
+        <a class="dl-btn" href="../legal/terms_of_use_en.docx" download>DOCX</a>
+        <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/assets/legal/terms_of_use_en.md" title="Quelle: terms_of_use_en.md">Markdown ↗</a>
+      </div>
+    </div>
+  </div>
+  <h3>Registrierungsvereinbarung <a class="src" href="https://github.com/RealUnitCH/app/tree/develop/assets/legal" title="Quelle: assets/legal/">↗</a></h3>
+  <div class="tests cols-2">
+    <div class="test legal-doc" id="legal-registration_agreement-de">
+      <div class="head">
+        <a class="name permalink" href="#legal-registration_agreement-de">registration_agreement_de</a>
+        <button class="copy-link" type="button" data-target="legal-registration_agreement-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+        <span class="src">de</span>
+      </div>
+      <div class="downloads">
+        <span class="doc-title">Registrierungsvereinbarung</span>
+        <a class="dl-btn" href="../legal/registration_agreement_de.pdf" download>PDF</a>
+        <a class="dl-btn" href="../legal/registration_agreement_de.docx" download>DOCX</a>
+        <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/assets/legal/registration_agreement_de.md" title="Quelle: registration_agreement_de.md">Markdown ↗</a>
+      </div>
+    </div>
+    <div class="test legal-doc" id="legal-registration_agreement-en">
+      <div class="head">
+        <a class="name permalink" href="#legal-registration_agreement-en">registration_agreement_en</a>
+        <button class="copy-link" type="button" data-target="legal-registration_agreement-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+        <span class="src">en</span>
+      </div>
+      <div class="downloads">
+        <span class="doc-title">Registration Agreement</span>
+        <a class="dl-btn" href="../legal/registration_agreement_en.pdf" download>PDF</a>
+        <a class="dl-btn" href="../legal/registration_agreement_en.docx" download>DOCX</a>
+        <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/assets/legal/registration_agreement_en.md" title="Quelle: registration_agreement_en.md">Markdown ↗</a>
+      </div>
+    </div>
+  </div>
+</details>
+<!-- END:legal-downloads -->
       </main>
     </div>
   </body>

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -78,6 +78,22 @@ server {
         return 302 /de/;
     }
 
+    # Legal downloads (/legal/*.pdf, /legal/*.docx) — the derived PDF/DOCX export
+    # of assets/legal/*.md. Force a download disposition (nginx's default
+    # mime.types has no .docx mapping; it would otherwise serve as
+    # application/octet-stream, which downloads but without an explicit
+    # filename). add_header is all-or-nothing per location, so the server-level
+    # security headers are restated here. auth_basic is inherited — these stay
+    # behind the same Basic-Auth gate as the rest of the handbook.
+    location ~* \.(pdf|docx)$ {
+        add_header Content-Disposition "attachment" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Cache-Control "private, no-store" always;
+        try_files $uri =404;
+    }
+
     location / {
         try_files $uri $uri/ =404;
     }

--- a/scripts/assemble-handbook-legal.py
+++ b/scripts/assemble-handbook-legal.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Generate the handbook legal-downloads block from the in-app legal Markdown.
+
+The Markdown under assets/legal/ is the single source of truth for the three
+RealUnit documents that the app renders in-app (LegalDocumentPage reads
+assets/legal/<base>_<lang>.md via rootBundle). The handbook section at
+handbook.realunit.app is a *derived export* of those files — never hand-edited.
+This mirrors the upstream/downstream relationship that the store-listing and
+mails/ sections already have.
+
+Usage:
+    scripts/assemble-handbook-legal.py <output-dir>
+
+Used by:
+  - Dockerfile.handbook (legal-docs-builder stage → rewrites docs/handbook/de/
+    index.html; the PDF/DOCX binaries are produced separately by
+    scripts/build-legal-downloads.sh — see the determinism note below)
+  - .github/workflows/handbook-build-check.yaml (sync gate: re-run + git diff)
+  - local previews (run it, then open docs/handbook/de/index.html)
+
+What it does:
+  1. Discovers the document set: for each base in BASES, globs
+     assets/legal/<base>_*.md to find the available languages. Errors out if a
+     base has zero languages.
+  2. Resolves each document's title from assets/languages/strings_<lang>.arb
+     (the mapped ARB key per base, see TITLE_KEYS) so the handbook titles stay
+     in lockstep with the in-app titles. Falls back to the `de` title if a
+     language's ARB lacks the key.
+  3. Renders scripts/templates/legal-downloads.html.tmpl into
+     <out>/legal-downloads.html and substitutes the rendered block between the
+     <!-- BEGIN:legal-downloads --> / <!-- END:legal-downloads --> markers in
+     docs/handbook/de/index.html in place (idempotent).
+
+What it deliberately does NOT do:
+  - It does NOT invoke pandoc and does NOT emit any PDF/DOCX. Those binaries are
+    non-deterministic (embedded timestamps, tool-version metadata) and are
+    produced only inside the image by scripts/build-legal-downloads.sh, git-
+    ignored like the screenshots. Keeping pandoc out of this script is what lets
+    the rendered HTML block be deterministic and therefore sync-gateable.
+
+  Every value interpolated into the HTML (titles from ARB, discovered language
+  codes) is HTML-escaped; the document bases are a fixed allowlist (BASES).
+"""
+import html
+import re
+import sys
+from pathlib import Path
+
+BEGIN = "<!-- BEGIN:legal-downloads -->"
+END = "<!-- END:legal-downloads -->"
+
+# The exact three in-app documents rendered from repo-local Markdown. DFX,
+# Aktionariat and the externally-hosted corporate PDFs are out of scope — they
+# have no Markdown source in the repo and cannot be a derived export.
+BASES = ["privacy_policy", "terms_of_use", "registration_agreement"]
+
+# Maps each document base to the ARB key the app uses for its title, so the
+# handbook label matches what the user sees in-app.
+TITLE_KEYS = {
+    "privacy_policy": "legalDisclaimerCheckboxPrivacyPolicy",
+    "terms_of_use": "termsOfUse",
+    "registration_agreement": "legalDisclaimerCheckboxRegistrationAgreement",
+}
+
+# Languages are discovered, never hardcoded; this only validates that a token
+# extracted from a filename looks like a language code before it is used in an
+# id / href / download path.
+_LANG_RE = re.compile(r"^[a-z0-9-]+$")
+_PLACEHOLDER = re.compile(r"\{\{ (\w+) \}\}")
+
+REPO = "https://github.com/RealUnitCH/app"
+
+
+def _esc(value: str) -> str:
+    """HTML-escape a value for safe interpolation into text or an attribute."""
+    return html.escape(value, quote=True)
+
+
+def load_arb(repo: Path, lang: str) -> dict:
+    """Load assets/languages/strings_<lang>.arb (JSON). Errors if missing."""
+    import json
+
+    path = repo / "assets/languages" / f"strings_{lang}.arb"
+    if not path.is_file():
+        raise SystemExit(f"error: ARB file missing for discovered language '{lang}': {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def discover(repo: Path) -> "dict[str, list[str]]":
+    """For each base, glob assets/legal/<base>_*.md → sorted language list."""
+    legal = repo / "assets/legal"
+    result = {}
+    for base in BASES:
+        langs = []
+        for md in legal.glob(f"{base}_*.md"):
+            lang = md.name[len(base) + 1 : -len(".md")]
+            if not _LANG_RE.match(lang):
+                raise SystemExit(f"error: unexpected language token '{lang}' from {md.name}")
+            langs.append(lang)
+        if not langs:
+            raise SystemExit(f"error: no source Markdown found for '{base}' (assets/legal/{base}_*.md)")
+        result[base] = sorted(langs)
+    return result
+
+
+def render_rows(doc_langs: "dict[str, list[str]]", titles: "dict[str, dict[str, str]]") -> str:
+    """Build the per-(base, lang) download cards. Deterministic ordering:
+    BASES order, then languages sorted alphabetically."""
+    parts = []
+    for base in BASES:
+        de_title = _esc(titles[base]["de"])
+        parts.append(
+            f'  <h3>{de_title} '
+            f'<a class="src" href="{REPO}/tree/develop/assets/legal" '
+            f'title="Quelle: assets/legal/">↗</a></h3>'
+        )
+        parts.append('  <div class="tests cols-2">')
+        for lang in doc_langs[base]:
+            anchor = f"legal-{base}-{lang}"
+            stem = f"{base}_{lang}"
+            title = _esc(titles[base][lang])
+            lang_e = _esc(lang)
+            parts.append(
+                f'    <div class="test legal-doc" id="{_esc(anchor)}">\n'
+                f'      <div class="head">\n'
+                f'        <a class="name permalink" href="#{_esc(anchor)}">{_esc(stem)}</a>\n'
+                f'        <button class="copy-link" type="button" data-target="{_esc(anchor)}" '
+                f'title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>\n'
+                f'        <span class="src">{lang_e}</span>\n'
+                f'      </div>\n'
+                f'      <div class="downloads">\n'
+                f'        <span class="doc-title">{title}</span>\n'
+                f'        <a class="dl-btn" href="../legal/{_esc(stem)}.pdf" download>PDF</a>\n'
+                f'        <a class="dl-btn" href="../legal/{_esc(stem)}.docx" download>DOCX</a>\n'
+                f'        <a class="src" href="{REPO}/blob/develop/assets/legal/{_esc(stem)}.md" '
+                f'title="Quelle: {_esc(stem)}.md">Markdown ↗</a>\n'
+                f'      </div>\n'
+                f'    </div>'
+            )
+        parts.append('  </div>')
+    return "\n".join(parts)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <output-dir>", file=sys.stderr)
+        return 2
+
+    repo = Path(__file__).resolve().parent.parent
+    out = Path(sys.argv[1])
+
+    # 1) Discover documents + languages from the filesystem (never hardcoded).
+    doc_langs = discover(repo)
+
+    # 2) Resolve titles from the ARB files, falling back to `de`. Every document
+    #    must have a `de` source, since `de` is the per-document title and
+    #    heading fallback language (render_rows() uses titles[base]["de"]).
+    for base in BASES:
+        if "de" not in doc_langs[base]:
+            raise SystemExit(
+                f"error: '{base}' has no `de` document (assets/legal/{base}_de.md) — "
+                "`de` is the per-document title/heading fallback language"
+            )
+    all_langs = sorted({lang for langs in doc_langs.values() for lang in langs})
+    arbs = {lang: load_arb(repo, lang) for lang in all_langs}
+    titles = {}
+    for base in BASES:
+        key = TITLE_KEYS[base]
+        de_title = arbs["de"].get(key)
+        if not de_title:
+            raise SystemExit(f"error: ARB key '{key}' (for '{base}') missing from strings_de.arb")
+        titles[base] = {}
+        for lang in doc_langs[base]:
+            titles[base][lang] = arbs[lang].get(key) or de_title
+
+    # 3) Render the block from the template (single pass: each placeholder
+    #    resolved exactly once, a substituted value is never re-scanned).
+    template = Path(__file__).parent / "templates/legal-downloads.html.tmpl"
+    ctx = {"rows": render_rows(doc_langs, titles)}
+    unknown = []
+
+    def substitute(match):
+        key = match.group(1)
+        if key not in ctx:
+            unknown.append(key)
+            return match.group(0)
+        return ctx[key]
+
+    rendered = _PLACEHOLDER.sub(substitute, template.read_text(encoding="utf-8").strip("\n"))
+    if unknown:
+        print(f"error: unknown template placeholder(s): {sorted(set(unknown))}", file=sys.stderr)
+        return 1
+
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "legal-downloads.html").write_text(rendered + "\n", encoding="utf-8")
+
+    # 4) Substitute the block in docs/handbook/de/index.html in place (idempotent).
+    index = repo / "docs/handbook/de/index.html"
+    content = index.read_text(encoding="utf-8")
+    if BEGIN not in content or END not in content:
+        print(
+            f"error: {index} is missing the {BEGIN} / {END} markers — add them once "
+            "(see issue #658) before running this script.",
+            file=sys.stderr,
+        )
+        return 1
+    b = content.index(BEGIN)
+    e = content.index(END) + len(END)
+    new = content[:b] + BEGIN + "\n" + rendered + "\n" + END + content[e:]
+    index.write_text(new, encoding="utf-8")
+
+    n = sum(len(v) for v in doc_langs.values())
+    print(f"rendered legal-downloads block ({n} sources across {len(BASES)} docs) into {out}; synced {index}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build-legal-downloads.sh
+++ b/scripts/build-legal-downloads.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Build the downloadable PDF + DOCX of the in-app legal documents from their
+# Markdown sources under assets/legal/, into <output-dir>/legal/.
+#
+# Usage:
+#   scripts/build-legal-downloads.sh <output-dir>
+#
+# Run ONLY inside the handbook image's legal-docs-builder stage (needs pandoc +
+# weasyprint). The output is intentionally NON-deterministic — pandoc embeds
+# timestamps and tool-version metadata — so it is treated like the assembled
+# screenshots: generated only in the image, git-ignored, never committed, and
+# never sync-gated. The deterministic HTML block (the download links) is the
+# separate concern of scripts/assemble-handbook-legal.py.
+#
+# weasyprint is used as the PDF engine (HTML/CSS based) deliberately, to avoid
+# pulling a full TeX Live into the image just for PDF rendering.
+#
+# Document discovery mirrors assemble-handbook-legal.py: the same three bases,
+# languages discovered by glob (never hardcoded), so a future assets/legal/
+# <base>_<lang>.md is picked up automatically.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <output-dir>" >&2
+  exit 2
+fi
+
+out="$1"
+# Resolve the repo root from this script's location (scripts/..), so the script
+# works regardless of the caller's working directory.
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo="$(cd "$script_dir/.." && pwd)"
+legal_src="$repo/assets/legal"
+legal_out="$out/legal"
+
+bases="privacy_policy terms_of_use registration_agreement"
+
+mkdir -p "$legal_out"
+
+count=0
+for base in $bases; do
+  found=0
+  for md in "$legal_src/$base"_*.md; do
+    # Guard against a literal no-match glob.
+    [ -e "$md" ] || continue
+    found=1
+    stem="$(basename "$md" .md)"
+    pandoc "$md" -o "$legal_out/$stem.docx"
+    pandoc "$md" --pdf-engine=weasyprint -o "$legal_out/$stem.pdf"
+    count=$((count + 2))
+  done
+  if [ "$found" -eq 0 ]; then
+    echo "error: no source Markdown found for '$base' ($legal_src/${base}_*.md)" >&2
+    exit 1
+  fi
+done
+
+echo "built $count legal download files into $legal_out"

--- a/scripts/templates/legal-downloads.html.tmpl
+++ b/scripts/templates/legal-downloads.html.tmpl
@@ -1,0 +1,31 @@
+<details id="spec-legal-downloads" class="spec" open>
+  <summary>
+    <div class="spec-head">
+      <div class="lhs">
+        <h2><span class="num">L</span>Rechtsdokumente — Downloads</h2>
+        <div class="file">assets/legal/*.md</div>
+      </div>
+      <div class="rhs">
+        <b>Live aus Repo</b>
+        <div class="links">
+          <a href="https://github.com/RealUnitCH/app/tree/develop/assets/legal">assets/legal ↗</a>
+        </div>
+      </div>
+    </div>
+  </summary>
+
+  <p class="spec-intro">
+    Single source of truth für die App-eigenen Rechtstexte sind die Markdown-Dateien
+    unter <code>assets/legal/*.md</code>. Die In-App-Ansicht (<code>LegalDocumentPage</code>)
+    und die Downloads hier rendern aus denselben Dateien; jede Änderung am Text geht
+    ausschliesslich über einen PR auf diese Markdown-Quellen. Pro Dokument und Sprache
+    gibt es einen <b>PDF</b>- und <b>DOCX</b>-Download (im Handbook-Image via
+    <code>pandoc</code> erzeugt) sowie einen Direkt-Link (🔗) auf den jeweiligen Eintrag
+    und einen <span class="src">↗</span>-Link auf die Markdown-Quelldatei.
+    DFX- und Aktionariat-Dokumente sowie die extern gehosteten Unternehmensdokumente
+    (Prospekte, Statuten) sind <em>nicht</em> Teil dieses Exports — sie haben keine
+    Markdown-Quelle im Repo.
+  </p>
+
+{{ rows }}
+</details>


### PR DESCRIPTION
Implements [#658](https://github.com/RealUnitCH/app/issues/658).

Adds a **"Rechtsdokumente — Downloads"** (nav `L`) section to the handbook that exposes RealUnit's three in-app legal documents as a **derived PDF + DOCX export** of the repo's Markdown — the same upstream/downstream model the store-listing and mail sections already use. `assets/legal/*.md` stays the single source of truth.

### In scope (exactly the 3 repo-local docs)
| Document | Source | ARB title key |
|---|---|---|
| Datenschutzbestimmungen | `assets/legal/privacy_policy_<lang>.md` | `legalDisclaimerCheckboxPrivacyPolicy` |
| Nutzungsbedingungen | `assets/legal/terms_of_use_<lang>.md` | `termsOfUse` |
| Registrierungsvereinbarung | `assets/legal/registration_agreement_<lang>.md` | `legalDisclaimerCheckboxRegistrationAgreement` |

Languages are **discovered by glob** (never hardcoded) → today `de` + `en` = 3 docs × 2 langs = **6 PDF + 6 DOCX**. A future `_fr.md` appears automatically. DFX, Aktionariat and the externally-hosted corporate PDFs are intentionally **out of scope** (no Markdown source in the repo).

### Per (document, language): three access paths
Each card carries, consistent with the existing handbook `.test` cards (same `permalink` anchor + `🔗 Link` copy-button pattern):
- a **PDF** download and a **DOCX** download,
- a **direct link / permalink** to the entry (`id="legal-<base>-<lang>"`, copy-to-clipboard button), and
- a `↗` link to the **Markdown source** on `develop`.

> Direct-links per the follow-up request: each document now also has a Direktlink/permalink built exactly like the other handbook sections (`a.name.permalink` + generic `.copy-link[data-target]` JS), so the look stays consistent across the handbook.

### The critical determinism split
- **HTML block** (download list) — produced by the pure-stdlib `scripts/assemble-handbook-legal.py`, **deterministic → committed → sync-gated** (CI re-runs the generator and fails on a non-empty `git diff` of `index.html`).
- **PDF/DOCX binaries** — produced by `scripts/build-legal-downloads.sh` via pandoc (weasyprint PDF engine), **non-deterministic → git-ignored → built only inside the image → never committed, never sync-gated** (same treatment as the assembled screenshots).

### Changes
- `scripts/assemble-handbook-legal.py` — deterministic generator (mirrors `assemble-handbook-store-listing.py`).
- `scripts/templates/legal-downloads.html.tmpl` — section template.
- `scripts/build-legal-downloads.sh` — pandoc PDF/DOCX builder (image-only).
- `Dockerfile.handbook` — new `legal-docs-builder` stage chained on `store-listing-builder` (so both rewritten blocks survive); installs `font-dejavu` so weasyprint can render.
- `handbook.nginx.conf` — `/legal/*.{pdf,docx}` served with `Content-Disposition: attachment`, behind the existing Basic-Auth gate.
- `.github/workflows/handbook-build-check.yaml` — paths, the legal HTML sync gate, and download-presence smoke checks.
- `.gitignore` — `docs/handbook/legal/`.
- `docs/handbook/de/index.html` — markers, nav entry, CSS, and the committed (generated) block.

### Local verification
- `docker build -f Dockerfile.handbook` is **green**; the `legal-docs-builder` stage produces **12 files**.
- PDFs are valid (`%PDF-`); DOCX are valid OOXML (zip with `word/document.xml` + `word/styles.xml`) — i.e. real **editable Word documents**, the artifact requested for legal review.
- DOCX content matches the Markdown (German text incl. umlauts intact, e.g. "Geltungsbereich", "RealUnit Schweiz AG").
- Generator is **idempotent** (re-run = byte-identical); the legal sync gate is in sync.
- Container serves the downloads (200/401 behind auth) with the attachment disposition.

Draft until CI is green.
