### PR TITLE
Render merge-processing waiting state on RealUnit registration

### DIFF
--- a/lib/packages/service/dfx/models/wallet/real_unit_registration_state.dart
+++ b/lib/packages/service/dfx/models/wallet/real_unit_registration_state.dart
@@ -13,15 +13,23 @@ enum RealUnitRegistrationState {
 
   /// No prior Aktionariat registration on this account. The app shows
   /// the full registration form, pre-filled from `userData` when present.
-  newRegistration(jsonName: 'NewRegistration');
+  newRegistration(jsonName: 'NewRegistration'),
+
+  /// An account merge for this user is still propagating on the backend, so
+  /// `userData` is not yet available. The app renders a waiting state and
+  /// re-checks instead of treating the absent `userData` as a failure.
+  mergeProcessing(jsonName: 'MergeProcessing');
 
   final String jsonName;
   const RealUnitRegistrationState({required this.jsonName});
 
+  /// Unknown values fall back to [mergeProcessing] (a benign waiting state the
+  /// user can re-check) so an additively-introduced backend state never crashes
+  /// the client — mirrors the tolerant parsing of other server-mirror enums.
   factory RealUnitRegistrationState.fromJson(String value) {
     return RealUnitRegistrationState.values.firstWhere(
       (e) => e.jsonName == value,
-      orElse: () => throw ArgumentError('Unknown RealUnitRegistrationState: $value'),
+      orElse: () => RealUnitRegistrationState.mergeProcessing,
     );
   }
 }

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -152,6 +152,13 @@ class KycCubit extends Cubit<KycState> {
             ),
           );
           return;
+        case RealUnitRegistrationState.mergeProcessing:
+          // A merge for this user is still propagating, so the registration
+          // data isn't ready. Render the waiting screen and let the user
+          // re-check instead of routing into a half-populated form — same
+          // signal the KYC processStatus path surfaces below.
+          emit(const KycMergeProcessing());
+          return;
       }
 
       // Account-merge invitation is still surfaced from the step list because

--- a/lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart
+++ b/lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart
@@ -3,6 +3,7 @@ import 'dart:developer' as developer;
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_registration_state.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
 import 'package:realunit_wallet/packages/utils/jwt_decoder.dart';
 
@@ -78,12 +79,18 @@ class KycEmailVerificationCubit extends Cubit<KycEmailVerificationState> {
     try {
       final info = await _registrationService.getRegistrationInfo();
       if (isClosed || generation != _runGeneration) return false;
+      if (info.state == RealUnitRegistrationState.mergeProcessing) {
+        // The merge is confirmed (JWT account already changed) but the backend
+        // is still re-parenting the merged-in data, so `userData` isn't ready
+        // yet. This is the expected post-merge propagation window — render a
+        // waiting state (not a failure) so the user re-checks instead of seeing
+        // a scary error. The retry skips the auth-side check via `_mergeDetected`.
+        emit(const KycEmailVerificationMergeProcessing());
+        return false;
+      }
       if (info.realUnitUserDataDto == null) {
-        // Backend race: the auth service reports the merged account while the
-        // user-data service hasn't propagated yet. Surface as a recoverable
-        // failure so the user can retry by tapping the confirmation button
-        // again — by then propagation will usually have completed, and the
-        // retry path skips the auth-side check thanks to `_mergeDetected`.
+        // No merge in progress yet still no userData — a genuine failure the
+        // user should retry / report.
         developer.log(
           'getRegistrationInfo returned null realUnitUserDataDto after merge',
         );

--- a/lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_state.dart
+++ b/lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_state.dart
@@ -27,3 +27,7 @@ class KycEmailVerificationRegistrationFailure
     extends KycEmailVerificationState {
   const KycEmailVerificationRegistrationFailure();
 }
+
+class KycEmailVerificationMergeProcessing extends KycEmailVerificationState {
+  const KycEmailVerificationMergeProcessing();
+}

--- a/lib/screens/kyc/steps/email/subpages/kyc_email_verification_page.dart
+++ b/lib/screens/kyc/steps/email/subpages/kyc_email_verification_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
@@ -91,6 +92,8 @@ class KycEmailVerificationView extends StatelessWidget {
                         child: BlocBuilder<KycEmailVerificationCubit, KycEmailVerificationState>(
                           builder: (context, state) {
                             final isLoading = state is KycEmailVerificationLoading;
+                            final isMergeProcessing =
+                                state is KycEmailVerificationMergeProcessing;
                             final isBitbox = context
                                     .read<HomeBloc>()
                                     .state
@@ -100,6 +103,15 @@ class KycEmailVerificationView extends StatelessWidget {
                             return Column(
                               spacing: 12,
                               children: [
+                                if (isMergeProcessing) ...[
+                                  const CupertinoActivityIndicator(),
+                                  Text(
+                                    S.of(context).kycMergeProcessingDescription,
+                                    textAlign: TextAlign.center,
+                                    style: Theme.of(context).textTheme.bodyMedium
+                                        ?.copyWith(color: RealUnitColors.neutral500),
+                                  ),
+                                ],
                                 AppFilledButton(
                                   state: isLoading ? .loading : .idle,
                                   onPressed: () => context

--- a/test/packages/service/dfx/models/wallet/real_unit_registration_state_test.dart
+++ b/test/packages/service/dfx/models/wallet/real_unit_registration_state_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_registration_state.dart';
+
+void main() {
+  group('RealUnitRegistrationState.fromJson', () {
+    test('parses all known server values', () {
+      expect(
+        RealUnitRegistrationState.fromJson('AlreadyRegistered'),
+        RealUnitRegistrationState.alreadyRegistered,
+      );
+      expect(
+        RealUnitRegistrationState.fromJson('AddWallet'),
+        RealUnitRegistrationState.addWallet,
+      );
+      expect(
+        RealUnitRegistrationState.fromJson('NewRegistration'),
+        RealUnitRegistrationState.newRegistration,
+      );
+      expect(
+        RealUnitRegistrationState.fromJson('MergeProcessing'),
+        RealUnitRegistrationState.mergeProcessing,
+      );
+    });
+
+    test('falls back to mergeProcessing for an unknown (additively introduced) value', () {
+      // A future backend state must not crash the client — it degrades to a
+      // benign waiting state the user can re-check.
+      expect(
+        RealUnitRegistrationState.fromJson('SomethingNewFromBackend'),
+        RealUnitRegistrationState.mergeProcessing,
+      );
+    });
+  });
+}

--- a/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
+++ b/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
@@ -279,6 +279,28 @@ void main() {
       ],
     );
 
+    blocTest<KycCubit, KycState>(
+      'emits KycMergeProcessing when wallet status reports MergeProcessing',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(level: KycLevel.level20),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+        when(() => registrationService.getRegistrationInfo()).thenAnswer(
+          (_) async => _walletStatus(RealUnitRegistrationState.mergeProcessing),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        cubit.markLegalDisclaimerAccepted();
+        await cubit.checkKyc();
+      },
+      expect: () => [
+        const KycLoading(),
+        const KycMergeProcessing(),
+      ],
+    );
+
     // Wallet-mode signing-capability gate: the address+signature debug
     // wallet cannot produce an EIP-712 signature. The cubit must surface
     // `KycSignatureUnsupportedFailure` BEFORE emitting `KycSuccess` for any

--- a/test/screens/kyc/steps/email/kyc_email_verification_cubit_test.dart
+++ b/test/screens/kyc/steps/email/kyc_email_verification_cubit_test.dart
@@ -149,6 +149,32 @@ void main() {
     );
 
     blocTest<KycEmailVerificationCubit, KycEmailVerificationState>(
+      'changed account id + state=mergeProcessing → MergeProcessing, no '
+      'RegistrationFailure, no registerWallet (post-merge propagation window '
+      'renders a waiting state instead of an error)',
+      setUp: () {
+        final tokens = [_fakeJwt(1), _fakeJwt(2)];
+        var i = 0;
+        when(() => auth.getAuthToken()).thenAnswer((_) async => tokens[i++]);
+        when(() => registrationService.getRegistrationInfo()).thenAnswer(
+          (_) async => RealUnitRegistrationInfoDto(
+            state: RealUnitRegistrationState.mergeProcessing,
+            realUnitUserDataDto: null,
+          ),
+        );
+      },
+      build: build,
+      act: (c) => c.checkEmailVerification(),
+      expect: () => [
+        isA<KycEmailVerificationLoading>(),
+        isA<KycEmailVerificationMergeProcessing>(),
+      ],
+      verify: (_) {
+        verifyNever(() => registrationService.registerWallet(any()));
+      },
+    );
+
+    blocTest<KycEmailVerificationCubit, KycEmailVerificationState>(
       'registerWallet throws → RegistrationFailure, no Success '
       '(failure is surfaced so the user can retry instead of proceeding '
       'with a wallet that is not actually registered)',


### PR DESCRIPTION
## Summary
After an account merge (a new wallet signs up with an email that already belongs to an existing account), the app showed a red "Wallet registration not complete" error — even though the merge had succeeded server-side. Cause: right after the merge the registration endpoint briefly returns no `userData` (the merge is still propagating), and the app inferred a hard failure from the absent `userData`.

This consumes the new API `MergeProcessing` registration state and renders a waiting state instead of an error — aligning with "API as Decision Authority" (render the API's `state`, don't infer business meaning locally).

## Changes
- `RealUnitRegistrationState`: add `mergeProcessing` (mirror of the new API value). `fromJson` is now tolerant (unknown → `mergeProcessing`) so a future additively-introduced backend state never crashes the client — mirrors `SupportIssueState`'s tolerant parsing.
- `KycEmailVerificationCubit._completeRegistration`: when `state == mergeProcessing`, emit the new `KycEmailVerificationMergeProcessing` state (no `registerWallet`, no error). The `userData == null` branch now only fires for a genuine non-processing failure. The existing `_mergeDetected` retry path lets the user re-check; once propagation completes it proceeds to `registerWallet` → success.
- `KycEmailVerificationPage`: render a `CupertinoActivityIndicator` + `kycMergeProcessingDescription` for the new state; the confirm button stays tappable for re-check. The red error SnackBar no longer fires for the propagation window.
- `KycCubit._runCheckKyc`: handle `mergeProcessing` → emit the existing `KycMergeProcessing` waiting screen (Refresh → re-check). Keeps the registration-state switch exhaustive.
- Tests: enum `fromJson` (known values + unknown fallback), email cubit (mergeProcessing → waiting state, no registerWallet), KYC cubit (registration state mergeProcessing → KycMergeProcessing).

## Pair-PR
Backend half: **DFXswiss/api#3848** (adds `MergeProcessing` to `GET /v1/realunit/registration` when an account merge is still propagating). The API PR should land on `develop` for the new state to appear on DEV; this app PR is backwards-tolerant (unknown state → waiting) so it is safe regardless of rollout order.

## i18n
Reuses existing `kycMergeProcessing*` keys — no new keys, no arb changes.

## Test plan
- [x] `flutter analyze` (changed files) clean
- [x] `flutter test` — enum, email cubit, KYC cubit, and the email-verification golden (default state, no regression) all pass
- [ ] DEV end-to-end after API#3848 lands: trigger an account merge → during propagation the app shows the merge-processing waiting state (not the red error), then proceeds automatically once propagated