### PR TITLE
chore(legal): sync in-app DE privacy policy & terms to RUCH June 2026 finals

### DIFF
--- a/assets/legal/privacy_policy_de.md
+++ b/assets/legal/privacy_policy_de.md
@@ -1,6 +1,6 @@
 # Datenschutzerklärung der RealUnit Wallet App
 
-*Stand: Februar 2026*
+*Stand: Juni 2026*
 
 
 ## 1. Verantwortliche Stelle
@@ -29,7 +29,7 @@ RealUnit hat **keinen Zugriff** auf Ihre privaten Schlüssel, Ihre Wiederherstel
 
 ## 3. Erhebung und Weitergabe persönlicher Daten
 
-Für den Kauf und Verkauf von RealUnit-Aktientoken sowie die Eintragung in das Aktienbuch ist eine Registrierung erforderlich. Dabei werden folgende persönliche Daten erhoben:
+Für den Kauf und Verkauf von RealUnit Aktientoken sowie die Eintragung in das Aktienbuch ist eine Registrierung erforderlich. Dabei werden folgende persönliche Daten erhoben:
 
 - Vorname und Nachname
 - E-Mail-Adresse
@@ -42,10 +42,11 @@ Für den Kauf und Verkauf von RealUnit-Aktientoken sowie die Eintragung in das A
 Diese Daten werden an folgende Unternehmen übermittelt und von diesen verarbeitet:
 
 - **RealUnit Schweiz AG** – zur Führung des Aktienbuchs und zur Erfüllung gesetzlicher Pflichten (z.B. Meldepflichten, AIA)
-- **DFX AG** – zur Abwicklung von Kauf- und Verkaufstransaktionen sowie zur Durchführung der Identitätsprüfung (KYC)
+- **DFX AG** – zur Abwicklung von Kauf- und Verkaufstransaktionen sowie zur Durchführung der Identitätsprüfung (KYC) und zum Abgleich mit Sanktions-Embargolisten (Sanctions-Screening)
 - **Aktionariat AG** – zur technischen Unterstützung der Aktionärsregistrierung und Tokenisierung
+- **Yapeal AG** – zur Abwicklung von Ein- und Auszahlungen (Zahlungsverkehr)
 
-Die Verarbeitung erfolgt auf Grundlage Ihrer Einwilligung sowie zur Erfüllung vertraglicher und gesetzlicher Pflichten (Art. 6 DSG; Art. 6 Abs. 1 lit. a, b und c DSGVO).
+Die Bearbeitung dieser Daten ist zur Anbahnung und Erfüllung des Vertragsverhältnisses sowie zur Erfüllung gesetzlicher Pflichten (z.B. Melde- und Aufbewahrungspflichten) erforderlich; soweit wir Daten gestützt auf Ihre Einwilligung bearbeiten, können Sie diese jederzeit widerrufen. Für Nutzerinnen und Nutzer im Anwendungsbereich der DSGVO stützt sich die Verarbeitung auf Art. 6 Abs. 1 lit. a, b und c DSGVO.
 
 
 ## 4. Identitätsprüfung (KYC)
@@ -57,8 +58,10 @@ Ab bestimmten Beträgen ist eine Identitätsprüfung (Know Your Customer, KYC) e
 
 Diese Daten werden von DFX AG gemäss deren eigener Datenschutzrichtlinie verarbeitet.
 
+Die im Rahmen der Video-Identifikation erhobenen biometrischen Daten zur Gesichtserkennung sind besonders schützenswerte Personendaten (Art. 5 lit. c Ziff. 4 DSG) bzw. besondere Kategorien personenbezogener Daten (Art. 9 DSGVO). Ihre Bearbeitung erfolgt mit Ihrer ausdrücklichen Einwilligung (Art. 9 Abs. 2 lit. a DSGVO).
 
-## 5. Kommunikation mit externen Diensten
+
+## 5. Kommunikation mit externen Diensten und Bekanntgabe ins Ausland
 
 Die App kommuniziert für bestimmte Funktionen mit externen Diensten:
 
@@ -66,6 +69,8 @@ Die App kommuniziert für bestimmte Funktionen mit externen Diensten:
 - **Ethereum-Blockchain-Nodes**: Für die Übermittlung von Transaktionen und die Abfrage von Blockchain-Daten. Dabei können Ihre Wallet-Adresse und Ihre IP-Adresse an die Node-Betreiber übermittelt werden.
 
 Für die Nutzung dieser Drittanbieterdienste gelten deren jeweilige Datenschutzrichtlinien.
+
+Einzelne der genannten Empfänger oder deren Subdienstleister können personenbezogene Daten ausserhalb der Schweiz bearbeiten (z.B. Sumsub für die Identitätsprüfung, Betreiber von Blockchain-Nodes sowie App-Store-Betreiber). Erfolgt eine Bekanntgabe in einen Staat ohne angemessenes Datenschutzniveau, stellen wir geeignete Garantien sicher (insbesondere Standardvertragsklauseln) oder stützen uns auf eine gesetzliche Ausnahme (Art. 16 f. DSG; Art. 44 ff. DSGVO).
 
 
 ## 6. Blockchain-Transparenz
@@ -97,10 +102,16 @@ Sie haben jederzeit das Recht:
 - Die **Löschung** Ihrer Daten zu verlangen, soweit keine gesetzlichen Aufbewahrungspflichten entgegenstehen
 - Ihre **Einwilligung** zur Datenverarbeitung jederzeit zu widerrufen
 
+Soweit die DSGVO anwendbar ist, stehen Ihnen zudem das Recht auf Datenübertragbarkeit (Art. 20 DSGVO), das Recht auf Widerspruch (Art. 21 DSGVO) und das Recht auf Einschränkung der Bearbeitung (Art. 18 DSGVO) zu. Sie haben überdies das Recht, sich bei einer Aufsichtsbehörde zu beschweren (in der Schweiz: Eidgenössischer Datenschutz- und Öffentlichkeitsbeauftragter, EDÖB; im Anwendungsbereich der DSGVO: zuständige Datenschutzaufsichtsbehörde).
+
 Zur Ausübung dieser Rechte wenden Sie sich bitte an info@realunit.ch.
 
 
 ## 10. Schlussbestimmungen
+
+### Aufbewahrung
+
+Wir bewahren personenbezogene Daten so lange auf, wie dies für die genannten Zwecke oder aufgrund gesetzlicher Aufbewahrungspflichten erforderlich ist; danach werden sie gelöscht oder anonymisiert.
 
 ### Salvatorische Klausel
 

--- a/assets/legal/terms_of_use_de.md
+++ b/assets/legal/terms_of_use_de.md
@@ -1,18 +1,18 @@
 # Nutzungsbedingungen der RealUnit Wallet App
 
-*Stand: Februar 2026*
+*Stand: Juni 2026*
 
 
 ## 1. Geltungsbereich
 
 Diese Nutzungsbedingungen regeln die Verwendung der RealUnit Wallet App (nachfolgend «App»), herausgegeben von der RealUnit Schweiz AG, Schochenmühlestrasse 6, 6340 Baar, Schweiz (nachfolgend «RealUnit» oder «wir»).
 
-Mit der Nutzung der App erklären Sie sich mit diesen Nutzungsbedingungen einverstanden. Für den Kauf und Verkauf von RealUnit Aktien-Token gelten zusätzlich die Allgemeinen Geschäftsbedingungen (AGB).
+Mit der Nutzung der App erklären Sie sich mit diesen Nutzungsbedingungen einverstanden. Für den Kauf und Verkauf von RealUnit Aktientoken gelten zusätzlich die Allgemeinen Geschäftsbedingungen der DFX AG (nachfolgend «AGB»; abrufbar unter https://docs.dfx.swiss/de/tnc.html).
 
 
 ## 2. Beschreibung der App
 
-Die App ist eine Self-Custody-Wallet für die Verwaltung von RealUnit Aktien-Token (REALU) und weiteren ERC-20-Token auf der Ethereum-Blockchain. Sie ermöglicht insbesondere:
+Die App ist eine Self-Custody-Wallet für die Verwaltung von RealUnit Aktientoken (REALU) und weiteren ERC-20-Token auf der Ethereum-Blockchain. Sie ermöglicht insbesondere:
 
 - Erstellen und Wiederherstellen von Wallets mittels Wiederherstellungs-Wörtern (Seed Phrase)
 - Empfangen und Senden von Token
@@ -34,7 +34,7 @@ Die App ist eine Self-Custody-Lösung. Das bedeutet:
 
 ## 4. Nutzungsvoraussetzungen
 
-Die App richtet sich an Personen, die in einem Land ansässig sind, dessen Rechtsordnung die Nutzung dieser App sowie den Erwerb und Besitz von tokenisierten Aktien erlaubt. Die App richtet sich insbesondere **nicht** an Personen mit Wohnsitz in den USA, Kanada, Singapur oder China.
+Die App richtet sich an Personen, die in einem Land ansässig sind, dessen Rechtsordnung die Nutzung dieser App sowie den Erwerb und Besitz von tokenisierten Aktien erlaubt. Die App und der Erwerb der RealUnit Aktientoken richten sich ausschliesslich an Personen mit Wohnsitz in der Schweiz, im Vereinigten Königreich oder im Europäischen Wirtschaftsraum bzw. an Staatsangehörige der Schweiz, Deutschlands, Liechtensteins oder Österreichs. Das öffentliche Angebot erfolgt nur in der Schweiz, in Liechtenstein und in Deutschland. Ausgeschlossen sind insbesondere Personen mit Wohnsitz in den Vereinigten Staaten sowie in Gebieten, die einem Embargo- oder Sanktionsprogramm unterliegen; massgebend ist die im Onboarding hinterlegte Länder- und Sanktionsprüfung.
 
 Sie bestätigen, dass Sie handlungsfähig sind und das in Ihrem Land geltende Mindestalter für die Nutzung digitaler Finanzdienstleistungen erreicht haben.
 
@@ -85,7 +85,7 @@ Die App wird «wie besehen» («as is») zur Verfügung gestellt. RealUnit über
 - Schäden oder Verluste, die durch unsachgemässe Handhabung, Verlust der Wiederherstellungs-Wörter oder unbefugten Zugriff Dritter entstehen
 - Schäden oder Verluste, die durch Störungen oder Ausfälle der Ethereum-Blockchain oder anderer Netzwerke entstehen
 
-Die Haftung von RealUnit ist im gesetzlich zulässigen Rahmen ausgeschlossen, insbesondere für indirekte Schäden, Folgeschäden und entgangenen Gewinn.
+Die Haftung von RealUnit ist im gesetzlich zulässigen Rahmen ausgeschlossen, insbesondere für indirekte Schäden, Folgeschäden und entgangenen Gewinn. Unberührt bleibt die Haftung für Schäden aus rechtswidriger Absicht oder grober Fahrlässigkeit; eine solche Haftung kann nach Art. 100 Abs. 1 OR nicht zum Voraus wegbedungen werden.
 
 
 ## 10. Geistiges Eigentum
@@ -95,12 +95,14 @@ Sämtliche Rechte an der App, einschliesslich Design, Quellcode, Marken und Inha
 
 ## 11. Änderungen der Nutzungsbedingungen
 
-RealUnit behält sich vor, diese Nutzungsbedingungen jederzeit zu ändern. Geänderte Nutzungsbedingungen werden über ein App-Update bereitgestellt. Die fortgesetzte Nutzung der App nach einem Update gilt als Zustimmung zu den geänderten Nutzungsbedingungen.
+RealUnit behält sich vor, diese Nutzungsbedingungen jederzeit zu ändern. Bei wesentlichen Änderungen informieren wir Sie vorgängig in geeigneter Weise; soweit gesetzlich erforderlich, holen wir Ihre ausdrückliche Zustimmung ein.
+
+Geänderte Nutzungsbedingungen werden über ein App-Update bereitgestellt. Die fortgesetzte Nutzung der App nach einem Update gilt bei nicht wesentlichen Änderungen als Zustimmung zu den geänderten Nutzungsbedingungen.
 
 
 ## 12. Anwendbares Recht und Gerichtsstand
 
-Es gilt ausschliesslich schweizerisches Recht. Gerichtsstand ist Baar, Kanton Zug, Schweiz, soweit gesetzlich zulässig.
+Es gilt ausschliesslich schweizerisches Recht. Gerichtsstand ist Baar, Kanton Zug, Schweiz, soweit gesetzlich zulässig. Zwingende Gerichtsstände sowie zwingendes Konsumentenschutzrecht am Wohnsitz von Verbraucherinnen und Verbrauchern bleiben vorbehalten.
 
 
 ## 13. Kontakt
@@ -110,4 +112,5 @@ Schochenmühlestrasse 6\
 6340 Baar, Schweiz
 
 Telefon: +41 41 761 00 90\
+E-Mail: info@realunit.ch\
 Website: realunit.ch


### PR DESCRIPTION
## Summary

Syncs the **in-app DE legal documents** to the final versions David Lehner (RUCH Legal) circulated on **05 Jun 2026** (`260605_Datenschutzerklaerung_App_final.docx`, `260605_Nutzungsbedingungen_App_final.docx`). Pure asset content update — no code, no UI.

### Datenschutzerklärung (`privacy_policy_de.md`)
- **Yapeal AG** added as data recipient; **Sanctions-Screening** added to the DFX AG entry
- Legal basis restated (Vertrag + gesetzliche Pflichten; DSGVO Art. 6(1)); explicit consent + special-category note for **biometric KYC** data
- **Cross-border disclosure** clause (SCC / DSG Art. 16f, DSGVO Art. 44ff)
- Additional **DSGVO rights** (Art. 18/20/21) + supervisory authority (EDÖB)
- **Data-retention** clause
- `Stand: Februar 2026` → `Juni 2026`

### Nutzungsbedingungen (`terms_of_use_de.md`)
- Tightened **eligibility/geography** clause (CH/UK/EEA residents + CH/DE/LIE/AT nationals; public offer CH/LIE/DE only; OFAC/embargo exclusion via the onboarding country & sanctions check) — aligns with the AML framework
- DFX **AGB URL**; **OR Art. 100(1)** liability carve-out; material-change notice; mandatory-venue/consumer-protection reservation; contact email
- Naming unified to **RealUnit Aktientoken**

## Notes
- Handbook legal-downloads block stays in sync (titles unchanged → `assemble-handbook-legal.py` produces no diff). The PDF/DOCX downloads are rebuilt by pandoc at deploy.
- The `legal_document` golden uses an inline stub decoupled from the live asset → **no golden regeneration needed**.
- Non-golden legal tests green locally (31 passed).

## Deferred
- **EN finals** (`*_en.md`) — David supplied DE only. Left unchanged; needs the English versions from RUCH.

## Test plan
- [ ] Analyze & Test green
- [ ] Visual Regression green (no rendered change expected)
- [ ] Handbook Build Check green
- [ ] Legal reviewer (David) confirms wording matches the final docx
