### PR TITLE
fix(android): publish releases to Open testing track (not internal)

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -45,7 +45,8 @@ end
 platform :android do
 
   def release_track
-    return "internal"
+    # Open testing ("beta"): public, link-shareable track. Internal-only uploads left the Open test on a stale build, so opt-in testers got "not found".
+    return "beta"
   end
 
   def aab_path


### PR DESCRIPTION
## Problem
`release_track` in `android/fastlane/Fastfile` was hard-pinned to `internal`, so **every release only ever reached the Internal testing track**. The Open testing track therefore never received new builds — it stayed stuck on an old version (1.0.84), and public opt-in testers (via `play.google.com/apps/testing/swiss.realunit.app`) got **"not found"** when trying to install.

## Fix
Switch the binary upload track to **`beta`** (Open testing) so each release lands in the public, link-shareable channel.

## Notes / to verify
- **Track name:** `beta` is the standard Google Play API name for the *Open testing* track. If our Open test is configured as a *custom-named* track in the Play Console, this must be set to that exact name instead — please verify before merging.
- **Trade-off:** Open testing releases go through Google review on each publish (slower than internal). If fast internal iteration is still wanted, we can additionally push to `internal` in a follow-up.
- The `store_metadata` lane stays intentionally pinned to `internal` (it only syncs listing metadata, never a binary) — left untouched.

## Context
Pairs with the Play Console fix where app availability was switched back from "Veröffentlichung aufgehoben" to **Veröffentlicht** (done manually in the Console — that part has no API). This PR ensures that, once the app is available again, the Open test keeps getting the current build automatically.
