### PR TITLE
docs(legal): disclose Sumsub KYC data collection in privacy policy

### DIFF
--- a/assets/legal/privacy_policy_de.md
+++ b/assets/legal/privacy_policy_de.md
@@ -55,8 +55,11 @@ Ab bestimmten Beträgen ist eine Identitätsprüfung (Know Your Customer, KYC) e
 
 - Ausweisdokumente (Reisepass, Identitätskarte)
 - Biometrische Daten zur Gesichtserkennung (im Rahmen der Video-Identifikation)
+- Ungefährer und genauer Standort (durch Sumsub als Betrugspräventions- und Geo-Risiko-Signal)
 
 Diese Daten werden von DFX AG gemäss deren eigener Datenschutzrichtlinie verarbeitet.
+
+Der von Sumsub (Sum and Substance Ltd.) erhobene ungefähre und genaue Standort wird als Signal zur Betrugsprävention an die Server von Sumsub übermittelt und gemäss der Datenschutzerklärung von Sumsub (https://sumsub.com/privacy-notice/) verarbeitet. Diese Standortdaten werden nur erhoben, wenn Sie die Identitätsprüfung starten.
 
 Die im Rahmen der Video-Identifikation erhobenen biometrischen Daten zur Gesichtserkennung sind besonders schützenswerte Personendaten (Art. 5 lit. c Ziff. 4 DSG) bzw. besondere Kategorien personenbezogener Daten (Art. 9 DSGVO). Ihre Bearbeitung erfolgt mit Ihrer ausdrücklichen Einwilligung (Art. 9 Abs. 2 lit. a DSGVO).
 

--- a/assets/legal/privacy_policy_de.md
+++ b/assets/legal/privacy_policy_de.md
@@ -57,9 +57,9 @@ Ab bestimmten Beträgen ist eine Identitätsprüfung (Know Your Customer, KYC) e
 - Biometrische Daten zur Gesichtserkennung (im Rahmen der Video-Identifikation)
 - Ungefährer und genauer Standort (durch Sumsub als Betrugspräventions- und Geo-Risiko-Signal)
 
-Diese Daten werden von DFX AG gemäss deren eigener Datenschutzrichtlinie verarbeitet.
+Die Ausweisdokumente und biometrischen Daten werden von DFX AG gemäss deren eigener Datenschutzrichtlinie verarbeitet.
 
-Der von Sumsub (Sum and Substance Ltd.) erhobene ungefähre und genaue Standort wird als Signal zur Betrugsprävention an die Server von Sumsub übermittelt und gemäss der Datenschutzerklärung von Sumsub (https://sumsub.com/privacy-notice/) verarbeitet. Diese Standortdaten werden nur erhoben, wenn Sie die Identitätsprüfung starten.
+Der von Sumsub (Sum and Substance Ltd.) erhobene ungefähre und genaue Standort wird als Signal zur Betrugsprävention an die Server von Sumsub übermittelt und gemäss der Datenschutzrichtlinie von Sumsub (https://sumsub.com/privacy-notice/) verarbeitet. Diese Standortdaten werden nur erhoben, wenn Sie die Identitätsprüfung starten.
 
 Die im Rahmen der Video-Identifikation erhobenen biometrischen Daten zur Gesichtserkennung sind besonders schützenswerte Personendaten (Art. 5 lit. c Ziff. 4 DSG) bzw. besondere Kategorien personenbezogener Daten (Art. 9 DSGVO). Ihre Bearbeitung erfolgt mit Ihrer ausdrücklichen Einwilligung (Art. 9 Abs. 2 lit. a DSGVO).
 

--- a/assets/legal/privacy_policy_en.md
+++ b/assets/legal/privacy_policy_en.md
@@ -55,8 +55,11 @@ Identity verification (Know Your Customer, KYC) is required above certain amount
 
 - Identity documents (passport, identity card)
 - Biometric data for facial recognition (as part of video identification)
+- Approximate and precise location (collected by Sumsub as a fraud-prevention and geo-risk signal)
 
 This data is processed by DFX AG in accordance with their own privacy policy.
+
+The approximate and precise location collected by Sumsub (Sum and Substance Ltd.) is transmitted to Sumsub's servers as a fraud-prevention signal and processed in accordance with Sumsub's privacy notice (https://sumsub.com/privacy-notice/). This location data is only collected if you start the identity verification.
 
 The biometric data for facial recognition collected during video identification constitutes sensitive personal data (Art. 5 lit. c no. 4 DSG) or special categories of personal data (Art. 9 GDPR). It is processed with your explicit consent (Art. 9 para. 2 lit. a GDPR).
 

--- a/assets/legal/privacy_policy_en.md
+++ b/assets/legal/privacy_policy_en.md
@@ -57,9 +57,9 @@ Identity verification (Know Your Customer, KYC) is required above certain amount
 - Biometric data for facial recognition (as part of video identification)
 - Approximate and precise location (collected by Sumsub as a fraud-prevention and geo-risk signal)
 
-This data is processed by DFX AG in accordance with their own privacy policy.
+The identity documents and biometric data are processed by DFX AG in accordance with their own privacy policy.
 
-The approximate and precise location collected by Sumsub (Sum and Substance Ltd.) is transmitted to Sumsub's servers as a fraud-prevention signal and processed in accordance with Sumsub's privacy notice (https://sumsub.com/privacy-notice/). This location data is only collected if you start the identity verification.
+The approximate and precise location collected by Sumsub (Sum and Substance Ltd.) is transmitted to Sumsub's servers as a fraud-prevention signal and processed in accordance with Sumsub's privacy policy (https://sumsub.com/privacy-notice/). This location data is only collected if you start the identity verification.
 
 The biometric data for facial recognition collected during video identification constitutes sensitive personal data (Art. 5 lit. c no. 4 DSG) or special categories of personal data (Art. 9 GDPR). It is processed with your explicit consent (Art. 9 para. 2 lit. a GDPR).
 


### PR DESCRIPTION
## What

Extends section 4 (Identity Verification / KYC) of the in-app privacy policy — both `privacy_policy_de.md` and `privacy_policy_en.md` — to disclose that the **Sumsub KYC SDK** collects **approximate and precise location** as an anti-fraud / geo-risk signal during identity verification, transmits it to Sumsub's servers, and processes it under Sumsub's privacy notice. The location is only collected once the user actually starts the KYC flow.

Before this change, section 4 listed only ID documents and biometric face data for KYC — no location — which is what the current staging text (June 2026 finals) still says.

## Why

Google Play has been **rejecting Android updates** (`swiss.realunit.app`) because its automated review detects location data transmitted off-device (via the native Sumsub AAR `com.sumsub.sns:idensic-mobile-sdk`) that is not declared. The fix has two halves:

1. **Play Console Data Safety form** — owner action, documented step-by-step in the issue (not a code change).
2. **User-facing privacy policy** — this PR: the linked policy must disclose Sumsub's location collection.

## Scope

- DE + EN kept consistent (one bullet + one paragraph each), factual and minimal, in the style of the existing text.
- No `lib/` code, no ARB, no store-listing changes. Only the two privacy-policy Markdown assets.

## Relationship to other legal PRs

- The **June 2026 legal finals (#759)** updated these same two files but do **not** cover Sumsub location — this disclosure is additive on top of #759.
- **#725** (legal-check app copy & store listing) does **not** touch `assets/legal/*.md`, so there is no file overlap with this PR.

## Requires legal sign-off

The wording is a factual first draft prepared to unblock the Play rejection. It is **not** covered by the June 2026 legal finals and **REQUIRES LEGAL SIGN-OFF** (RealUnit AG + DFX legal) before merge. Kept DRAFT until then.

Refs #463
