### PR TITLE
fix(user): compare all UserData fields in Equatable props

### DIFF
--- a/lib/packages/service/dfx/models/country/country.dart
+++ b/lib/packages/service/dfx/models/country/country.dart
@@ -20,6 +20,8 @@ class Country extends Equatable {
   });
 
   @override
+  // Deliberately id-keyed: dropdown seeding matches a Country fetched in one
+  // epoch against the items list of another, tolerating field drift.
   List<Object?> get props => [id];
 }
 

--- a/lib/packages/service/dfx/models/user/user_data.dart
+++ b/lib/packages/service/dfx/models/user/user_data.dart
@@ -32,5 +32,18 @@ class UserData extends Equatable {
   });
 
   @override
-  List<Object?> get props => [email, name];
+  List<Object?> get props => [
+    type,
+    email,
+    name,
+    phoneNumber,
+    birthday,
+    nationality,
+    addressStreet,
+    addressPostalCode,
+    addressCity,
+    addressCountry,
+    swissTaxResidence,
+    lang,
+  ];
 }

--- a/lib/screens/settings_user_data/cubit/settings_user_data_cubit.dart
+++ b/lib/screens/settings_user_data/cubit/settings_user_data_cubit.dart
@@ -72,14 +72,18 @@ class SettingsUserDataCubit extends Cubit<SettingsUserDataState> {
       final nationalityCountry = countryResults.elementAt(0);
       final addressCountry = countryResults.elementAt(1);
 
+      // '' (no birthday on record) parses to null; date-only UTC so equal dates compare equal.
+      final parsedBirthday = DateTime.tryParse(userDataDto.birthday);
+
       emit(
         SettingsUserDataSuccess(
           userData: UserData(
             type: RegistrationUserType.fromName(userDataDto.type),
             name: userDataDto.name,
             email: userDataDto.email,
-            // The API returns '' when no birthday is on record.
-            birthday: DateTime.tryParse(userDataDto.birthday),
+            birthday: parsedBirthday == null
+                ? null
+                : DateTime.utc(parsedBirthday.year, parsedBirthday.month, parsedBirthday.day),
             nationality: nationalityCountry,
             addressStreet: userDataDto.addressStreet,
             addressCity: userDataDto.addressCity,

--- a/test/packages/service/dfx/models/user/user_data_test.dart
+++ b/test/packages/service/dfx/models/user/user_data_test.dart
@@ -80,42 +80,35 @@ void main() {
       expect(data.lang, 'en');
     });
 
-    // The Equatable `props` list intentionally only includes `email` and
-    // `name`. The two assertions below pin both branches: identical
-    // email+name compares equal (even with differing nationality/phone),
-    // and divergent email or name breaks equality. The narrow props
-    // surface mirrors that user identity in the app is keyed on the
-    // mailbox + display name, not on every detail the API ships.
-    test('equality only considers email and name (props are narrow)', () {
-      final a = makeUserData(
-        phoneNumber: '+41790000001',
-        addressStreet: 'A',
-      );
-      final b = makeUserData(
-        phoneNumber: '+41790000002',
-        addressStreet: 'B',
-      );
+    test('instances with identical fields are equal', () {
+      final a = makeUserData();
+      final b = makeUserData();
 
       expect(a, equals(b));
       expect(a.hashCode, b.hashCode);
     });
 
-    test('different email or name breaks equality', () {
-      final base = makeUserData();
-      final differentEmail = makeUserData(email: 'bob@example.com');
-      final differentName = makeUserData(name: 'Bob Doe');
+    test('differing only in birthday breaks equality', () {
+      final base = makeUserData(birthday: DateTime.utc(1990, 1, 1));
+      final other = makeUserData(birthday: DateTime.utc(1991, 2, 3));
 
-      expect(base, isNot(equals(differentEmail)));
-      expect(base, isNot(equals(differentName)));
+      expect(base, isNot(equals(other)));
     });
 
-    test('props exposes exactly [email, name]', () {
-      // Catches accidental additions to props that would silently widen
-      // the equality contract beyond identity (and break the existing
-      // call sites that lean on `email == name` matching).
-      final data = makeUserData();
+    test('equality reflects the full field set', () {
+      final base = makeUserData();
 
-      expect(data.props, [data.email, data.name]);
+      expect(base, isNot(equals(makeUserData(email: 'bob@example.com'))));
+      expect(base, isNot(equals(makeUserData(name: 'Bob Doe'))));
+      expect(base, isNot(equals(makeUserData(type: RegistrationUserType.corporation))));
+      expect(base, isNot(equals(makeUserData(phoneNumber: '+41790000009'))));
+      expect(base, isNot(equals(makeUserData(nationality: germany))));
+      expect(base, isNot(equals(makeUserData(addressStreet: 'Other 2'))));
+      expect(base, isNot(equals(makeUserData(addressPostalCode: '9999'))));
+      expect(base, isNot(equals(makeUserData(addressCity: 'Geneva'))));
+      expect(base, isNot(equals(makeUserData(addressCountry: germany))));
+      expect(base, isNot(equals(makeUserData(swissTaxResidence: false))));
+      expect(base, isNot(equals(makeUserData(lang: 'en'))));
     });
   });
 }

--- a/test/packages/service/dfx/models/user/user_data_test.dart
+++ b/test/packages/service/dfx/models/user/user_data_test.dart
@@ -88,13 +88,6 @@ void main() {
       expect(a.hashCode, b.hashCode);
     });
 
-    test('differing only in birthday breaks equality', () {
-      final base = makeUserData(birthday: DateTime.utc(1990, 1, 1));
-      final other = makeUserData(birthday: DateTime.utc(1991, 2, 3));
-
-      expect(base, isNot(equals(other)));
-    });
-
     test('equality reflects the full field set', () {
       final base = makeUserData();
 
@@ -109,6 +102,7 @@ void main() {
       expect(base, isNot(equals(makeUserData(addressCountry: germany))));
       expect(base, isNot(equals(makeUserData(swissTaxResidence: false))));
       expect(base, isNot(equals(makeUserData(lang: 'en'))));
+      expect(base, isNot(equals(makeUserData(birthday: DateTime.utc(1991, 2, 3)))));
     });
   });
 }


### PR DESCRIPTION
Closes #761

## Problem
`UserData extends Equatable` but its `props` getter only listed `[email, name]`. As a result, two `UserData` instances that differ only in `type`, `phoneNumber`, `birthday`, `nationality`, `addressStreet`, `addressPostalCode`, `addressCity`, `addressCountry`, `swissTaxResidence`, or `lang` compared **equal**.

Equatable equality drives Bloc/Cubit state diffing. `SettingsUserDataSuccess` carries a `UserData` in its own `props`, so a new state whose only difference is one of the omitted fields (e.g. a birthday edited on the settings screen) could be treated as a no-op and skip the rebuild, leaving stale UI.

## Fix
List every field in `props` so the equality contract matches the full field set:

```dart
List<Object?> get props => [
  type, email, name, phoneNumber, birthday, nationality,
  addressStreet, addressPostalCode, addressCity, addressCountry,
  swissTaxResidence, lang,
];
```

## Investigation: was the narrow identity load-bearing?
No. `UserData` is constructed in exactly one place (`SettingsUserDataCubit`) and only ever held inside `SettingsUserDataSuccess.userData`. There is no `Set<UserData>`/`Map` keying, no `distinct()` on a `UserData` stream, and no `buildWhen`/comparison anywhere that relies on `[email, name]` identity. Widening `props` cannot break any existing consumer.

The two non-primitive field types are value-comparable, so structural equality holds: `Country extends Equatable`, and `RegistrationUserType` is an enum.

## Tests
Updated `test/packages/service/dfx/models/user/user_data_test.dart` to assert that instances with identical fields are equal, that instances differing only in `birthday` are not equal, and that each field participates in equality. Full test suite green (the only failures are pre-existing, environment-specific `generate_release_info` process-launch tests unrelated to this change).

## Review follow-ups
- **Birthday normalized to date-only UTC.** `DateTime.tryParse('1990-01-01')` yields a local-zone `DateTime`, which compares unequal to `DateTime.utc(1990, 1, 1)` for the same calendar date. Since `birthday` now participates in equality, the cubit normalizes the parsed value to `DateTime.utc(year, month, day)` so equal dates compare equal regardless of parse locale. The only display path (`DateFormat('dd.MM.yyyy')` on the settings page) formats the stored date fields directly and renders identically.
- **`Country.props` stays `[id]`, now documented.** `UserData` embeds two `Country` fields whose equality is id-keyed, so a change to e.g. `kycAllowed` for the same id is invisible to `UserData` equality. This is deliberate: `DfxCountryService` is a cached factory, so the country dropdown can match a seeded `Country` from one fetch against an items list from a later fetch — id is the stable key that keeps preselection working if other fields drift, and an existing test pins this contract. A comment on `props` now records the rationale.
- **Field-set test completed.** The `equality reflects the full field set` test now covers all 12 fields including `birthday`; the redundant birthday-only test was folded into it.
