### PR TITLE
docs(handbook): Download / Test access section (#spec-downloads)

### DIFF
--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -43,18 +43,22 @@
 
         // Copy-link buttons next to each flow name: one click copies the
         // absolute deep-link to the clipboard, updates the URL bar to that
-        // anchor, and flashes a checkmark for 1.2s. Falls back to the
-        // textarea+execCommand trick on browsers without async clipboard.
-        // Original label is captured per-button at wire-up time (not per
-        // click) so a rapid second click while the "✓ Kopiert" state is
-        // still showing can't lock the label in the flashed state.
+        // anchor, and flashes a checkmark for 1.2s. Buttons carrying
+        // data-copy-url instead copy that URL verbatim (used by
+        // #spec-downloads for the public tester links) and leave the URL
+        // bar untouched. Falls back to the textarea+execCommand trick on
+        // browsers without async clipboard. Original label is captured
+        // per-button at wire-up time (not per click) so a rapid second
+        // click while the "✓ Kopiert" state is still showing can't lock
+        // the label in the flashed state.
         document.querySelectorAll('.copy-link').forEach(function (btn) {
           var origText = btn.textContent;
           var resetTimer = null;
           btn.addEventListener('click', function () {
             var target = btn.dataset.target;
-            if (!target) return;
-            var url = location.origin + location.pathname + '#' + target;
+            var copyUrl = btn.dataset.copyUrl;
+            if (!target && !copyUrl) return;
+            var url = copyUrl || location.origin + location.pathname + '#' + target;
             var done = function () {
               btn.textContent = '✓ Kopiert';
               btn.dataset.copied = 'true';
@@ -64,7 +68,7 @@
                 btn.removeAttribute('data-copied');
                 resetTimer = null;
               }, 1200);
-              if (location.hash !== '#' + target) location.hash = target;
+              if (target && location.hash !== '#' + target) location.hash = target;
             };
             if (navigator.clipboard && navigator.clipboard.writeText) {
               navigator.clipboard.writeText(url).then(done, function () {
@@ -692,6 +696,54 @@
         border-radius: 8px;
         padding: 14px 16px;
       }
+      /* Downloads section (#spec-downloads) — static, hand-maintained list of
+         the three public tester/download links. Reuses the .test card chrome
+         (border + :target highlight) and the .copy-link button; the body adds a
+         self-contained inline-SVG QR code per link so a tester can scan it from
+         the desktop handbook. The copy button carries data-copy-url so it copies
+         the actual store/download URL rather than a handbook deep-link. */
+      .test.download .dl-body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 12px;
+        padding: 16px 14px;
+      }
+      .test.download .dl-desc {
+        margin: 0;
+        font-size: 13px;
+        color: var(--ink-2);
+        text-align: center;
+      }
+      .test.download .dl-qr {
+        width: 132px;
+        height: 132px;
+        padding: 8px;
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+      }
+      .test.download .dl-qr svg {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+      .test.download .dl-actions {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 8px;
+      }
+      .test.download .dl-url {
+        width: 100%;
+        margin: 0;
+        font-family: 'SF Mono', Menlo, Consolas, monospace;
+        font-size: 11px;
+        color: var(--ink-3);
+        text-align: center;
+        overflow-wrap: anywhere;
+        word-break: break-all;
+      }
     </style>
   </head>
   <body>
@@ -775,6 +827,9 @@
             </li>
             <li>
               <a href="#spec-legal-downloads"><span class="spec-num">L</span>Rechtsdokumente</a>
+            </li>
+            <li>
+              <a href="#spec-downloads"><span class="spec-num">D</span>Download / Test</a>
             </li>
             <li>
               <a href="#spec-tasks"><span class="spec-num">A</span>Aufgaben</a>
@@ -2621,6 +2676,93 @@ Jetzt herunterladen und Ihre finanzielle Souveränität zurückgewinnen.</div></
   </div>
 </details>
 <!-- END:legal-downloads -->
+
+        <details id="spec-downloads" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">D</span>Download / Test-Zugang</h2>
+                <div class="file">docs/handbook/de/index.html</div>
+              </div>
+              <div class="rhs">
+                <b>3 Plattformen</b>
+                <div class="links">
+                  <a href="https://github.com/RealUnitCH/app/releases">Releases ↗</a>
+                </div>
+              </div>
+            </div>
+          </summary>
+
+          <p class="spec-intro">
+            Die öffentlichen Test- und Download-Zugänge der RealUnit-App an einem Ort —
+            iOS über <b>TestFlight</b>, Android über den <b>offenen Test im Play Store</b>
+            oder als <b>APK-Direkt-Download</b>. Die Links sind öffentlich und stabil und
+            werden statisch hier im Handbook gepflegt; pro Zugang gibt es den Link, einen
+            Kopier-Button und einen QR-Code zum Scannen mit dem Handy. Bei einem künftigen
+            Wechsel (z.&nbsp;B. neue TestFlight-Public-Gruppe oder geänderter
+            Play-Test-Pfad) diese Sektion aktualisieren.
+          </p>
+
+          <div class="tests cols-3">
+            <div class="test download" id="dl-testflight">
+              <div class="head">
+                <a class="name permalink" href="#dl-testflight">Apple TestFlight</a>
+                <span class="src">iOS</span>
+              </div>
+              <div class="dl-body">
+                <div class="dl-qr"><svg role="img" viewBox="0 0 37 37"><title>QR-Code: Apple TestFlight</title><path fill="#fff" d="M0 0h37v37h-37z"/><path stroke="#343233" d="M4 4.5h7m1 0h1m1 0h2m3 0h6m1 0h7m-29 1h1m5 0h1m1 0h1m1 0h1m1 0h1m1 0h1m2 0h2m1 0h1m1 0h1m5 0h1m-29 1h1m1 0h3m1 0h1m2 0h1m1 0h1m1 0h2m1 0h1m2 0h1m2 0h1m1 0h3m1 0h1m-29 1h1m1 0h3m1 0h1m1 0h1m3 0h1m1 0h4m2 0h1m1 0h1m1 0h3m1 0h1m-29 1h1m1 0h3m1 0h1m2 0h1m1 0h1m2 0h4m1 0h1m2 0h1m1 0h3m1 0h1m-29 1h1m5 0h1m5 0h2m2 0h1m1 0h2m2 0h1m5 0h1m-29 1h7m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h7m-21 1h5m4 0h2m1 0h1m-21 1h1m1 0h2m1 0h3m2 0h1m3 0h2m1 0h1m1 0h2m1 0h1m2 0h1m1 0h2m-28 1h2m7 0h1m3 0h1m1 0h9m3 0h1m-27 1h2m2 0h1m1 0h3m1 0h2m2 0h1m1 0h1m2 0h1m1 0h1m2 0h2m-27 1h1m1 0h1m5 0h2m1 0h4m3 0h1m3 0h1m4 0h1m-28 1h2m3 0h2m5 0h2m2 0h1m5 0h1m1 0h2m-26 1h1m3 0h1m1 0h3m1 0h2m2 0h1m1 0h1m1 0h1m2 0h1m3 0h3m-28 1h2m1 0h4m3 0h2m3 0h2m1 0h1m1 0h1m1 0h2m1 0h3m-28 1h2m1 0h2m6 0h1m1 0h1m1 0h1m2 0h3m2 0h1m2 0h1m-28 1h3m3 0h2m2 0h1m2 0h1m1 0h1m2 0h4m2 0h2m1 0h1m-27 1h1m1 0h1m6 0h2m1 0h1m1 0h1m1 0h1m5 0h1m1 0h3m-28 1h1m3 0h5m2 0h2m1 0h4m3 0h4m1 0h1m-25 1h4m2 0h1m8 0h2m2 0h1m4 0h1m-26 1h2m1 0h3m4 0h1m1 0h14m-19 1h1m1 0h1m3 0h1m1 0h5m3 0h5m-29 1h7m1 0h1m1 0h1m2 0h2m1 0h5m1 0h1m1 0h2m1 0h1m-28 1h1m5 0h1m1 0h1m1 0h6m2 0h1m1 0h1m3 0h2m-26 1h1m1 0h3m1 0h1m2 0h2m6 0h2m1 0h5m1 0h3m-29 1h1m1 0h3m1 0h1m1 0h1m1 0h2m1 0h4m3 0h2m1 0h3m2 0h1m-29 1h1m1 0h3m1 0h1m1 0h1m1 0h1m2 0h1m2 0h5m2 0h1m2 0h1m1 0h1m-29 1h1m5 0h1m3 0h1m1 0h1m7 0h1m3 0h2m1 0h1m-28 1h7m1 0h3m2 0h1m1 0h1m2 0h5m2 0h1m1 0h1"/></svg></div>
+                <p class="dl-desc">
+                  Öffentlicher Tester-Zugang für iPhone &amp; iPad. Link auf dem Gerät
+                  öffnen, TestFlight installieren (falls noch nicht vorhanden) und dem
+                  Test beitreten — Updates kommen automatisch über TestFlight.
+                </p>
+                <div class="dl-actions">
+                  <a class="dl-btn" href="https://testflight.apple.com/join/xpAAwseS" target="_blank" rel="noopener">Öffnen ↗</a>
+                  <button class="copy-link" type="button" data-copy-url="https://testflight.apple.com/join/xpAAwseS" title="Link kopieren" aria-label="TestFlight-Link kopieren">🔗 Link kopieren</button>
+                </div>
+                <code class="dl-url">https://testflight.apple.com/join/xpAAwseS</code>
+              </div>
+            </div>
+            <div class="test download" id="dl-playstore">
+              <div class="head">
+                <a class="name permalink" href="#dl-playstore">Google Play — Offener Test</a>
+                <span class="src">Android</span>
+              </div>
+              <div class="dl-body">
+                <div class="dl-qr"><svg role="img" viewBox="0 0 41 41"><title>QR-Code: Google Play — Offener Test</title><path fill="#fff" d="M0 0h41v41h-41z"/><path stroke="#343233" d="M4 4.5h7m5 0h2m1 0h1m2 0h2m2 0h2m2 0h7m-33 1h1m5 0h1m2 0h1m1 0h5m1 0h1m2 0h2m1 0h1m2 0h1m5 0h1m-33 1h1m1 0h3m1 0h1m3 0h1m1 0h2m1 0h1m1 0h1m1 0h1m6 0h1m1 0h3m1 0h1m-33 1h1m1 0h3m1 0h1m6 0h2m1 0h1m1 0h2m2 0h1m3 0h1m1 0h3m1 0h1m-33 1h1m1 0h3m1 0h1m2 0h1m2 0h3m2 0h1m5 0h1m2 0h1m1 0h3m1 0h1m-33 1h1m5 0h1m1 0h1m4 0h1m1 0h6m1 0h1m3 0h1m5 0h1m-33 1h7m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h7m-23 1h2m3 0h7m-22 1h1m2 0h1m1 0h2m1 0h3m2 0h2m1 0h1m2 0h1m1 0h1m1 0h3m1 0h1m-28 1h1m4 0h1m2 0h1m4 0h1m3 0h1m2 0h2m3 0h3m3 0h2m-33 1h1m2 0h4m1 0h1m1 0h5m1 0h1m1 0h3m5 0h3m1 0h1m1 0h1m-33 1h3m2 0h1m1 0h1m1 0h1m1 0h1m1 0h1m7 0h2m5 0h2m1 0h2m-27 1h2m3 0h1m2 0h1m1 0h2m1 0h3m1 0h1m1 0h3m1 0h1m1 0h2m-32 1h1m2 0h1m6 0h2m1 0h2m2 0h2m2 0h1m1 0h1m1 0h1m1 0h5m-32 1h3m1 0h3m3 0h1m2 0h4m3 0h1m1 0h5m2 0h2m-32 1h2m1 0h3m1 0h2m1 0h4m2 0h7m1 0h1m1 0h2m3 0h1m-32 1h1m4 0h3m1 0h1m4 0h10m2 0h1m1 0h1m2 0h1m-31 1h3m4 0h3m1 0h2m2 0h1m3 0h1m2 0h2m2 0h1m1 0h1m-24 1h1m1 0h1m2 0h2m1 0h1m1 0h1m1 0h1m11 0h3m-33 1h3m1 0h1m4 0h1m1 0h1m1 0h5m2 0h4m1 0h1m1 0h1m3 0h2m-30 1h1m1 0h3m3 0h3m3 0h2m1 0h2m1 0h3m1 0h1m-18 1h1m2 0h1m1 0h1m4 0h1m1 0h1m3 0h1m3 0h3m-33 1h2m1 0h1m2 0h4m1 0h1m4 0h2m1 0h1m1 0h2m2 0h4m3 0h1m-32 1h2m2 0h1m1 0h1m2 0h2m1 0h1m1 0h1m2 0h6m1 0h2m1 0h2m-30 1h1m1 0h1m1 0h1m1 0h1m1 0h2m1 0h1m1 0h1m3 0h1m1 0h3m2 0h5m2 0h2m-25 1h3m2 0h2m2 0h1m1 0h6m3 0h2m1 0h2m-33 1h7m2 0h4m3 0h3m5 0h1m1 0h1m1 0h4m-32 1h1m5 0h1m1 0h1m1 0h1m3 0h2m1 0h1m1 0h4m1 0h1m3 0h1m-29 1h1m1 0h3m1 0h1m2 0h1m3 0h2m3 0h1m1 0h3m1 0h6m2 0h1m-33 1h1m1 0h3m1 0h1m1 0h1m2 0h6m4 0h1m4 0h1m1 0h2m-30 1h1m1 0h3m1 0h1m2 0h2m4 0h2m1 0h1m1 0h2m1 0h1m4 0h2m2 0h1m-33 1h1m5 0h1m2 0h4m4 0h5m2 0h1m4 0h1m-30 1h7m1 0h2m1 0h1m3 0h1m3 0h1m1 0h1m2 0h3m1 0h2m1 0h1"/></svg></div>
+                <p class="dl-desc">
+                  Offener Test im Play Store. Link auf dem Android-Gerät öffnen, dem
+                  Test beitreten und die App regulär über den Play Store installieren —
+                  Updates kommen automatisch.
+                </p>
+                <div class="dl-actions">
+                  <a class="dl-btn" href="https://play.google.com/apps/testing/swiss.realunit.app" target="_blank" rel="noopener">Öffnen ↗</a>
+                  <button class="copy-link" type="button" data-copy-url="https://play.google.com/apps/testing/swiss.realunit.app" title="Link kopieren" aria-label="Play-Store-Test-Link kopieren">🔗 Link kopieren</button>
+                </div>
+                <code class="dl-url">https://play.google.com/apps/testing/swiss.realunit.app</code>
+              </div>
+            </div>
+            <div class="test download" id="dl-apk">
+              <div class="head">
+                <a class="name permalink" href="#dl-apk">Android APK</a>
+                <span class="src">Android</span>
+              </div>
+              <div class="dl-body">
+                <div class="dl-qr"><svg role="img" viewBox="0 0 37 37"><title>QR-Code: Android APK (GitHub Releases)</title><path fill="#fff" d="M0 0h37v37h-37z"/><path stroke="#343233" d="M4 4.5h7m3 0h3m1 0h1m3 0h1m3 0h7m-29 1h1m5 0h1m1 0h2m4 0h1m1 0h1m3 0h1m1 0h1m5 0h1m-29 1h1m1 0h3m1 0h1m1 0h1m2 0h2m2 0h2m1 0h1m3 0h1m1 0h3m1 0h1m-29 1h1m1 0h3m1 0h1m1 0h2m1 0h1m1 0h1m2 0h1m3 0h1m1 0h1m1 0h3m1 0h1m-29 1h1m1 0h3m1 0h1m2 0h2m5 0h1m2 0h2m1 0h1m1 0h3m1 0h1m-29 1h1m5 0h1m3 0h1m3 0h1m5 0h1m1 0h1m5 0h1m-29 1h7m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h7m-21 1h2m1 0h1m2 0h2m4 0h1m-21 1h1m5 0h1m1 0h1m1 0h8m3 0h2m2 0h3m-28 1h6m3 0h1m1 0h2m1 0h2m1 0h3m1 0h1m1 0h2m1 0h2m-27 1h7m1 0h1m1 0h1m3 0h3m6 0h1m-23 1h2m4 0h2m4 0h3m1 0h2m1 0h1m3 0h1m-25 1h3m2 0h2m8 0h1m2 0h1m2 0h2m4 0h1m-29 1h2m1 0h2m3 0h1m2 0h1m2 0h2m1 0h2m1 0h1m1 0h3m2 0h2m-29 1h1m2 0h1m1 0h2m6 0h1m1 0h1m2 0h1m1 0h2m2 0h3m-25 1h1m1 0h2m2 0h2m1 0h2m3 0h1m2 0h1m3 0h2m1 0h1m1 0h1m-27 1h2m2 0h2m3 0h7m1 0h1m1 0h1m1 0h1m1 0h2m-27 1h1m2 0h2m2 0h2m2 0h2m2 0h2m2 0h1m2 0h3m1 0h3m-29 1h2m2 0h1m1 0h1m2 0h5m1 0h3m1 0h1m4 0h2m2 0h1m-29 1h1m2 0h3m2 0h1m1 0h1m3 0h1m3 0h1m1 0h1m1 0h1m-23 1h1m2 0h2m1 0h2m1 0h1m1 0h6m2 0h6m1 0h3m-21 1h1m1 0h1m1 0h1m2 0h1m2 0h1m1 0h1m3 0h2m-26 1h7m6 0h1m1 0h6m1 0h1m1 0h3m-27 1h1m5 0h1m4 0h1m2 0h1m4 0h2m3 0h1m3 0h1m-29 1h1m1 0h3m1 0h1m2 0h3m1 0h5m1 0h7m1 0h1m-28 1h1m1 0h3m1 0h1m3 0h4m1 0h7m3 0h2m1 0h1m-29 1h1m1 0h3m1 0h1m4 0h2m1 0h3m1 0h10m-28 1h1m5 0h1m6 0h3m2 0h1m3 0h2m1 0h2m1 0h1m-29 1h7m1 0h2m1 0h1m2 0h1m2 0h3m2 0h3m1 0h1"/></svg></div>
+                <p class="dl-desc">
+                  Direkt-Download ohne Play Store: APK des gewünschten Releases von
+                  GitHub laden und installieren (Installation aus unbekannten Quellen
+                  zulassen). Kein Auto-Update — neue Versionen manuell laden.
+                </p>
+                <div class="dl-actions">
+                  <a class="dl-btn" href="https://github.com/RealUnitCH/app/releases" target="_blank" rel="noopener">Öffnen ↗</a>
+                  <button class="copy-link" type="button" data-copy-url="https://github.com/RealUnitCH/app/releases" title="Link kopieren" aria-label="APK-Releases-Link kopieren">🔗 Link kopieren</button>
+                </div>
+                <code class="dl-url">https://github.com/RealUnitCH/app/releases</code>
+              </div>
+            </div>
+          </div>
+        </details>
 
         <details id="spec-tasks" class="spec" open>
           <summary>


### PR DESCRIPTION
## Was

Neue Handbook-Sektion **„Download / Test-Zugang"** (`#spec-downloads`), die die drei öffentlichen Test-/Download-Zugänge der RealUnit-App an einem Ort bündelt — direkt neben „Rechtsdokumente" (`#spec-legal-downloads`) und „Aufgaben" (`#spec-tasks`). Damit stehen die aktuell gültigen Tester-Links dauerhaft im Handbook statt nur in einer Mail.

Closes #690

## Inhalt

Drei Einträge, je mit Plattform-Name, kurzer Install-Beschreibung, Link, „🔗 Link kopieren"-Button und QR-Code:

| Zugang | Link |
| --- | --- |
| Apple TestFlight (öffentlicher Tester-Link) | `https://testflight.apple.com/join/xpAAwseS` |
| Google Play — Offener Test | `https://play.google.com/apps/testing/swiss.realunit.app` |
| Android APK (Direkt-Download, alle Releases) | `https://github.com/RealUnitCH/app/releases` |

## Umsetzung

- Neue `<details id="spec-downloads">`-Sektion + Nav-Eintrag „D Download / Test", Styling/Card-Chrome + Copy-Button analog zu den bestehenden Sektionen.
- **QR-Code je Link** als selbst-enthaltenes Inline-SVG (kein externer Request, kein Build-Schritt) — Tester können den Link direkt vom Desktop-Handbook scannen. Die SVGs wurden generiert und per Decode-Round-Trip gegen die Soll-URLs verifiziert.
- Der gemeinsame Copy-Link-Handler bekommt ein optionales `data-copy-url`-Attribut: solche Buttons kopieren die echte Store-/Download-URL (statt eines Handbook-Deep-Links) und lassen die URL-Leiste unverändert. Bestehende `data-target`-Buttons bleiben unverändert.
- **Rein statisches HTML.** Die Sektion liegt **außerhalb** der `BEGIN/END`-Blöcke der Generatoren (`store-listing`, `legal-downloads`) → die Handbook-Workflows greifen ohne Anpassung.

## Lokal verifiziert

- ✅ `assemble-handbook-store-listing.py` + `assemble-handbook-legal.py` erzeugen **keinen** Diff (Sync-Gates grün)
- ✅ `assemble-handbook-screenshots.sh` → 52 Screenshots (unverändert)
- ✅ `docker build -f Dockerfile.handbook` erfolgreich
- ✅ Container-Smoke: `/healthz` = 200, `/de/` = 401 (Auth-Wall aktiv), Sektion im ausgelieferten `/de/index.html` vorhanden; Image-`index.html` identisch zum Working-Tree
- ✅ HTML tag-balance OK, keine doppelten IDs, Inline-Scripts `node --check` OK
- ✅ QR-Codes dekodieren korrekt zurück zu den drei URLs
