### PR TITLE
fix(kyc): alphanumerische PLZ in Adressformularen erlauben

### DIFF
--- a/lib/screens/kyc/steps/registration/steps/kyc_registration_address_step.dart
+++ b/lib/screens/kyc/steps/registration/steps/kyc_registration_address_step.dart
@@ -84,7 +84,12 @@ class KycRegistrationAddressStep extends StatelessWidget {
                         hintText: '8000',
                         controller: postalCodeCtrl,
                         label: S.of(context).postcodeAbr,
-                        keyboardType: TextInputType.number,
+                        // Postal codes are alphanumeric in many residence
+                        // countries (e.g. NL "1011 AB", UK "EC1A 1BB", CA
+                        // "K1A 0B1"). A number-only keyboard makes those
+                        // impossible to type, while the validator + backend
+                        // already accept letters and spaces.
+                        keyboardType: TextInputType.text,
                         validator: (value) {
                           if (value == null || value.isEmpty) return '';
                           if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;

--- a/lib/screens/settings_user_data/subpages/edit_address/settings_edit_address_page.dart
+++ b/lib/screens/settings_user_data/subpages/edit_address/settings_edit_address_page.dart
@@ -142,7 +142,12 @@ class _SettingsEditAddressViewState extends State<SettingsEditAddressView> {
                                         hintText: '8000',
                                         controller: _postalCodeCtrl,
                                         label: S.of(context).postcodeAbr,
-                                        keyboardType: .number,
+                                        // Postal codes are alphanumeric in many residence
+                                        // countries (e.g. NL "1011 AB", UK "EC1A 1BB", CA
+                                        // "K1A 0B1"). A number-only keyboard makes those
+                                        // impossible to type, while the validator + backend
+                                        // already accept letters and spaces.
+                                        keyboardType: .text,
                                         validator: (value) {
                                           if (value == null || value.isEmpty) return '';
                                           if (!isSwissPaymentText(value)) return S.of(context).swissPaymentTextInvalid;

--- a/test/screens/kyc/steps/kyc_registration_page_test.dart
+++ b/test/screens/kyc/steps/kyc_registration_page_test.dart
@@ -14,6 +14,7 @@ import 'package:realunit_wallet/screens/kyc/steps/registration/cubits/registrati
 import 'package:realunit_wallet/screens/kyc/steps/registration/kyc_registration_page.dart';
 import 'package:realunit_wallet/screens/kyc/steps/registration/steps/kyc_registration_address_step.dart';
 import 'package:realunit_wallet/screens/kyc/steps/registration/steps/kyc_registration_personal_step.dart';
+import 'package:realunit_wallet/widgets/form/labeled_text_field.dart';
 
 import '../../../helper/helper.dart';
 
@@ -130,6 +131,32 @@ void main() {
       await tester.pump();
 
       expect(find.byType(KycRegistrationAddressStep), findsOne);
+    });
+
+    testWidgets('postal code field uses a text keyboard for alphanumeric codes',
+        (tester) async {
+      // Regression guard: foreign postal codes are alphanumeric (NL "1011 AB",
+      // UK "EC1A 1BB"). A number-only keyboard blocked customers from entering
+      // them even though the validator + backend accept letters and spaces.
+      final state = const KycRegistrationStepState(
+        step: KycRegistrationStep.address,
+        steps: [
+          KycRegistrationStep.personal,
+          KycRegistrationStep.address,
+        ],
+      );
+      when(() => registrationStepCubit.state).thenReturn(state);
+
+      await tester.pumpApp(buildSubject(const KycRegistrationView()));
+      await tester.pump();
+
+      (tester.widget(find.byType(PageView)) as PageView).controller?.jumpToPage(state.index);
+      await tester.pump();
+
+      final postalField = tester.widget<LabeledTextField>(
+        find.byWidgetPredicate((w) => w is LabeledTextField && w.hintText == '8000'),
+      );
+      expect(postalField.keyboardType, TextInputType.text);
     });
   });
 

--- a/test/screens/settings_user_data/subpages/settings_edit_address_page_test.dart
+++ b/test/screens/settings_user_data/subpages/settings_edit_address_page_test.dart
@@ -117,6 +117,21 @@ void main() {
       expect(find.byType(CupertinoActivityIndicator), findsNothing);
     });
 
+    testWidgets('postal code field uses a text keyboard for alphanumeric codes',
+        (tester) async {
+      // Foreign postal codes are alphanumeric (NL "1011 AB", UK "EC1A 1BB").
+      // A number-only keyboard would make them impossible to type.
+      when(() => settingsEditAddressCubit.state).thenReturn(const SettingsEditAddressReady('url'));
+
+      await tester.pumpApp(buildSubject(const SettingsEditAddressView()));
+      await tester.pumpAndSettle();
+
+      final postalField = tester.widget<LabeledTextField>(
+        find.byWidgetPredicate((w) => w is LabeledTextField && w.hintText == '8000'),
+      );
+      expect(postalField.keyboardType, TextInputType.text);
+    });
+
     testWidgets('renders correctly when submitting', (tester) async {
       when(
         () => settingsEditAddressCubit.state,


### PR DESCRIPTION
## Problem
Ein Kunde konnte auf der Registration-Page seine **PLZ nicht eintragen**.

## Ursache
Das PLZ-Feld nutzte `keyboardType: TextInputType.number` → reiner Ziffernblock (auf iOS gibt es keine Buchstaben-Tasten). Bei nicht-schweizerischem Wohnsitz sind PLZ aber häufig **alphanumerisch** (🇳🇱 `1011 AB`, 🇬🇧 `EC1A 1BB`, 🇨🇦 `K1A 0B1`, 🇮🇪 `D02 AF30`) — diese ließen sich gar nicht tippen.

Der Validator `isSwissPaymentText` und der dazu passende Backend-Decorator `@IsSwissPaymentText` **akzeptieren** Buchstaben/Ziffern/Leerzeichen. Die Tastatur war also strenger als Validator **und** Backend — ein reiner UI-Affordance-Bug.

## Fix
`keyboardType` des PLZ-Felds → `TextInputType.text` an beiden Stellen:
- `kyc_registration_address_step.dart` (Registration)
- `settings_edit_address_page.dart` (Adresse ändern)

Plus Regressions-Tests, die den `keyboardType` absichern. Kein Layout-/Golden-Impact.

## CONTRIBUTING-Konformität
- **app**: `keyboardType` ist explizit "UI concern" — erlaubt. Keine Business-Logik in der App.
- **api**: Format-Autorität bleibt in der API (`Config.formats.swissPaymentText`, gespiegelt in `swiss_payment_text.dart`); keine Capability betroffen, keine API-Änderung nötig.