### PR TITLE
fix(bitbox): coalesce overlapping scan ticks onto a single init()

### DIFF
--- a/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
+++ b/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
@@ -89,7 +89,13 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
   }
 
   Future<void> connectToBitbox(sdk.BitboxDevice device) async {
-    if (state is BitboxConnecting) return;
+    // Coalesce overlapping scan ticks onto ONE connect attempt: the state
+    // guard alone is defeated once the flow moves past BitboxConnecting
+    // (e.g. BitboxCheckHash) while the init future is still pending — a late
+    // tick then started a second init() on the shared SDK manager and wedged
+    // pairing (issue #657 P7 F1). `_pendingInit` covers that whole window; it
+    // is cleared on failure, so a genuine retry still passes.
+    if (state is BitboxConnecting || _pendingInit != null) return;
     emit(BitboxConnecting(device));
     try {
       // Snapshot any hash from a prior pairing on the same BitboxService

--- a/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
+++ b/lib/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit.dart
@@ -80,7 +80,8 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
 
   Future<void> checkForBitbox() async {
     final devices = await _service.getAllUsbDevices();
-    if (isClosed) return;
+    // An overlapping tick must not stomp the state machine or start a second connect.
+    if (isClosed || state is! BitboxNotConnected || _pendingInit != null) return;
     if (devices.isNotEmpty) {
       emit(BitboxFound(devices.first));
       _checkForTimer?.cancel();
@@ -89,12 +90,7 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
   }
 
   Future<void> connectToBitbox(sdk.BitboxDevice device) async {
-    // Coalesce overlapping scan ticks onto ONE connect attempt: the state
-    // guard alone is defeated once the flow moves past BitboxConnecting
-    // (e.g. BitboxCheckHash) while the init future is still pending — a late
-    // tick then started a second init() on the shared SDK manager and wedged
-    // pairing (issue #657 P7 F1). `_pendingInit` covers that whole window; it
-    // is cleared on failure, so a genuine retry still passes.
+    // A second init() on the shared SDK manager wedges pairing; ticks are gated upstream too.
     if (state is BitboxConnecting || _pendingInit != null) return;
     emit(BitboxConnecting(device));
     try {
@@ -148,11 +144,20 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
       emit(BitboxCheckHash(device, channelHash));
     } catch (e) {
       developer.log(e.toString(), name: '$ConnectBitboxCubit');
-      _pendingInit = null;
+      _releasePendingInit();
       if (isClosed) return;
       emit(BitboxNotConnected());
       _checkForTimer = Timer.periodic(const Duration(milliseconds: 500), (_) => checkForBitbox());
     }
+  }
+
+  /// Frees the connect gate once the orphaned init() settles (pairing budget caps a zombie).
+  void _releasePendingInit() {
+    final orphan = _pendingInit;
+    if (orphan == null) return;
+    orphan.timeout(_pairingPinTimeout, onTimeout: () => false).whenComplete(() {
+      if (identical(_pendingInit, orphan)) _pendingInit = null;
+    });
   }
 
   Future<void> confirmPairing() async {
@@ -166,6 +171,8 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
         onTimeout: () => false,
       );
       if (!initOk) throw Exception('pairing not confirmed on device');
+      // Consumed — release the gate so every later path can pair afresh.
+      _pendingInit = null;
       await _service.confirmPairing().timeout(
         _confirmPairingTimeout,
         onTimeout: () => throw TimeoutException(
@@ -188,7 +195,7 @@ class ConnectBitboxCubit extends Cubit<BitboxConnectionState> {
       await _acquireWalletAndConnect();
     } catch (e) {
       developer.log(e.toString(), name: '$ConnectBitboxCubit');
-      _pendingInit = null;
+      _releasePendingInit();
       if (isClosed) return;
       emit(BitboxNotConnected());
       _checkForTimer = Timer.periodic(const Duration(milliseconds: 500), (_) => checkForBitbox());

--- a/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
+++ b/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
@@ -122,6 +122,36 @@ void main() {
       verify(() => authService.ensureSignatureFor(any())).called(1);
     });
 
+    test('a late scan tick does not start a second init while one is pending '
+        '(issue #657 P7 F1)', () async {
+      final initCompleter = Completer<bool>();
+      var pollCount = 0;
+      when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
+      when(() => service.init(any())).thenAnswer((_) => initCompleter.future);
+      when(() => service.getChannelHash()).thenAnswer((_) async {
+        pollCount++;
+        return pollCount < 2 ? '' : 'HASH-1';
+      });
+
+      final cubit = makeCubit();
+      addTearDown(cubit.close);
+
+      // First connect runs init() once and settles in BitboxCheckHash — state
+      // is now past BitboxConnecting while the init future is still pending.
+      await waitForState<BitboxCheckHash>(cubit);
+      verify(() => service.init(any())).called(1);
+
+      // An overlapping/late scan tick re-invokes connectToBitbox.
+      await cubit.connectToBitbox(device);
+
+      // It must coalesce onto the in-flight init, NOT start a second init on
+      // the shared SDK manager (which used to wedge pairing).
+      verifyNever(() => service.init(any()));
+      expect(cubit.state, isA<BitboxCheckHash>());
+
+      initCompleter.complete(true);
+    });
+
     test('emits BitboxSignatureFailed when the signature capture throws', () async {
       var pollCount = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);

--- a/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
+++ b/test/screens/hardware_connect_bitbox/bloc/connect_bitbox_cubit_test.dart
@@ -122,8 +122,8 @@ void main() {
       verify(() => authService.ensureSignatureFor(any())).called(1);
     });
 
-    test('a late scan tick does not start a second init while one is pending '
-        '(issue #657 P7 F1)', () async {
+    test('a late scan tick neither stomps the state nor starts a second init '
+        'while one is pending', () async {
       final initCompleter = Completer<bool>();
       var pollCount = 0;
       when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
@@ -136,20 +136,82 @@ void main() {
       final cubit = makeCubit();
       addTearDown(cubit.close);
 
-      // First connect runs init() once and settles in BitboxCheckHash — state
-      // is now past BitboxConnecting while the init future is still pending.
+      // First connect settles in BitboxCheckHash while init() is still pending.
       await waitForState<BitboxCheckHash>(cubit);
       verify(() => service.init(any())).called(1);
 
-      // An overlapping/late scan tick re-invokes connectToBitbox.
-      await cubit.connectToBitbox(device);
+      // A late overlapping scan tick re-runs the full tick body.
+      await cubit.checkForBitbox();
 
-      // It must coalesce onto the in-flight init, NOT start a second init on
-      // the shared SDK manager (which used to wedge pairing).
+      // Must neither stomp the hash screen nor start a second init().
       verifyNever(() => service.init(any()));
       expect(cubit.state, isA<BitboxCheckHash>());
+    });
 
-      initCompleter.complete(true);
+    test('after a pairing-pin timeout the orphaned init gates fresh connects '
+        'until it settles or the release cap elapses', () async {
+      final initCompleter = Completer<bool>(); // never completes: zombie init
+      var pollCount = 0;
+      when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
+      when(() => service.init(any())).thenAnswer((_) => initCompleter.future);
+      when(() => service.getChannelHash()).thenAnswer((_) async {
+        pollCount++;
+        return pollCount < 2 ? '' : 'HASH-1';
+      });
+
+      final cubit = makeCubit(pairingPinTimeout: const Duration(milliseconds: 200));
+      addTearDown(cubit.close);
+
+      await waitForState<BitboxCheckHash>(cubit);
+      verify(() => service.init(any())).called(1);
+
+      await cubit.confirmPairing();
+      expect(cubit.state, isA<BitboxNotConnected>());
+
+      // The orphaned init() is still live: no second init(), no state stomp.
+      await cubit.checkForBitbox();
+      verifyNever(() => service.init(any()));
+      expect(cubit.state, isA<BitboxNotConnected>());
+
+      // Once the release cap elapses, the next tick pairs afresh (the tick
+      // fires connectToBitbox unawaited, so give init() a beat).
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+      await cubit.checkForBitbox();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      verify(() => service.init(any())).called(1);
+    });
+
+    test('a failed recheck after BitboxNotInitialized re-arms scanning that '
+        'can actually reconnect', () async {
+      var pollCount = 0;
+      when(() => service.getAllUsbDevices()).thenAnswer((_) async => [device]);
+      when(() => service.init(any())).thenAnswer((_) async => true);
+      when(() => service.getChannelHash()).thenAnswer((_) async {
+        pollCount++;
+        return pollCount < 2 ? '' : 'HASH-1';
+      });
+      when(() => service.confirmPairing()).thenAnswer((_) async {});
+      when(() => service.getDeviceStatus()).thenAnswer((_) async => 'uninitialized');
+
+      final cubit = makeCubit();
+      addTearDown(cubit.close);
+
+      await waitForState<BitboxCheckHash>(cubit);
+      verify(() => service.init(any())).called(1);
+
+      await cubit.confirmPairing();
+      expect(cubit.state, isA<BitboxNotInitialized>());
+
+      // The user seeded the device; the wallet acquisition still fails once.
+      when(() => service.getDeviceStatus()).thenAnswer((_) async => 'initialized');
+      when(() => walletService.createBitboxWallet(any())).thenThrow(Exception('nope'));
+      await cubit.recheckDeviceStatus();
+      expect(cubit.state, isA<BitboxNotConnected>());
+
+      // The consumed gate must allow a fresh pairing (tick fires connectToBitbox unawaited).
+      await cubit.checkForBitbox();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      verify(() => service.init(any())).called(1);
     });
 
     test('emits BitboxSignatureFailed when the signature capture throws', () async {


### PR DESCRIPTION
Addresses **Issue #657** — Part 7, finding **F1** (HIGH).

## Problem
`connectToBitbox` guarded re-entry only with `state is BitboxConnecting`. Once the flow moved past that state (`BitboxCheckHash`) while the init future was still pending, a late 500 ms scan tick re-entered and started a **second `init()` on the shared BitBox SDK manager** — undefined behaviour that wedged pairing.

A guard inside `connectToBitbox` alone turned out to be insufficient — review found three sibling holes with the same root cause (overlapping scan ticks + an unmanaged `_pendingInit` lifecycle):

1. the late tick's unconditional `emit(BitboxFound)` still stomped `BitboxCheckHash` (pairing UI dead-ends even when the second `init()` is blocked);
2. the failure catches cleared `_pendingInit` while the underlying `init()` was still in flight, so the sanctioned retry started the same overlapping second `init()` via another path;
3. paths that keep `_pendingInit` set without failing (`BitboxNotInitialized` early-return → failed `recheckDeviceStatus`, and the success path) would leave a `_pendingInit != null` guard permanently blocking every later reconnect.

## Fix
Single-flight at the tick source, plus a lifecycle-safe gate:

- **`checkForBitbox`** bails unless the cubit is actually scanning (`state is BitboxNotConnected`) and no `init()` is owned — a late tick can no longer stomp the state machine, race the guard-to-init window, or start a second connect. The timer keeps ticking while the gate is held, so recovery is automatic.
- **Failure paths** release the gate via `_releasePendingInit()`: only once the orphaned `init()` settles (capped by the SDK's own pairing budget for a zombie that never settles) may a fresh connect start — a retry never overlaps a live `init()` on the shared manager.
- **`confirmPairing`** clears the gate as soon as the init result is consumed, so the unseeded-device recheck flow and the post-success path can always pair afresh.
- `connectToBitbox` keeps the extended guard (`state is BitboxConnecting || _pendingInit != null`) as defense in depth for direct callers.

Rebased onto current `staging` (the branch predated `BitboxNotInitialized`/`recheckDeviceStatus`; hole 3 only exists against the current base, so the fix had to be validated there).

## Tests (RED→GREEN, proven, device-free)
Three regressions, each verified to fail before the fix:
- a late scan tick — driven through `checkForBitbox()`, the real production trigger — neither stomps `BitboxCheckHash` nor starts a second `init()`;
- after a pairing-pin timeout, the orphaned `init()` gates fresh connects (no overlap, no state stomp) until it settles or the release cap elapses, then scanning reconnects;
- a failed `recheckDeviceStatus` after `BitboxNotInitialized` re-arms scanning that can actually reconnect (the gate is consumed, not left dangling).

Full `hardware_connect_bitbox` suite + `test/integration/connect_bitbox_flow_test.dart` + `kyc_link_wallet_page_test.dart` green (note: the integration replug leg drives `service.init` directly, so the cubit-level guard is covered by the unit regressions above, not by that file); `flutter analyze` clean; `dart format --page-width=100` clean.
