### PR TITLE
refactor(kyc): drop unreachable KycRequired registration state

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -122,7 +122,6 @@
   "kycMergeProcessingTitle": "Konten werden zusammengeführt",
   "kycPending": "Daten werden geprüft",
   "kycPendingDescription": "Ihr folgender Schritt ist gerade noch unter Prüfung: ${step}. Bitte haben Sie noch ein wenig Geduld und schauen Sie zu einem späteren Zeitpunkt nochmal rein.",
-  "kycRequiredFailureMessage": "Bitte schliessen Sie zuerst Ihre Verifizierung ab.",
   "kycSignatureUnsupportedDescription": "Dieses Feature erfordert eine EIP-712-Signatur. Im Debug-Modus (Adresse + Signatur) ist dies technisch nicht möglich. Bitte verwenden Sie eine Software-Wallet oder BitBox, um RealUnit zu nutzen.",
   "kycSignatureUnsupportedTitle": "Signatur nicht verfügbar",
   "kycUnsupportedStepDescription": "Der aktuelle KYC-Schritt (${step}) kann in dieser App nicht abgeschlossen werden. Bitte kontaktieren Sie den Support.",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -122,7 +122,6 @@
   "kycMergeProcessingTitle": "Merging your accounts",
   "kycPending": "Data is being verified",
   "kycPendingDescription": "Your next step is currently being reviewed: ${step}. Please be patient and check back later.",
-  "kycRequiredFailureMessage": "Please complete your identity verification first.",
   "kycSignatureUnsupportedDescription": "This feature requires an EIP-712 signature. The Debug mode (address + signature) cannot produce one. Please use a Software Wallet or a BitBox to use RealUnit.",
   "kycSignatureUnsupportedTitle": "Signature not available",
   "kycUnsupportedStepDescription": "The current KYC step (${step}) cannot be completed in this app. Please contact support.",

--- a/docs/wallet-modes.md
+++ b/docs/wallet-modes.md
@@ -19,7 +19,7 @@ enum WalletType { software, bitbox, debug }
 |---|---|---|---|
 | `software` | yes (12-word seed, encrypted at rest) | signs in the background, near-zero user friction | full app — register, link wallet, trade |
 | `bitbox` | yes (on the hardware device) | requires confirmation on the connected unlocked BitBox | full app — register, link wallet, trade |
-| `debug` | no (address only, plus a stored signature attestation) | **cannot sign** — `DebugWalletAccount.signMessage` throws `UnsupportedError` | read-only browsing of a known address, plus any flow that the API accepts without a fresh signature (`AlreadyRegistered`, `KycRequired`) |
+| `debug` | no (address only, plus a stored signature attestation) | **cannot sign** — `DebugWalletAccount.signMessage` throws `UnsupportedError` | read-only browsing of a known address, plus any flow that the API accepts without a fresh signature (`AlreadyRegistered`) |
 
 ## Features that require signing
 
@@ -37,8 +37,8 @@ current wallet is `WalletType.debug` and the API has routed to either of the
 above states, the cubit emits `KycSignatureUnsupportedFailure` instead of
 `KycSuccess`, and `KycPageManager` renders `KycSignatureUnsupportedPage`.
 
-`AlreadyRegistered` and `KycRequired` do not invoke the signer, so debug-mode
-users flow through them unchanged.
+`AlreadyRegistered` does not invoke the signer, so debug-mode
+users flow through it unchanged.
 
 ## Why this gate is local
 

--- a/lib/packages/service/dfx/models/wallet/real_unit_registration_info_dto.dart
+++ b/lib/packages/service/dfx/models/wallet/real_unit_registration_info_dto.dart
@@ -6,7 +6,7 @@ class RealUnitRegistrationInfoDto {
   /// `KycCubit._runCheckKyc` — see CONTRIBUTING.md "API as Decision
   /// Authority". `userData` is populated for `addWallet` (prior payload)
   /// and `newRegistration` (KYC pre-fill); `null` for `alreadyRegistered`
-  /// (no UX needed) and `kycRequired` (edge case).
+  /// (no UX needed).
   final RealUnitRegistrationState state;
   final RealUnitUserDataDto? realUnitUserDataDto;
 

--- a/lib/packages/service/dfx/models/wallet/real_unit_registration_state.dart
+++ b/lib/packages/service/dfx/models/wallet/real_unit_registration_state.dart
@@ -13,12 +13,7 @@ enum RealUnitRegistrationState {
 
   /// No prior Aktionariat registration on this account. The app shows
   /// the full registration form, pre-filled from `userData` when present.
-  newRegistration(jsonName: 'NewRegistration'),
-
-  /// Edge case — KYC not done yet. Reachable from the wallet-status
-  /// endpoint only when something is very wrong; surfaced as
-  /// `KycUnsupportedStepFailure`.
-  kycRequired(jsonName: 'KycRequired');
+  newRegistration(jsonName: 'NewRegistration');
 
   final String jsonName;
   const RealUnitRegistrationState({required this.jsonName});

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -152,9 +152,6 @@ class KycCubit extends Cubit<KycState> {
             ),
           );
           return;
-        case RealUnitRegistrationState.kycRequired:
-          emit(const KycRequiredFailure());
-          return;
       }
 
       // Account-merge invitation is still surfaced from the step list because

--- a/lib/screens/kyc/cubits/kyc/kyc_state.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_state.dart
@@ -92,15 +92,6 @@ class KycFailure extends KycState {
   List<Object?> get props => [message];
 }
 
-/// Emitted when `getRegistrationInfo()` reports `kycRequired` — i.e. the
-/// wallet cannot be added without first completing the identity verification
-/// flow. Distinct from `KycUnsupportedStepFailure` so the user sees a
-/// tailored "complete your verification" message instead of the generic
-/// "step (-) cannot be completed" fallback.
-class KycRequiredFailure extends KycState {
-  const KycRequiredFailure();
-}
-
 /// Emitted when the wallet currently in use cannot produce EIP-712 signatures
 /// (today: the address+signature debug wallet) and the API has routed the
 /// user to a state (`NewRegistration` / `AddWallet`) that would require one.

--- a/lib/screens/kyc/kyc_page_manager.dart
+++ b/lib/screens/kyc/kyc_page_manager.dart
@@ -50,9 +50,6 @@ class KycViewManager extends StatelessWidget {
       builder: (context, state) => switch (state) {
         KycLoading() => const KycLoadingPage(),
         KycFailure(:final message) => KycFailurePage(message: message),
-        KycRequiredFailure() => KycFailurePage(
-          message: S.of(context).kycRequiredFailureMessage,
-        ),
         KycSignatureUnsupportedFailure() => const KycSignatureUnsupportedPage(),
         KycUnsupportedStepFailure(:final stepName) => KycFailurePage(
           message: S.of(context).kycUnsupportedStepDescription(stepName?.value ?? '-'),

--- a/test/packages/service/dfx/models/aggregate_dtos_test.dart
+++ b/test/packages/service/dfx/models/aggregate_dtos_test.dart
@@ -206,16 +206,6 @@ void main() {
       expect(dto.realUnitUserDataDto, isNotNull);
     });
 
-    test('parses KycRequired with null userData (edge case)', () {
-      final dto = RealUnitRegistrationInfoDto.fromJson({
-        'state': 'KycRequired',
-        'userData': null,
-      });
-
-      expect(dto.state, RealUnitRegistrationState.kycRequired);
-      expect(dto.realUnitUserDataDto, isNull);
-    });
-
     test('throws ArgumentError on unknown state', () {
       expect(
         () => RealUnitRegistrationInfoDto.fromJson({

--- a/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
+++ b/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
@@ -279,37 +279,12 @@ void main() {
       ],
     );
 
-    // `KycRequired` gets its own dedicated state so the failure page can show
-    // a tailored "complete your verification" message instead of the generic
-    // "step (-) cannot be completed" fallback.
-    blocTest<KycCubit, KycState>(
-      'emits KycRequiredFailure when wallet status reports KycRequired',
-      setUp: () {
-        when(() => kycService.getKycStatus()).thenAnswer(
-          (_) async => _kycStatus(level: KycLevel.level20),
-        );
-        when(() => kycService.getUser()).thenAnswer((_) async => _user());
-        when(() => registrationService.getRegistrationInfo()).thenAnswer(
-          (_) async => _walletStatus(RealUnitRegistrationState.kycRequired),
-        );
-      },
-      build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
-      expect: () => [
-        const KycLoading(),
-        const KycRequiredFailure(),
-      ],
-    );
-
     // Wallet-mode signing-capability gate: the address+signature debug
     // wallet cannot produce an EIP-712 signature. The cubit must surface
     // `KycSignatureUnsupportedFailure` BEFORE emitting `KycSuccess` for any
     // state that would require signing (`NewRegistration` / `AddWallet`).
-    // States that don't require signing (`AlreadyRegistered`, `KycRequired`)
-    // still flow through normally.
+    // States that don't require signing (`AlreadyRegistered`) still flow
+    // through normally.
     blocTest<KycCubit, KycState>(
       'emits KycSignatureUnsupportedFailure when debug wallet + NewRegistration',
       setUp: () {


### PR DESCRIPTION
## Summary
Backend [DFXswiss/api#3836](https://github.com/DFXswiss/api/pull/3836) drops `KycRequired` from `RealUnitRegistrationState` (YAGNI — it is no longer emitted by `GET /v1/realunit/registration`). This removes the now-unreachable consumer-side handling so the app stops carrying dead code for a state the API never sends.

## Changes
- `real_unit_registration_state.dart` — remove the `kycRequired(jsonName: 'KycRequired')` enum value.
- `kyc_cubit.dart` — remove the `case RealUnitRegistrationState.kycRequired` dispatch arm.
- `kyc_state.dart` — remove the `KycRequiredFailure` state class.
- `kyc_page_manager.dart` — remove the `KycRequiredFailure()` → `KycFailurePage` switch arm.
- `real_unit_registration_info_dto.dart` — drop the stale `kycRequired` mention from the doc comment.
- `strings_de.arb` / `strings_en.arb` — remove the unused `kycRequiredFailureMessage` key.
- `docs/wallet-modes.md` — drop the registration `KycRequired` references.
- Tests — remove the obsolete `KycRequired` parse test and the `KycRequiredFailure` cubit test.

## Note
`PaymentInfoError.kycRequired` (buy/sell) and the transaction-status `kycRequired` are unrelated concepts and remain untouched. After this change, an unexpected `state: 'KycRequired'` payload would throw `ArgumentError` (covered by the existing unknown-state test) — acceptable since the API no longer emits it.

## Test plan
- [x] `flutter analyze` — clean (only a pre-existing, unrelated generated-i18n warning present on `staging`)
- [x] `flutter test` — 2272 non-golden tests pass
- [ ] Visual Regression / goldens via CI (no golden references the removed state)