### PR TITLE
feat(kyc): widen birthday year range to API 140-year contract + BirthdayField test coverage

### DIFF
--- a/lib/widgets/form/birthday_field.dart
+++ b/lib/widgets/form/birthday_field.dart
@@ -19,9 +19,11 @@ class _BirthdayFieldState extends State<BirthdayField> {
   String? selectedMonth;
   String? selectedYear;
 
+  static const _yearsBack = 140;
+
   List<String> days = List.generate(31, (i) => '${i + 1}'.padLeft(2, '0'));
   List<String> months = List.generate(12, (i) => '${i + 1}'.padLeft(2, '0'));
-  List<String> years = List.generate(141, (i) => '${DateTime.now().year - i}');
+  List<String> years = List.generate(_yearsBack + 1, (i) => '${DateTime.now().year - i}');
 
   @override
   void initState() {
@@ -46,16 +48,16 @@ class _BirthdayFieldState extends State<BirthdayField> {
     }
   }
 
-  // False for impossible combinations like 31.02.: DateTime rolls the
-  // overflow into the next month.
-  bool get isValidCalendarDate {
+  // False for impossible combinations like 31.02. (DateTime rolls the
+  // overflow into the next month) and for dates after today.
+  bool get isValidBirthdate {
     if (selectedDay == null || selectedMonth == null || selectedYear == null) return true;
     final date = DateTime(
       int.parse(selectedYear!),
       int.parse(selectedMonth!),
       int.parse(selectedDay!),
     );
-    return date.month == int.parse(selectedMonth!);
+    return date.month == int.parse(selectedMonth!) && !date.isAfter(DateTime.now());
   }
 
   @override
@@ -90,7 +92,7 @@ class _BirthdayFieldState extends State<BirthdayField> {
                   setState(() => selectedDay = v);
                   updateBirthday();
                 },
-                validator: (v) => v == null || !isValidCalendarDate ? '' : null,
+                validator: (v) => v == null || !isValidBirthdate ? '' : null,
               ),
             ),
             Expanded(

--- a/lib/widgets/form/birthday_field.dart
+++ b/lib/widgets/form/birthday_field.dart
@@ -21,7 +21,7 @@ class _BirthdayFieldState extends State<BirthdayField> {
 
   List<String> days = List.generate(31, (i) => '${i + 1}'.padLeft(2, '0'));
   List<String> months = List.generate(12, (i) => '${i + 1}'.padLeft(2, '0'));
-  List<String> years = List.generate(82, (i) => '${DateTime.now().year - i - 18}');
+  List<String> years = List.generate(141, (i) => '${DateTime.now().year - i}');
 
   @override
   void initState() {

--- a/test/widgets/form/birthday_field_test.dart
+++ b/test/widgets/form/birthday_field_test.dart
@@ -35,17 +35,48 @@ void main() {
     testWidgets('seeds only the parts the dropdowns offer for an out-of-range year', (
       tester,
     ) async {
-      // The API accepts birthdays outside the 18-99 range of the year
+      // The API accepts birthdays older than the now-140 floor of the year
       // dropdown. Seeding an unoffered year trips DropdownButtonFormField's
       // "exactly one item with value" assert and blanks the screen.
       await tester.pumpApp(
-        _host(BirthdayField(controller: ValueNotifier<String?>('1920-05-15'))),
+        _host(BirthdayField(controller: ValueNotifier<String?>('1850-05-15'))),
       );
 
       expect(tester.takeException(), isNull);
       expect(find.text('05'), findsOneWidget);
       expect(find.text('15'), findsOneWidget);
-      expect(find.text('1920'), findsNothing);
+      expect(find.text('1850'), findsNothing);
+    });
+
+    testWidgets('offers years older than 99 within the now-140 window (#762)', (
+      tester,
+    ) async {
+      // Before #762 the dropdown only spanned ages 18-99, so a 1920 birthday
+      // fell outside the offered years and was silently dropped. The window
+      // now runs now-140..now, so 1920 must be selectable.
+      await tester.pumpApp(
+        _host(BirthdayField(controller: ValueNotifier<String?>('1920-05-15'))),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('1920'), findsOneWidget);
+      expect(find.text('05'), findsOneWidget);
+      expect(find.text('15'), findsOneWidget);
+    });
+
+    testWidgets('ignores malformed month/day parts outside the dropdown items', (
+      tester,
+    ) async {
+      // Only the year guard was covered before. A malformed month (13) or day
+      // (40) is not an offered item and must be dropped without asserting.
+      await tester.pumpApp(
+        _host(BirthdayField(controller: ValueNotifier<String?>('1990-13-40'))),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('1990'), findsOneWidget);
+      expect(find.text('13'), findsNothing);
+      expect(find.text('40'), findsNothing);
     });
 
     testWidgets('validate() fails for an impossible calendar date', (tester) async {
@@ -76,6 +107,77 @@ void main() {
       );
 
       expect(formKey.currentState!.validate(), isTrue);
+    });
+
+    testWidgets('validate() fails for Feb 29 in a non-leap year', (tester) async {
+      // 2003 is not a leap year: DateTime(2003, 2, 29) rolls over to March 1,
+      // so the month no longer matches and the date is rejected.
+      final formKey = GlobalKey<FormState>();
+      await tester.pumpApp(
+        _host(
+          Form(
+            key: formKey,
+            child: BirthdayField(controller: ValueNotifier<String?>('2003-02-29')),
+          ),
+        ),
+      );
+
+      expect(formKey.currentState!.validate(), isFalse);
+    });
+
+    testWidgets('validate() passes for Feb 29 in a leap year', (tester) async {
+      // 2004 is a leap year: DateTime(2004, 2, 29) stays in February.
+      final formKey = GlobalKey<FormState>();
+      await tester.pumpApp(
+        _host(
+          Form(
+            key: formKey,
+            child: BirthdayField(controller: ValueNotifier<String?>('2004-02-29')),
+          ),
+        ),
+      );
+
+      expect(formKey.currentState!.validate(), isTrue);
+    });
+
+    testWidgets('selecting day/month/year via the dropdowns writes the controller', (
+      tester,
+    ) async {
+      final controller = ValueNotifier<String?>(null);
+      final formKey = GlobalKey<FormState>();
+      await tester.pumpApp(
+        _host(
+          Form(
+            key: formKey,
+            child: BirthdayField(controller: controller),
+          ),
+        ),
+      );
+
+      Future<void> select(int fieldIndex, String value) async {
+        await tester.tap(find.byType(DropdownField<String>).at(fieldIndex));
+        await tester.pumpAndSettle();
+        // The menu builds its items lazily, so scroll the freshly-opened menu
+        // (the last scrollable on screen) until the target item is rendered.
+        // While a menu is open its value is unique to that menu.
+        await tester.scrollUntilVisible(
+          find.text(value),
+          50.0,
+          scrollable: find.byType(Scrollable).last,
+        );
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(value));
+        await tester.pumpAndSettle();
+      }
+
+      await select(0, '31'); // day
+      await select(1, '02'); // month
+      await select(2, '2000'); // year
+
+      // updateBirthday writes once all three parts are set.
+      expect(controller.value, '2000-02-31');
+      // 31 February is impossible, so the field validates as false.
+      expect(formKey.currentState!.validate(), isFalse);
     });
 
     testWidgets('does not throw when the birthday has no separators', (tester) async {

--- a/test/widgets/form/birthday_field_test.dart
+++ b/test/widgets/form/birthday_field_test.dart
@@ -60,8 +60,6 @@ void main() {
 
       expect(tester.takeException(), isNull);
       expect(find.text('1920'), findsOneWidget);
-      expect(find.text('05'), findsOneWidget);
-      expect(find.text('15'), findsOneWidget);
     });
 
     testWidgets('ignores malformed month/day parts outside the dropdown items', (
@@ -79,60 +77,60 @@ void main() {
       expect(find.text('40'), findsNothing);
     });
 
-    testWidgets('validate() fails for an impossible calendar date', (tester) async {
+    // Impossible dates (31.02., 29.02. outside leap years) roll into the next
+    // month, which validate() rejects.
+    final year30 = '${DateTime.now().year - 30}';
+    for (final (seed, expectedValid) in [
+      ('$year30-02-31', false),
+      ('$year30-02-28', true),
+      ('2003-02-29', false),
+      ('2004-02-29', true),
+    ]) {
+      testWidgets('validate() is $expectedValid for $seed', (tester) async {
+        final formKey = GlobalKey<FormState>();
+        await tester.pumpApp(
+          _host(
+            Form(
+              key: formKey,
+              child: BirthdayField(controller: ValueNotifier<String?>(seed)),
+            ),
+          ),
+        );
+
+        expect(formKey.currentState!.validate(), expectedValid);
+      });
+    }
+
+    testWidgets('validate() fails for a birthday in the future', (tester) async {
       final formKey = GlobalKey<FormState>();
-      final year = '${DateTime.now().year - 30}';
+      final tomorrow = DateTime.now().add(const Duration(days: 1));
+      final seed =
+          '${tomorrow.year}-'
+          '${'${tomorrow.month}'.padLeft(2, '0')}-'
+          '${'${tomorrow.day}'.padLeft(2, '0')}';
       await tester.pumpApp(
         _host(
           Form(
             key: formKey,
-            child: BirthdayField(controller: ValueNotifier<String?>('$year-02-31')),
+            child: BirthdayField(controller: ValueNotifier<String?>(seed)),
           ),
         ),
       );
 
+      // Rejected via isValidBirthdate, or on Dec 31 (rolled year not offered,
+      // seed guard nulls it) via the null check — false either way.
       expect(formKey.currentState!.validate(), isFalse);
     });
 
-    testWidgets('validate() passes for a valid calendar date', (tester) async {
+    testWidgets('validate() passes for today', (tester) async {
       final formKey = GlobalKey<FormState>();
-      final year = '${DateTime.now().year - 30}';
+      final now = DateTime.now();
+      final seed = '${now.year}-${'${now.month}'.padLeft(2, '0')}-${'${now.day}'.padLeft(2, '0')}';
       await tester.pumpApp(
         _host(
           Form(
             key: formKey,
-            child: BirthdayField(controller: ValueNotifier<String?>('$year-02-28')),
-          ),
-        ),
-      );
-
-      expect(formKey.currentState!.validate(), isTrue);
-    });
-
-    testWidgets('validate() fails for Feb 29 in a non-leap year', (tester) async {
-      // 2003 is not a leap year: DateTime(2003, 2, 29) rolls over to March 1,
-      // so the month no longer matches and the date is rejected.
-      final formKey = GlobalKey<FormState>();
-      await tester.pumpApp(
-        _host(
-          Form(
-            key: formKey,
-            child: BirthdayField(controller: ValueNotifier<String?>('2003-02-29')),
-          ),
-        ),
-      );
-
-      expect(formKey.currentState!.validate(), isFalse);
-    });
-
-    testWidgets('validate() passes for Feb 29 in a leap year', (tester) async {
-      // 2004 is a leap year: DateTime(2004, 2, 29) stays in February.
-      final formKey = GlobalKey<FormState>();
-      await tester.pumpApp(
-        _host(
-          Form(
-            key: formKey,
-            child: BirthdayField(controller: ValueNotifier<String?>('2004-02-29')),
+            child: BirthdayField(controller: ValueNotifier<String?>(seed)),
           ),
         ),
       );
@@ -144,40 +142,36 @@ void main() {
       tester,
     ) async {
       final controller = ValueNotifier<String?>(null);
-      final formKey = GlobalKey<FormState>();
-      await tester.pumpApp(
-        _host(
-          Form(
-            key: formKey,
-            child: BirthdayField(controller: controller),
-          ),
-        ),
-      );
+      await tester.pumpApp(_host(BirthdayField(controller: controller)));
 
       Future<void> select(int fieldIndex, String value) async {
         await tester.tap(find.byType(DropdownField<String>).at(fieldIndex));
         await tester.pumpAndSettle();
+        // A closed sibling dropdown can show the same label as an item in the
+        // open menu (day '05' while picking month '05'), so match only inside
+        // the open menu's scrollable, which renders last in the tree.
+        final item = find.descendant(
+          of: find.byType(Scrollable).last,
+          matching: find.text(value),
+        );
         // The menu builds its items lazily, so scroll the freshly-opened menu
         // (the last scrollable on screen) until the target item is rendered.
-        // While a menu is open its value is unique to that menu.
         await tester.scrollUntilVisible(
-          find.text(value),
+          item,
           50.0,
           scrollable: find.byType(Scrollable).last,
         );
         await tester.pumpAndSettle();
-        await tester.tap(find.text(value));
+        await tester.tap(item);
         await tester.pumpAndSettle();
       }
 
-      await select(0, '31'); // day
-      await select(1, '02'); // month
-      await select(2, '2000'); // year
+      await select(0, '05');
+      await select(1, '05');
+      await select(2, '2000');
 
       // updateBirthday writes once all three parts are set.
-      expect(controller.value, '2000-02-31');
-      // 31 February is impossible, so the field validates as false.
-      expect(formKey.currentState!.validate(), isFalse);
+      expect(controller.value, '2000-05-05');
     });
 
     testWidgets('does not throw when the birthday has no separators', (tester) async {


### PR DESCRIPTION
## #762 — widen the birthday year dropdown

The birthday year dropdown previously offered ages 18-99 (`now-18 .. now-99`). The API enforces no minimum age, so the dropdown now aligns with the API contract: it offers `now .. now-140` inclusive (141 entries, newest first). The 18+ floor is dropped and the oldest year is `now-140`.

## #760 — BirthdayField test coverage

Added tests covering previously-untested paths:

- **Leap-year Feb 29**: `validate()` is false for Feb 29 in a non-leap year (2003) and true in a leap year (2004), using literal years to avoid drift across leap boundaries.
- **Dropdown interaction path**: taps day/month/year through the `DropdownField`s and asserts `updateBirthday` writes `controller.value`, and that 31 February validates as false.
- **Month/day seed guards**: a malformed `1990-13-40` is seeded without throwing and the out-of-range `13`/`40` parts are not shown.
- **Widened-range regression**: a `1920-05-15` birthday (previously outside the 18-99 window) is now selectable, pinning the range against a silent revert. The existing out-of-range seed test was repurposed to a genuinely out-of-range year (`1850`).

Closes #762
Closes #760

## Review follow-ups

- **Future-date guard**: the widened window includes the current year, so a future date like Dec 31 of this year passed `validate()`. The validity getter (renamed `isValidBirthdate`) now also rejects dates after today, with tests for a future date (negative) and today (positive control).
- **Named window constant**: the year list is generated from `_yearsBack = 140` (`_yearsBack + 1` entries) instead of a bare `141`, naming the API's 140-year contract and the inclusive fencepost.
- **Menu-scoped interaction taps**: the dropdown interaction test now matches items only inside the open menu's scrollable; a closed sibling dropdown can show the same label as a menu item (day `05` while picking month `05`), which previously made unscoped taps ambiguous. The test selects the colliding pair `05`/`05`/`2000` so the scoping stays load-bearing, and only asserts the controller write — impossible-date validation is owned by the dedicated `validate()` tests.
- **Table-driven validate() tests**: the four identical validate() scaffolds (02-31, 02-28, and the two Feb-29 cases) are collapsed into one loop over a (seed, expected) table.
- **Trimmed redundant assertions**: the #762 regression test keeps the no-exception and `1920` assertions; the day/month assertions it duplicated are owned by the adjacent seed-guard test.
