### PR TITLE
fix(dashboard): skip null-value portfolio points instead of plotting 0

### DIFF
--- a/lib/packages/service/dfx/real_unit_account_service.dart
+++ b/lib/packages/service/dfx/real_unit_account_service.dart
@@ -29,16 +29,23 @@ class RealUnitAccountService {
     final body = jsonDecode(response.body) as Map<String, dynamic>;
     final accountSummary = AccountSummaryDto.fromJson(body);
 
-    return accountSummary.historicalBalances.map((h) {
-      final value = switch (currency) {
-        Currency.chf => h.valueChf,
-        Currency.eur => h.valueEur,
-      };
-      return PortfolioValuePoint(
-        value: BigInt.from((value ?? 0) * 100),
-        balance: BigInt.parse(h.balance),
-        time: h.timestamp,
-      );
-    }).toList();
+    return accountSummary.historicalBalances
+        .map((h) {
+          final value = switch (currency) {
+            Currency.chf => h.valueChf,
+            Currency.eur => h.valueEur,
+          };
+          // A null value means the API could not price this point (e.g. quote
+          // currently unavailable). Skip it rather than plotting it as 0, which
+          // would crash the chart line to zero and show a false -100% change.
+          if (value == null) return null;
+          return PortfolioValuePoint(
+            value: BigInt.from(value * 100),
+            balance: BigInt.parse(h.balance),
+            time: h.timestamp,
+          );
+        })
+        .whereType<PortfolioValuePoint>()
+        .toList();
   }
 }

--- a/test/packages/service/dfx/real_unit_account_service_test.dart
+++ b/test/packages/service/dfx/real_unit_account_service_test.dart
@@ -87,7 +87,7 @@ void main() {
       expect(points.single.value, BigInt.from(1150));
     });
 
-    test('getPortfolioHistory treats a null value as 0', () async {
+    test('getPortfolioHistory skips a point whose value is null', () async {
       final client = MockClient((_) async => http.Response(
             jsonEncode(_summary(chf: null)),
             200,
@@ -95,7 +95,57 @@ void main() {
 
       final points = await build(client).getPortfolioHistory(Currency.chf);
 
+      // A null value means "unknown price", not "worth 0" — the point is
+      // dropped so the chart does not crash to zero / show a false -100%.
+      expect(points, isEmpty);
+    });
+
+    test('getPortfolioHistory keeps a genuine 0.0 value (distinct from null)', () async {
+      final client = MockClient((_) async => http.Response(
+            jsonEncode(_summary(chf: 0.0, balance: '0')),
+            200,
+          ));
+
+      final points = await build(client).getPortfolioHistory(Currency.chf);
+
       expect(points.single.value, BigInt.zero);
+    });
+
+    test('getPortfolioHistory drops a trailing null point but keeps earlier valued points', () async {
+      final body = {
+        'address': '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+        'addressType': 0,
+        'balance': '0',
+        'lastUpdated': '2026-01-03T00:00:00Z',
+        'historicalBalances': [
+          {
+            'balance': '1000000',
+            'timestamp': '2026-01-01T00:00:00Z',
+            'valueChf': 12.34,
+            'valueEur': null,
+          },
+          {
+            'balance': '1000000',
+            'timestamp': '2026-01-02T00:00:00Z',
+            'valueChf': 13.00,
+            'valueEur': null,
+          },
+          {
+            // Most recent point: balance still held, but price unavailable.
+            'balance': '1000000',
+            'timestamp': '2026-01-03T00:00:00Z',
+            'valueChf': null,
+            'valueEur': null,
+          },
+        ],
+      };
+      final client = MockClient((_) async => http.Response(jsonEncode(body), 200));
+
+      final points = await build(client).getPortfolioHistory(Currency.chf);
+
+      expect(points, hasLength(2));
+      expect(points.last.value, BigInt.from(1300));
+      expect(points.last.time, DateTime.utc(2026, 1, 2));
     });
 
     test('getPortfolioHistory returns [] on non-200 (does not throw)', () async {


### PR DESCRIPTION
## Problem

When the REALU quote is temporarily unavailable, the dashboard showed a corrupt portfolio chart: the line crashed to **0** at the most recent point and the performance box reported **-921.27 CHF | -100.00%**, even though the header correctly rendered the total as `--.--`.

Root cause: the API returns `valueChf` / `valueEur` as `null` for points it cannot price. `RealUnitAccountService.getPortfolioHistory` mapped that `null` to `0` (`value ?? 0`). The latest history point (balance still held, price `null`) was therefore plotted as a zero-value point, dragging the chart to the x-axis and making the `last - first` performance calc read `-100%`.

## Fix

- Skip history points whose value is `null` in the selected currency instead of mapping them to `0`. The chart now ends at the last **known** value and the change is computed against it; the header keeps showing `--.--` (already handled).
- A genuine `0.0` value (balance held but worth zero) is preserved and stays distinct from `null` (unknown).

Single change at the API boundary — no chart/cubit/widget changes needed, since the false `0` originated in the service mapping.

## Tests

- Rewrote the obsolete `treats a null value as 0` test → `skips a point whose value is null` (point is dropped).
- Added `keeps a genuine 0.0 value (distinct from null)`.
- Added `drops a trailing null point but keeps earlier valued points`.
- `flutter analyze` clean; dashboard + dfx service suites green (516 tests).

## Test plan

- [ ] Wallet with holdings while the quote endpoint returns `null` for the latest point → chart stays at last known value, header `--.--`, no `-100%`.
- [ ] Normal case with all values present → unchanged.
- [ ] Holding genuinely worth 0 → still renders 0, not dropped.