### PR TITLE
feat: pass app language to receipt PDF endpoint

### DIFF
--- a/lib/packages/service/dfx/models/pdf/multi_receipt_dto.dart
+++ b/lib/packages/service/dfx/models/pdf/multi_receipt_dto.dart
@@ -1,18 +1,22 @@
 import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
 
 class MultiReceiptDto {
   final List<String> txIds;
   final Currency currency;
+  final Language? language;
 
   const MultiReceiptDto({
     required this.txIds,
     this.currency = Currency.chf,
+    this.language,
   });
 
   Map<String, dynamic> toJson() {
     return {
       'txHashes': txIds,
       'currency': currency.code,
+      if (language != null) 'language': language!.code.toUpperCase(),
     };
   }
 }

--- a/lib/packages/service/dfx/models/pdf/single_receipt_dto.dart
+++ b/lib/packages/service/dfx/models/pdf/single_receipt_dto.dart
@@ -1,18 +1,22 @@
 import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
 
 class SingleReceiptDto {
   final String txId;
   final Currency currency;
+  final Language? language;
 
   const SingleReceiptDto({
     required this.txId,
     this.currency = Currency.chf,
+    this.language,
   });
 
   Map<String, dynamic> toJson() {
     return {
       'txHash': txId,
       'currency': currency.code,
+      if (language != null) 'language': language!.code.toUpperCase(),
     };
   }
 }

--- a/lib/packages/service/dfx/real_unit_pdf_service.dart
+++ b/lib/packages/service/dfx/real_unit_pdf_service.dart
@@ -49,6 +49,7 @@ class RealUnitPdfService extends DFXAuthService {
   Future<PdfDto> getTransactionsReceipt(
     List<String> ids, {
     Currency currency = Currency.chf,
+    Language? language,
   }) async {
     final uri = buildUri(host, _transactionsReceiptMultiPath);
     final response = await authenticatedPost(
@@ -56,7 +57,7 @@ class RealUnitPdfService extends DFXAuthService {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: jsonEncode(MultiReceiptDto(txIds: ids, currency: currency)),
+      body: jsonEncode(MultiReceiptDto(txIds: ids, currency: currency, language: language)),
     );
 
     if (response.statusCode != 200 && response.statusCode != 201) {
@@ -67,14 +68,14 @@ class RealUnitPdfService extends DFXAuthService {
     return PdfDto.fromJson(jsonDecode(response.body));
   }
 
-  Future<PdfDto> getTransactionReceipt(String id, {Currency currency = Currency.chf}) async {
+  Future<PdfDto> getTransactionReceipt(String id, {Currency currency = Currency.chf, Language? language}) async {
     final uri = buildUri(host, _transactionsReceiptSinglePath);
     final response = await authenticatedPost(
       uri,
       headers: {
         'Content-Type': 'application/json',
       },
-      body: jsonEncode(SingleReceiptDto(txId: id, currency: currency)),
+      body: jsonEncode(SingleReceiptDto(txId: id, currency: currency, language: language)),
     );
 
     if (response.statusCode != 200 && response.statusCode != 201) {

--- a/lib/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit.dart
+++ b/lib/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit.dart
@@ -7,6 +7,7 @@ import 'package:realunit_wallet/packages/io/documents_directory_port.dart';
 import 'package:realunit_wallet/packages/io/path_provider_adapter.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_pdf_service.dart';
 import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
 
 part 'transaction_history_multi_receipt_state.dart';
 
@@ -21,11 +22,11 @@ class TransactionHistoryMultiReceiptCubit extends Cubit<TransactionHistoryMultiR
        _directory = directory ?? const PathProviderAdapter(),
        super(const TransactionHistoryMultiReceiptInitial());
 
-  Future<void> generateReceipt(List<String> ids, {Currency currency = Currency.chf}) async {
+  Future<void> generateReceipt(List<String> ids, {Currency currency = Currency.chf, Language? language}) async {
     try {
       emit(const TransactionHistoryMultiReceiptLoading());
 
-      final response = await _pdfService.getTransactionsReceipt(ids, currency: currency);
+      final response = await _pdfService.getTransactionsReceipt(ids, currency: currency, language: language);
       if (isClosed) return;
       final file = await _createFileFromBytes(response.pdfData);
       if (isClosed) return;

--- a/lib/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit.dart
+++ b/lib/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit.dart
@@ -7,6 +7,7 @@ import 'package:realunit_wallet/packages/io/documents_directory_port.dart';
 import 'package:realunit_wallet/packages/io/path_provider_adapter.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_pdf_service.dart';
 import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
 
 part 'transaction_history_receipt_state.dart';
 
@@ -21,11 +22,11 @@ class TransactionHistoryReceiptCubit extends Cubit<TransactionHistoryReceiptStat
        _directory = directory ?? const PathProviderAdapter(),
        super(const TransactionHistoryReceiptInitial());
 
-  Future<void> generateReceipt(String txId, {Currency currency = Currency.chf}) async {
+  Future<void> generateReceipt(String txId, {Currency currency = Currency.chf, Language? language}) async {
     try {
       emit(const TransactionHistoryReceiptLoading());
 
-      final response = await _pdfService.getTransactionReceipt(txId, currency: currency);
+      final response = await _pdfService.getTransactionReceipt(txId, currency: currency, language: language);
       if (isClosed) return;
       final file = await _createFileFromBytes(response.pdfData, txId);
       if (isClosed) return;

--- a/lib/screens/transaction_history/widgets/transaction_history_download_button.dart
+++ b/lib/screens/transaction_history/widgets/transaction_history_download_button.dart
@@ -84,6 +84,7 @@ class TransactionHistoryDownloadButtonView extends StatelessWidget {
                         context.read<TransactionHistoryMultiReceiptCubit>().generateReceipt(
                           transactionsIds,
                           currency: context.read<SettingsBloc>().state.currency,
+                          language: context.read<SettingsBloc>().state.language,
                         ),
                     child: Container(
                       height: 44,

--- a/lib/screens/transaction_history/widgets/transaction_history_row.dart
+++ b/lib/screens/transaction_history/widgets/transaction_history_row.dart
@@ -149,6 +149,7 @@ class TransactionHistoryRowView extends StatelessWidget {
                             context.read<TransactionHistoryReceiptCubit>().generateReceipt(
                               transaction.txId,
                               currency: context.read<SettingsBloc>().state.currency,
+                              language: context.read<SettingsBloc>().state.language,
                             );
                           },
                           child: const Icon(


### PR DESCRIPTION
## Summary
- Forward the current UI language from `SettingsBloc` through DTOs, service, and cubits to the receipt PDF API endpoint
- The API uses this language override to generate receipts in the user's chosen app language instead of falling back to the user profile language
- Companion to [DFXswiss/api#3865](https://github.com/DFXswiss/api/pull/3865) which adds the backend support for the `language` parameter and the enhanced RealUnit receipt layout

## Changes
- `SingleReceiptDto` / `MultiReceiptDto`: added optional `Language? language` field, serialized as uppercase code
- `RealUnitPdfService`: both `getTransactionReceipt` and `getTransactionsReceipt` accept and forward `language`
- `TransactionHistoryReceiptCubit` / `TransactionHistoryMultiReceiptCubit`: accept `language` in `generateReceipt`
- `TransactionHistoryRow` / `TransactionHistoryDownloadButton`: read `language` from `SettingsBloc` state and pass it to the cubit

## Test plan
- [x] All 47 existing transaction history tests pass
- [ ] Manual test: set app to German → download receipt → verify PDF is in German
- [ ] Manual test: set app to English → download receipt → verify PDF is in English
- [ ] Verify with API PR [#3865](https://github.com/DFXswiss/api/pull/3865) deployed