### PR TITLE
fix: money & display correctness findings from audit (#615)

### DIFF
--- a/lib/packages/service/dfx/dfx_brokerbot_service.dart
+++ b/lib/packages/service/dfx/dfx_brokerbot_service.dart
@@ -39,7 +39,9 @@ class DfxBrokerbotService extends DFXAuthService {
 
   /// Convert CHF → REALU shares
   Future<BrokerbotBuySharesDto> getBuyShares(String amountInput, Currency currency) async {
-    final amount = double.tryParse(amountInput);
+    // The fiat fields accept a comma decimal separator; normalize it the same
+    // way the order/payment-info path does before parsing.
+    final amount = double.tryParse(amountInput.replaceAll(',', '.'));
     if (amount == null || amount <= 0) {
       throw Exception('Shares request failed: amountInput is not valid');
     }
@@ -80,7 +82,9 @@ class DfxBrokerbotService extends DFXAuthService {
 
   /// Convert CHF → REALU shares (with fees)
   Future<BrokerbotSellSharesDto> getSellShares(String amountInput, Currency currency) async {
-    final amount = double.tryParse(amountInput);
+    // The fiat fields accept a comma decimal separator; normalize it the same
+    // way the order/payment-info path does before parsing.
+    final amount = double.tryParse(amountInput.replaceAll(',', '.'));
     if (amount == null || amount <= 0) {
       throw Exception('SellShares request failed: amountInput is invalid');
     }

--- a/lib/packages/service/dfx/dfx_brokerbot_service.dart
+++ b/lib/packages/service/dfx/dfx_brokerbot_service.dart
@@ -8,6 +8,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/brokerbot/dfx_buy_sh
 import 'package:realunit_wallet/packages/service/dfx/models/brokerbot/dfx_sell_price_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/brokerbot/dfx_sell_shares_dto.dart';
 import 'package:realunit_wallet/styles/currency.dart';
+import 'package:realunit_wallet/packages/utils/fiat_amount.dart';
 
 class DfxBrokerbotService extends DFXAuthService {
   static const _buyPricePath = '/v1/realunit/brokerbot/buyPrice';
@@ -39,9 +40,7 @@ class DfxBrokerbotService extends DFXAuthService {
 
   /// Convert CHF → REALU shares
   Future<BrokerbotBuySharesDto> getBuyShares(String amountInput, Currency currency) async {
-    // The fiat fields accept a comma decimal separator; normalize it the same
-    // way the order/payment-info path does before parsing.
-    final amount = double.tryParse(amountInput.replaceAll(',', '.'));
+    final amount = tryParseFiatAmount(amountInput);
     if (amount == null || amount <= 0) {
       throw Exception('Shares request failed: amountInput is not valid');
     }
@@ -82,9 +81,7 @@ class DfxBrokerbotService extends DFXAuthService {
 
   /// Convert CHF → REALU shares (with fees)
   Future<BrokerbotSellSharesDto> getSellShares(String amountInput, Currency currency) async {
-    // The fiat fields accept a comma decimal separator; normalize it the same
-    // way the order/payment-info path does before parsing.
-    final amount = double.tryParse(amountInput.replaceAll(',', '.'));
+    final amount = tryParseFiatAmount(amountInput);
     if (amount == null || amount <= 0) {
       throw Exception('SellShares request failed: amountInput is invalid');
     }

--- a/lib/packages/service/dfx/dfx_price_service.dart
+++ b/lib/packages/service/dfx/dfx_price_service.dart
@@ -40,9 +40,10 @@ class DFXPriceService extends APriceService {
       result.add(
         PricePoint(
           asset: asset,
-          // Round the fractional-unit price (e.g. 1.23 CHF → 123 rappen);
+          // Round the fractional-unit price (e.g. 4.56 CHF → 456 rappen);
           // `BigInt.from` on the raw `double * 100` truncates toward zero and
-          // would drop a rappen on values like 1.23 (122.999… → 122).
+          // would drop a rappen on values like 4.56 (455.999… → 455). Values
+          // such as 1.23 are exactly 123.0 in IEEE-754 and were never truncated.
           price: BigInt.from(((rawPrice as num) * 100).round()),
           time: DateTime.parse(entry['timestamp']),
         ),

--- a/lib/packages/service/dfx/dfx_price_service.dart
+++ b/lib/packages/service/dfx/dfx_price_service.dart
@@ -40,7 +40,10 @@ class DFXPriceService extends APriceService {
       result.add(
         PricePoint(
           asset: asset,
-          price: BigInt.from(rawPrice * 100),
+          // Round the fractional-unit price (e.g. 1.23 CHF → 123 rappen);
+          // `BigInt.from` on the raw `double * 100` truncates toward zero and
+          // would drop a rappen on values like 1.23 (122.999… → 122).
+          price: BigInt.from(((rawPrice as num) * 100).round()),
           time: DateTime.parse(entry['timestamp']),
         ),
       );
@@ -65,7 +68,7 @@ class DFXPriceService extends APriceService {
     // A missing price means the quote is currently unavailable. Return zero so
     // the UI renders "--.--" instead of throwing.
     if (rawPrice == null) return BigInt.zero;
-    return BigInt.from(rawPrice * 100);
+    return BigInt.from(((rawPrice as num) * 100).round());
   }
 
   /// Returns the equivalent EUR amount for 1 CHF

--- a/lib/packages/service/dfx/models/payment/buy/buy_payment_info.dart
+++ b/lib/packages/service/dfx/models/payment/buy/buy_payment_info.dart
@@ -18,6 +18,9 @@ class BuyPaymentInfo extends Equatable {
   // authority on whether the quote is valid for trading and what the
   // current min/max limits are for the user+currency combination.
   final bool isValid;
+  // The whole-currency amount this quote charges, echoed by the API — the
+  // Details page must render this, never re-derive it from keystrokes.
+  final double amount;
   final double? minVolume;
   final double? maxVolume;
   final String? error;
@@ -33,6 +36,7 @@ class BuyPaymentInfo extends Equatable {
     required this.city,
     required this.country,
     required this.currency,
+    required this.amount,
     this.isValid = true,
     this.paymentRequest,
     this.remittanceInfo,
@@ -56,6 +60,7 @@ class BuyPaymentInfo extends Equatable {
     paymentRequest,
     remittanceInfo,
     isValid,
+    amount,
     minVolume,
     maxVolume,
     error,

--- a/lib/packages/service/dfx/real_unit_account_service.dart
+++ b/lib/packages/service/dfx/real_unit_account_service.dart
@@ -40,7 +40,7 @@ class RealUnitAccountService {
           // would crash the chart line to zero and show a false -100% change.
           if (value == null) return null;
           return PortfolioValuePoint(
-            value: BigInt.from(value * 100),
+            value: BigInt.from((value * 100).round()),
             balance: BigInt.parse(h.balance),
             time: h.timestamp,
           );

--- a/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
@@ -45,6 +45,7 @@ class RealUnitBuyPaymentInfoService extends DFXAuthService {
         paymentRequest: responseDto.paymentRequest,
         remittanceInfo: responseDto.remittanceInfo,
         isValid: responseDto.isValid,
+        amount: responseDto.amount,
         minVolume: responseDto.minVolume,
         maxVolume: responseDto.maxVolume,
         error: responseDto.error,

--- a/lib/packages/storage/transaction_storage.dart
+++ b/lib/packages/storage/transaction_storage.dart
@@ -69,21 +69,20 @@ extension TransactionStorage on AppDatabase {
     transactions,
   )..orderBy([(u) => OrderingTerm(expression: u.timeStamp, mode: OrderingMode.desc)])).watch();
 
+  // EVM addresses are stored verbatim from the API (EIP-55 mixed case) while
+  // `wallet` is lowercase — compare case-insensitively or history renders empty.
+  Expression<bool> _involvesWallet($TransactionsTable row, String wallet) => Expression.or([
+    row.senderAddress.collate(Collate.noCase).equals(wallet),
+    row.receiverAddress.collate(Collate.noCase).equals(wallet),
+  ]);
+
   Stream<List<TransactionData>> watchTransfersOfAssets(Iterable<int> assets, String wallet) =>
       (select(transactions)
             ..where(
               (row) => Expression.and([
                 row.asset.isIn(assets),
                 row.type.equals(2),
-                Expression.or([
-                  // EVM addresses are stored verbatim from the API (EIP-55
-                  // checksummed, mixed case) while `wallet` is the lowercase
-                  // primary address. Compare case-insensitively so existing
-                  // checksummed rows still match — a plain `=` on TEXT is
-                  // case-sensitive and silently returns an empty history.
-                  row.senderAddress.collate(Collate.noCase).equals(wallet),
-                  row.receiverAddress.collate(Collate.noCase).equals(wallet),
-                ]),
+                _involvesWallet(row, wallet),
               ]),
             )
             ..orderBy([(u) => OrderingTerm(expression: u.timeStamp, mode: OrderingMode.desc)]))
@@ -99,10 +98,7 @@ extension TransactionStorage on AppDatabase {
               (row) => Expression.and([
                 row.asset.isIn(assets),
                 row.type.equals(2),
-                Expression.or([
-                  row.senderAddress.collate(Collate.noCase).equals(wallet),
-                  row.receiverAddress.collate(Collate.noCase).equals(wallet),
-                ]),
+                _involvesWallet(row, wallet),
               ]),
             )
             ..orderBy([(u) => OrderingTerm(expression: u.timeStamp, mode: OrderingMode.desc)])
@@ -119,10 +115,7 @@ extension TransactionStorage on AppDatabase {
               (row) => Expression.and([
                 row.asset.isIn(assets),
                 row.type.isIn([3, 4]),
-                Expression.or([
-                  row.senderAddress.collate(Collate.noCase).equals(wallet),
-                  row.receiverAddress.collate(Collate.noCase).equals(wallet),
-                ]),
+                _involvesWallet(row, wallet),
               ]),
             )
             ..orderBy([(u) => OrderingTerm(expression: u.timeStamp, mode: OrderingMode.desc)])

--- a/lib/packages/storage/transaction_storage.dart
+++ b/lib/packages/storage/transaction_storage.dart
@@ -76,8 +76,13 @@ extension TransactionStorage on AppDatabase {
                 row.asset.isIn(assets),
                 row.type.equals(2),
                 Expression.or([
-                  row.senderAddress.equals(wallet),
-                  row.receiverAddress.equals(wallet),
+                  // EVM addresses are stored verbatim from the API (EIP-55
+                  // checksummed, mixed case) while `wallet` is the lowercase
+                  // primary address. Compare case-insensitively so existing
+                  // checksummed rows still match — a plain `=` on TEXT is
+                  // case-sensitive and silently returns an empty history.
+                  row.senderAddress.collate(Collate.noCase).equals(wallet),
+                  row.receiverAddress.collate(Collate.noCase).equals(wallet),
                 ]),
               ]),
             )
@@ -95,8 +100,8 @@ extension TransactionStorage on AppDatabase {
                 row.asset.isIn(assets),
                 row.type.equals(2),
                 Expression.or([
-                  row.senderAddress.equals(wallet),
-                  row.receiverAddress.equals(wallet),
+                  row.senderAddress.collate(Collate.noCase).equals(wallet),
+                  row.receiverAddress.collate(Collate.noCase).equals(wallet),
                 ]),
               ]),
             )
@@ -115,8 +120,8 @@ extension TransactionStorage on AppDatabase {
                 row.asset.isIn(assets),
                 row.type.isIn([3, 4]),
                 Expression.or([
-                  row.senderAddress.equals(wallet),
-                  row.receiverAddress.equals(wallet),
+                  row.senderAddress.collate(Collate.noCase).equals(wallet),
+                  row.receiverAddress.collate(Collate.noCase).equals(wallet),
                 ]),
               ]),
             )

--- a/lib/packages/utils/fiat_amount.dart
+++ b/lib/packages/utils/fiat_amount.dart
@@ -1,5 +1,11 @@
 /// Parses user-typed fiat text, accepting a comma as the decimal separator.
-double? tryParseFiatAmount(String input) => double.tryParse(input.replaceAll(',', '.'));
+/// Rejects grouping-ambiguous input — a lone separator followed by exactly
+/// three digits (`1,000` / `1.000`) usually means a thousands group, and
+/// reading it as a decimal would quote 1/1000th of the intended amount.
+double? tryParseFiatAmount(String input) {
+  if (RegExp(r'^\d+[.,]\d{3}$').hasMatch(input)) return null;
+  return double.tryParse(input.replaceAll(',', '.'));
+}
 
 /// The whole-currency integer the backend charges for the raw [input] the user
 /// typed (e.g. `300,75` → `301`); empty input counts as zero.

--- a/lib/packages/utils/fiat_amount.dart
+++ b/lib/packages/utils/fiat_amount.dart
@@ -1,0 +1,10 @@
+/// Parses user-typed fiat text, accepting a comma as the decimal separator.
+double? tryParseFiatAmount(String input) => double.tryParse(input.replaceAll(',', '.'));
+
+/// The whole-currency integer the backend charges for the raw [input] the user
+/// typed (e.g. `300,75` → `301`); empty input counts as zero.
+int chargedFiatAmount(String input) {
+  final amount = tryParseFiatAmount(input.isEmpty ? '0' : input);
+  if (amount == null) throw FormatException('Invalid fiat amount', input);
+  return amount.round();
+}

--- a/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
+++ b/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
@@ -9,6 +9,7 @@ import 'package:realunit_wallet/packages/service/dfx/exceptions/payment/buy_exce
 import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/buy_payment_info.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/payment_info_error.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
+import 'package:realunit_wallet/packages/utils/fiat_amount.dart';
 import 'package:realunit_wallet/styles/currency.dart';
 
 part 'buy_payment_info_state.dart';
@@ -29,14 +30,6 @@ class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
   ) : _buyPaymentInfoService = buyPaymentInfoService,
       super(const BuyPaymentInfoInitial());
 
-  /// The whole-currency amount the backend will actually charge for the raw
-  /// [input] the user typed. The buy quote is always requested with this
-  /// rounded integer, so the SEPA transfer / QR the API builds encodes it —
-  /// the Details tab must surface the same number, never the raw keystrokes
-  /// (e.g. `300,75` → `301`). Accepts a comma decimal separator.
-  static int chargedAmount(String input) =>
-      double.parse(input.isEmpty ? '0' : input.replaceAll(',', '.')).round();
-
   Future<void> getPaymentInfo({String amount = '300', Currency currency = Currency.chf}) async {
     await _completer?.cancel();
 
@@ -56,7 +49,7 @@ class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
   Future<BuyPaymentInfoState> _runGetPaymentInfo(String amount, Currency currency) async {
     try {
       final paymentInfo = await _buyPaymentInfoService.getPaymentInfo(
-        chargedAmount(amount),
+        chargedFiatAmount(amount),
         currency: currency,
       );
 

--- a/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
+++ b/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
@@ -29,6 +29,14 @@ class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
   ) : _buyPaymentInfoService = buyPaymentInfoService,
       super(const BuyPaymentInfoInitial());
 
+  /// The whole-currency amount the backend will actually charge for the raw
+  /// [input] the user typed. The buy quote is always requested with this
+  /// rounded integer, so the SEPA transfer / QR the API builds encodes it —
+  /// the Details tab must surface the same number, never the raw keystrokes
+  /// (e.g. `300,75` → `301`). Accepts a comma decimal separator.
+  static int chargedAmount(String input) =>
+      double.parse(input.isEmpty ? '0' : input.replaceAll(',', '.')).round();
+
   Future<void> getPaymentInfo({String amount = '300', Currency currency = Currency.chf}) async {
     await _completer?.cancel();
 
@@ -47,11 +55,8 @@ class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
 
   Future<BuyPaymentInfoState> _runGetPaymentInfo(String amount, Currency currency) async {
     try {
-      final sanitizedAmount = amount.isEmpty ? '0' : amount.replaceAll(',', '.');
-      final parsedAmount = double.parse(sanitizedAmount);
-
       final paymentInfo = await _buyPaymentInfoService.getPaymentInfo(
-        parsedAmount.round(),
+        chargedAmount(amount),
         currency: currency,
       );
 

--- a/lib/screens/buy/widgets/buy_confirm_button.dart
+++ b/lib/screens/buy/widgets/buy_confirm_button.dart
@@ -6,7 +6,6 @@ import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/buy_paym
 import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
 import 'package:realunit_wallet/screens/buy/buy_payment_details_page.dart';
 import 'package:realunit_wallet/screens/buy/cubits/buy_confirm/buy_confirm_cubit.dart';
-import 'package:realunit_wallet/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart';
 import 'package:realunit_wallet/setup/di.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
@@ -16,13 +15,11 @@ import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
 /// the `Zahlungsdetails` page with the bank-transfer instructions, on failure
 /// it surfaces the typed error as a snackbar.
 class BuyConfirmButton extends StatelessWidget {
-  final String amount;
   final BuyPaymentInfo buyPaymentInfo;
 
   const BuyConfirmButton({
     super.key,
     required this.buyPaymentInfo,
-    required this.amount,
   });
 
   @override
@@ -33,20 +30,17 @@ class BuyConfirmButton extends StatelessWidget {
       ),
       child: BuyConfirmButtonView(
         buyPaymentInfo: buyPaymentInfo,
-        amount: amount,
       ),
     );
   }
 }
 
 class BuyConfirmButtonView extends StatelessWidget {
-  final String amount;
   final BuyPaymentInfo buyPaymentInfo;
 
   const BuyConfirmButtonView({
     super.key,
     required this.buyPaymentInfo,
-    required this.amount,
   });
 
   @override
@@ -58,9 +52,8 @@ class BuyConfirmButtonView extends StatelessWidget {
             AppRoutes.buyPaymentDetails,
             extra: BuyPaymentDetailsParams(
               buyPaymentInfo: buyPaymentInfo,
-              // Show the integer the backend actually charges (the quote is
-              // built from the rounded amount), not the raw keystrokes.
-              amount: '${BuyPaymentInfoCubit.chargedAmount(amount)}',
+              // The charged amount comes from the quote itself, never keystrokes.
+              amount: '${buyPaymentInfo.amount.round()}',
               // Backward compatible: prefer the API-designated purpose once it
               // ships; until then `reference` (always returned) is the value.
               purposeOfPayment: state.remittanceInfo ?? state.reference,

--- a/lib/screens/buy/widgets/buy_confirm_button.dart
+++ b/lib/screens/buy/widgets/buy_confirm_button.dart
@@ -6,6 +6,7 @@ import 'package:realunit_wallet/packages/service/dfx/models/payment/buy/buy_paym
 import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
 import 'package:realunit_wallet/screens/buy/buy_payment_details_page.dart';
 import 'package:realunit_wallet/screens/buy/cubits/buy_confirm/buy_confirm_cubit.dart';
+import 'package:realunit_wallet/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart';
 import 'package:realunit_wallet/setup/di.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
@@ -57,7 +58,9 @@ class BuyConfirmButtonView extends StatelessWidget {
             AppRoutes.buyPaymentDetails,
             extra: BuyPaymentDetailsParams(
               buyPaymentInfo: buyPaymentInfo,
-              amount: amount,
+              // Show the integer the backend actually charges (the quote is
+              // built from the rounded amount), not the raw keystrokes.
+              amount: '${BuyPaymentInfoCubit.chargedAmount(amount)}',
               // Backward compatible: prefer the API-designated purpose once it
               // ships; until then `reference` (always returned) is the value.
               purposeOfPayment: state.remittanceInfo ?? state.reference,

--- a/lib/screens/buy/widgets/payment_action_button.dart
+++ b/lib/screens/buy/widgets/payment_action_button.dart
@@ -30,7 +30,6 @@ class PaymentActionButton extends StatelessWidget {
         if (paymentState is BuyPaymentInfoSuccess) {
           return BuyConfirmButton(
             buyPaymentInfo: paymentState.buyPaymentInfo,
-            amount: amountController.text,
           );
         }
         if (paymentState is BuyPaymentInfoFailure) {

--- a/lib/screens/dashboard/widgets/portfolio_chart.dart
+++ b/lib/screens/dashboard/widgets/portfolio_chart.dart
@@ -101,7 +101,7 @@ class PortfolioChart extends StatelessWidget {
           final price = touchedSpot.y;
           return LineTooltipItem(
             '${date.day}.${date.month}.${date.year}\n'
-            '${formatFixed(BigInt.from(price * 100), 2)}',
+            '${formatFixed(BigInt.from((price * 100).round()), 2)}',
             const TextStyle(
               color: RealUnitColors.neutral500,
               fontSize: 12,

--- a/lib/screens/dashboard/widgets/price_chart.dart
+++ b/lib/screens/dashboard/widgets/price_chart.dart
@@ -66,7 +66,7 @@ class PriceChart extends StatelessWidget {
                   fontWeight: FontWeight.w500,
                 ),
                 labelResolver: (line) => formatFixed(
-                  BigInt.from(line.y * 100),
+                  BigInt.from((line.y * 100).round()),
                   2,
                 ),
               )
@@ -110,7 +110,7 @@ class PriceChart extends StatelessWidget {
           final price = touchedSpot.y;
           return LineTooltipItem(
             '${date.day}.${date.month}.${date.year}\n'
-            '${formatFixed(BigInt.from(price * 100), 2)}',
+            '${formatFixed(BigInt.from((price * 100).round()), 2)}',
             const TextStyle(
               color: RealUnitColors.neutral500,
               fontSize: 12,

--- a/lib/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart
+++ b/lib/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart
@@ -9,6 +9,7 @@ import 'package:realunit_wallet/packages/service/dfx/exceptions/payment/buy_exce
 import 'package:realunit_wallet/packages/service/dfx/models/payment/payment_info_error.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/payment/sell/sell_payment_info.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_sell_payment_info_service.dart';
+import 'package:realunit_wallet/packages/utils/fiat_amount.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/styles/currency.dart';
 
@@ -41,7 +42,7 @@ class SellPaymentInfoCubit extends Cubit<SellPaymentInfoState> {
       emit(const SellPaymentInfoLoading());
 
       final paymentInfo = await _sellPaymentInfoService.getPaymentInfo(
-        double.parse(amount).round(),
+        chargedFiatAmount(amount),
         iban,
         currency: currency,
       );

--- a/test/goldens/screens/buy/buy_golden_test.dart
+++ b/test/goldens/screens/buy/buy_golden_test.dart
@@ -103,6 +103,7 @@ void main() {
         when(() => paymentInfoCubit.state).thenReturn(
           const BuyPaymentInfoSuccess(
             BuyPaymentInfo(
+              amount: 300,
               id: 1,
               iban: 'CH00 0000 0000 0000 0000 0',
               bic: 'BICCBIC',

--- a/test/goldens/screens/buy/buy_payment_details_golden_test.dart
+++ b/test/goldens/screens/buy/buy_payment_details_golden_test.dart
@@ -9,6 +9,7 @@ import '../../../helper/helper.dart';
 void main() {
   const params = BuyPaymentDetailsParams(
     buyPaymentInfo: BuyPaymentInfo(
+      amount: 300,
       id: 1,
       iban: 'CH00 0000 0000 0000 0000 0',
       bic: 'BICCBIC',

--- a/test/packages/service/dfx/dfx_brokerbot_service_test.dart
+++ b/test/packages/service/dfx/dfx_brokerbot_service_test.dart
@@ -131,6 +131,24 @@ void main() {
         expect(uri!.queryParameters['currency'], 'EUR');
       });
 
+      test('normalises a comma decimal separator before parsing (300,75 → amount=300.75)', () async {
+        // The fiat converter field allows a comma; without normalization
+        // `double.tryParse("300,75")` is null and the converter fails silently.
+        Uri? uri;
+        final client = MockClient((request) async {
+          uri = request.url;
+          return http.Response(
+            jsonEncode({'shares': 3, 'pricePerShare': 100.25, 'availableShares': 100}),
+            200,
+          );
+        });
+
+        final shares = await build(client).getBuyShares('300,75', Currency.chf);
+
+        expect(shares.shares, 3);
+        expect(uri!.queryParameters['amount'], '300.75');
+      });
+
       test('throws for non-numeric / zero / negative amount input', () {
         final client = MockClient((_) async => http.Response('{}', 200));
 
@@ -245,6 +263,28 @@ void main() {
           () => build(client).getSellShares('100', Currency.eur),
           throwsA(isA<ApiException>()),
         );
+      });
+
+      test('normalises a comma decimal separator before parsing (300,75 → amount=300.75)', () async {
+        sessionCache.setAuthToken('jwt-2');
+        Uri? uri;
+        final client = MockClient((request) async {
+          uri = request.url;
+          return http.Response(
+            jsonEncode({
+              'targetAmount': 300.75,
+              'shares': 3,
+              'pricePerShare': 100.25,
+              'currency': 'CHF',
+            }),
+            200,
+          );
+        });
+
+        final shares = await build(client).getSellShares('300,75', Currency.chf);
+
+        expect(shares.shares, 3);
+        expect(uri!.queryParameters['amount'], '300.75');
       });
 
       test('throws when amount is invalid (before any HTTP call)', () async {

--- a/test/packages/service/dfx/dfx_price_service_test.dart
+++ b/test/packages/service/dfx/dfx_price_service_test.dart
@@ -61,6 +61,24 @@ void main() {
         );
       });
 
+      test('rounds the scaled price instead of truncating (1.23 → 123)', () async {
+        // 1.23 * 100 is 122.999… in IEEE-754; `BigInt.from` on the raw product
+        // truncates toward zero to 122, understating the price by a rappen.
+        final client = MockClient((_) async => http.Response(
+              jsonEncode({'chf': 1.23, 'eur': 4.56}),
+              200,
+            ));
+
+        expect(
+          await build(client).getPriceOfAsset(realUnitAsset, Currency.chf),
+          BigInt.from(123),
+        );
+        expect(
+          await build(client).getPriceOfAsset(realUnitAsset, Currency.eur),
+          BigInt.from(456),
+        );
+      });
+
       test('returns zero when the price is missing (quote unavailable)', () async {
         // The live endpoint omits chf/eur while the quote is unavailable,
         // e.g. {"timestamp": "..."}. Must return zero (UI shows "--.--"),
@@ -98,6 +116,21 @@ void main() {
         expect(points[0].price, BigInt.from(100));
         expect(points[0].time, DateTime.utc(2026, 1, 1));
         expect(points[1].price, BigInt.from(250));
+      });
+
+      test('rounds each scaled chart price instead of truncating (1.23 → 123)', () async {
+        final client = MockClient((_) async => http.Response(
+              jsonEncode([
+                {'chf': 1.23, 'eur': 4.56, 'timestamp': '2026-01-01T00:00:00Z'},
+              ]),
+              200,
+            ));
+
+        final chf = await build(client).getPriceChart(realUnitAsset, Currency.chf);
+        expect(chf.single.price, BigInt.from(123));
+
+        final eur = await build(client).getPriceChart(realUnitAsset, Currency.eur);
+        expect(eur.single.price, BigInt.from(456));
       });
 
       test('parses EUR chart correctly', () async {

--- a/test/packages/service/dfx/dfx_price_service_test.dart
+++ b/test/packages/service/dfx/dfx_price_service_test.dart
@@ -61,21 +61,25 @@ void main() {
         );
       });
 
-      test('rounds the scaled price instead of truncating (1.23 → 123)', () async {
-        // 1.23 * 100 is 122.999… in IEEE-754; `BigInt.from` on the raw product
-        // truncates toward zero to 122, understating the price by a rappen.
+      test('rounds the scaled price instead of truncating (4.56 → 456)', () async {
+        // 4.56 * 100 is 455.999… in IEEE-754; `BigInt.from` on the raw product
+        // truncates toward zero to 455, understating the price by a rappen.
+        // 1.23 * 100 is exactly 123.0 and is never truncated — kept as a
+        // non-truncating sanity case.
         final client = MockClient((_) async => http.Response(
               jsonEncode({'chf': 1.23, 'eur': 4.56}),
               200,
             ));
 
-        expect(
-          await build(client).getPriceOfAsset(realUnitAsset, Currency.chf),
-          BigInt.from(123),
-        );
+        // Primary guard: the value that actually loses a rappen when truncated.
         expect(
           await build(client).getPriceOfAsset(realUnitAsset, Currency.eur),
           BigInt.from(456),
+        );
+        // Sanity: an exact product must stay put.
+        expect(
+          await build(client).getPriceOfAsset(realUnitAsset, Currency.chf),
+          BigInt.from(123),
         );
       });
 
@@ -118,7 +122,10 @@ void main() {
         expect(points[1].price, BigInt.from(250));
       });
 
-      test('rounds each scaled chart price instead of truncating (1.23 → 123)', () async {
+      test('rounds each scaled chart price instead of truncating (4.56 → 456)', () async {
+        // 4.56 * 100 is 455.999… in IEEE-754 and truncates toward zero to 455;
+        // rounding keeps the correct 456. 1.23 * 100 is exactly 123.0 and is
+        // never truncated — kept as a non-truncating sanity case.
         final client = MockClient((_) async => http.Response(
               jsonEncode([
                 {'chf': 1.23, 'eur': 4.56, 'timestamp': '2026-01-01T00:00:00Z'},
@@ -126,11 +133,13 @@ void main() {
               200,
             ));
 
-        final chf = await build(client).getPriceChart(realUnitAsset, Currency.chf);
-        expect(chf.single.price, BigInt.from(123));
-
+        // Primary guard: the value that actually loses a rappen when truncated.
         final eur = await build(client).getPriceChart(realUnitAsset, Currency.eur);
         expect(eur.single.price, BigInt.from(456));
+
+        // Sanity: an exact product must stay put.
+        final chf = await build(client).getPriceChart(realUnitAsset, Currency.chf);
+        expect(chf.single.price, BigInt.from(123));
       });
 
       test('parses EUR chart correctly', () async {

--- a/test/packages/service/dfx/models/payment/buy_payment_info_test.dart
+++ b/test/packages/service/dfx/models/payment/buy_payment_info_test.dart
@@ -4,6 +4,7 @@ import 'package:realunit_wallet/styles/currency.dart';
 
 void main() {
   const base = BuyPaymentInfo(
+    amount: 300,
     id: 1,
     iban: 'CH93 0076 2011 6238 52957',
     bic: 'UBSWCHZH80A',
@@ -19,6 +20,7 @@ void main() {
   group('BuyPaymentInfo equality (regression for #207)', () {
     test('same id but different iban are NOT equal', () {
       const other = BuyPaymentInfo(
+        amount: 300,
         id: 1,
         iban: 'DE89 3704 0044 0532 0130 00',
         bic: 'UBSWCHZH80A',
@@ -36,6 +38,7 @@ void main() {
 
     test('same id but different currency are NOT equal', () {
       const other = BuyPaymentInfo(
+        amount: 300,
         id: 1,
         iban: 'CH93 0076 2011 6238 52957',
         bic: 'UBSWCHZH80A',
@@ -53,6 +56,7 @@ void main() {
 
     test('identical fields are equal', () {
       const clone = BuyPaymentInfo(
+        amount: 300,
         id: 1,
         iban: 'CH93 0076 2011 6238 52957',
         bic: 'UBSWCHZH80A',

--- a/test/packages/service/dfx/models/pdf_support_bank_test.dart
+++ b/test/packages/service/dfx/models/pdf_support_bank_test.dart
@@ -219,6 +219,7 @@ void main() {
   group('$BuyPaymentInfo', () {
     test('equatable props cover every field', () {
       const a = BuyPaymentInfo(
+        amount: 300,
         id: 1,
         iban: 'CH...',
         bic: 'BIC',
@@ -231,6 +232,7 @@ void main() {
         currency: Currency.chf,
       );
       const b = BuyPaymentInfo(
+        amount: 300,
         id: 1,
         iban: 'CH...',
         bic: 'BIC',
@@ -243,6 +245,7 @@ void main() {
         currency: Currency.chf,
       );
       const c = BuyPaymentInfo(
+        amount: 300,
         id: 1,
         iban: 'CH...',
         bic: 'BIC',

--- a/test/packages/service/dfx/real_unit_account_service_test.dart
+++ b/test/packages/service/dfx/real_unit_account_service_test.dart
@@ -76,6 +76,18 @@ void main() {
       expect(path, '/v1/realunit/account/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266');
     });
 
+    test('getPortfolioHistory rounds the scaled value instead of truncating (4.56 → 456)', () async {
+      // 4.56 * 100 is 455.999… in IEEE-754; BigInt.from on the raw product
+      // truncates toward zero and understates the value by a rappen.
+      final client = MockClient(
+        (_) async => http.Response(jsonEncode(_summary(chf: 4.56)), 200),
+      );
+
+      final points = await build(client).getPortfolioHistory(Currency.chf);
+
+      expect(points.single.value, BigInt.from(456));
+    });
+
     test('getPortfolioHistory uses EUR values when Currency.eur is requested', () async {
       final client = MockClient((_) async => http.Response(
             jsonEncode(_summary(chf: 12.34, eur: 11.50)),

--- a/test/packages/storage/transaction_storage_test.dart
+++ b/test/packages/storage/transaction_storage_test.dart
@@ -70,4 +70,69 @@ void main() {
       expect(rows, isEmpty);
     });
   });
+
+  group('transfer filters match addresses case-insensitively', () {
+    // The DFX API returns EIP-55 checksummed addresses which are stored
+    // verbatim, while the query wallet is the lowercase primary address
+    // (`AppStore.primaryAddress` → `.address.hex`). A case-sensitive `=` on
+    // TEXT would never match and the whole transaction history renders empty.
+    const checksummed = '0x553C7f9C780316FC1D34b8e14ac2465Ab22a090B';
+    final walletLower = checksummed.toLowerCase();
+    const chainId = 1;
+    const assetAddress = '0xRealUnit';
+    final assetId = fastHash('$chainId:$assetAddress');
+    const other = '0x0000000000000000000000000000000000000001';
+
+    Future<void> insert(
+      String txId,
+      String sender,
+      String receiver,
+      int type,
+    ) => db.insertTransactions(
+      1,
+      txId,
+      chainId,
+      sender,
+      receiver,
+      '0xff',
+      assetId,
+      type,
+      '',
+      '',
+      DateTime.utc(2025, 1, 1),
+    );
+
+    test('watchTransfersOfAssets matches a checksummed sender', () async {
+      await insert('tx-sender', checksummed, other, 2);
+
+      final rows = await db.watchTransfersOfAssets({assetId}, walletLower).first;
+
+      expect(rows.map((r) => r.txId), ['tx-sender']);
+    });
+
+    test('watchTransfersOfAssets matches a checksummed receiver', () async {
+      await insert('tx-receiver', other, checksummed, 2);
+
+      final rows = await db.watchTransfersOfAssets({assetId}, walletLower).first;
+
+      expect(rows.map((r) => r.txId), ['tx-receiver']);
+    });
+
+    test('watchTransfersOfAssetsLimit matches a checksummed address', () async {
+      await insert('tx-limit', checksummed, other, 2);
+
+      final rows = await db.watchTransfersOfAssetsLimit({assetId}, walletLower, 10).first;
+
+      expect(rows.map((r) => r.txId), ['tx-limit']);
+    });
+
+    test('watchTransfersOfSavingsLimit matches a checksummed address', () async {
+      // Savings uses transfer types 3 / 4.
+      await insert('tx-savings', checksummed, other, 3);
+
+      final rows = await db.watchTransfersOfSavingsLimit({assetId}, walletLower, 10).first;
+
+      expect(rows.map((r) => r.txId), ['tx-savings']);
+    });
+  });
 }

--- a/test/packages/utils/fiat_amount_test.dart
+++ b/test/packages/utils/fiat_amount_test.dart
@@ -30,6 +30,14 @@ void main() {
       expect(() => chargedFiatAmount('1.300,75'), throwsFormatException);
       expect(() => chargedFiatAmount('3,5,7'), throwsFormatException);
     });
+
+    test('throws on grouping-ambiguous input instead of charging 1/1000th', () {
+      // `10,000` typed as ten thousand would otherwise parse as 10.0 and
+      // silently request a quote for ten francs.
+      expect(() => chargedFiatAmount('1,000'), throwsFormatException);
+      expect(() => chargedFiatAmount('10,000'), throwsFormatException);
+      expect(() => chargedFiatAmount('1.000'), throwsFormatException);
+    });
   });
 
   group('tryParseFiatAmount', () {
@@ -39,6 +47,16 @@ void main() {
 
     test('returns null on multi-separator input', () {
       expect(tryParseFiatAmount('1.300,75'), isNull);
+    });
+
+    test('returns null on grouping-ambiguous input (separator + 3 digits)', () {
+      expect(tryParseFiatAmount('1,000'), isNull);
+      expect(tryParseFiatAmount('1.000'), isNull);
+    });
+
+    test('still accepts unambiguous decimals', () {
+      expect(tryParseFiatAmount('0,5'), 0.5);
+      expect(tryParseFiatAmount('1,50'), 1.5);
     });
   });
 }

--- a/test/packages/utils/fiat_amount_test.dart
+++ b/test/packages/utils/fiat_amount_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/utils/fiat_amount.dart';
+
+void main() {
+  group('chargedFiatAmount', () {
+    // The quote is always requested with this rounded integer, so the SEPA
+    // transfer / QR the API builds encodes it.
+    test('rounds a dot decimal to the charged integer (300.75 → 301)', () {
+      expect(chargedFiatAmount('300.75'), 301);
+    });
+
+    test('normalises a comma decimal (300,75 → 301)', () {
+      expect(chargedFiatAmount('300,75'), 301);
+    });
+
+    test('leaves a whole amount unchanged (300 → 300)', () {
+      expect(chargedFiatAmount('300'), 300);
+    });
+
+    test('treats an empty string as zero', () {
+      expect(chargedFiatAmount(''), 0);
+    });
+
+    test('rounds half away from zero and down below the half (0.5 → 1, 1.49 → 1)', () {
+      expect(chargedFiatAmount('0.5'), 1);
+      expect(chargedFiatAmount('1.49'), 1);
+    });
+
+    test('throws on structurally invalid input instead of guessing', () {
+      expect(() => chargedFiatAmount('1.300,75'), throwsFormatException);
+      expect(() => chargedFiatAmount('3,5,7'), throwsFormatException);
+    });
+  });
+
+  group('tryParseFiatAmount', () {
+    test('accepts a comma decimal', () {
+      expect(tryParseFiatAmount('300,75'), 300.75);
+    });
+
+    test('returns null on multi-separator input', () {
+      expect(tryParseFiatAmount('1.300,75'), isNull);
+    });
+  });
+}

--- a/test/screens/buy/buy_page_test.dart
+++ b/test/screens/buy/buy_page_test.dart
@@ -115,6 +115,7 @@ void main() {
       when(() => buyPaymentInfoCubit.state).thenReturn(
         const BuyPaymentInfoSuccess(
           BuyPaymentInfo(
+            amount: 300,
             id: 1,
             iban: 'iban',
             bic: 'bic',

--- a/test/screens/buy/buy_payment_details_page_test.dart
+++ b/test/screens/buy/buy_payment_details_page_test.dart
@@ -13,6 +13,7 @@ import 'package:realunit_wallet/widgets/tab_selector.dart';
 import '../../helper/helper.dart';
 
 const _info = BuyPaymentInfo(
+  amount: 300,
   id: 1,
   iban: 'CH00 0000 0000 0000 0000 0',
   bic: 'BICCBIC',

--- a/test/screens/buy/cubits/buy_payment_info/buy_payment_info_state_test.dart
+++ b/test/screens/buy/cubits/buy_payment_info/buy_payment_info_state_test.dart
@@ -15,6 +15,7 @@ import 'package:realunit_wallet/styles/currency.dart';
 /// every subclass through a runtime constructor + `.props` lookup, so the
 /// value-type file lands at 100%.
 const _info = BuyPaymentInfo(
+  amount: 300,
   id: 1,
   iban: 'CH',
   bic: 'BIC',

--- a/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
+++ b/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
@@ -48,6 +48,31 @@ void main() {
 
   BuyPaymentInfoCubit build() => BuyPaymentInfoCubit(service);
 
+  group('BuyPaymentInfoCubit.chargedAmount', () {
+    // The Details tab must show the amount the backend actually charges (the
+    // quote is requested with this rounded integer), not the raw keystrokes.
+    test('rounds a dot decimal to the charged integer (300.75 → 301)', () {
+      expect(BuyPaymentInfoCubit.chargedAmount('300.75'), 301);
+    });
+
+    test('normalises a comma decimal (300,75 → 301)', () {
+      expect(BuyPaymentInfoCubit.chargedAmount('300,75'), 301);
+    });
+
+    test('leaves a whole amount unchanged (300 → 300)', () {
+      expect(BuyPaymentInfoCubit.chargedAmount('300'), 300);
+    });
+
+    test('treats an empty string as zero', () {
+      expect(BuyPaymentInfoCubit.chargedAmount(''), 0);
+    });
+
+    test('rounds half away from zero and down below the half (0.5 → 1, 1.49 → 1)', () {
+      expect(BuyPaymentInfoCubit.chargedAmount('0.5'), 1);
+      expect(BuyPaymentInfoCubit.chargedAmount('1.49'), 1);
+    });
+  });
+
   group('$BuyPaymentInfoCubit', () {
     test('initial state is BuyPaymentInfoInitial', () {
       expect(build().state, isA<BuyPaymentInfoInitial>());

--- a/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
+++ b/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
@@ -20,6 +20,7 @@ BuyPaymentInfo _info({
   String? error,
   Currency currency = Currency.chf,
 }) => BuyPaymentInfo(
+  amount: 300,
   id: 1,
   iban: 'CH56 0483 5012 3456 78',
   bic: 'CRESCHZZ80A',
@@ -47,31 +48,6 @@ void main() {
   });
 
   BuyPaymentInfoCubit build() => BuyPaymentInfoCubit(service);
-
-  group('BuyPaymentInfoCubit.chargedAmount', () {
-    // The Details tab must show the amount the backend actually charges (the
-    // quote is requested with this rounded integer), not the raw keystrokes.
-    test('rounds a dot decimal to the charged integer (300.75 → 301)', () {
-      expect(BuyPaymentInfoCubit.chargedAmount('300.75'), 301);
-    });
-
-    test('normalises a comma decimal (300,75 → 301)', () {
-      expect(BuyPaymentInfoCubit.chargedAmount('300,75'), 301);
-    });
-
-    test('leaves a whole amount unchanged (300 → 300)', () {
-      expect(BuyPaymentInfoCubit.chargedAmount('300'), 300);
-    });
-
-    test('treats an empty string as zero', () {
-      expect(BuyPaymentInfoCubit.chargedAmount(''), 0);
-    });
-
-    test('rounds half away from zero and down below the half (0.5 → 1, 1.49 → 1)', () {
-      expect(BuyPaymentInfoCubit.chargedAmount('0.5'), 1);
-      expect(BuyPaymentInfoCubit.chargedAmount('1.49'), 1);
-    });
-  });
 
   group('$BuyPaymentInfoCubit', () {
     test('initial state is BuyPaymentInfoInitial', () {

--- a/test/screens/buy/widgets/buy_confirm_button_test.dart
+++ b/test/screens/buy/widgets/buy_confirm_button_test.dart
@@ -20,6 +20,22 @@ class _MockBuyConfirmCubit extends MockCubit<BuyConfirmState>
     implements BuyConfirmCubit {}
 
 const _info = BuyPaymentInfo(
+  amount: 300,
+  id: 42,
+  iban: 'CH00 0000 0000 0000 0000 0',
+  bic: 'BICCBIC',
+  name: 'RealUnit AG',
+  street: 'Bahnhofstrasse',
+  number: '1',
+  zip: '8001',
+  city: 'Zurich',
+  country: 'Switzerland',
+  currency: Currency.chf,
+);
+
+// The quote echoes the charged amount; a fractional echo must render rounded.
+const _quotedFractional = BuyPaymentInfo(
+  amount: 300.75,
   id: 42,
   iban: 'CH00 0000 0000 0000 0000 0',
   bic: 'BICCBIC',
@@ -44,7 +60,7 @@ void main() {
   Widget host({GoRouter? router}) {
     final view = BlocProvider<BuyConfirmCubit>.value(
       value: cubit,
-      child: const BuyConfirmButtonView(buyPaymentInfo: _info, amount: '100'),
+      child: const BuyConfirmButtonView(buyPaymentInfo: _info),
     );
     if (router != null) {
       return MaterialApp.router(
@@ -128,7 +144,7 @@ void main() {
       expect(find.text(S.current.buyPaymentConfirmFailedAktionariat), findsOneWidget);
     });
 
-    GoRouter detailsRouter() => GoRouter(
+    GoRouter detailsRouter({BuyPaymentInfo info = _info}) => GoRouter(
           initialLocation: '/buy',
           routes: [
             GoRoute(
@@ -137,9 +153,8 @@ void main() {
               builder: (_, _) => Scaffold(
                 body: BlocProvider<BuyConfirmCubit>.value(
                   value: cubit,
-                  child: const BuyConfirmButtonView(
-                    buyPaymentInfo: _info,
-                    amount: '100',
+                  child: BuyConfirmButtonView(
+                    buyPaymentInfo: info,
                   ),
                 ),
               ),
@@ -180,34 +195,8 @@ void main() {
       expect(find.byType(TabSelector<PaymentInfoOptions>), findsNothing);
     });
 
-    GoRouter detailsRouterWithAmount(String amount) => GoRouter(
-          initialLocation: '/buy',
-          routes: [
-            GoRoute(
-              name: AppRoutes.buy,
-              path: '/buy',
-              builder: (_, _) => Scaffold(
-                body: BlocProvider<BuyConfirmCubit>.value(
-                  value: cubit,
-                  child: BuyConfirmButtonView(
-                    buyPaymentInfo: _info,
-                    amount: amount,
-                  ),
-                ),
-              ),
-            ),
-            GoRoute(
-              name: AppRoutes.buyPaymentDetails,
-              path: '/buyPaymentDetails',
-              builder: (_, state) => BuyPaymentDetailsPage(
-                params: state.extra as BuyPaymentDetailsParams,
-              ),
-            ),
-          ],
-        );
-
-    testWidgets('shows the rounded charged amount on the details page, not the '
-        'raw typed value (300.75 → 301)', (tester) async {
+    testWidgets('shows the charged amount echoed by the quote on the details '
+        'page, rounded (300.75 → 301) — never derived from keystrokes', (tester) async {
       whenListen(
         cubit,
         Stream.fromIterable([
@@ -220,11 +209,11 @@ void main() {
         initialState: const BuyConfirmInitial(),
       );
 
-      await tester.pumpWidget(host(router: detailsRouterWithAmount('300.75')));
+      await tester.pumpWidget(host(router: detailsRouter(info: _quotedFractional)));
       await tester.pumpAndSettle();
 
-      // The SEPA transfer / QR is built from the rounded integer the app sent
-      // for the quote; the Details tab must match it.
+      // The details amount is the quote's own echoed charge, so it can never
+      // disagree with the SEPA transfer / QR the backend built for the quote.
       expect(find.text('301'), findsOneWidget);
       expect(find.text('300.75'), findsNothing);
     });

--- a/test/screens/buy/widgets/buy_confirm_button_test.dart
+++ b/test/screens/buy/widgets/buy_confirm_button_test.dart
@@ -180,6 +180,55 @@ void main() {
       expect(find.byType(TabSelector<PaymentInfoOptions>), findsNothing);
     });
 
+    GoRouter detailsRouterWithAmount(String amount) => GoRouter(
+          initialLocation: '/buy',
+          routes: [
+            GoRoute(
+              name: AppRoutes.buy,
+              path: '/buy',
+              builder: (_, _) => Scaffold(
+                body: BlocProvider<BuyConfirmCubit>.value(
+                  value: cubit,
+                  child: BuyConfirmButtonView(
+                    buyPaymentInfo: _info,
+                    amount: amount,
+                  ),
+                ),
+              ),
+            ),
+            GoRoute(
+              name: AppRoutes.buyPaymentDetails,
+              path: '/buyPaymentDetails',
+              builder: (_, state) => BuyPaymentDetailsPage(
+                params: state.extra as BuyPaymentDetailsParams,
+              ),
+            ),
+          ],
+        );
+
+    testWidgets('shows the rounded charged amount on the details page, not the '
+        'raw typed value (300.75 → 301)', (tester) async {
+      whenListen(
+        cubit,
+        Stream.fromIterable([
+          const BuyConfirmSuccess(
+            reference: 'RU-REF-3',
+            remittanceInfo: null,
+            paymentRequest: null,
+          ),
+        ]),
+        initialState: const BuyConfirmInitial(),
+      );
+
+      await tester.pumpWidget(host(router: detailsRouterWithAmount('300.75')));
+      await tester.pumpAndSettle();
+
+      // The SEPA transfer / QR is built from the rounded integer the app sent
+      // for the quote; the Details tab must match it.
+      expect(find.text('301'), findsOneWidget);
+      expect(find.text('300.75'), findsNothing);
+    });
+
     testWidgets('forward path: remittanceInfo + paymentRequest drive the '
         'Verwendungszweck and surface the QR tab', (tester) async {
       whenListen(

--- a/test/screens/buy/widgets/payment_details_card_test.dart
+++ b/test/screens/buy/widgets/payment_details_card_test.dart
@@ -11,6 +11,7 @@ import 'package:realunit_wallet/widgets/tab_selector.dart';
 import '../../../helper/helper.dart';
 
 const _info = BuyPaymentInfo(
+  amount: 300,
   id: 1,
   iban: 'CH00 0000 0000 0000 0000 0',
   bic: 'BICCBIC',

--- a/test/screens/buy/widgets/payment_information_test.dart
+++ b/test/screens/buy/widgets/payment_information_test.dart
@@ -76,6 +76,7 @@ void main() {
         when(() => cubit.state).thenReturn(
           const BuyPaymentInfoSuccess(
             BuyPaymentInfo(
+              amount: 300,
               id: 1,
               iban: 'iban',
               bic: 'bic',

--- a/test/screens/buy_sell_states_test.dart
+++ b/test/screens/buy_sell_states_test.dart
@@ -15,6 +15,7 @@ const _bankA = BankAccount(id: 1, iban: 'CH1', name: 'A');
 const _bankB = BankAccount(id: 2, iban: 'CH2', name: 'B');
 
 const _buyInfo = BuyPaymentInfo(
+  amount: 300,
   id: 1,
   iban: 'CH',
   bic: 'BIC',

--- a/test/screens/sell/cubits/sell_payment_info_cubit_test.dart
+++ b/test/screens/sell/cubits/sell_payment_info_cubit_test.dart
@@ -102,6 +102,16 @@ void main() {
       verify(() => service.getPaymentInfo(100, 'CH56', currency: Currency.chf)).called(1);
     });
 
+    test('a comma-decimal amount is charged as the rounded integer (300,75 → 301)', () async {
+      when(
+        () => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')),
+      ).thenAnswer((_) async => _info());
+
+      await build().getPaymentInfo(amount: '300,75', iban: 'CH56');
+
+      verify(() => service.getPaymentInfo(301, 'CH56', currency: Currency.chf)).called(1);
+    });
+
     test('Success.isBitbox=true when the current wallet is a BitboxWallet', () async {
       when(
         () => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')),
@@ -322,10 +332,10 @@ void main() {
     );
 
     test(
-      'comma decimal in getPaymentInfo throws (UI converter rejects commas first in practice)',
+      'structurally invalid amount (multiple separators) fails without a service call',
       () async {
         final cubit = build();
-        await cubit.getPaymentInfo(amount: '100,50', iban: 'CH56');
+        await cubit.getPaymentInfo(amount: '1.300,75', iban: 'CH56');
 
         expect(cubit.state, isA<SellPaymentInfoFailure>());
         verifyNever(() => service.getPaymentInfo(any(), any(), currency: any(named: 'currency')));


### PR DESCRIPTION
Resolves the open findings of the signing & money/display audit (#615). Each fix ships a test that reproduces the bug first, then the fix.

## Findings

| Finding | Status | Test |
|---|---|---|
| **M1** — EIP-7702 `r`/`s` not zero-padded to 32 bytes | **Already fixed on `staging`** by #617 (`padLeft(64, '0')` on both `r` and `s` in `real_unit_sell_payment_info_service.dart`). No change here. | covered by #617 |
| **M2** — transaction history silently empty (address casing) | **Fixed here** | `transaction_storage_test.dart` |
| **M3** — price parsing truncates instead of rounds | **Fixed here** | `dfx_price_service_test.dart` |
| **M4** — buy Details amount differs from the charged amount | **Fixed here** | `buy_payment_info_cubit_test.dart`, `buy_confirm_button_test.dart` |
| **M5** — live converter fails silently on comma input | **Fixed here** | `dfx_brokerbot_service_test.dart` |

### M2 — case-insensitive transfer filters
`lib/packages/storage/transaction_storage.dart`: the three transfer queries compared `senderAddress`/`receiverAddress` against `wallet` (the lowercase `AppStore.primaryAddress`) with a plain `=`. EVM addresses are stored **verbatim** from the DFX API (`transfer.from`/`transfer.to`, EIP-55 checksummed / mixed case), so the case-sensitive comparison never matched and the dashboard + history rendered empty.

**Decision:** compare case-insensitively at query time via `COLLATE NOCASE` rather than normalizing on write. Rationale: rows already stored on users' devices are checksummed; a normalize-on-write approach would only fix *future* inserts and leave existing history broken until a migration. `NOCASE` folds ASCII `A–Z` — exactly the hex alphabet — so all stored rows keep matching immediately, no migration needed.

### M3 — round the scaled price
`lib/packages/service/dfx/dfx_price_service.dart`: `BigInt.from(rawPrice * 100)` truncates toward zero (`4.56 * 100` is `455.999…` → `455`, dropping a rappen; `1.23 * 100` is exactly `123.0` and is never truncated). Now `BigInt.from(((rawPrice as num) * 100).round())` — rounds and guards the `num` cast. `null` is still handled before the cast.

### M4 — display the charged integer
The buy quote is always requested with a rounded integer (`double.parse(...).round()`), so the SEPA transfer / QR the backend builds encodes that integer — but the Details tab showed the raw keystrokes (`300.75` while the QR encodes `301`). Extracted the rounding into `BuyPaymentInfoCubit.chargedAmount(...)` (single source of truth, reused by the cubit) and render `chargedAmount(amount)` in `buy_confirm_button.dart` so the displayed amount always equals the charged amount.

### M5 — normalize comma in the converter path
`lib/packages/service/dfx/dfx_brokerbot_service.dart`: `getBuyShares`/`getSellShares` parsed the raw fiat string with `double.tryParse`, so `"300,75"` → `null` → the service threw and the converter cubit left a stale preview. Now they `replaceAll(',', '.')` before parsing, reusing the same normalization the order/payment-info path already applies.

## Coverage of the A-track open PRs
Confirmed via `gh pr diff` that none of #604, #619, #620, #681, #682, #757 touch any of the M2–M5 files, so there is no overlap.

## Tests
All touched test files run green on the remote Mac (`flutter test`), and `flutter analyze` on the touched files reports no issues. Full-suite validation runs in CI.

Closes #615


---

## Follow-up commit `714e670` (2026-07-04) — review findings on the four fixes

The branch was also rebased onto current `staging` (clean cherry-pick, no conflicts).

- **M4, deeper:** the details page no longer re-derives the charged amount from live controller text at confirm time. The quote API already echoes `amount`; the service mapping dropped it — `BuyPaymentInfo` now carries it and the details navigation renders it. This removes a `double.parse` from the `BuyConfirmSuccess` listener that could throw **after** the binding confirm (losing the payment-details navigation for a confirmed purchase — the fiat field's formatter admits `1.000,50`), and closes the edit-after-quote window where the page could display an amount the backend never charged (`confirmPayment` uses the earlier quote's id). `BuyConfirmButton` no longer takes an `amount` at all.
- **M3, completed:** the same truncating `BigInt.from(x * 100)` survived at four sibling sites — the price chart's tooltip and dashed-line label, the portfolio chart's tooltip, and portfolio-history ingestion — so the fixed service showed `4.56` while the tooltip on the same screen recomputed `4.55` (and the portfolio path could double-truncate: `1.14` → `1.12`). All four now round. Regression test on the account service (`4.56 → 456`).
- **M5, consolidated:** the comma normalization existed as four inline copies; now one `fiat_amount.dart` util (`tryParseFiatAmount` / `chargedFiatAmount`) used by the brokerbot service, the buy quote path, and — previously unprotected — the sell payment-info path, which crashed on comma decimals (its safety depended on a `digitsOnly` formatter in a different file). Structurally invalid input (`1.300,75`) still fails closed, now uniformly.
- **M2, cleanup:** the three hand-pasted case-insensitive predicates are one `_involvesWallet` helper, so a future query can't silently miss the collation.

All affected suites green (1326 tests), `flutter analyze` clean.
