### PR TITLE
chore: bump bitbox_flutter to v0.0.8

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,8 +77,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v0.0.7"
-      resolved-ref: ebe0fb04e0fb1d56ae6fa815277598c980ac1940
+      ref: "v0.0.8"
+      resolved-ref: "7786f6e70b716287f08f4b7082762e6d7d0546bf"
       url: "https://github.com/DFXswiss/bitbox_flutter.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,7 +79,7 @@ dependencies:
   bitbox_flutter:
     git:
       url: https://github.com/DFXswiss/bitbox_flutter.git
-      ref: v0.0.7
+      ref: v0.0.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
Bumps the `bitbox_flutter` dependency from `v0.0.7` to `v0.0.8`.

`v0.0.8` contains the Android pairing-code fix (DFXswiss/bitbox_flutter#26): `initBitBox` now runs off the serial MethodChannel task queue, so the BitBox pairing code (channel hash) appears in the app and on the device **simultaneously**, instead of only after confirming on the device. iOS was already unaffected.

## Test plan
- [ ] `flutter pub get` resolves `bitbox_flutter v0.0.8`
- [ ] Android BitBox pairing: pairing code shows in-app at the same time as on the device (before on-device confirmation)
- [ ] Existing BitBox flows (connect / sign) unaffected