### PR TITLE
test(realunit): cover NewRegistration with null userData (first-time empty form)

### DIFF
--- a/test/packages/service/dfx/models/aggregate_dtos_test.dart
+++ b/test/packages/service/dfx/models/aggregate_dtos_test.dart
@@ -206,6 +206,16 @@ void main() {
       expect(dto.realUnitUserDataDto, isNotNull);
     });
 
+    test('parses NewRegistration with null userData (first-time user → empty form)', () {
+      final dto = RealUnitRegistrationInfoDto.fromJson({
+        'state': 'NewRegistration',
+        'userData': null,
+      });
+
+      expect(dto.state, RealUnitRegistrationState.newRegistration);
+      expect(dto.realUnitUserDataDto, isNull);
+    });
+
     test('throws ArgumentError on unknown state', () {
       expect(
         () => RealUnitRegistrationInfoDto.fromJson({


### PR DESCRIPTION
## Summary

Follow-up coverage for the `KycRequired` → `NewRegistration` empty-form fix
(#705, consuming [api#3836](https://github.com/DFXswiss/api/pull/3836)).

#705 removed the `parses KycRequired` test but did not add a case for the
state the fix actually exists for: a first-time user gets `NewRegistration`
with **no** `userData`, and the app must render an empty form. This pins
that contract so a regression (e.g. re-introducing a non-empty expectation)
fails loudly.

## Changes

- `aggregate_dtos_test.dart` — add `parses NewRegistration with null userData
  (first-time user → empty form)`, asserting `state == newRegistration` and
  `realUnitUserDataDto == null`.

Test-only, no production code touched.
