### PR TITLE
chore(l10n): remove unused `logout` string key

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -152,7 +152,6 @@
   "legalDocumentLoadFailedDescription": "Beim Laden des Dokuments ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
   "legalDocuments": "Rechtsdokumente",
   "location": "Ort",
-  "logout": "Abmelden",
   "max": "Max",
   "month": "Monat",
   "name": "Name",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -152,7 +152,6 @@
   "legalDocumentLoadFailedDescription": "Something went wrong while loading this document. Please try again.",
   "legalDocuments": "Legal documents",
   "location": "Location",
-  "logout": "Logout",
   "max": "Max",
   "month": "Month",
   "name": "Name",


### PR DESCRIPTION
## Summary
Follow-up to [#746](https://github.com/RealUnitCH/app/pull/746). That PR relabelled the Settings wallet action to **"Reset wallet" / "Wallet zurücksetzen"** and switched the confirm button to the existing `reset` key. The generic `logout` key — whose only consumer was that button — is now unreferenced.

## Change
- Remove `"logout"` from `assets/languages/strings_de.arb` ("Abmelden") and `strings_en.arb` ("Logout").

## Verification
- `S.of(context).logout` has **0 call sites** across `lib/` and `test/` (`isLogout` in `settings_page.dart` is an unrelated local bool, not the key).
- ARB stays valid; DE/EN key parity preserved (358 = 358).
- No widget renders the string, so **no goldens change** and `Visual Regression` is unaffected.

## Test plan
- [ ] `Analyze & Test` green
- [ ] `Visual Regression` green (no baseline change expected)
- [ ] `Coverage Floor Gate` green