### PR TITLE
fix(android): bump bitbox_flutter to v0.0.9 (16 KB page alignment)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,8 +77,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v0.0.8"
-      resolved-ref: "7786f6e70b716287f08f4b7082762e6d7d0546bf"
+      ref: "v0.0.9"
+      resolved-ref: "6172a2e76ccb5f45a92a37e89f92ff224e0ca4d1"
       url: "https://github.com/DFXswiss/bitbox_flutter.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,7 +79,7 @@ dependencies:
   bitbox_flutter:
     git:
       url: https://github.com/DFXswiss/bitbox_flutter.git
-      ref: v0.0.8
+      ref: v0.0.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Why

Google Play flags the app bundle: its native code is not 16 KB page aligned, so it cannot run on Android 15+ devices that use 16 KB memory pages. The only offending library was `libgojni.so` (the gomobile-built Go binding shipped by `bitbox_flutter`) — its arm64-v8a `PT_LOAD` segments were `p_align = 0x1000` (4 KB). Every other native lib in the bundle (libflutter, libapp, libsqlite3mc, libtensorflowlite_jni, …) is already ≥ 16 KB.

## What

Bump `bitbox_flutter` `v0.0.8 → v0.0.9`. v0.0.9 rebuilds the gomobile binding with `-extldflags=-Wl,-z,max-page-size=16384`, producing 16 KB-aligned `.so` libraries. See DFXswiss/bitbox_flutter#30.

`pubspec.lock` updated to the v0.0.9 commit (`6172a2e`); no other lock entries change.

## Verification

- `bitbox_flutter` v0.0.9 `jni/arm64-v8a/libgojni.so` + `x86_64`: `p_align` `0x1000` → **`0x4000`** (16 KB)
- API-safe bump: javap public signatures (146 lines) and exported dynamic symbols (284) are **byte-identical** between v0.0.8 and v0.0.9 — only ELF alignment changed, so no source-level impact
- `bitbox_flutter` PR gate green (go vet/test, dart format, analyze, flutter test)

## Test plan

- [ ] App CI green (Analyze & Test, Visual Regression, Coverage Floor Gate)
- [ ] Release build: confirm `lib/arm64-v8a/libgojni.so` reports 16 KB alignment in the final AAB and the Play Console warning clears