### PR TITLE
feat(receipt): send UI language with transaction receipt requests

### DIFF
--- a/lib/packages/service/dfx/models/pdf/multi_receipt_dto.dart
+++ b/lib/packages/service/dfx/models/pdf/multi_receipt_dto.dart
@@ -1,18 +1,22 @@
 import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
 
 class MultiReceiptDto {
   final List<String> txIds;
   final Currency currency;
+  final Language language;
 
   const MultiReceiptDto({
     required this.txIds,
     this.currency = Currency.chf,
+    this.language = Language.en,
   });
 
   Map<String, dynamic> toJson() {
     return {
       'txHashes': txIds,
       'currency': currency.code,
+      'language': language.code.toUpperCase(),
     };
   }
 }

--- a/lib/packages/service/dfx/models/pdf/single_receipt_dto.dart
+++ b/lib/packages/service/dfx/models/pdf/single_receipt_dto.dart
@@ -1,18 +1,22 @@
 import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
 
 class SingleReceiptDto {
   final String txId;
   final Currency currency;
+  final Language language;
 
   const SingleReceiptDto({
     required this.txId,
     this.currency = Currency.chf,
+    this.language = Language.en,
   });
 
   Map<String, dynamic> toJson() {
     return {
       'txHash': txId,
       'currency': currency.code,
+      'language': language.code.toUpperCase(),
     };
   }
 }

--- a/lib/packages/service/dfx/real_unit_pdf_service.dart
+++ b/lib/packages/service/dfx/real_unit_pdf_service.dart
@@ -49,6 +49,7 @@ class RealUnitPdfService extends DFXAuthService {
   Future<PdfDto> getTransactionsReceipt(
     List<String> ids, {
     Currency currency = Currency.chf,
+    required Language language,
   }) async {
     final uri = buildUri(host, _transactionsReceiptMultiPath);
     final response = await authenticatedPost(
@@ -56,7 +57,7 @@ class RealUnitPdfService extends DFXAuthService {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: jsonEncode(MultiReceiptDto(txIds: ids, currency: currency)),
+      body: jsonEncode(MultiReceiptDto(txIds: ids, currency: currency, language: language)),
     );
 
     if (response.statusCode != 200 && response.statusCode != 201) {
@@ -67,14 +68,18 @@ class RealUnitPdfService extends DFXAuthService {
     return PdfDto.fromJson(jsonDecode(response.body));
   }
 
-  Future<PdfDto> getTransactionReceipt(String id, {Currency currency = Currency.chf}) async {
+  Future<PdfDto> getTransactionReceipt(
+    String id, {
+    Currency currency = Currency.chf,
+    required Language language,
+  }) async {
     final uri = buildUri(host, _transactionsReceiptSinglePath);
     final response = await authenticatedPost(
       uri,
       headers: {
         'Content-Type': 'application/json',
       },
-      body: jsonEncode(SingleReceiptDto(txId: id, currency: currency)),
+      body: jsonEncode(SingleReceiptDto(txId: id, currency: currency, language: language)),
     );
 
     if (response.statusCode != 200 && response.statusCode != 201) {

--- a/lib/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit.dart
+++ b/lib/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit.dart
@@ -22,11 +22,19 @@ class TransactionHistoryMultiReceiptCubit extends Cubit<TransactionHistoryMultiR
        _directory = directory ?? const PathProviderAdapter(),
        super(const TransactionHistoryMultiReceiptInitial());
 
-  Future<void> generateReceipt(List<String> ids, {Currency currency = Currency.chf, required Language language}) async {
+  Future<void> generateReceipt(
+    List<String> ids, {
+    Currency currency = Currency.chf,
+    required Language language,
+  }) async {
     try {
       emit(const TransactionHistoryMultiReceiptLoading());
 
-      final response = await _pdfService.getTransactionsReceipt(ids, currency: currency, language: language);
+      final response = await _pdfService.getTransactionsReceipt(
+        ids,
+        currency: currency,
+        language: language,
+      );
       if (isClosed) return;
       final file = await _createFileFromBytes(response.pdfData);
       if (isClosed) return;

--- a/lib/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit.dart
+++ b/lib/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit.dart
@@ -7,6 +7,7 @@ import 'package:realunit_wallet/packages/io/documents_directory_port.dart';
 import 'package:realunit_wallet/packages/io/path_provider_adapter.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_pdf_service.dart';
 import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
 
 part 'transaction_history_multi_receipt_state.dart';
 
@@ -21,11 +22,11 @@ class TransactionHistoryMultiReceiptCubit extends Cubit<TransactionHistoryMultiR
        _directory = directory ?? const PathProviderAdapter(),
        super(const TransactionHistoryMultiReceiptInitial());
 
-  Future<void> generateReceipt(List<String> ids, {Currency currency = Currency.chf}) async {
+  Future<void> generateReceipt(List<String> ids, {Currency currency = Currency.chf, required Language language}) async {
     try {
       emit(const TransactionHistoryMultiReceiptLoading());
 
-      final response = await _pdfService.getTransactionsReceipt(ids, currency: currency);
+      final response = await _pdfService.getTransactionsReceipt(ids, currency: currency, language: language);
       if (isClosed) return;
       final file = await _createFileFromBytes(response.pdfData);
       if (isClosed) return;

--- a/lib/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit.dart
+++ b/lib/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit.dart
@@ -22,11 +22,19 @@ class TransactionHistoryReceiptCubit extends Cubit<TransactionHistoryReceiptStat
        _directory = directory ?? const PathProviderAdapter(),
        super(const TransactionHistoryReceiptInitial());
 
-  Future<void> generateReceipt(String txId, {Currency currency = Currency.chf, required Language language}) async {
+  Future<void> generateReceipt(
+    String txId, {
+    Currency currency = Currency.chf,
+    required Language language,
+  }) async {
     try {
       emit(const TransactionHistoryReceiptLoading());
 
-      final response = await _pdfService.getTransactionReceipt(txId, currency: currency, language: language);
+      final response = await _pdfService.getTransactionReceipt(
+        txId,
+        currency: currency,
+        language: language,
+      );
       if (isClosed) return;
       final file = await _createFileFromBytes(response.pdfData, txId);
       if (isClosed) return;

--- a/lib/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit.dart
+++ b/lib/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit.dart
@@ -7,6 +7,7 @@ import 'package:realunit_wallet/packages/io/documents_directory_port.dart';
 import 'package:realunit_wallet/packages/io/path_provider_adapter.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_pdf_service.dart';
 import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
 
 part 'transaction_history_receipt_state.dart';
 
@@ -21,11 +22,11 @@ class TransactionHistoryReceiptCubit extends Cubit<TransactionHistoryReceiptStat
        _directory = directory ?? const PathProviderAdapter(),
        super(const TransactionHistoryReceiptInitial());
 
-  Future<void> generateReceipt(String txId, {Currency currency = Currency.chf}) async {
+  Future<void> generateReceipt(String txId, {Currency currency = Currency.chf, required Language language}) async {
     try {
       emit(const TransactionHistoryReceiptLoading());
 
-      final response = await _pdfService.getTransactionReceipt(txId, currency: currency);
+      final response = await _pdfService.getTransactionReceipt(txId, currency: currency, language: language);
       if (isClosed) return;
       final file = await _createFileFromBytes(response.pdfData, txId);
       if (isClosed) return;

--- a/lib/screens/transaction_history/widgets/transaction_history_download_button.dart
+++ b/lib/screens/transaction_history/widgets/transaction_history_download_button.dart
@@ -84,6 +84,7 @@ class TransactionHistoryDownloadButtonView extends StatelessWidget {
                         context.read<TransactionHistoryMultiReceiptCubit>().generateReceipt(
                           transactionsIds,
                           currency: context.read<SettingsBloc>().state.currency,
+                          language: context.read<SettingsBloc>().state.language,
                         ),
                     child: Container(
                       height: 44,

--- a/lib/screens/transaction_history/widgets/transaction_history_row.dart
+++ b/lib/screens/transaction_history/widgets/transaction_history_row.dart
@@ -149,6 +149,7 @@ class TransactionHistoryRowView extends StatelessWidget {
                             context.read<TransactionHistoryReceiptCubit>().generateReceipt(
                               transaction.txId,
                               currency: context.read<SettingsBloc>().state.currency,
+                              language: context.read<SettingsBloc>().state.language,
                             );
                           },
                           child: const Icon(

--- a/test/packages/service/dfx/models/pdf_support_bank_test.dart
+++ b/test/packages/service/dfx/models/pdf_support_bank_test.dart
@@ -15,10 +15,10 @@ import 'package:realunit_wallet/styles/language.dart';
 
 void main() {
   group('$MultiReceiptDto.toJson', () {
-    test('defaults currency to CHF and renames txIds → txHashes', () {
+    test('defaults currency to CHF and language to EN, renames txIds → txHashes', () {
       const dto = MultiReceiptDto(txIds: ['a', 'b']);
 
-      expect(dto.toJson(), {'txHashes': ['a', 'b'], 'currency': 'CHF'});
+      expect(dto.toJson(), {'txHashes': ['a', 'b'], 'currency': 'CHF', 'language': 'EN'});
     });
 
     test('honours a custom currency', () {
@@ -26,19 +26,31 @@ void main() {
 
       expect(dto.toJson()['currency'], 'EUR');
     });
+
+    test('honours a language override and uppercases the code', () {
+      const dto = MultiReceiptDto(txIds: ['x'], language: Language.de);
+
+      expect(dto.toJson()['language'], 'DE');
+    });
   });
 
   group('$SingleReceiptDto.toJson', () {
-    test('defaults currency to CHF and renames txId → txHash', () {
+    test('defaults currency to CHF and language to EN, renames txId → txHash', () {
       const dto = SingleReceiptDto(txId: '0xabc');
 
-      expect(dto.toJson(), {'txHash': '0xabc', 'currency': 'CHF'});
+      expect(dto.toJson(), {'txHash': '0xabc', 'currency': 'CHF', 'language': 'EN'});
     });
 
     test('honours a custom currency', () {
       const dto = SingleReceiptDto(txId: '0xabc', currency: Currency.eur);
 
       expect(dto.toJson()['currency'], 'EUR');
+    });
+
+    test('honours a language override and uppercases the code', () {
+      const dto = SingleReceiptDto(txId: '0xabc', language: Language.de);
+
+      expect(dto.toJson()['language'], 'DE');
     });
   });
 

--- a/test/packages/service/dfx/real_unit_pdf_service_test.dart
+++ b/test/packages/service/dfx/real_unit_pdf_service_test.dart
@@ -119,12 +119,15 @@ void main() {
         final pdf = await build(client).getTransactionsReceipt(
           ['0xa', '0xb', '0xc'],
           currency: Currency.eur,
+          language: Language.de,
         );
 
         expect(pdf.pdfData, 'MULTI');
         expect(path, '/v1/realunit/transactions/receipt/multi');
         expect(body!['txHashes'], ['0xa', '0xb', '0xc']);
         expect(body!['currency'], 'EUR');
+        // Language is uppercased on the wire.
+        expect(body!['language'], 'DE');
       });
 
       test('defaults currency to CHF when not specified', () async {
@@ -134,7 +137,7 @@ void main() {
           return http.Response(jsonEncode({'pdfData': 'X'}), 200);
         });
 
-        await build(client).getTransactionsReceipt(['0x1']);
+        await build(client).getTransactionsReceipt(['0x1'], language: Language.en);
 
         expect(body!['currency'], 'CHF');
       });
@@ -146,7 +149,7 @@ void main() {
             ));
 
         expect(
-          () => build(client).getTransactionsReceipt(['0x1']),
+          () => build(client).getTransactionsReceipt(['0x1'], language: Language.en),
           throwsA(isA<ApiException>()),
         );
       });
@@ -165,12 +168,15 @@ void main() {
         final pdf = await build(client).getTransactionReceipt(
           '0xabc',
           currency: Currency.eur,
+          language: Language.de,
         );
 
         expect(pdf.pdfData, 'SINGLE');
         expect(path, '/v1/realunit/transactions/receipt/single');
         expect(body!['txHash'], '0xabc');
         expect(body!['currency'], 'EUR');
+        // Language is uppercased on the wire.
+        expect(body!['language'], 'DE');
       });
 
       test('defaults currency to CHF when not specified', () async {
@@ -180,7 +186,7 @@ void main() {
           return http.Response(jsonEncode({'pdfData': 'X'}), 200);
         });
 
-        await build(client).getTransactionReceipt('0xabc');
+        await build(client).getTransactionReceipt('0xabc', language: Language.en);
 
         expect(body!['currency'], 'CHF');
       });
@@ -192,7 +198,7 @@ void main() {
             ));
 
         expect(
-          () => build(client).getTransactionReceipt('0xmissing'),
+          () => build(client).getTransactionReceipt('0xmissing', language: Language.en),
           throwsA(isA<ApiException>()),
         );
       });

--- a/test/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit_test.dart
+++ b/test/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit_test.dart
@@ -9,6 +9,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/pdf/pdf_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_pdf_service.dart';
 import 'package:realunit_wallet/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit.dart';
 import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
 
 class _MockPdfService extends Mock implements RealUnitPdfService {}
 
@@ -38,6 +39,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(Currency.chf);
+    registerFallbackValue(Language.en);
   });
 
   setUp(() {
@@ -67,7 +69,7 @@ void main() {
     test('generateReceipt writes the PDF and emits Success with the file path', () async {
       final pdfBytes = utf8.encode('%PDF-1.4 fake-multi');
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(pdfBytes)));
 
       final cubit = buildCubit();
@@ -79,7 +81,7 @@ void main() {
         ]),
       );
 
-      await cubit.generateReceipt(['tx-1', 'tx-2'], currency: Currency.eur);
+      await cubit.generateReceipt(['tx-1', 'tx-2'], currency: Currency.eur, language: Language.de);
       await emissions;
 
       expect(cubit.state, isA<TransactionHistoryMultiReceiptSuccess>());
@@ -89,28 +91,30 @@ void main() {
       expect(File(success.receiptPath).readAsBytesSync(), pdfBytes);
       expect(directoryPort.calls, 1);
       verify(
-        () => service.getTransactionsReceipt(['tx-1', 'tx-2'], currency: Currency.eur),
+        () => service.getTransactionsReceipt(['tx-1', 'tx-2'], currency: Currency.eur, language: Language.de),
       ).called(1);
     });
 
     test('generateReceipt uses Currency.chf as default', () async {
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(<int>[1])));
 
       final cubit = buildCubit();
-      await cubit.generateReceipt(['tx-1']);
+      await cubit.generateReceipt(['tx-1'], language: Language.en);
 
-      verify(() => service.getTransactionsReceipt(['tx-1'], currency: Currency.chf)).called(1);
+      verify(
+        () => service.getTransactionsReceipt(['tx-1'], currency: Currency.chf, language: Language.en),
+      ).called(1);
     });
 
     test('generateReceipt emits Failure on service error', () async {
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) async => throw Exception('network'));
 
       final cubit = buildCubit();
-      await cubit.generateReceipt(['tx-1', 'tx-2']);
+      await cubit.generateReceipt(['tx-1', 'tx-2'], language: Language.en);
 
       expect(cubit.state, isA<TransactionHistoryMultiReceiptFailure>());
       final failure = cubit.state as TransactionHistoryMultiReceiptFailure;
@@ -122,11 +126,11 @@ void main() {
       final brokenPort = _FakeDocumentsDirectoryPort(missing);
 
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(<int>[1])));
 
       final cubit = TransactionHistoryMultiReceiptCubit(service, directory: brokenPort);
-      await cubit.generateReceipt(['tx-1']);
+      await cubit.generateReceipt(['tx-1'], language: Language.en);
 
       expect(cubit.state, isA<TransactionHistoryMultiReceiptFailure>());
     });
@@ -134,11 +138,11 @@ void main() {
     test('does not emit Success when closed during service call', () async {
       final completer = Completer<PdfDto>();
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) => completer.future);
 
       final cubit = buildCubit();
-      unawaited(cubit.generateReceipt(['tx-1']));
+      unawaited(cubit.generateReceipt(['tx-1'], language: Language.en));
       await cubit.close();
       completer.complete(PdfDto(pdfData: base64Encode(<int>[1])));
     });
@@ -146,11 +150,11 @@ void main() {
     test('does not emit Failure after close', () async {
       final completer = Completer<PdfDto>();
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) => completer.future);
 
       final cubit = buildCubit();
-      unawaited(cubit.generateReceipt(['tx-1']));
+      unawaited(cubit.generateReceipt(['tx-1'], language: Language.en));
       await cubit.close();
       completer.completeError(Exception('late'));
     });

--- a/test/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit_test.dart
+++ b/test/screens/transaction_history/cubits/multi_receipt/transaction_history_multi_receipt_cubit_test.dart
@@ -69,7 +69,11 @@ void main() {
     test('generateReceipt writes the PDF and emits Success with the file path', () async {
       final pdfBytes = utf8.encode('%PDF-1.4 fake-multi');
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionsReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(pdfBytes)));
 
       final cubit = buildCubit();
@@ -91,26 +95,42 @@ void main() {
       expect(File(success.receiptPath).readAsBytesSync(), pdfBytes);
       expect(directoryPort.calls, 1);
       verify(
-        () => service.getTransactionsReceipt(['tx-1', 'tx-2'], currency: Currency.eur, language: Language.de),
+        () => service.getTransactionsReceipt(
+          ['tx-1', 'tx-2'],
+          currency: Currency.eur,
+          language: Language.de,
+        ),
       ).called(1);
     });
 
     test('generateReceipt uses Currency.chf as default', () async {
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionsReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(<int>[1])));
 
       final cubit = buildCubit();
       await cubit.generateReceipt(['tx-1'], language: Language.en);
 
       verify(
-        () => service.getTransactionsReceipt(['tx-1'], currency: Currency.chf, language: Language.en),
+        () => service.getTransactionsReceipt(
+          ['tx-1'],
+          currency: Currency.chf,
+          language: Language.en,
+        ),
       ).called(1);
     });
 
     test('generateReceipt emits Failure on service error', () async {
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionsReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) async => throw Exception('network'));
 
       final cubit = buildCubit();
@@ -126,7 +146,11 @@ void main() {
       final brokenPort = _FakeDocumentsDirectoryPort(missing);
 
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionsReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(<int>[1])));
 
       final cubit = TransactionHistoryMultiReceiptCubit(service, directory: brokenPort);
@@ -138,7 +162,11 @@ void main() {
     test('does not emit Success when closed during service call', () async {
       final completer = Completer<PdfDto>();
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionsReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) => completer.future);
 
       final cubit = buildCubit();
@@ -150,7 +178,11 @@ void main() {
     test('does not emit Failure after close', () async {
       final completer = Completer<PdfDto>();
       when(
-        () => service.getTransactionsReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionsReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) => completer.future);
 
       final cubit = buildCubit();

--- a/test/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit_test.dart
+++ b/test/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit_test.dart
@@ -69,7 +69,11 @@ void main() {
     test('generateReceipt writes the PDF and emits Success with the file path', () async {
       final pdfBytes = utf8.encode('%PDF-1.4 fake-tx');
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(pdfBytes)));
 
       final cubit = buildCubit();
@@ -97,7 +101,11 @@ void main() {
 
     test('generateReceipt uses Currency.chf as default', () async {
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(<int>[1])));
 
       final cubit = buildCubit();
@@ -110,7 +118,11 @@ void main() {
 
     test('generateReceipt emits Failure on service error', () async {
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) async => throw Exception('network'));
 
       final cubit = buildCubit();
@@ -126,7 +138,11 @@ void main() {
       final brokenPort = _FakeDocumentsDirectoryPort(missing);
 
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(<int>[1])));
 
       final cubit = TransactionHistoryReceiptCubit(service, directory: brokenPort);
@@ -138,7 +154,11 @@ void main() {
     test('does not emit Success when closed during service call', () async {
       final completer = Completer<PdfDto>();
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) => completer.future);
 
       final cubit = buildCubit();
@@ -152,7 +172,11 @@ void main() {
     test('does not emit Failure after close', () async {
       final completer = Completer<PdfDto>();
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
+        () => service.getTransactionReceipt(
+          any(),
+          currency: any(named: 'currency'),
+          language: any(named: 'language'),
+        ),
       ).thenAnswer((_) => completer.future);
 
       final cubit = buildCubit();

--- a/test/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit_test.dart
+++ b/test/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit_test.dart
@@ -9,6 +9,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/pdf/pdf_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_pdf_service.dart';
 import 'package:realunit_wallet/screens/transaction_history/cubits/receipt/transaction_history_receipt_cubit.dart';
 import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/styles/language.dart';
 
 class _MockPdfService extends Mock implements RealUnitPdfService {}
 
@@ -38,6 +39,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(Currency.chf);
+    registerFallbackValue(Language.en);
   });
 
   setUp(() {
@@ -67,7 +69,7 @@ void main() {
     test('generateReceipt writes the PDF and emits Success with the file path', () async {
       final pdfBytes = utf8.encode('%PDF-1.4 fake-tx');
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(pdfBytes)));
 
       final cubit = buildCubit();
@@ -79,7 +81,7 @@ void main() {
         ]),
       );
 
-      await cubit.generateReceipt('tx-42', currency: Currency.eur);
+      await cubit.generateReceipt('tx-42', currency: Currency.eur, language: Language.de);
       await emissions;
 
       expect(cubit.state, isA<TransactionHistoryReceiptSuccess>());
@@ -88,27 +90,31 @@ void main() {
       expect(File(success.receiptPath).existsSync(), isTrue);
       expect(File(success.receiptPath).readAsBytesSync(), pdfBytes);
       expect(directoryPort.calls, 1);
-      verify(() => service.getTransactionReceipt('tx-42', currency: Currency.eur)).called(1);
+      verify(
+        () => service.getTransactionReceipt('tx-42', currency: Currency.eur, language: Language.de),
+      ).called(1);
     });
 
     test('generateReceipt uses Currency.chf as default', () async {
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(<int>[1])));
 
       final cubit = buildCubit();
-      await cubit.generateReceipt('tx-1');
+      await cubit.generateReceipt('tx-1', language: Language.en);
 
-      verify(() => service.getTransactionReceipt('tx-1', currency: Currency.chf)).called(1);
+      verify(
+        () => service.getTransactionReceipt('tx-1', currency: Currency.chf, language: Language.en),
+      ).called(1);
     });
 
     test('generateReceipt emits Failure on service error', () async {
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) async => throw Exception('network'));
 
       final cubit = buildCubit();
-      await cubit.generateReceipt('tx-1');
+      await cubit.generateReceipt('tx-1', language: Language.en);
 
       expect(cubit.state, isA<TransactionHistoryReceiptFailure>());
       final failure = cubit.state as TransactionHistoryReceiptFailure;
@@ -120,11 +126,11 @@ void main() {
       final brokenPort = _FakeDocumentsDirectoryPort(missing);
 
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) async => PdfDto(pdfData: base64Encode(<int>[1])));
 
       final cubit = TransactionHistoryReceiptCubit(service, directory: brokenPort);
-      await cubit.generateReceipt('tx-1');
+      await cubit.generateReceipt('tx-1', language: Language.en);
 
       expect(cubit.state, isA<TransactionHistoryReceiptFailure>());
     });
@@ -132,11 +138,11 @@ void main() {
     test('does not emit Success when closed during service call', () async {
       final completer = Completer<PdfDto>();
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) => completer.future);
 
       final cubit = buildCubit();
-      unawaited(cubit.generateReceipt('tx-1'));
+      unawaited(cubit.generateReceipt('tx-1', language: Language.en));
       await cubit.close();
       completer.complete(PdfDto(pdfData: base64Encode(<int>[1])));
 
@@ -146,11 +152,11 @@ void main() {
     test('does not emit Failure after close', () async {
       final completer = Completer<PdfDto>();
       when(
-        () => service.getTransactionReceipt(any(), currency: any(named: 'currency')),
+        () => service.getTransactionReceipt(any(), currency: any(named: 'currency'), language: any(named: 'language')),
       ).thenAnswer((_) => completer.future);
 
       final cubit = buildCubit();
-      unawaited(cubit.generateReceipt('tx-1'));
+      unawaited(cubit.generateReceipt('tx-1', language: Language.en));
       await cubit.close();
       completer.completeError(Exception('late'));
     });


### PR DESCRIPTION
## Summary

Transaction receipt PDFs (single + multi) are rendered by the DFX API, which derives the locale from the account language and falls back to EN. RealUnit CH accounts often sit on EN, so German-app users received English receipts.

This sends the current app UI language (`SettingsBloc.state.language`) as the `language` field on both receipt requests, mirroring the existing balance-report flow (`BalancePdfDto`).

## Changes
- `SingleReceiptDto` / `MultiReceiptDto`: add `language` field, serialized as uppercase code (`DE`/`EN`)
- `RealUnitPdfService.getTransactionReceipt` / `getTransactionsReceipt`: add required `language` parameter
- Receipt cubits: thread `language` through `generateReceipt`
- Transaction-history widgets: pass `SettingsBloc.state.language`
- Tests updated accordingly

## Depends on
Requires the API-side change DFXswiss/api#3865, which adds the `language` parameter to the receipt endpoints. Until that ships the field is simply ignored (no harm).

## Test plan
- [ ] `flutter analyze` + `flutter test` green (CI)
- [ ] Single + multi receipt with app language DE renders a German PDF
- [ ] App language EN renders English