### PR TITLE
docs(handbook): add transaction-receipt examples section

### DIFF
--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -214,6 +214,44 @@ jobs:
           ls -la docs/handbook/mails/ | head -40
           echo "Generated $(ls docs/handbook/mails/*.html | wc -l | tr -d ' ') mail preview files"
 
+      - name: Stage RealUnit receipt examples from api repo
+        env:
+          API_DIR: _api-checkout
+          # The api repo commits four example receipt PDFs under
+          # docs/examples/realunit-receipt/: transaction-{confirmation,history}-{de,en}.pdf.
+          # `-ne` below fails the build on ANY drift (add OR remove) so a change to
+          # the committed set upstream requires an explicit bump here in the SAME
+          # PR — same guard rationale as EXPECTED_HTML_COUNT above.
+          EXPECTED_PDF_COUNT: 4
+        run: |
+          set -euo pipefail
+
+          # Unlike the mail previews, these PDFs are already committed in the api
+          # repo (rendered from SwissQRService by the api-side spec
+          # realunit-receipt-example.spec.ts), so no generator / npm run is needed
+          # here — we only copy them into the build context. Reuses the same
+          # _api-checkout/ from the mail step above.
+          SRC_DIR="${API_DIR}/docs/examples/realunit-receipt"
+          if [ ! -d "${SRC_DIR}" ]; then
+            echo "::error::${SRC_DIR} not found in the api checkout — the committed example receipts are missing upstream (DFXswiss/api docs/examples/realunit-receipt/)."
+            exit 1
+          fi
+
+          PDF_COUNT=$(ls "${SRC_DIR}"/*.pdf 2>/dev/null | wc -l | tr -d ' ')
+          if [ "${PDF_COUNT}" -ne "${EXPECTED_PDF_COUNT}" ]; then
+            echo "::error::Expected exactly ${EXPECTED_PDF_COUNT} receipt PDFs in ${SRC_DIR}, got ${PDF_COUNT}. If this drift is intentional (example added/removed upstream), update EXPECTED_PDF_COUNT in this workflow in the same PR."
+            exit 1
+          fi
+
+          # Fresh staging dir (defensive, mirrors the mail step) so a stale PDF
+          # from a previous local run cannot survive into the build context.
+          rm -rf docs/handbook/receipts
+          mkdir -p docs/handbook/receipts
+          cp "${SRC_DIR}"/*.pdf docs/handbook/receipts/
+
+          ls -la docs/handbook/receipts/ | head -20
+          echo "Staged $(ls docs/handbook/receipts/*.pdf | wc -l | tr -d ' ') receipt example PDFs"
+
       # Cleanup runs even when the generator step above (or any other step
       # between staging and `docker build`) fails. Without `if: always()`, a
       # crash mid-pipeline would leave _api-checkout/ + _handlebars-only/

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,12 @@ app.*.map.json
 # from api repo"). Never commit; source of truth is the api repo.
 docs/handbook/mails/
 
+# Staged at handbook build time from DFXswiss/api's committed example receipts
+# (see .github/workflows/handbook.yaml — step "Stage RealUnit receipt examples
+# from api repo"). Never commit; source of truth is the api repo
+# (docs/examples/realunit-receipt/, rendered by SwissQRService).
+docs/handbook/receipts/
+
 # Assembled at handbook build time from test/goldens/screens/ via
 # scripts/assemble-handbook-screenshots.sh (see Dockerfile.handbook).
 # Source of truth are the Golden baselines under test/goldens/; this

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -172,6 +172,35 @@ rm -rf ./_handlebars-only
 (Den finalen Build-Step macht aber immer der CI — lokale Files sind nur fürs
 Vorab-Anschauen während eines Template-Refactors.)
 
+## Transaktionsbelege
+
+Die Sektion **B — Transaktionsbelege** verlinkt vier Muster-PDFs, die das
+Backend erzeugt (Transaktionshistorie + Transaktionsbestätigung, je DE/EN).
+Anders als die Mail-Previews werden diese PDFs **nicht** hier generiert — sie
+liegen bereits committet im api-Repo unter `docs/examples/realunit-receipt/`
+(gerendert vom `SwissQRService` via `realunit-receipt-example.spec.ts`) und
+werden beim Handbook-Build nur ins Image kopiert (Step "Stage RealUnit receipt
+examples from api repo" in `handbook.yaml`; Zielverzeichnis
+`docs/handbook/receipts/` ist gitignored). Single Source of Truth ist das
+api-Repo.
+
+Kommt upstream ein Beispiel hinzu oder weg, failt der Build am
+`EXPECTED_PDF_COUNT`-Guard — dann die Zahl in `handbook.yaml` und die
+Download-Karten in `docs/handbook/de/index.html` (`#spec-receipts`) im selben
+Zug anpassen.
+
+### Lokal ansehen
+
+```bash
+# PDFs aus einem lokalen api-Checkout ins (gitignored) receipts-Dir kopieren
+mkdir -p docs/handbook/receipts
+cp <api-checkout>/docs/examples/realunit-receipt/*.pdf docs/handbook/receipts/
+open docs/handbook/de/index.html   # Sektion "B — Transaktionsbelege"
+```
+
+Zum Regenerieren der Muster-PDFs selbst siehe das api-Repo
+(`GENERATE_RECEIPT_EXAMPLES=true npx jest realunit-receipt-example`).
+
 ## Beziehung zu den Tier-0/Tier-1-Tests
 
 Tier 0/1 (Unit + Widget + integration-mit-FakeBitboxCredentials) prüfen

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -823,6 +823,9 @@
               <a href="#spec-mails"><span class="spec-num">M</span>E-Mails</a>
             </li>
             <li>
+              <a href="#spec-receipts"><span class="spec-num">B</span>Transaktionsbelege</a>
+            </li>
+            <li>
               <a href="#spec-store-listing"><span class="spec-num">S</span>Store-Listing</a>
             </li>
             <li>
@@ -2435,6 +2438,89 @@
             manueller <code>workflow_dispatch</code> auf
             <code>handbook-deploy.yaml</code> im realunit-app-Repo) reingezogen.
           </p>
+        </details>
+
+        <details id="spec-receipts" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">B</span>Transaktionsbelege</h2>
+                <div class="file">DFXswiss/api · docs/examples/realunit-receipt/</div>
+              </div>
+              <div class="rhs">
+                <b>Live aus api-Repo</b>
+                <div class="links">
+                  <a href="../receipts/">Ordner öffnen ↗</a>
+                </div>
+              </div>
+            </div>
+          </summary>
+
+          <p class="spec-intro">
+            Beispiel-Belege, die das Backend als PDF erzeugt: die
+            <b>Transaktionshistorie</b> (Sammelbeleg über mehrere Transaktionen,
+            per Klick auf „Transaktionshistorie") und die
+            <b>Transaktionsbestätigung</b> (Einzelbeleg für eine Transaktion). Der
+            Renderer lebt im
+            <a href="https://github.com/DFXswiss/api">DFXswiss/api</a>-Repo
+            (<code>src/subdomains/supporting/payment/services/swiss-qr.service.ts</code>);
+            die verlinkten Muster-PDFs liegen dort als
+            <code>docs/examples/realunit-receipt/*.pdf</code> und werden bei jedem
+            Handbook-Build automatisch ins Image gezogen — Single Source of Truth
+            ist das api-Repo, dieses Handbook spiegelt nur den aktuellen Stand.
+          </p>
+
+          <h3>Transaktionshistorie <a class="src" href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-receipt" title="Quelle: docs/examples/realunit-receipt/">↗</a></h3>
+          <div class="tests cols-2">
+            <div class="test legal-doc" id="receipt-history-de">
+              <div class="head">
+                <a class="name permalink" href="#receipt-history-de">transaction_history_de</a>
+                <button class="copy-link" type="button" data-target="receipt-history-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">de</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Transaktionshistorie (Sammelbeleg)</span>
+                <a class="dl-btn" href="../receipts/transaction-history-de.pdf" download>PDF</a>
+              </div>
+            </div>
+            <div class="test legal-doc" id="receipt-history-en">
+              <div class="head">
+                <a class="name permalink" href="#receipt-history-en">transaction_history_en</a>
+                <button class="copy-link" type="button" data-target="receipt-history-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">en</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Transaction History</span>
+                <a class="dl-btn" href="../receipts/transaction-history-en.pdf" download>PDF</a>
+              </div>
+            </div>
+          </div>
+
+          <h3>Transaktionsbestätigung <a class="src" href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-receipt" title="Quelle: docs/examples/realunit-receipt/">↗</a></h3>
+          <div class="tests cols-2">
+            <div class="test legal-doc" id="receipt-confirmation-de">
+              <div class="head">
+                <a class="name permalink" href="#receipt-confirmation-de">transaction_confirmation_de</a>
+                <button class="copy-link" type="button" data-target="receipt-confirmation-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">de</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Transaktionsbestätigung (Einzelbeleg)</span>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-de.pdf" download>PDF</a>
+              </div>
+            </div>
+            <div class="test legal-doc" id="receipt-confirmation-en">
+              <div class="head">
+                <a class="name permalink" href="#receipt-confirmation-en">transaction_confirmation_en</a>
+                <button class="copy-link" type="button" data-target="receipt-confirmation-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">en</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Transaction Confirmation</span>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-en.pdf" download>PDF</a>
+              </div>
+            </div>
+          </div>
         </details>
 
         <!-- BEGIN:store-listing -->

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2450,7 +2450,7 @@
               <div class="rhs">
                 <b>Live aus api-Repo</b>
                 <div class="links">
-                  <a href="../receipts/">Ordner öffnen ↗</a>
+                  <a href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-receipt">im api-Repo ↗</a>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary

Adds a **Transaktionsbelege** section (`spec-receipts`, TOC letter **B**) to the handbook, linking the four example receipt PDFs that `DFXswiss/api` commits under `docs/examples/realunit-receipt/` (transaction history + confirmation, DE/EN).

## Mechanism

Mirrors the existing **RealUnit mail previews** pattern: a build-time step stages the PDFs from the api checkout into the gitignored `docs/handbook/receipts/`. Since the PDFs are already committed in api (rendered by `SwissQRService`), no generator run is needed — just a `cp` + an `EXPECTED_PDF_COUNT` drift guard. The HTML reuses the **legal-downloads** card pattern (PDF download buttons); the section sits in the derived-export block right after `spec-mails` and is outside every sync-gated block.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/handbook.yaml` | new "Stage RealUnit receipt examples from api repo" step (reuses the existing api checkout) |
| `docs/handbook/de/index.html` | new `spec-receipts` section + TOC entry |
| `.gitignore` | `docs/handbook/receipts/` (build-time, like `mails/`) |
| `docs/handbook/README.md` | "Transaktionsbelege" doc section |

## Verification

Reproduced the deploy path in Docker: api checkout (`develop`) → `cp` → nginx serve of `docs/handbook/` → `curl` confirms the PDFs serve as `200 application/pdf` and the section + 4 download links render.