### PR TITLE
fix(kyc): guard birthday parsing against non yyyy-MM-dd values

### DIFF
--- a/lib/widgets/form/birthday_field.dart
+++ b/lib/widgets/form/birthday_field.dart
@@ -29,9 +29,11 @@ class _BirthdayFieldState extends State<BirthdayField> {
     final value = widget.controller.value;
     if (value != null) {
       final parts = value.split('-');
-      selectedYear = parts[0];
-      selectedMonth = parts[1];
-      selectedDay = parts[2];
+      if (parts.length == 3) {
+        selectedYear = parts[0];
+        selectedMonth = parts[1];
+        selectedDay = parts[2];
+      }
     }
   }
 

--- a/test/widgets/form/birthday_field_test.dart
+++ b/test/widgets/form/birthday_field_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/widgets/form/birthday_field.dart';
+import 'package:realunit_wallet/widgets/form/dropdown_field.dart';
+
+import '../../helper/pump_app.dart';
+
+Widget _host(Widget child) => Scaffold(
+  body: SingleChildScrollView(
+    child: Padding(padding: const EdgeInsets.all(16), child: child),
+  ),
+);
+
+void main() {
+  group('$BirthdayField', () {
+    testWidgets('renders three dropdowns for an unset birthday', (tester) async {
+      await tester.pumpApp(
+        _host(BirthdayField(controller: ValueNotifier<String?>(null))),
+      );
+
+      expect(find.byType(DropdownField<String>), findsNWidgets(3));
+    });
+
+    testWidgets('seeds day/month/year from a "yyyy-MM-dd" birthday', (tester) async {
+      final year = '${DateTime.now().year - 30}';
+      await tester.pumpApp(
+        _host(BirthdayField(controller: ValueNotifier<String?>('$year-05-15'))),
+      );
+
+      expect(find.text(year), findsOneWidget);
+      expect(find.text('05'), findsOneWidget);
+      expect(find.text('15'), findsOneWidget);
+    });
+
+    testWidgets('does not throw when the birthday has no separators', (tester) async {
+      // The backend can return a present-but-empty birthday (""), whose
+      // `split('-')` yields a single element. Reading `parts[1]`/`parts[2]`
+      // used to throw RangeError during initState and blank the screen.
+      await tester.pumpApp(
+        _host(BirthdayField(controller: ValueNotifier<String?>(''))),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(DropdownField<String>), findsNWidgets(3));
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Opening the **Personal data** step of KYC registration crashes to the generic error view ("Something went wrong. Please restart the app.") for some accounts.

Root cause is in `BirthdayField.initState`, which seeds the day/month/year dropdowns from the backend `birthday` string:

```dart
final parts = value.split('-');
selectedYear  = parts[0];
selectedMonth = parts[1];   // RangeError when parts.length < 3
selectedDay   = parts[2];
```

When the backend returns a present-but-empty birthday (`""`), `"".split('-')` yields a single element, so `parts[1]` throws `RangeError (length): Only valid value is 0: 1` during `initState`. The uncaught error is caught by `ErrorWidget.builder` and replaces the whole screen. It reproduces in both debug and release (a real exception, not an `assert`).

Stack:
```
#0  List.[]
#1  _BirthdayFieldState.initState (birthday_field.dart:33)
#2  StatefulElement._firstBuild
```

## Fix

Only assign the dropdowns when the value splits into exactly three parts; otherwise leave them unset for the user to fill in.

## Test

`test/widgets/form/birthday_field_test.dart` (testWidgets, `pumpApp` helper):
- renders three dropdowns for an unset birthday
- seeds day/month/year from a `yyyy-MM-dd` birthday
- does not throw when the birthday has no separators (fails with `RangeError` without this fix)

`flutter analyze` clean; form-field test group green.