### PR TITLE
fix: handle residual birthday edge cases after #752

### DIFF
--- a/lib/packages/service/dfx/models/user/user_data.dart
+++ b/lib/packages/service/dfx/models/user/user_data.dart
@@ -7,7 +7,7 @@ class UserData extends Equatable {
   final String email;
   final String name;
   final String phoneNumber;
-  final DateTime birthday;
+  final DateTime? birthday;
   final Country nationality;
   final String addressStreet;
   final String addressPostalCode;

--- a/lib/screens/settings_user_data/cubit/settings_user_data_cubit.dart
+++ b/lib/screens/settings_user_data/cubit/settings_user_data_cubit.dart
@@ -78,7 +78,8 @@ class SettingsUserDataCubit extends Cubit<SettingsUserDataState> {
             type: RegistrationUserType.fromName(userDataDto.type),
             name: userDataDto.name,
             email: userDataDto.email,
-            birthday: DateTime.parse(userDataDto.birthday),
+            // The API returns '' when no birthday is on record.
+            birthday: DateTime.tryParse(userDataDto.birthday),
             nationality: nationalityCountry,
             addressStreet: userDataDto.addressStreet,
             addressCity: userDataDto.addressCity,

--- a/lib/screens/settings_user_data/settings_user_data_page.dart
+++ b/lib/screens/settings_user_data/settings_user_data_page.dart
@@ -44,7 +44,12 @@ class SettingsUserDataView extends StatelessWidget {
         padding: const .symmetric(horizontal: 20.0, vertical: 12.0),
         child: BlocBuilder<SettingsUserDataCubit, SettingsUserDataState>(
           builder: (context, state) => switch (state) {
-            SettingsUserDataSuccess(:final userData, :final email, :final pendingSteps, :final capabilities) =>
+            SettingsUserDataSuccess(
+              :final userData,
+              :final email,
+              :final pendingSteps,
+              :final capabilities,
+            ) =>
               userData != null
                   ? SingleChildScrollView(
                       child: Padding(
@@ -75,10 +80,11 @@ class SettingsUserDataView extends StatelessWidget {
                                       }
                                     : null,
                               ),
-                              _UserDataRow(
-                                label: S.of(context).birthday,
-                                value: DateFormat('dd.MM.yyyy').format(userData.birthday),
-                              ),
+                              if (userData.birthday != null)
+                                _UserDataRow(
+                                  label: S.of(context).birthday,
+                                  value: DateFormat('dd.MM.yyyy').format(userData.birthday!),
+                                ),
                               _UserDataRow(
                                 label: S.of(context).registerCitizenship,
                                 value: userData.nationality.name,

--- a/lib/widgets/form/birthday_field.dart
+++ b/lib/widgets/form/birthday_field.dart
@@ -30,9 +30,11 @@ class _BirthdayFieldState extends State<BirthdayField> {
     if (value != null) {
       final parts = value.split('-');
       if (parts.length == 3) {
-        selectedYear = parts[0];
-        selectedMonth = parts[1];
-        selectedDay = parts[2];
+        // Only seed values the dropdowns actually offer; a value outside the
+        // item list trips DropdownButtonFormField's single-match assert.
+        if (years.contains(parts[0])) selectedYear = parts[0];
+        if (months.contains(parts[1])) selectedMonth = parts[1];
+        if (days.contains(parts[2])) selectedDay = parts[2];
       }
     }
   }
@@ -42,6 +44,18 @@ class _BirthdayFieldState extends State<BirthdayField> {
       final value = '$selectedYear-$selectedMonth-$selectedDay';
       widget.controller.value = value;
     }
+  }
+
+  // False for impossible combinations like 31.02.: DateTime rolls the
+  // overflow into the next month.
+  bool get isValidCalendarDate {
+    if (selectedDay == null || selectedMonth == null || selectedYear == null) return true;
+    final date = DateTime(
+      int.parse(selectedYear!),
+      int.parse(selectedMonth!),
+      int.parse(selectedDay!),
+    );
+    return date.month == int.parse(selectedMonth!);
   }
 
   @override
@@ -76,7 +90,7 @@ class _BirthdayFieldState extends State<BirthdayField> {
                   setState(() => selectedDay = v);
                   updateBirthday();
                 },
-                validator: (v) => v == null ? '' : null,
+                validator: (v) => v == null || !isValidCalendarDate ? '' : null,
               ),
             ),
             Expanded(

--- a/test/screens/settings_user_data/settings_user_data_cubit_test.dart
+++ b/test/screens/settings_user_data/settings_user_data_cubit_test.dart
@@ -53,12 +53,13 @@ const _kycData = KycPersonalData(
 RealUnitUserDataDto _userData({
   String nationality = 'CH',
   String addressCountry = 'CH',
+  String birthday = '1990-01-15',
 }) => RealUnitUserDataDto(
   email: 'a@b.com',
   name: 'Test User',
   type: 'HUMAN',
   phoneNumber: '+41790000000',
-  birthday: '1990-01-15',
+  birthday: birthday,
   nationality: nationality,
   addressStreet: 'Teststrasse 1',
   addressPostalCode: '8000',
@@ -130,6 +131,34 @@ void main() {
       expect(success.userData!.addressCountry, _de);
       expect(success.pendingSteps, isEmpty);
       expect(success.capabilities.canEditName, isTrue);
+    });
+
+    test('Success with unset birthday when the API returns an empty birthday', () async {
+      // The API maps a missing birthday to '' for verified-name accounts;
+      // parsing it used to throw and surface the failure view.
+      when(() => registrationService.getRegistrationInfo()).thenAnswer(
+        (_) async => RealUnitRegistrationInfoDto(
+          state: RealUnitRegistrationState.addWallet,
+          realUnitUserDataDto: _userData(birthday: ''),
+        ),
+      );
+      when(() => kycService.getKycStatus()).thenAnswer(
+        (_) async => const KycLevelDto(kycLevel: KycLevel.level20, kycSteps: []),
+      );
+      when(() => kycService.getUser()).thenAnswer(
+        (_) async => const UserDto(
+          mail: 'a@b.com',
+          kyc: UserKycDto(hash: 'h', level: KycLevel.level20, dataComplete: true),
+        ),
+      );
+      when(() => countryService.getCountryBySymbol(any())).thenAnswer((_) async => _ch);
+
+      final cubit = build();
+      await cubit.stream.firstWhere((s) => s is SettingsUserDataSuccess);
+
+      final success = cubit.state as SettingsUserDataSuccess;
+      expect(success.userData, isNotNull);
+      expect(success.userData!.birthday, isNull);
     });
 
     test('Success surfaces pending change steps that are inReview', () async {

--- a/test/screens/settings_user_data/settings_user_data_page_test.dart
+++ b/test/screens/settings_user_data/settings_user_data_page_test.dart
@@ -120,6 +120,42 @@ void main() {
       );
     });
 
+    testWidgets('hides the birthday row when no birthday is on record', (tester) async {
+      const userData = UserData(
+        email: 'test-direct@dfx.swiss',
+        name: 'Test Direct',
+        type: RegistrationUserType.human,
+        phoneNumber: '+41791234567',
+        birthday: null,
+        nationality: Country(
+          id: 41,
+          symbol: 'CH',
+          name: 'Switzerland',
+          kycAllowed: true,
+        ),
+        addressStreet: 'Teststrasse',
+        addressPostalCode: '8000',
+        addressCity: 'Zurich',
+        addressCountry: Country(
+          id: 41,
+          symbol: 'CH',
+          name: 'Switzerland',
+          kycAllowed: true,
+        ),
+        swissTaxResidence: true,
+        lang: 'DE',
+      );
+
+      when(() => settingsUserDataCubit.state).thenReturn(
+        const SettingsUserDataSuccess(userData: userData),
+      );
+
+      await tester.pumpApp(buildSubject(const SettingsUserDataView()));
+
+      expect(find.text(S.current.birthday), findsNothing);
+      expect(find.text('Test Direct'), findsOne);
+    });
+
     testWidgets('renders correctly when user data was not found', (tester) async {
       when(() => settingsUserDataCubit.state).thenReturn(
         const SettingsUserDataSuccess(),

--- a/test/widgets/form/birthday_field_test.dart
+++ b/test/widgets/form/birthday_field_test.dart
@@ -32,6 +32,52 @@ void main() {
       expect(find.text('15'), findsOneWidget);
     });
 
+    testWidgets('seeds only the parts the dropdowns offer for an out-of-range year', (
+      tester,
+    ) async {
+      // The API accepts birthdays outside the 18-99 range of the year
+      // dropdown. Seeding an unoffered year trips DropdownButtonFormField's
+      // "exactly one item with value" assert and blanks the screen.
+      await tester.pumpApp(
+        _host(BirthdayField(controller: ValueNotifier<String?>('1920-05-15'))),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('05'), findsOneWidget);
+      expect(find.text('15'), findsOneWidget);
+      expect(find.text('1920'), findsNothing);
+    });
+
+    testWidgets('validate() fails for an impossible calendar date', (tester) async {
+      final formKey = GlobalKey<FormState>();
+      final year = '${DateTime.now().year - 30}';
+      await tester.pumpApp(
+        _host(
+          Form(
+            key: formKey,
+            child: BirthdayField(controller: ValueNotifier<String?>('$year-02-31')),
+          ),
+        ),
+      );
+
+      expect(formKey.currentState!.validate(), isFalse);
+    });
+
+    testWidgets('validate() passes for a valid calendar date', (tester) async {
+      final formKey = GlobalKey<FormState>();
+      final year = '${DateTime.now().year - 30}';
+      await tester.pumpApp(
+        _host(
+          Form(
+            key: formKey,
+            child: BirthdayField(controller: ValueNotifier<String?>('$year-02-28')),
+          ),
+        ),
+      );
+
+      expect(formKey.currentState!.validate(), isTrue);
+    });
+
     testWidgets('does not throw when the birthday has no separators', (tester) async {
       // The backend can return a present-but-empty birthday (""), whose
       // `split('-')` yields a single element. Reading `parts[1]`/`parts[2]`


### PR DESCRIPTION
Closes #755 — picks up the three follow-ups from the #752 review, in the issue's order.

## 1. Settings user data screen no longer fails on an empty birthday

`SettingsUserDataCubit` parsed the birthday unconditionally, so the API's present-but-empty value (`''`, returned for verified-name accounts with no birthday on record) threw `FormatException` and the whole screen fell into the failure view. `UserData.birthday` is now nullable, the cubit uses `DateTime.tryParse`, and the page hides the birthday row when no birthday is on record — every other field renders normally.

## 2. BirthdayField only seeds values the dropdowns offer

The #752 guard checked shape (`parts.length == 3`) but not membership: a well-formed but out-of-range value like `1920-05-15` (the API accepts dates outside the year dropdown's 18–99 span) seeded `selectedYear` with a value absent from the items, tripping `DropdownButtonFormField`'s "exactly one item with value" assert in debug — the same blank-screen symptom #752 fixed. Each part is now seeded only if the respective item list contains it; unoffered parts fall back to the hint for the user to pick.

The years range itself is left as is — widening it to the API's 140-year contract (and thereby dropping the implicit 18+ constraint) looks like a product decision rather than a bug fix.

## 3. Impossible calendar dates fail client-side

`updateBirthday()` joined day/month/year without calendar validation, so 31.02. survived `validate()` and the signing ceremony, only to fail server-side as a generic registration-failed snackbar. The day dropdown's validator now rejects combinations that don't exist on the calendar (detected via `DateTime` overflow normalization), marking the field red at "Next" — before signing.

Given the per-dropdown validators gate the personal step, an unset or malformed birthday can no longer reach `_onSubmit`, so the `birthdayCtrl.value ?? ''` path from the issue's last bullet is now unreachable in practice and was left untouched.

## Tests

- `settings_user_data_cubit_test.dart`: empty birthday → `Success` with `birthday == null` (was: failure view).
- `settings_user_data_page_test.dart`: birthday row hidden when no birthday is on record.
- `birthday_field_test.dart`: out-of-range year seeds only day/month without throwing; `validate()` fails for `-02-31` and passes for `-02-28`. Both new widget tests verified to fail against the pre-fix widget.

`flutter analyze` clean, full suite (2396 tests, goldens excluded) green on Flutter 3.41.6.