### PR TITLE
fix(dashboard): handle missing RealUnit price instead of crashing the price chart

### DIFF
--- a/lib/packages/service/dfx/dfx_price_service.dart
+++ b/lib/packages/service/dfx/dfx_price_service.dart
@@ -29,19 +29,18 @@ class DFXPriceService extends APriceService {
     final result = <PricePoint>[];
 
     for (final entry in body) {
-      BigInt price;
-      switch (currency) {
-        case Currency.eur:
-          price = BigInt.from(entry['eur'] * 100);
-          break;
-        case Currency.chf:
-          price = BigInt.from(entry['chf'] * 100);
-          break;
-      }
+      final rawPrice = switch (currency) {
+        Currency.eur => entry['eur'],
+        Currency.chf => entry['chf'],
+      };
+      // The API omits the price for points it cannot quote (e.g. the latest
+      // point while the quote is unavailable). Skip them instead of throwing,
+      // which would otherwise discard the entire chart.
+      if (rawPrice == null) continue;
       result.add(
         PricePoint(
           asset: asset,
-          price: price,
+          price: BigInt.from(rawPrice * 100),
           time: DateTime.parse(entry['timestamp']),
         ),
       );
@@ -59,12 +58,14 @@ class DFXPriceService extends APriceService {
 
     final body = jsonDecode(response.body);
 
-    switch (currency) {
-      case Currency.eur:
-        return BigInt.from(body['eur'] * 100);
-      case Currency.chf:
-        return BigInt.from(body['chf'] * 100);
-    }
+    final rawPrice = switch (currency) {
+      Currency.eur => body['eur'],
+      Currency.chf => body['chf'],
+    };
+    // A missing price means the quote is currently unavailable. Return zero so
+    // the UI renders "--.--" instead of throwing.
+    if (rawPrice == null) return BigInt.zero;
+    return BigInt.from(rawPrice * 100);
   }
 
   /// Returns the equivalent EUR amount for 1 CHF
@@ -75,8 +76,8 @@ class DFXPriceService extends APriceService {
     if (response.statusCode != 200) throw Exception(response.body);
 
     final body = jsonDecode(response.body);
-    final chf = (body['chf'] as num).toDouble();
-    final eur = (body['eur'] as num).toDouble();
+    final chf = (body['chf'] as num?)?.toDouble() ?? 0;
+    final eur = (body['eur'] as num?)?.toDouble() ?? 0;
 
     return chf > 0 ? eur / chf : 0.0;
   }

--- a/test/packages/service/dfx/dfx_price_service_test.dart
+++ b/test/packages/service/dfx/dfx_price_service_test.dart
@@ -60,6 +60,20 @@ void main() {
           throwsException,
         );
       });
+
+      test('returns zero when the price is missing (quote unavailable)', () async {
+        // The live endpoint omits chf/eur while the quote is unavailable,
+        // e.g. {"timestamp": "..."}. Must return zero (UI shows "--.--"),
+        // not throw on null * 100.
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'timestamp': '2026-06-04T22:28:16.539Z'}),
+              200,
+            ));
+
+        final price = await build(client).getPriceOfAsset(realUnitAsset, Currency.chf);
+
+        expect(price, BigInt.zero);
+      });
     });
 
     group('getPriceChart', () {
@@ -107,6 +121,25 @@ void main() {
           throwsException,
         );
       });
+
+      test('skips entries whose price is missing instead of discarding the whole chart', () async {
+        // A single trailing point without chf/eur must not wipe the entire
+        // chart — the prior valued points are kept.
+        final client = MockClient((_) async => http.Response(
+              jsonEncode([
+                {'chf': 1.0, 'eur': 0.95, 'timestamp': '2026-01-01T00:00:00Z'},
+                {'chf': 2.0, 'eur': 1.90, 'timestamp': '2026-01-02T00:00:00Z'},
+                {'timestamp': '2026-01-03T00:00:00Z'},
+              ]),
+              200,
+            ));
+
+        final points = await build(client).getPriceChart(realUnitAsset, Currency.chf);
+
+        expect(points, hasLength(2));
+        expect(points.last.price, BigInt.from(200));
+        expect(points.last.time, DateTime.utc(2026, 1, 2));
+      });
     });
 
     group('getChfToEurRate', () {
@@ -124,6 +157,17 @@ void main() {
       test('returns 0.0 when CHF is zero (avoids division by zero)', () async {
         final client = MockClient((_) async => http.Response(
               jsonEncode({'chf': 0.0, 'eur': 1.0}),
+              200,
+            ));
+
+        final rate = await build(client).getChfToEurRate();
+
+        expect(rate, 0.0);
+      });
+
+      test('returns 0.0 when the price is missing (quote unavailable)', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'timestamp': '2026-06-04T22:28:16.539Z'}),
               200,
             ));
 


### PR DESCRIPTION
## Problem

The public price view ("RealUnit Aktienkurs") shows an **empty chart** and `CHF --.--` whenever the RealUnit quote is temporarily unavailable.

Confirmed against the live API:
- `GET /v1/realunit/price` → `{"timestamp":"2026-06-04T22:28:16.539Z"}` — **no `chf`/`eur`**.
- `GET /v1/realunit/price/history?timeFrame=ALL` → **1514 points, 1513 valid**, only the latest (2026-06-04) has no `chf`/`eur`.

`DFXPriceService.getPriceChart` did `BigInt.from(entry['chf'] * 100)` for every entry, so the single null point threw (`null * 100`), the whole method threw, and `priceChart` stayed `[]` → the entire history (1513 valid points) was discarded and the chart rendered empty. `getPriceOfAsset` threw on the same null.

This is the same defect class as the portfolio-chart fix in #694, but in the **price** code path (`dfx_price_service.dart`), which #694 does not touch. It is more visible because it affects the wallet-less public price view.

## Fix

- `getPriceChart`: skip entries whose selected-currency price is `null` instead of throwing — the chart renders the full history minus the unpriced tail point.
- `getPriceOfAsset`: return `BigInt.zero` when the price is missing, so the UI renders `--.--` instead of throwing.
- `getChfToEurRate`: treat a missing `chf`/`eur` as `0` (already guards `chf > 0`).

## Tests

- `getPriceChart` skips a trailing null point and keeps earlier valued points.
- `getPriceOfAsset` returns zero on a missing price.
- `getChfToEurRate` returns `0.0` on a missing price.
- `flutter analyze` clean; price-service + price-chart-cubit suites green (22 tests).

## Test plan

- [ ] Open the app with no wallet while the quote endpoint omits `chf`/`eur` → price chart renders full history, header `--.--`, no empty chart.
- [ ] Normal case (all prices present) → unchanged.
- [ ] Current price endpoint without `chf`/`eur` → header `--.--`, no crash.

## Related

- Sibling fix for the portfolio chart: #694 (same null-handling defect, account endpoint).