### PR TITLE
fix(restore): surface a retryable error instead of an endless spinner

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -234,6 +234,7 @@
   "reset": "Zurücksetzen",
   "residence": "Residenz",
   "restoreWallet": "Wallet wiederherstellen",
+  "restoreWalletFailed": "Wiederherstellung fehlgeschlagen – erneut versuchen",
   "restoreWalletFromSeedDescription": "Bitte geben Sie Ihre 12 Wiederherstellungs-Wörter in der korrekten Reihenfolge ein, um wieder Zugriff auf Ihre Wallet zu erhalten.",
   "restoreWalletSubtitle": "Ich habe bereits eine Wallet (z.B. Aktionariat) und möchte diese wiederherstellen.",
   "restoreWalletSuccessful": "Wallet wiederhergestellt",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -234,6 +234,7 @@
   "reset": "Reset",
   "residence": "Residence",
   "restoreWallet": "Restore wallet",
+  "restoreWalletFailed": "Restore failed – tap to retry",
   "restoreWalletFromSeedDescription": "Please enter your 12 recovery words in the correct order to regain access to your wallet.",
   "restoreWalletSubtitle": "I already have a wallet (e.g., Aktionariat) and would like to restore it.",
   "restoreWalletSuccessful": "Wallet restored",

--- a/lib/screens/restore_wallet/cubit/restore_wallet/restore_wallet_cubit.dart
+++ b/lib/screens/restore_wallet/cubit/restore_wallet/restore_wallet_cubit.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -20,23 +21,38 @@ class RestoreWalletCubit extends Cubit<RestoreWalletState> {
 
     final normalizedSeed = seed.split(' ').where((element) => element.isNotEmpty).join(' ');
 
-    final wallet = await _walletService.restoreWallet('Obi-Wallet-Kenobi', normalizedSeed);
-    // Fire-and-forget the auth-signature capture so a 20 s HTTP timeout doesn't
-    // block the wallet-restore UI. The lazy path in DFXAuthService.getSignature
-    // is the safety net.
-    unawaited(
-      warmAuthSignature(
-        _authService,
-        wallet.currentAccount,
-        loggerName: '$RestoreWalletCubit',
-      ),
-    );
+    try {
+      final wallet = await _walletService.restoreWallet('Obi-Wallet-Kenobi', normalizedSeed);
+      // Fire-and-forget the auth-signature capture so a 20 s HTTP timeout doesn't
+      // block the wallet-restore UI. The lazy path in DFXAuthService.getSignature
+      // is the safety net.
+      unawaited(
+        warmAuthSignature(
+          _authService,
+          wallet.currentAccount,
+          loggerName: '$RestoreWalletCubit',
+        ),
+      );
 
-    emit(
-      RestoreWalletState(
-        isLoading: false,
-        wallet: wallet,
-      ),
-    );
+      if (isClosed) return;
+      emit(
+        RestoreWalletState(
+          isLoading: false,
+          wallet: wallet,
+        ),
+      );
+    } catch (e, stackTrace) {
+      // A persist/crypto/storage failure used to escape as an unhandled async
+      // error, stranding the UI on a permanent spinner with no retry
+      // (issue #657 P1 B1). Surface a terminal, retryable error state instead.
+      developer.log(
+        'restoreWallet failed',
+        name: '$RestoreWalletCubit',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      if (isClosed) return;
+      emit(const RestoreWalletState(isLoading: false, hasError: true));
+    }
   }
 }

--- a/lib/screens/restore_wallet/cubit/restore_wallet/restore_wallet_cubit.dart
+++ b/lib/screens/restore_wallet/cubit/restore_wallet/restore_wallet_cubit.dart
@@ -17,6 +17,7 @@ class RestoreWalletCubit extends Cubit<RestoreWalletState> {
   final DFXAuthService _authService;
 
   void restoreWallet(String seed) async {
+    if (state.isLoading) return;
     emit(const RestoreWalletState(isLoading: true));
 
     final normalizedSeed = seed.split(' ').where((element) => element.isNotEmpty).join(' ');

--- a/lib/screens/restore_wallet/cubit/restore_wallet/restore_wallet_state.dart
+++ b/lib/screens/restore_wallet/cubit/restore_wallet/restore_wallet_state.dart
@@ -2,13 +2,18 @@ part of 'restore_wallet_cubit.dart';
 
 class RestoreWalletState extends Equatable {
   final bool isLoading;
+
+  /// True when the restore attempt threw — the UI leaves the loading state and
+  /// offers a retry instead of spinning forever (issue #657 P1 B1).
+  final bool hasError;
   final SoftwareWallet? wallet;
 
   const RestoreWalletState({
     this.isLoading = false,
+    this.hasError = false,
     this.wallet,
   });
 
   @override
-  List<Object?> get props => [isLoading, wallet];
+  List<Object?> get props => [isLoading, hasError, wallet];
 }

--- a/lib/screens/restore_wallet/widgets/restore_wallet_button.dart
+++ b/lib/screens/restore_wallet/widgets/restore_wallet_button.dart
@@ -35,6 +35,17 @@ class RestoreWalletButton extends StatelessWidget {
             state: .success,
           );
         }
+        // Restore threw: leave the spinner and offer a tappable retry — the
+        // error-state button is non-interactive, so render an idle button
+        // with the failure label instead (issue #657 P1 B1).
+        if (restoreWalletState.hasError) {
+          return AppFilledButton(
+            icon: Icons.refresh,
+            label: S.of(context).restoreWalletFailed,
+            onPressed: () =>
+                context.read<RestoreWalletCubit>().restoreWallet(_controllers.seed),
+          );
+        }
         return AppFilledButton(
           label: S.of(context).next,
           state: .loading,

--- a/test/screens/restore_wallet/restore_wallet_cubit_test.dart
+++ b/test/screens/restore_wallet/restore_wallet_cubit_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
@@ -89,6 +91,26 @@ void main() {
 
       expect(cubit.state.wallet, same(restored));
       expect(cubit.state.hasError, isFalse);
+    });
+
+    test('restoreWallet ignores a second call while one is already in flight '
+        '(retry double-tap guard)', () async {
+      final restored = SoftwareWallet(1, 'W', _testMnemonic);
+      final completer = Completer<SoftwareWallet>();
+      when(() => service.restoreWallet(any(), any())).thenAnswer((_) => completer.future);
+      final cubit = RestoreWalletCubit(service, authService);
+
+      cubit.restoreWallet(_testMnemonic);
+      expect(cubit.state.isLoading, isTrue);
+
+      // A double-tap on the retry button must not start a second restore.
+      cubit.restoreWallet(_testMnemonic);
+
+      completer.complete(restored);
+      await cubit.stream.firstWhere((s) => s.wallet != null);
+
+      verify(() => service.restoreWallet(any(), any())).called(1);
+      expect(cubit.state.wallet, same(restored));
     });
 
     test('restoreWallet emits an interim isLoading=true state', () async {

--- a/test/screens/restore_wallet/restore_wallet_cubit_test.dart
+++ b/test/screens/restore_wallet/restore_wallet_cubit_test.dart
@@ -53,6 +53,44 @@ void main() {
       expect(cubit.state.isLoading, isFalse);
     });
 
+    test('restoreWallet emits a terminal hasError state (not endless loading) when the '
+        'service throws (issue #657 P1 B1)', () async {
+      when(() => service.restoreWallet(any(), any()))
+          .thenAnswer((_) async => throw Exception('persist failed'));
+      final cubit = RestoreWalletCubit(service, authService);
+
+      cubit.restoreWallet(_testMnemonic);
+      final errorState = await cubit.stream
+          .firstWhere((s) => s.hasError)
+          .timeout(const Duration(seconds: 1));
+
+      // No permanent spinner: loading cleared, error surfaced, no wallet.
+      expect(errorState.hasError, isTrue);
+      expect(errorState.isLoading, isFalse);
+      expect(errorState.wallet, isNull);
+    });
+
+    test('restoreWallet recovers on retry after a failure', () async {
+      final restored = SoftwareWallet(1, 'W', _testMnemonic);
+      var attempts = 0;
+      when(() => service.restoreWallet(any(), any())).thenAnswer((_) async {
+        attempts++;
+        if (attempts == 1) throw Exception('transient');
+        return restored;
+      });
+      final cubit = RestoreWalletCubit(service, authService);
+
+      cubit.restoreWallet(_testMnemonic);
+      await cubit.stream.firstWhere((s) => s.hasError);
+
+      // Retry: the same entry point is called again and now succeeds.
+      cubit.restoreWallet(_testMnemonic);
+      await cubit.stream.firstWhere((s) => s.wallet != null);
+
+      expect(cubit.state.wallet, same(restored));
+      expect(cubit.state.hasError, isFalse);
+    });
+
     test('restoreWallet emits an interim isLoading=true state', () async {
       final restored = SoftwareWallet(1, 'W', _testMnemonic);
       when(() => service.restoreWallet(any(), any())).thenAnswer((_) async => restored);

--- a/test/screens/restore_wallet/restore_wallet_page_test.dart
+++ b/test/screens/restore_wallet/restore_wallet_page_test.dart
@@ -182,6 +182,29 @@ void main() {
           findsOne,
         );
       });
+
+      testWidgets(
+          'offers a tappable retry (not a dead spinner) when restore failed '
+          '(issue #657 P1 B1)', (tester) async {
+        when(() => validateSeedCubit.state).thenReturn(ValidateSeedState.valid);
+        when(() => restoreWalletCubit.state)
+            .thenReturn(const RestoreWalletState(hasError: true));
+
+        await tester.pumpApp(buildSubject(const RestoreWalletView()));
+
+        final button = find.descendant(
+          of: find.byType(RestoreWalletButton),
+          matching: find.byType(FilledButton),
+        );
+        // Not stuck on the loading spinner; the button is interactive.
+        expect(find.byType(CupertinoActivityIndicator), findsNothing);
+        expect(tester.widget<FilledButton>(button).enabled, isTrue);
+
+        // Tapping it retries the restore.
+        await tester.tap(button);
+        await tester.pump();
+        verify(() => restoreWalletCubit.restoreWallet(any())).called(1);
+      });
     });
 
     group('$RestoreWalletInputField', () {

--- a/test/screens/restore_wallet/restore_wallet_page_test.dart
+++ b/test/screens/restore_wallet/restore_wallet_page_test.dart
@@ -192,6 +192,11 @@ void main() {
 
         await tester.pumpApp(buildSubject(const RestoreWalletView()));
 
+        // Paste a seed into the first cell; the paste handler spreads it over all 12.
+        const seed = 'test test test test test test test test test test test junk';
+        await tester.enterText(find.byType(TextField).first, seed);
+        await tester.pump();
+
         final button = find.descendant(
           of: find.byType(RestoreWalletButton),
           matching: find.byType(FilledButton),
@@ -200,10 +205,10 @@ void main() {
         expect(find.byType(CupertinoActivityIndicator), findsNothing);
         expect(tester.widget<FilledButton>(button).enabled, isTrue);
 
-        // Tapping it retries the restore.
+        // Tapping it retries the restore with the exact seed that was entered.
         await tester.tap(button);
         await tester.pump();
-        verify(() => restoreWalletCubit.restoreWallet(any())).called(1);
+        verify(() => restoreWalletCubit.restoreWallet(seed)).called(1);
       });
     });
 


### PR DESCRIPTION
Addresses **Issue #657** — Part 1, finding **B1** (HIGH).

## Problem
`restoreWallet()` had **no try/catch** — a persist/crypto failure escaped as an unhandled async error and the cubit stayed `isLoading`. The button renders `.loading` whenever `wallet == null`, so the user was stranded on a **permanent spinner with no retry**.

## Fix (beide Layer — Big-Brother-Design-Skeptic hatte einen Cubit-only-Fix als unvollständig geblockt)
- **Cubit:** try/catch + `isClosed` guard → terminaler `hasError`-State + Log
- **State:** neues `hasError`-Flag (in props)
- **Button:** bei `hasError` ein tappbarer *"Restore failed – tap to retry"* (idle + Refresh-Icon; der error-State-Button ist nicht interaktiv), der `restoreWallet` mit dem eingegebenen Seed erneut aufruft
- **l10n:** neuer `restoreWalletFailed`-String (EN/DE)

## Tests (RED→GREEN, proven)
Cubit: Error-State statt Endlos-Loading + Retry-Recovery (failt am alten Code, verifiziert). Widget: Retry tappbar, kein Spinner. Suite 30/30 grün, analyze clean.

🤖 Big Brother fleet analysis (Design-Skeptic scope verdict) + operator hand-finish. Ref #657.