### PR TITLE
Delegate post-merge registration routing to the KYC flow

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -221,7 +221,6 @@
   "registerEmailVerificationButton": "Ich habe meine E-Mail bestätigt",
   "registerEmailVerificationDescription": "Wie es aussieht, haben Sie bereits ein Konto. Wir haben Ihnen gerade eine E-Mail geschickt. Um mit Ihrem bestehenden Konto fortzufahren, bestätigen Sie bitte Ihre E-Mail-Adresse, indem Sie auf den zugesandten Link klicken.",
   "registerEmailVerificationFailed": "Sie haben Ihre E-Mail noch nicht bestätigt.",
-  "registerEmailVerificationRegistrationFailed": "Die Wallet-Registrierung wurde noch nicht abgeschlossen. Bitte versuchen Sie es in wenigen Sekunden erneut. Falls das Problem weiterhin besteht, kontaktieren Sie den Support.",
   "registerEmailVerificationTitle": "Willkommen zurück!",
   "registerPhoneNumberInvalid": "Telefonnummer ist erforderlich",
   "registerPhoneNumberOnlyDigits": "Nur Zahlen sind erlaubt",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -221,7 +221,6 @@
   "registerEmailVerificationButton": "I have confirmed my email address",
   "registerEmailVerificationDescription": "It looks like you already have an account. We have just sent you an email. To continue with your existing account, please confirm your email address by clicking on the link in the email.",
   "registerEmailVerificationFailed": "You have not yet confirmed your email address.",
-  "registerEmailVerificationRegistrationFailed": "Wallet registration is not yet complete. Please try again in a few seconds. If the issue persists, contact support.",
   "registerEmailVerificationTitle": "Welcome back!",
   "registerPhoneNumberInvalid": "Phone number is required",
   "registerPhoneNumberOnlyDigits": "Only numbers are allowed",

--- a/lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart
+++ b/lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart
@@ -1,16 +1,12 @@
-import 'dart:developer' as developer;
-
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
-import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
 import 'package:realunit_wallet/packages/utils/jwt_decoder.dart';
 
 part 'kyc_email_verification_state.dart';
 
 class KycEmailVerificationCubit extends Cubit<KycEmailVerificationState> {
   final DFXAuthService _dfxService;
-  final RealUnitRegistrationService _registrationService;
 
   // `Future.timeout` does not cancel the underlying work, so a late HTTP
   // response from an earlier call can still resume after a retry. Each
@@ -21,84 +17,37 @@ class KycEmailVerificationCubit extends Cubit<KycEmailVerificationState> {
   // sequences. Pattern mirrors `KycCubit._runGeneration`.
   int _runGeneration = 0;
 
-  // Once the JWT account-id change has confirmed the merge, the auth side
-  // is settled — re-running the account-id comparison on a retry would just
-  // emit `Failure` ("email not yet confirmed") because `getAuthToken` keeps
-  // returning the new (merged) account. The remaining work that can still
-  // race is `getRegistrationInfo` propagation on the user-data side, so a
-  // retry after a `RegistrationFailure` should skip the auth-side check and
-  // go straight to `_completeRegistration`.
-  bool _mergeDetected = false;
+  KycEmailVerificationCubit({required DFXAuthService dfxService})
+    : _dfxService = dfxService,
+      super(const KycEmailVerificationInitial());
 
-  KycEmailVerificationCubit({
-    required DFXAuthService dfxService,
-    required RealUnitRegistrationService registrationService,
-  }) : _dfxService = dfxService,
-       _registrationService = registrationService,
-       super(const KycEmailVerificationInitial());
-
+  /// Confirms the account merge by detecting that the backend re-issued the JWT
+  /// for the merged (master) account. Registration is intentionally NOT done
+  /// here: once the merge is confirmed, the KYC flow (`KycCubit`) is the single
+  /// source of truth for what this wallet needs next — add wallet vs. full
+  /// registration — see CONTRIBUTING.md "API as Decision Authority". The page
+  /// pops on [KycEmailVerificationSuccess] and `KycEmailPage` re-runs `checkKyc`.
   Future<void> checkEmailVerification() async {
     final generation = ++_runGeneration;
     if (isClosed) return;
     emit(const KycEmailVerificationLoading());
 
-    if (!_mergeDetected) {
-      final currentAccountId = await getAccountId();
-      if (isClosed || generation != _runGeneration) return;
-      _dfxService.invalidateAuthToken();
-      final newAccountId = await getAccountId();
-      if (isClosed || generation != _runGeneration) return;
+    final currentAccountId = await getAccountId();
+    if (isClosed || generation != _runGeneration) return;
+    _dfxService.invalidateAuthToken();
+    final newAccountId = await getAccountId();
+    if (isClosed || generation != _runGeneration) return;
 
-      if (currentAccountId == newAccountId) {
-        // Email link not yet clicked, or token still cached. The user can
-        // retry by tapping again once the link in the confirmation mail has
-        // actually been visited.
-        emit(const KycEmailVerificationFailure());
-        return;
-      }
-      _mergeDetected = true;
+    if (currentAccountId == newAccountId) {
+      // Email link not yet clicked, or token still cached. The user can retry
+      // by tapping again once the link in the confirmation mail has been visited.
+      emit(const KycEmailVerificationFailure());
+      return;
     }
 
-    // JWT account changed → backend recognised the merge. Now associate the
-    // new wallet with the merged user via the EIP-712 registration signature.
-    if (await _completeRegistration(generation)) {
-      if (isClosed || generation != _runGeneration) return;
-      emit(const KycEmailVerificationSuccess());
-    }
-    // else: _completeRegistration already emitted RegistrationFailure; we
-    // intentionally do NOT emit Success here so the verification page stays
-    // open and the user can retry without the failure being papered over.
-  }
-
-  /// Returns `true` when the wallet was successfully registered with the
-  /// (now-merged) user account. On failure the cubit is already in
-  /// [KycEmailVerificationRegistrationFailure] so the listener can show the
-  /// error to the user.
-  Future<bool> _completeRegistration(int generation) async {
-    try {
-      final info = await _registrationService.getRegistrationInfo();
-      if (isClosed || generation != _runGeneration) return false;
-      if (info.realUnitUserDataDto == null) {
-        // Backend race: the auth service reports the merged account while the
-        // user-data service hasn't propagated yet. Surface as a recoverable
-        // failure so the user can retry by tapping the confirmation button
-        // again — by then propagation will usually have completed, and the
-        // retry path skips the auth-side check thanks to `_mergeDetected`.
-        developer.log(
-          'getRegistrationInfo returned null realUnitUserDataDto after merge',
-        );
-        emit(const KycEmailVerificationRegistrationFailure());
-        return false;
-      }
-      await _registrationService.registerWallet(info.realUnitUserDataDto!);
-      if (isClosed || generation != _runGeneration) return false;
-      return true;
-    } catch (e) {
-      if (isClosed || generation != _runGeneration) return false;
-      developer.log('registerWallet failed: $e');
-      emit(const KycEmailVerificationRegistrationFailure());
-      return false;
-    }
+    // JWT account changed → the backend recognised the merge. Hand back to the
+    // KYC flow, which routes the wallet to add-wallet or full registration.
+    emit(const KycEmailVerificationSuccess());
   }
 
   Future<int?> getAccountId() async {

--- a/lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_state.dart
+++ b/lib/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_state.dart
@@ -22,8 +22,3 @@ class KycEmailVerificationSuccess extends KycEmailVerificationState {
 class KycEmailVerificationFailure extends KycEmailVerificationState {
   const KycEmailVerificationFailure();
 }
-
-class KycEmailVerificationRegistrationFailure
-    extends KycEmailVerificationState {
-  const KycEmailVerificationRegistrationFailure();
-}

--- a/lib/screens/kyc/steps/email/kyc_email_page.dart
+++ b/lib/screens/kyc/steps/email/kyc_email_page.dart
@@ -80,12 +80,12 @@ class _KycEmailFormState extends State<KycEmailForm> {
               ),
             );
             if (isConfirmed == true && context.mounted) {
-              // A successful merge confirmation already registered this
-              // wallet via `KycEmailVerificationCubit._completeRegistration`
-              // → `RealUnitRegistrationService.registerWallet`. The next
-              // `checkKyc()` re-fetches `getRegistrationInfo`, sees
-              // `AlreadyRegistered`, and routes forward — no local sign-gate
-              // flag needed.
+              // Merge confirmed. `checkKyc()` re-fetches `getRegistrationInfo`
+              // and routes this wallet by the API `state`: AddWallet → link
+              // wallet, NewRegistration → full registration form,
+              // AlreadyRegistered → forward. The KYC flow is the single source
+              // of registration routing — see CONTRIBUTING.md "API as Decision
+              // Authority".
               context.read<KycCubit>().checkKyc();
             }
           }

--- a/lib/screens/kyc/steps/email/subpages/kyc_email_verification_page.dart
+++ b/lib/screens/kyc/steps/email/subpages/kyc_email_verification_page.dart
@@ -5,7 +5,6 @@ import 'package:go_router/go_router.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/hardware_wallet/bitbox_credentials.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
-import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
 import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
 import 'package:realunit_wallet/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart';
 import 'package:realunit_wallet/setup/di.dart';
@@ -20,7 +19,6 @@ class KycEmailVerificationPage extends StatelessWidget {
     return BlocProvider(
       create: (context) => KycEmailVerificationCubit(
         dfxService: getIt<DfxWidgetService>(),
-        registrationService: getIt<RealUnitRegistrationService>(),
       ),
       child: const KycEmailVerificationView(),
     );
@@ -38,16 +36,6 @@ class KycEmailVerificationView extends StatelessWidget {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(S.of(context).registerEmailVerificationFailed),
-              backgroundColor: RealUnitColors.status.red600,
-            ),
-          );
-        }
-        if (state is KycEmailVerificationRegistrationFailure) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                S.of(context).registerEmailVerificationRegistrationFailed,
-              ),
               backgroundColor: RealUnitColors.status.red600,
             ),
           );

--- a/test/screens/kyc/steps/email/kyc_email_verification_cubit_test.dart
+++ b/test/screens/kyc/steps/email/kyc_email_verification_cubit_test.dart
@@ -4,17 +4,9 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
-import 'package:realunit_wallet/packages/service/dfx/models/registration/registration_status.dart';
-import 'package:realunit_wallet/packages/service/dfx/models/user/dto/real_unit_user_data_dto.dart';
-import 'package:realunit_wallet/packages/service/dfx/models/registration/kyc/kyc_personal_data.dart';
-import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_registration_info_dto.dart';
-import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_registration_state.dart';
-import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
 import 'package:realunit_wallet/screens/kyc/steps/email/cubits/email_verification/kyc_email_verification_cubit.dart';
 
 class _MockAuthService extends Mock implements DFXAuthService {}
-
-class _MockRegistrationService extends Mock implements RealUnitRegistrationService {}
 
 String _fakeJwt(int accountId) {
   final header = base64Url
@@ -26,53 +18,16 @@ String _fakeJwt(int accountId) {
   return '$header.$payload.signature';
 }
 
-const _kycData = KycPersonalData(
-  accountType: KycAccountType.personal,
-  firstName: 'A',
-  lastName: 'B',
-  phone: '+41',
-  address: KycAddress(
-    street: 'S',
-    zip: '8000',
-    city: 'Zurich',
-    country: 41,
-  ),
-);
-
-const _userData = RealUnitUserDataDto(
-  email: 'a@b.com',
-  name: 'A B',
-  type: 'HUMAN',
-  phoneNumber: '+41',
-  birthday: '2000-01-01',
-  nationality: 'CH',
-  addressStreet: 'S',
-  addressPostalCode: '8000',
-  addressCity: 'Zurich',
-  addressCountry: 'CH',
-  swissTaxResidence: true,
-  lang: 'de',
-  kycData: _kycData,
-);
-
 void main() {
   late _MockAuthService auth;
-  late _MockRegistrationService registrationService;
-
-  setUpAll(() {
-    registerFallbackValue(_userData);
-  });
 
   setUp(() {
     auth = _MockAuthService();
-    registrationService = _MockRegistrationService();
     when(() => auth.invalidateAuthToken()).thenReturn(null);
   });
 
-  KycEmailVerificationCubit build() => KycEmailVerificationCubit(
-        dfxService: auth,
-        registrationService: registrationService,
-      );
+  KycEmailVerificationCubit build() =>
+      KycEmailVerificationCubit(dfxService: auth);
 
   group('initial state', () {
     test('emits $KycEmailVerificationInitial', () {
@@ -82,9 +37,10 @@ void main() {
 
   group('checkEmailVerification', () {
     blocTest<KycEmailVerificationCubit, KycEmailVerificationState>(
-      'same account id before + after invalidation → Failure',
+      'same account id before + after invalidation → Failure '
+      '(confirmation link not visited yet)',
       setUp: () {
-        // Both calls return the same token, so the same account id is parsed.
+        // Both reads return the same token, so the same account id is parsed.
         when(() => auth.getAuthToken()).thenAnswer((_) async => _fakeJwt(1));
       },
       build: build,
@@ -93,26 +49,16 @@ void main() {
         isA<KycEmailVerificationLoading>(),
         isA<KycEmailVerificationFailure>(),
       ],
-      verify: (_) {
-        verify(() => auth.invalidateAuthToken()).called(1);
-        verifyNever(() => registrationService.registerWallet(any()));
-      },
+      verify: (_) => verify(() => auth.invalidateAuthToken()).called(1),
     );
 
     blocTest<KycEmailVerificationCubit, KycEmailVerificationState>(
-      'changed account id + existing user data → registerWallet + Success',
+      'changed account id → Success (merge confirmed; the KYC flow handles '
+      'registration — nothing is registered here)',
       setUp: () {
         final tokens = [_fakeJwt(1), _fakeJwt(2)];
         var i = 0;
         when(() => auth.getAuthToken()).thenAnswer((_) async => tokens[i++]);
-        when(() => registrationService.getRegistrationInfo()).thenAnswer(
-          (_) async => RealUnitRegistrationInfoDto(
-            state: RealUnitRegistrationState.addWallet,
-            realUnitUserDataDto: _userData,
-          ),
-        );
-        when(() => registrationService.registerWallet(any()))
-            .thenAnswer((_) async => RegistrationStatus.completed);
       },
       build: build,
       act: (c) => c.checkEmailVerification(),
@@ -120,87 +66,17 @@ void main() {
         isA<KycEmailVerificationLoading>(),
         isA<KycEmailVerificationSuccess>(),
       ],
-      verify: (_) => verify(() => registrationService.registerWallet(_userData)).called(1),
     );
 
     blocTest<KycEmailVerificationCubit, KycEmailVerificationState>(
-      'changed account id but no userData → RegistrationFailure, no Success '
-      '(propagation race: user can retry by tapping the confirm button again)',
+      'retry: first tap (link not visited) → Failure, second tap (account now '
+      'changed) → Success',
       setUp: () {
-        final tokens = [_fakeJwt(1), _fakeJwt(2)];
+        // tap 1: both reads = account 1 → Failure.
+        // tap 2: account 1 → 2 → Success.
+        final tokens = [_fakeJwt(1), _fakeJwt(1), _fakeJwt(1), _fakeJwt(2)];
         var i = 0;
         when(() => auth.getAuthToken()).thenAnswer((_) async => tokens[i++]);
-        when(() => registrationService.getRegistrationInfo()).thenAnswer(
-          (_) async => RealUnitRegistrationInfoDto(
-            state: RealUnitRegistrationState.newRegistration,
-            realUnitUserDataDto: null,
-          ),
-        );
-      },
-      build: build,
-      act: (c) => c.checkEmailVerification(),
-      expect: () => [
-        isA<KycEmailVerificationLoading>(),
-        isA<KycEmailVerificationRegistrationFailure>(),
-      ],
-      verify: (_) {
-        verifyNever(() => registrationService.registerWallet(any()));
-      },
-    );
-
-    blocTest<KycEmailVerificationCubit, KycEmailVerificationState>(
-      'registerWallet throws → RegistrationFailure, no Success '
-      '(failure is surfaced so the user can retry instead of proceeding '
-      'with a wallet that is not actually registered)',
-      setUp: () {
-        final tokens = [_fakeJwt(1), _fakeJwt(2)];
-        var i = 0;
-        when(() => auth.getAuthToken()).thenAnswer((_) async => tokens[i++]);
-        when(() => registrationService.getRegistrationInfo()).thenAnswer(
-          (_) async => RealUnitRegistrationInfoDto(
-            state: RealUnitRegistrationState.addWallet,
-            realUnitUserDataDto: _userData,
-          ),
-        );
-        when(() => registrationService.registerWallet(any()))
-            .thenAnswer((_) async => throw Exception('boom'));
-      },
-      build: build,
-      act: (c) => c.checkEmailVerification(),
-      expect: () => [
-        isA<KycEmailVerificationLoading>(),
-        isA<KycEmailVerificationRegistrationFailure>(),
-      ],
-      verify: (_) => verify(() => registrationService.registerWallet(_userData)).called(1),
-    );
-
-    blocTest<KycEmailVerificationCubit, KycEmailVerificationState>(
-      'retry after null-userData race: second call skips account-id check '
-      '(propagation completed → registerWallet succeeds → Success)',
-      setUp: () {
-        // First call: account-id changes, userData not yet propagated.
-        // Second call: same account-id (already merged), userData now present.
-        // Without the `_mergeDetected` short-circuit the second call would
-        // hit the same-account-id guard and emit Failure ("email not yet
-        // confirmed") — verifying the retry path works.
-        final tokens = [_fakeJwt(1), _fakeJwt(2), _fakeJwt(2), _fakeJwt(2)];
-        var i = 0;
-        when(() => auth.getAuthToken()).thenAnswer((_) async => tokens[i++]);
-        var walletStatusCallCount = 0;
-        when(() => registrationService.getRegistrationInfo()).thenAnswer((_) async {
-          walletStatusCallCount++;
-          return walletStatusCallCount == 1
-              ? RealUnitRegistrationInfoDto(
-                  state: RealUnitRegistrationState.newRegistration,
-                  realUnitUserDataDto: null,
-                )
-              : RealUnitRegistrationInfoDto(
-                  state: RealUnitRegistrationState.addWallet,
-                  realUnitUserDataDto: _userData,
-                );
-        });
-        when(() => registrationService.registerWallet(any()))
-            .thenAnswer((_) async => RegistrationStatus.completed);
       },
       build: build,
       act: (c) async {
@@ -209,13 +85,10 @@ void main() {
       },
       expect: () => [
         isA<KycEmailVerificationLoading>(),
-        isA<KycEmailVerificationRegistrationFailure>(),
+        isA<KycEmailVerificationFailure>(),
         isA<KycEmailVerificationLoading>(),
         isA<KycEmailVerificationSuccess>(),
       ],
-      verify: (_) {
-        verify(() => registrationService.registerWallet(_userData)).called(1);
-      },
     );
   });
 

--- a/test/screens/kyc/steps/kyc_step_states_test.dart
+++ b/test/screens/kyc/steps/kyc_step_states_test.dart
@@ -27,14 +27,12 @@ void main() {
   });
 
   group('$KycEmailVerificationState', () {
-    test('all four states are distinct singletons by type', () {
+    test('all states are distinct singletons by type', () {
       expect(const KycEmailVerificationInitial(), const KycEmailVerificationInitial());
       expect(const KycEmailVerificationInitial(),
           isNot(const KycEmailVerificationLoading()));
       expect(const KycEmailVerificationSuccess(),
           isNot(const KycEmailVerificationFailure()));
-      expect(const KycEmailVerificationFailure(),
-          isNot(const KycEmailVerificationRegistrationFailure()));
     });
   });
 


### PR DESCRIPTION
## Summary
Fixes the post-account-merge "Wallet registration not complete" error (red banner) in the RealUnit app, the CONTRIBUTING-aligned way.

When a new wallet signs up with an email that already belongs to an existing **DFX** account (account merge) and that account has **no prior RealUnit registration**, `GET /v1/realunit/registration` returns `state=NewRegistration`. The email-verification step, however, called `registerWallet` (`POST /register/wallet`) **unconditionally** — that endpoint only *adds* a wallet to an **existing** registration, so the API returns `400 "No RealUnit registration found"`.

## Root cause — runtime-confirmed (PROD App Insights)
- `GET /v1/realunit/registration` → **200** (state=NewRegistration, userData present from existing KYC)
- `POST /v1/realunit/register/wallet` → **400 `{"message":"No RealUnit registration found"}`** (×4 retries)
- recovery: the user reached the KYC registration form → `POST /v1/realunit/register/complete` → **201**
- DB: the merged account had no `RealUnitRegistration` step until `register/complete` created it. 7-day breadth: 7× this 400 (affects every merge into a DFX account without a prior RealUnit registration).

## Fix (app-only) — single source of registration routing
The email-verification flow is reduced to its actual job: **confirm the merge** (detect the JWT account change) and hand back to the KYC flow. `KycCubit` is now the only place that interprets the registration `state` and routes it (addWallet → link wallet, NewRegistration → full registration form, AlreadyRegistered → forward) — per CONTRIBUTING.md "API as Decision Authority". This removes the duplicated, unconditional `register/wallet` call.

Dead code removed accordingly: `_completeRegistration`, `_mergeDetected`, the `RealUnitRegistrationService` dependency, the `KycEmailVerificationRegistrationFailure` state, and the now-unused i18n key `registerEmailVerificationRegistrationFailed` (de + en).

## Tests
- email cubit (simplified): same account → Failure (link not visited); changed account → Success (merge confirmed; no registration here); retry (Failure → Success).
- `kyc_step_states_test` updated for the removed state.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test --exclude-tags golden` — full suite passes (2312)
- [x] Coverage Floor Gate replicated locally — scoped **lines 100.0%** (floor 100)
- [ ] DEV end-to-end: merge into a DFX account without RealUnit registration → no red error → lands on the registration form → register/complete

Supersedes #711 (minimal variant) and the earlier incorrect MergeProcessing PRs DFXswiss/api#3848 + RealUnitCH/app#709.