### PR TITLE
docs(legal): update privacy policy and terms of use to June 2026

### DIFF
--- a/assets/legal/privacy_policy_de.md
+++ b/assets/legal/privacy_policy_de.md
@@ -1,6 +1,6 @@
 # Datenschutzerklärung der RealUnit Wallet App
 
-*Stand: Februar 2026*
+*Stand: Juni 2026*
 
 
 ## 1. Verantwortliche Stelle
@@ -29,7 +29,7 @@ RealUnit hat **keinen Zugriff** auf Ihre privaten Schlüssel, Ihre Wiederherstel
 
 ## 3. Erhebung und Weitergabe persönlicher Daten
 
-Für den Kauf und Verkauf von RealUnit-Aktientoken sowie die Eintragung in das Aktienbuch ist eine Registrierung erforderlich. Dabei werden folgende persönliche Daten erhoben:
+Für den Kauf und Verkauf von RealUnit Aktientoken sowie die Eintragung in das Aktienbuch ist eine Registrierung erforderlich. Dabei werden folgende persönliche Daten erhoben:
 
 - Vorname und Nachname
 - E-Mail-Adresse
@@ -42,10 +42,11 @@ Für den Kauf und Verkauf von RealUnit-Aktientoken sowie die Eintragung in das A
 Diese Daten werden an folgende Unternehmen übermittelt und von diesen verarbeitet:
 
 - **RealUnit Schweiz AG** – zur Führung des Aktienbuchs und zur Erfüllung gesetzlicher Pflichten (z.B. Meldepflichten, AIA)
-- **DFX AG** – zur Abwicklung von Kauf- und Verkaufstransaktionen sowie zur Durchführung der Identitätsprüfung (KYC)
+- **DFX AG** – zur Abwicklung von Kauf- und Verkaufstransaktionen sowie zur Durchführung der Identitätsprüfung (KYC) und zum Abgleich mit Sanktions-Embargolisten (Sanctions-Screening)
 - **Aktionariat AG** – zur technischen Unterstützung der Aktionärsregistrierung und Tokenisierung
+- **Yapeal AG** – zur Abwicklung von Ein- und Auszahlungen (Zahlungsverkehr)
 
-Die Verarbeitung erfolgt auf Grundlage Ihrer Einwilligung sowie zur Erfüllung vertraglicher und gesetzlicher Pflichten (Art. 6 DSG; Art. 6 Abs. 1 lit. a, b und c DSGVO).
+Die Bearbeitung dieser Daten ist zur Anbahnung und Erfüllung des Vertragsverhältnisses sowie zur Erfüllung gesetzlicher Pflichten (z.B. Melde- und Aufbewahrungspflichten) erforderlich; soweit wir Daten gestützt auf Ihre Einwilligung bearbeiten, können Sie diese jederzeit widerrufen. Für Nutzerinnen und Nutzer im Anwendungsbereich der DSGVO stützt sich die Verarbeitung auf Art. 6 Abs. 1 lit. a, b und c DSGVO.
 
 
 ## 4. Identitätsprüfung (KYC)
@@ -57,15 +58,17 @@ Ab bestimmten Beträgen ist eine Identitätsprüfung (Know Your Customer, KYC) e
 
 Diese Daten werden von DFX AG gemäss deren eigener Datenschutzrichtlinie verarbeitet.
 
+Die im Rahmen der Video-Identifikation erhobenen biometrischen Daten zur Gesichtserkennung sind besonders schützenswerte Personendaten (Art. 5 lit. c Ziff. 4 DSG) bzw. besondere Kategorien personenbezogener Daten (Art. 9 DSGVO). Ihre Bearbeitung erfolgt mit Ihrer ausdrücklichen Einwilligung (Art. 9 Abs. 2 lit. a DSGVO).
 
-## 5. Kommunikation mit externen Diensten
 
-Die App kommuniziert für bestimmte Funktionen mit externen Diensten:
+## 5. Kommunikation mit externen Diensten und Bekanntgabe ins Ausland
 
 - **DFX AG**: Für Kursabfragen, Guthabenabfragen, Kauf-/Verkaufs- und Registrierungsfunktionen. Dabei werden Ihre Wallet-Adresse und ggf. personenbezogene Daten übermittelt.
 - **Ethereum-Blockchain-Nodes**: Für die Übermittlung von Transaktionen und die Abfrage von Blockchain-Daten. Dabei können Ihre Wallet-Adresse und Ihre IP-Adresse an die Node-Betreiber übermittelt werden.
 
 Für die Nutzung dieser Drittanbieterdienste gelten deren jeweilige Datenschutzrichtlinien.
+
+Einzelne der genannten Empfänger oder deren Subdienstleister können personenbezogene Daten ausserhalb der Schweiz bearbeiten (z.B. Sumsub für die Identitätsprüfung, Betreiber von Blockchain-Nodes sowie App-Store-Betreiber). Erfolgt eine Bekanntgabe in einen Staat ohne angemessenes Datenschutzniveau, stellen wir geeignete Garantien sicher (insbesondere Standardvertragsklauseln) oder stützen uns auf eine gesetzliche Ausnahme (Art. 16 f. DSG; Art. 44 ff. DSGVO).
 
 
 ## 6. Blockchain-Transparenz
@@ -74,8 +77,6 @@ Sämtliche Transaktionen auf der Ethereum-Blockchain sind **öffentlich einsehba
 
 
 ## 7. Geräteberechtigungen
-
-Die App kann folgende Geräteberechtigungen anfordern:
 
 - **Kamera**: Zum Scannen von QR-Codes (z.B. für Wallet-Adressen oder Zahlungsanforderungen)
 - **Biometrische Sensoren**: Für Face ID oder Fingerabdruck-Entsperrung (optional)
@@ -97,10 +98,16 @@ Sie haben jederzeit das Recht:
 - Die **Löschung** Ihrer Daten zu verlangen, soweit keine gesetzlichen Aufbewahrungspflichten entgegenstehen
 - Ihre **Einwilligung** zur Datenverarbeitung jederzeit zu widerrufen
 
+Soweit die DSGVO anwendbar ist, stehen Ihnen zudem das Recht auf Datenübertragbarkeit (Art. 20 DSGVO), das Recht auf Widerspruch (Art. 21 DSGVO) und das Recht auf Einschränkung der Bearbeitung (Art. 18 DSGVO) zu. Sie haben überdies das Recht, sich bei einer Aufsichtsbehörde zu beschweren (in der Schweiz: Eidgenössischer Datenschutz- und Öffentlichkeitsbeauftragter, EDÖB; im Anwendungsbereich der DSGVO: zuständige Datenschutzaufsichtsbehörde).
+
 Zur Ausübung dieser Rechte wenden Sie sich bitte an info@realunit.ch.
 
 
 ## 10. Schlussbestimmungen
+
+### Aufbewahrung
+
+Wir bewahren personenbezogene Daten so lange auf, wie dies für die genannten Zwecke oder aufgrund gesetzlicher Aufbewahrungspflichten erforderlich ist; danach werden sie gelöscht oder anonymisiert.
 
 ### Salvatorische Klausel
 

--- a/assets/legal/privacy_policy_en.md
+++ b/assets/legal/privacy_policy_en.md
@@ -1,6 +1,6 @@
 # Privacy Policy of the RealUnit Wallet App
 
-*As of: February 2026*
+*As of: June 2026*
 
 
 ## 1. Responsible Entity
@@ -42,10 +42,11 @@ Registration is required for the purchase and sale of RealUnit share tokens and 
 This data is transmitted to and processed by the following companies:
 
 - **RealUnit Schweiz AG** – for maintaining the share register and fulfilling legal obligations (e.g. reporting obligations, AEOI)
-- **DFX AG** – for processing buy and sell transactions and conducting identity verification (KYC)
+- **DFX AG** – for processing buy and sell transactions and conducting identity verification (KYC) and for screening against sanctions/embargo lists (sanctions screening)
 - **Aktionariat AG** – for technical support of shareholder registration and tokenization
+- **Yapeal AG** – for processing deposits and withdrawals (payment transactions)
 
-Processing is based on your consent and for the fulfillment of contractual and legal obligations (Art. 6 DSG; Art. 6 para. 1 lit. a, b and c GDPR).
+Processing of this data is necessary for initiating and performing the contractual relationship and for fulfilling legal obligations (e.g. reporting and retention obligations); insofar as we process data based on your consent, you may withdraw it at any time. For users within the scope of the GDPR, processing is based on Art. 6 para. 1 lit. a, b and c GDPR.
 
 
 ## 4. Identity Verification (KYC)
@@ -57,15 +58,17 @@ Identity verification (Know Your Customer, KYC) is required above certain amount
 
 This data is processed by DFX AG in accordance with their own privacy policy.
 
+The biometric data for facial recognition collected during video identification constitutes sensitive personal data (Art. 5 lit. c no. 4 DSG) or special categories of personal data (Art. 9 GDPR). It is processed with your explicit consent (Art. 9 para. 2 lit. a GDPR).
 
-## 5. Communication with External Services
 
-The app communicates with external services for certain functions:
+## 5. Communication with External Services and Disclosure Abroad
 
 - **DFX AG**: For exchange rate queries, balance queries, buy/sell and registration functions. Your wallet address and, where applicable, personal data are transmitted.
 - **Ethereum Blockchain Nodes**: For submitting transactions and querying blockchain data. Your wallet address and IP address may be transmitted to node operators.
 
 The respective privacy policies of these third-party services apply to their use.
+
+Some of the aforementioned recipients or their sub-processors may process personal data outside Switzerland (e.g. Sumsub for identity verification, blockchain node operators, and app store operators). Where data is disclosed to a country without an adequate level of data protection, we ensure appropriate safeguards (in particular standard contractual clauses) or rely on a statutory exception (Art. 16 et seq. DSG; Art. 44 et seq. GDPR).
 
 
 ## 6. Blockchain Transparency
@@ -74,8 +77,6 @@ All transactions on the Ethereum blockchain are **publicly visible**. This means
 
 
 ## 7. Device Permissions
-
-The app may request the following device permissions:
 
 - **Camera**: For scanning QR codes (e.g. for wallet addresses or payment requests)
 - **Biometric sensors**: For Face ID or fingerprint unlock (optional)
@@ -97,10 +98,16 @@ You have the right at any time to:
 - **Request deletion** of your data, insofar as no statutory retention obligations apply
 - **Revoke your consent** to data processing at any time
 
+Insofar as the GDPR applies, you are also entitled to the right to data portability (Art. 20 GDPR), the right to object (Art. 21 GDPR), and the right to restriction of processing (Art. 18 GDPR). You furthermore have the right to lodge a complaint with a supervisory authority (in Switzerland: the Federal Data Protection and Information Commissioner, FDPIC; within the scope of the GDPR: the competent data protection supervisory authority).
+
 To exercise these rights, please contact info@realunit.ch.
 
 
 ## 10. Final Provisions
+
+### Retention
+
+We retain personal data for as long as necessary for the stated purposes or due to statutory retention obligations; thereafter it is deleted or anonymized.
 
 ### Severability Clause
 

--- a/assets/legal/terms_of_use_de.md
+++ b/assets/legal/terms_of_use_de.md
@@ -1,18 +1,18 @@
 # Nutzungsbedingungen der RealUnit Wallet App
 
-*Stand: Februar 2026*
+*Stand: Juni 2026*
 
 
 ## 1. Geltungsbereich
 
 Diese Nutzungsbedingungen regeln die Verwendung der RealUnit Wallet App (nachfolgend «App»), herausgegeben von der RealUnit Schweiz AG, Schochenmühlestrasse 6, 6340 Baar, Schweiz (nachfolgend «RealUnit» oder «wir»).
 
-Mit der Nutzung der App erklären Sie sich mit diesen Nutzungsbedingungen einverstanden. Für den Kauf und Verkauf von RealUnit Aktien-Token gelten zusätzlich die Allgemeinen Geschäftsbedingungen (AGB).
+Mit der Nutzung der App erklären Sie sich mit diesen Nutzungsbedingungen einverstanden. Für den Kauf und Verkauf von RealUnit Aktientoken gelten zusätzlich die Allgemeinen Geschäftsbedingungen der DFX AG (nachfolgend «AGB»; abrufbar unter [https://docs.dfx.swiss/de/tnc.html](https://docs.dfx.swiss/de/tnc.html)).
 
 
 ## 2. Beschreibung der App
 
-Die App ist eine Self-Custody-Wallet für die Verwaltung von RealUnit Aktien-Token (REALU) und weiteren ERC-20-Token auf der Ethereum-Blockchain. Sie ermöglicht insbesondere:
+Die App ist eine Self-Custody-Wallet für die Verwaltung von RealUnit Aktientoken (REALU) und weiteren ERC-20-Token auf der Ethereum-Blockchain. Sie ermöglicht insbesondere:
 
 - Erstellen und Wiederherstellen von Wallets mittels Wiederherstellungs-Wörtern (Seed Phrase)
 - Empfangen und Senden von Token
@@ -34,7 +34,7 @@ Die App ist eine Self-Custody-Lösung. Das bedeutet:
 
 ## 4. Nutzungsvoraussetzungen
 
-Die App richtet sich an Personen, die in einem Land ansässig sind, dessen Rechtsordnung die Nutzung dieser App sowie den Erwerb und Besitz von tokenisierten Aktien erlaubt. Die App richtet sich insbesondere **nicht** an Personen mit Wohnsitz in den USA, Kanada, Singapur oder China.
+Die App richtet sich an Personen, die in einem Land ansässig sind, dessen Rechtsordnung die Nutzung dieser App sowie den Erwerb und Besitz von tokenisierten Aktien erlaubt. Die App und der Erwerb der RealUnit Aktientoken richten sich ausschliesslich an Personen mit Wohnsitz in der Schweiz, im Vereinigten Königreich oder im Europäischen Wirtschaftsraum bzw. an Staatsangehörige der Schweiz, Deutschlands, Liechtensteins oder Österreichs. Das öffentliche Angebot erfolgt nur in der Schweiz, in Liechtenstein und in Deutschland. Ausgeschlossen sind insbesondere Personen mit Wohnsitz in den Vereinigten Staaten sowie in Gebieten, die einem Embargo- oder Sanktionsprogramm unterliegen; massgebend ist die im Onboarding hinterlegte Länder- und Sanktionsprüfung.
 
 Sie bestätigen, dass Sie handlungsfähig sind und das in Ihrem Land geltende Mindestalter für die Nutzung digitaler Finanzdienstleistungen erreicht haben.
 
@@ -56,8 +56,6 @@ Für bestimmte Funktionen (z.B. Kursabfragen, Guthabenabfragen) kommuniziert die
 
 
 ## 7. Geräteberechtigungen
-
-Die App kann folgende Geräteberechtigungen anfordern:
 
 - **Kamera**: Zum Scannen von QR-Codes
 - **Biometrische Sensoren**: Für Face ID oder Fingerabdruck-Entsperrung (optional)
@@ -85,7 +83,7 @@ Die App wird «wie besehen» («as is») zur Verfügung gestellt. RealUnit über
 - Schäden oder Verluste, die durch unsachgemässe Handhabung, Verlust der Wiederherstellungs-Wörter oder unbefugten Zugriff Dritter entstehen
 - Schäden oder Verluste, die durch Störungen oder Ausfälle der Ethereum-Blockchain oder anderer Netzwerke entstehen
 
-Die Haftung von RealUnit ist im gesetzlich zulässigen Rahmen ausgeschlossen, insbesondere für indirekte Schäden, Folgeschäden und entgangenen Gewinn.
+Die Haftung von RealUnit ist im gesetzlich zulässigen Rahmen ausgeschlossen, insbesondere für indirekte Schäden, Folgeschäden und entgangenen Gewinn. Unberührt bleibt die Haftung für Schäden aus rechtswidriger Absicht oder grober Fahrlässigkeit; eine solche Haftung kann nach Art. 100 Abs. 1 OR nicht zum Voraus wegbedungen werden.
 
 
 ## 10. Geistiges Eigentum
@@ -95,12 +93,12 @@ Sämtliche Rechte an der App, einschliesslich Design, Quellcode, Marken und Inha
 
 ## 11. Änderungen der Nutzungsbedingungen
 
-RealUnit behält sich vor, diese Nutzungsbedingungen jederzeit zu ändern. Geänderte Nutzungsbedingungen werden über ein App-Update bereitgestellt. Die fortgesetzte Nutzung der App nach einem Update gilt als Zustimmung zu den geänderten Nutzungsbedingungen.
+RealUnit behält sich vor, diese Nutzungsbedingungen jederzeit zu ändern. Bei wesentlichen Änderungen informieren wir Sie vorgängig in geeigneter Weise; soweit gesetzlich erforderlich, holen wir Ihre ausdrückliche Zustimmung ein. Geänderte Nutzungsbedingungen werden über ein App-Update bereitgestellt. Die fortgesetzte Nutzung der App nach einem Update gilt bei nicht wesentlichen Änderungen als Zustimmung zu den geänderten Nutzungsbedingungen.
 
 
 ## 12. Anwendbares Recht und Gerichtsstand
 
-Es gilt ausschliesslich schweizerisches Recht. Gerichtsstand ist Baar, Kanton Zug, Schweiz, soweit gesetzlich zulässig.
+Es gilt ausschliesslich schweizerisches Recht. Gerichtsstand ist Baar, Kanton Zug, Schweiz, soweit gesetzlich zulässig. Zwingende Gerichtsstände sowie zwingendes Konsumentenschutzrecht am Wohnsitz von Verbraucherinnen und Verbrauchern bleiben vorbehalten.
 
 
 ## 13. Kontakt
@@ -110,4 +108,5 @@ Schochenmühlestrasse 6\
 6340 Baar, Schweiz
 
 Telefon: +41 41 761 00 90\
+E-Mail: info@realunit.ch\
 Website: realunit.ch

--- a/assets/legal/terms_of_use_en.md
+++ b/assets/legal/terms_of_use_en.md
@@ -1,13 +1,13 @@
 # Terms of Use for the RealUnit Wallet App
 
-*As of: February 2026*
+*As of: June 2026*
 
 
 ## 1. Scope
 
 These terms of use govern the use of the RealUnit Wallet App (hereinafter "App"), published by RealUnit Schweiz AG, Schochenmühlestrasse 6, 6340 Baar, Switzerland (hereinafter "RealUnit" or "we").
 
-By using the App, you agree to these terms of use. The General Terms and Conditions (GTC) additionally apply to the purchase and sale of RealUnit stock tokens.
+By using the App, you agree to these terms of use. The General Terms and Conditions of DFX AG (hereinafter "GTC"; available at [https://docs.dfx.swiss/en/tnc.html](https://docs.dfx.swiss/en/tnc.html)) additionally apply to the purchase and sale of RealUnit stock tokens.
 
 
 ## 2. Description of the App
@@ -34,7 +34,7 @@ The App is a self-custody solution. This means:
 
 ## 4. Usage Requirements
 
-The App is intended for persons residing in a country whose legal system permits the use of this App as well as the acquisition and possession of tokenised shares. The App is specifically **not** intended for persons residing in the USA, Canada, Singapore, or China.
+The App is intended for persons residing in a country whose legal system permits the use of this App as well as the acquisition and possession of tokenised shares. The App and the acquisition of RealUnit stock tokens are directed exclusively at persons resident in Switzerland, the United Kingdom, or the European Economic Area, or at nationals of Switzerland, Germany, Liechtenstein, or Austria. The public offering is made only in Switzerland, Liechtenstein, and Germany. Excluded are in particular persons resident in the United States as well as in territories subject to an embargo or sanctions programme; the country and sanctions screening recorded during onboarding is decisive.
 
 You confirm that you have legal capacity and have reached the minimum age required in your country for the use of digital financial services.
 
@@ -56,8 +56,6 @@ For certain functions (e.g., price queries, balance queries), the App communicat
 
 
 ## 7. Device Permissions
-
-The App may request the following device permissions:
 
 - **Camera**: For scanning QR codes
 - **Biometric sensors**: For Face ID or fingerprint unlock (optional)
@@ -85,7 +83,7 @@ The App is provided "as is". RealUnit makes no warranty for:
 - Damages or losses arising from improper handling, loss of recovery words, or unauthorised access by third parties
 - Damages or losses arising from disruptions or failures of the Ethereum blockchain or other networks
 
-RealUnit's liability is excluded to the extent permitted by law, in particular for indirect damages, consequential damages, and lost profits.
+RealUnit's liability is excluded to the extent permitted by law, in particular for indirect damages, consequential damages, and lost profits. Liability for damages arising from unlawful intent or gross negligence remains unaffected; such liability cannot be excluded in advance pursuant to Art. 100 para. 1 CO.
 
 
 ## 10. Intellectual Property
@@ -95,12 +93,12 @@ All rights to the App, including design, source code, trademarks, and content, b
 
 ## 11. Changes to the Terms of Use
 
-RealUnit reserves the right to change these terms of use at any time. Changed terms of use will be provided via an app update. Continued use of the App after an update constitutes acceptance of the changed terms of use.
+RealUnit reserves the right to change these terms of use at any time. In the case of material changes, we will inform you in advance in an appropriate manner; insofar as legally required, we will obtain your explicit consent. Changed terms of use will be provided via an app update. In the case of non-material changes, continued use of the App after an update constitutes acceptance of the changed terms of use.
 
 
 ## 12. Applicable Law and Jurisdiction
 
-Swiss law applies exclusively. The place of jurisdiction is Baar, Canton of Zug, Switzerland, to the extent permitted by law.
+Swiss law applies exclusively. The place of jurisdiction is Baar, Canton of Zug, Switzerland, to the extent permitted by law. Mandatory places of jurisdiction and mandatory consumer protection law at the domicile of consumers remain reserved.
 
 
 ## 13. Contact
@@ -110,4 +108,5 @@ Schochenmühlestrasse 6\
 6340 Baar, Switzerland
 
 Phone: +41 41 761 00 90\
+Email: info@realunit.ch\
 Website: realunit.ch


### PR DESCRIPTION
## What

Updates the in-app **privacy policy** and **terms of use** (DE + EN) to the **June 2026** legal versions provided by RealUnit legal (David Lehner legal check, 5 June 2026). The in-app version 0.99 still shipped the February 2026 texts; these are the versions that must be in the app before the App Store release.

Only the four Markdown sources under `assets/legal/` change:

- `privacy_policy_de.md`, `privacy_policy_en.md`
- `terms_of_use_de.md`, `terms_of_use_en.md`

## Key content changes

**Privacy policy**
- Adds **Yapeal AG** as a data recipient; adds sanctions/embargo screening for DFX AG
- Adds the biometric special-category-data basis (Art. 9 GDPR / Art. 5 lit. c no. 4 DSG, explicit consent)
- Renames §5 and adds the cross-border **disclosure abroad** clause (standard contractual clauses)
- Adds GDPR data-portability / objection / restriction rights and the supervisory-authority complaint right
- Adds a **data-retention** provision; restates the processing legal basis

**Terms of use**
- Rewrites the **usage requirements**: residents of CH / UK / EEA and nationals of CH / DE / LI / AT; public offer only in CH / LI / DE; US and sanctioned territories excluded; onboarding screening is decisive (replaces the old "USA, Canada, Singapore, China" wording)
- References the DFX GTC by URL
- Adds the Art. 100 para. 1 CO carve-out to the liability exclusion
- Expands the change and jurisdiction clauses; adds the contact email

Both documents now read *June 2026*.

## Notes for reviewers

- **English**: RealUnit provided the German source only. The EN files are a faithful, complete translation that mirrors the new DE structure and content 1:1. Please have RealUnit legal sign off on the EN wording before the store release.
- **Golden fixture unchanged — intentional**: `test/goldens/screens/legal/legal_document_golden_test.dart` uses an inline `_termsMarkdownStub` that is deliberately decoupled from the live asset ("kept inline so the golden does not depend on the live asset file changing"). It renders a representative document and is not the shipped text, so it stays as-is and the visual-regression baseline does not change.
- **No other surface affected**: no `lib/` code changes (coverage floor unaffected); the handbook `legal-downloads` block depends only on discovered languages + ARB titles, both unchanged, so the handbook sync gate stays green.
- **Out of scope**: the remaining David-Lehner legal-check items (store-listing advertising notice / prospectus hint, "kostenfrei" wording, tagline unification, store privacy URL, product-naming consistency) are mostly store-listing and in-app marketing copy and are tracked separately.
