### PR TITLE
fix(buy): Button "Zurück zum Hauptbereich" navigiert zum Dashboard

### DIFF
--- a/lib/screens/buy/buy_payment_details_page.dart
+++ b/lib/screens/buy/buy_payment_details_page.dart
@@ -79,7 +79,7 @@ class BuyPaymentDetailsPage extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 20.0),
                   child: AppFilledButton(
-                    onPressed: () => context.goNamed(AppRoutes.home),
+                    onPressed: () => context.goNamed(AppRoutes.dashboard),
                     label: S.of(context).buyBackToMain,
                   ),
                 ),

--- a/test/screens/buy/buy_payment_details_page_test.dart
+++ b/test/screens/buy/buy_payment_details_page_test.dart
@@ -97,14 +97,14 @@ void main() {
       expect(find.text(S.current.buyBackToMain), findsOneWidget);
     });
 
-    testWidgets('back-to-main button navigates to home', (tester) async {
+    testWidgets('back-to-main button navigates to dashboard', (tester) async {
       final router = GoRouter(
         initialLocation: '/buyPaymentDetails',
         routes: [
           GoRoute(
-            name: AppRoutes.home,
-            path: '/home',
-            builder: (_, _) => const Scaffold(body: Text('HOME-AREA')),
+            name: AppRoutes.dashboard,
+            path: '/dashboard',
+            builder: (_, _) => const Scaffold(body: Text('DASHBOARD-AREA')),
           ),
           GoRoute(
             name: AppRoutes.buyPaymentDetails,
@@ -132,7 +132,7 @@ void main() {
       await tester.tap(find.text(S.current.buyBackToMain));
       await tester.pumpAndSettle();
 
-      expect(find.text('HOME-AREA'), findsOneWidget);
+      expect(find.text('DASHBOARD-AREA'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Problem
Der Button **"Zurück zum Hauptbereich"** auf der Zahlungsdetails-Seite (`buy_payment_details_page.dart`) navigierte nach `AppRoutes.home`.

`/home` ist aber **nicht** der Hauptbereich, sondern die **Nutzungsbedingungen-/Splash-Seite** (`HomePage` mit Disclaimer-Text + "Start"-Button). Laut `main.dart` `_navigate()` ist `AppRoutes.home` nur das Ziel, **solange die Software-Terms noch nicht akzeptiert sind**:
```dart
if (!homeState.softwareTermsAccepted) {
  targetRoute = AppRoutes.home;
}
```
Da `_navigate()` kein GoRouter-`redirect` ist, sondern nur bei `HomeBloc`/`PinAuthCubit`-State-Änderungen feuert, ändert ein blosser `goNamed(AppRoutes.home)` keinen State → die Weiterleitung greift nicht und der User **strandet auf der Terms-Seite**.

## Fix
Ziel korrigiert auf `AppRoutes.dashboard` — den tatsächlichen Hauptbereich (`DashboardPage`).

## Tests
- `back-to-main button navigates to dashboard` angepasst (vorher `home`).
- `flutter analyze` sauber, `flutter test test/screens/buy/buy_payment_details_page_test.dart` **grün** (6/6).