### PR TITLE
fix(security): seed & key material at-rest hardening (#612)

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,11 +3,54 @@ import UIKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
+  private static let backupExclusionChannelName = "swiss.realunit.app/backup_exclusion"
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    if let controller = window?.rootViewController as? FlutterViewController {
+      let channel = FlutterMethodChannel(
+        name: AppDelegate.backupExclusionChannelName,
+        binaryMessenger: controller.binaryMessenger
+      )
+      channel.setMethodCallHandler { call, result in
+        guard call.method == "excludeFromBackup" else {
+          result(FlutterMethodNotImplemented)
+          return
+        }
+        guard let paths = call.arguments as? [String] else {
+          result(
+            FlutterError(
+              code: "invalid_arguments",
+              message: "excludeFromBackup expects a list of file paths",
+              details: nil
+            )
+          )
+          return
+        }
+        for path in paths {
+          AppDelegate.excludeFromBackup(path: path)
+        }
+        result(nil)
+      }
+    }
+
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  /// Sets `NSURLIsExcludedFromBackupKey` on the file at `path` so it is left out
+  /// of iCloud / iTunes / Finder backups. Best-effort: files that do not exist
+  /// (e.g. a `-wal`/`-shm` sidecar not yet created) are skipped, and any failure
+  /// to set the attribute is intentionally swallowed — the exclusion is
+  /// defence-in-depth on an already-encrypted database, not a correctness
+  /// invariant.
+  private static func excludeFromBackup(path: String) {
+    guard FileManager.default.fileExists(atPath: path) else { return }
+    var url = URL(fileURLWithPath: path)
+    var values = URLResourceValues()
+    values.isExcludedFromBackup = true
+    try? url.setResourceValues(values)
   }
 }

--- a/lib/packages/io/backup_exclusion_adapter.dart
+++ b/lib/packages/io/backup_exclusion_adapter.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:realunit_wallet/packages/io/backup_exclusion_port.dart';
+
+/// Production [BackupExclusionPort]. On iOS it forwards the paths to the native
+/// side (`AppDelegate`) over a method channel, which sets
+/// `URLResourceValues.isExcludedFromBackup = true` on each existing file. On
+/// every other platform it is a no-op — Android already disables app backup
+/// via `android:allowBackup="false"`, so there is nothing to exclude.
+///
+/// The method-channel round-trip is the platform boundary itself, so — like
+/// [PathProviderAdapter] — its body cannot be exercised under `flutter test`
+/// without re-introducing the very plugin it abstracts away. The callers that
+/// depend on the port are covered against an in-memory fake instead.
+// @no-integration-test: thin platform-channel forwarder; the native effect
+//   (NSURLIsExcludedFromBackupKey) is only observable on a real iOS device.
+class BackupExclusionAdapter implements BackupExclusionPort {
+  const BackupExclusionAdapter();
+
+  static const MethodChannel _channel = MethodChannel('swiss.realunit.app/backup_exclusion');
+
+  // coverage:ignore-start
+  @override
+  Future<void> excludeFromBackup(List<String> paths) async {
+    if (!Platform.isIOS) return;
+    await _channel.invokeMethod<void>('excludeFromBackup', paths);
+  }
+  // coverage:ignore-end
+}

--- a/lib/packages/io/backup_exclusion_port.dart
+++ b/lib/packages/io/backup_exclusion_port.dart
@@ -1,0 +1,17 @@
+/// Boundary in front of the platform-specific "exclude this file from the
+/// device backup" call, so callers (today: `AppDatabase`) can be unit-tested
+/// without going through a platform channel.
+///
+/// Production wiring defaults to [BackupExclusionAdapter], which talks to the
+/// iOS native side via a method channel. On Android the backup is already
+/// disabled app-wide (`android:allowBackup="false"` in the manifest), so the
+/// adapter is a no-op there. Tests supply a fake that records the paths.
+abstract class BackupExclusionPort {
+  /// Marks each existing file in [paths] as excluded from the OS backup
+  /// (iCloud / iTunes / Finder on iOS via `NSURLIsExcludedFromBackupKey`).
+  ///
+  /// Best-effort and idempotent: paths that do not exist are skipped by the
+  /// platform implementation, and re-applying the flag on an already-excluded
+  /// file is a no-op — so it is safe to call on every app start.
+  Future<void> excludeFromBackup(List<String> paths);
+}

--- a/lib/packages/storage/database.dart
+++ b/lib/packages/storage/database.dart
@@ -5,6 +5,8 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path/path.dart' as p;
+import 'package:realunit_wallet/packages/io/backup_exclusion_adapter.dart';
+import 'package:realunit_wallet/packages/io/backup_exclusion_port.dart';
 import 'package:realunit_wallet/packages/io/documents_directory_port.dart';
 import 'package:realunit_wallet/packages/io/path_provider_adapter.dart';
 import 'package:realunit_wallet/packages/storage/asset_storage.dart';
@@ -96,6 +98,35 @@ class AppDatabase extends _$AppDatabase {
   ]) async {
     final path = await directory.getApplicationDocumentsDirectory();
     return p.join(path.path, _databaseFileName);
+  }
+
+  /// Excludes the SQLCipher database (and its SQLite `-wal` / `-shm` /
+  /// `-journal` sidecars) from the iOS device backup so the encrypted seed is
+  /// never uploaded to iCloud. Fixes #298 (NEW-20).
+  ///
+  /// The file stays at its current path in `Documents/` — excluding it in place
+  /// via `NSURLIsExcludedFromBackupKey` (the native side of
+  /// [BackupExclusionPort]) avoids moving a wallet-bearing file and the
+  /// migration risk that carries (the earlier move-based #293 was closed
+  /// unmerged; a lost DB during a move would lose the user's wallet). Note that
+  /// `Library/Application Support/` is itself backed up by default, so the move
+  /// alone would not have excluded it anyway.
+  ///
+  /// No-op on Android (backup already disabled via
+  /// `android:allowBackup="false"`) and on any non-iOS platform. Idempotent, so
+  /// callers invoke it on every launch after the DB is opened; sidecars that do
+  /// not exist yet are silently skipped by the platform implementation.
+  static Future<void> excludeDatabaseFromBackup([
+    BackupExclusionPort exclusion = const BackupExclusionAdapter(),
+    DocumentsDirectoryPort directory = const PathProviderAdapter(),
+  ]) async {
+    final dbPath = await getDatabasePath(directory);
+    await exclusion.excludeFromBackup([
+      dbPath,
+      '$dbPath-wal',
+      '$dbPath-shm',
+      '$dbPath-journal',
+    ]);
   }
 }
 

--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -181,13 +181,37 @@ class SecureStorage {
     return '${base64.encode(iv)}:${base64.encode(ciphertext)}';
   }
 
+  /// Decrypts a seed produced by [encryptSeed].
+  ///
+  /// Every malformed / tampered input is surfaced as a typed
+  /// [SeedDecryptionException] instead of the raw failure it wraps:
+  ///  * a missing `:` separator (previously an uncaught [RangeError] from
+  ///    `substring(0, -1)`),
+  ///  * a non-base64 IV / ciphertext or non-UTF-8 plaintext (a
+  ///    [FormatException]),
+  ///  * a wrong key, a tampered ciphertext, or a truncated GCM tag (an
+  ///    [InvalidCipherTextException]).
+  ///
+  /// This lets the unlock path catch one known type and show a controlled
+  /// error rather than crashing on a corrupted `walletInfos.seed` row.
+  /// AES-GCM rejecting a tampered ciphertext stays fully intact — this only
+  /// makes the rejection *typed*, it does not weaken authentication.
   static String decryptSeed(Uint8List key, String encoded) {
     final colonIndex = encoded.indexOf(':');
-    final iv = base64.decode(encoded.substring(0, colonIndex));
-    final ciphertext = base64.decode(encoded.substring(colonIndex + 1));
-    final cipher = GCMBlockCipher(AESEngine())
-      ..init(false, AEADParameters(KeyParameter(key), 128, iv, Uint8List(0)));
-    return utf8.decode(cipher.process(ciphertext));
+    if (colonIndex < 0) {
+      throw const SeedDecryptionException('missing IV separator');
+    }
+    try {
+      final iv = base64.decode(encoded.substring(0, colonIndex));
+      final ciphertext = base64.decode(encoded.substring(colonIndex + 1));
+      final cipher = GCMBlockCipher(AESEngine())
+        ..init(false, AEADParameters(KeyParameter(key), 128, iv, Uint8List(0)));
+      return utf8.decode(cipher.process(ciphertext));
+    } on InvalidCipherTextException catch (e) {
+      throw SeedDecryptionException('authentication failed: ${e.message}');
+    } on FormatException catch (e) {
+      throw SeedDecryptionException('malformed ciphertext: ${e.message}');
+    }
   }
 
   static Uint8List _secureRandomBytes(int length) {
@@ -198,3 +222,17 @@ class SecureStorage {
 
 String _hashPinIsolate(({String pin, Uint8List salt, int iterations}) args) =>
     SecureStorage.hashPin(args.pin, args.salt, iterations: args.iterations);
+
+/// Thrown by [SecureStorage.decryptSeed] when the stored ciphertext cannot be
+/// decrypted — because it is structurally malformed (missing separator, invalid
+/// base64), was tampered with, or was written under a different key (GCM tag
+/// mismatch). Lets callers on the unlock path distinguish "the stored seed is
+/// corrupt" from an unrelated crash and react with a controlled recovery flow.
+class SeedDecryptionException implements Exception {
+  const SeedDecryptionException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'SeedDecryptionException: $message';
+}

--- a/lib/screens/restore_wallet/restore_wallet_view.dart
+++ b/lib/screens/restore_wallet/restore_wallet_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:no_screenshot/no_screenshot.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
 import 'package:realunit_wallet/screens/restore_wallet/cubit/restore_wallet/restore_wallet_cubit.dart';
@@ -22,6 +23,20 @@ class RestoreWalletView extends StatefulWidget {
 class _RestoreWalletViewState extends State<RestoreWalletView> {
   final _controllers = List.generate(12, (_) => MnemonicInputFieldController());
   final _focusNodes = List.generate(12, (_) => FocusNode());
+
+  // @no-integration-test: no_screenshot suppresses the OS screenshot /
+  // app-switcher thumbnail / screen-recording via a platform channel — the
+  // real effect is only observable on a device, not in a widget/golden test.
+  @override
+  void initState() {
+    // The user types their existing 12-word recovery phrase here, so this
+    // screen handles real seed material just like the sibling seed screens
+    // (create/settings/verify). Block screenshots + the app-switcher snapshot
+    // while it is on screen; re-enabled on dispose so other screens stay
+    // screenshot-able.
+    NoScreenshot.instance.screenshotOff();
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) => MultiBlocListener(
@@ -121,6 +136,7 @@ class _RestoreWalletViewState extends State<RestoreWalletView> {
 
   @override
   void dispose() {
+    NoScreenshot.instance.screenshotOn();
     for (final controller in _controllers) {
       controller.dispose();
     }

--- a/lib/setup/di.dart
+++ b/lib/setup/di.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -89,6 +90,12 @@ Future<void> finishSetup(String encryptionKey) async {
   await setupBlocs();
 
   await setupDefaultAssets();
+
+  // `setupDefaultAssets` has now opened the SQLCipher file, so it exists on
+  // disk. Keep the encrypted seed database out of the iOS iCloud/iTunes backup
+  // (#298 / NEW-20). Best-effort and idempotent; `unawaited` so a platform
+  // hiccup surfaces in the zone instead of blocking boot. No-op off iOS.
+  unawaited(AppDatabase.excludeDatabaseFromBackup());
 }
 
 void setupRepositories() {

--- a/lib/setup/lifecycle_initializer.dart
+++ b/lib/setup/lifecycle_initializer.dart
@@ -42,27 +42,55 @@ class _LifecycleInitializerState extends State<LifecycleInitializer> {
     developer.log(state.name, name: 'AppLifecycleListener');
   }
 
+  /// Guards the background-lock so it arms at most once per background episode.
+  /// A normal backgrounding raises both `hidden` and `paused` (order and
+  /// coalescing vary by platform), so without this guard the mnemonic drop +
+  /// PIN re-lock would run twice — the second `lockCurrentWallet()` would
+  /// double-decrement [WalletService]'s active-unlock-holder count. Reset on
+  /// resume so the next backgrounding arms again.
+  bool _armedForBackground = false;
+
   void _onDetached() {}
 
   void _onResumed() {
+    _armedForBackground = false;
     getIt<PinAuthCubit>().onAppResumed();
     getIt<BalanceService>().updateBalance(getIt<AppStore>().primaryAddress);
   }
 
+  // `inactive` is deliberately NOT a lock trigger. On iOS it fires for
+  // transient interruptions that are still in front of the user — the
+  // biometric (Face ID / Touch ID) prompt, permission dialogs, the incoming
+  // call banner, the Control Center / notification-shade swipe. The biometric
+  // unlock prompt in particular raises `inactive`, so locking here would drop
+  // the mnemonic and re-arm the PIN gate in the middle of the very unlock the
+  // user is completing. We arm only on `paused` / `hidden`, which both mean the
+  // app is actually backgrounded.
   void _onInactive() {}
 
-  void _onHidden() {
+  void _onHidden() => _armBackgroundLock();
+
+  void _onPaused() {
+    getIt<BalanceService>().cancelSync();
+    _armBackgroundLock();
+  }
+
+  /// Drops the in-memory mnemonic and arms the PIN re-lock when the app is
+  /// backgrounded. Armed from both `hidden` and `paused` so a platform that
+  /// skips or coalesces `hidden` still locks (the finding's core gap), and made
+  /// idempotent via [_armedForBackground] so the `hidden` + `paused` pair locks
+  /// exactly once.
+  void _armBackgroundLock() {
+    if (_armedForBackground) return;
+    _armedForBackground = true;
+
     getIt<PinAuthCubit>().onAppHidden();
-    // Drop the mnemonic before iOS suspends the isolate. `lockCurrentWallet`
+    // Drop the mnemonic before the OS suspends the isolate. `lockCurrentWallet`
     // is defensive on its own — no try/catch / catchError by design, so a
     // Future.error surfaces in the Zone instead of being silently swallowed.
     // Microtask race to watch: if `_onResumed` ever calls
     // `ensureCurrentWalletUnlocked`, ordering against this pending lock matters.
     unawaited(getIt<WalletService>().lockCurrentWallet());
-  }
-
-  void _onPaused() {
-    getIt<BalanceService>().cancelSync();
   }
 
   @override

--- a/test/goldens/screens/restore_wallet/restore_wallet_golden_test.dart
+++ b/test/goldens/screens/restore_wallet/restore_wallet_golden_test.dart
@@ -21,6 +21,13 @@ void main() {
   late _MockValidateSeedCubit validateSeedCubit;
   late MockHomeBloc homeBloc;
 
+  setUpAll(() {
+    // RestoreWalletView now calls NoScreenshot.screenshotOff() in initState;
+    // stub the platform channel so the golden render does not throw a
+    // MissingPluginException (same pattern as the sibling seed golden tests).
+    stubNoScreenshotChannel();
+  });
+
   setUp(() {
     restoreWalletCubit = _MockRestoreWalletCubit();
     validateSeedCubit = _MockValidateSeedCubit();

--- a/test/packages/service/dfx/exceptions/exception_surface_test.dart
+++ b/test/packages/service/dfx/exceptions/exception_surface_test.dart
@@ -3,6 +3,7 @@ import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.da
 import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_address_unavailable_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/bitbox_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/payment/buy_exceptions.dart';
+import 'package:realunit_wallet/packages/storage/secure_storage.dart';
 import 'package:realunit_wallet/packages/wallet/exceptions/signing_cancelled_exception.dart';
 
 // Guard against a recurring failure mode: an Exception subclass without a
@@ -26,6 +27,7 @@ void main() {
         requiredLevel: 1,
         currentLevel: 0,
       ),
+      const SeedDecryptionException('test'),
     ];
 
     for (final ex in exceptions) {

--- a/test/packages/storage/database_test.dart
+++ b/test/packages/storage/database_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
+import 'package:realunit_wallet/packages/io/backup_exclusion_port.dart';
 import 'package:realunit_wallet/packages/io/documents_directory_port.dart';
 import 'package:realunit_wallet/packages/storage/database.dart';
 
@@ -80,6 +81,59 @@ void main() {
       expect(secondPath, p.join(secondDir.path, 'wallet.db.enc'));
     });
   });
+
+  group('AppDatabase.excludeDatabaseFromBackup', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('app_database_backup_test_');
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('excludes the db file and its wal/shm/journal sidecars in place', () async {
+      final dirPort = _FakeDocumentsDirectoryPort(tempDir);
+      final exclusionPort = _RecordingBackupExclusionPort();
+
+      await AppDatabase.excludeDatabaseFromBackup(exclusionPort, dirPort);
+
+      final dbPath = p.join(tempDir.path, 'wallet.db.enc');
+      expect(exclusionPort.calls, hasLength(1));
+      expect(exclusionPort.calls.single, [
+        dbPath,
+        '$dbPath-wal',
+        '$dbPath-shm',
+        '$dbPath-journal',
+      ]);
+      // The database keeps its resolved documents-dir path — the exclusion is
+      // applied in place, with no move (and therefore no migration risk).
+      expect(exclusionPort.calls.single.first, dbPath);
+    });
+
+    test('resolves the path through the documents port (no hard-coded location)', () async {
+      final dirPort = _FakeDocumentsDirectoryPort(tempDir);
+      final exclusionPort = _RecordingBackupExclusionPort();
+
+      await AppDatabase.excludeDatabaseFromBackup(exclusionPort, dirPort);
+
+      expect(dirPort.docsCalls, 1);
+    });
+  });
+}
+
+/// Records every [excludeFromBackup] invocation so tests can assert the exact
+/// set of paths handed to the platform boundary.
+class _RecordingBackupExclusionPort implements BackupExclusionPort {
+  final List<List<String>> calls = <List<String>>[];
+
+  @override
+  Future<void> excludeFromBackup(List<String> paths) async {
+    calls.add(paths);
+  }
 }
 
 /// Hands back each directory in [_directories] in turn; pins that

--- a/test/packages/storage/secure_storage_static_test.dart
+++ b/test/packages/storage/secure_storage_static_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -140,14 +141,22 @@ void main() {
       test('decryptSeed with a tampered ciphertext throws a typed SeedDecryptionException', () {
         final key = aesKey();
         final encoded = SecureStorage.encryptSeed(key, 'secret');
-        // Flip the last character of the base64 ciphertext half so the GCM
-        // authentication tag no longer verifies.
-        final tampered = encoded.substring(0, encoded.length - 1) +
-            (encoded.endsWith('A') ? 'B' : 'A');
+        final colonIndex = encoded.indexOf(':');
+        final ciphertext = base64.decode(encoded.substring(colonIndex + 1));
+        // Flip one bit mid-ciphertext and re-encode so the base64 stays valid
+        // and the failure comes from the GCM authentication tag check.
+        ciphertext[ciphertext.length ~/ 2] ^= 0x01;
+        final tampered = '${encoded.substring(0, colonIndex)}:${base64.encode(ciphertext)}';
 
         expect(
           () => SecureStorage.decryptSeed(key, tampered),
-          throwsA(isA<SeedDecryptionException>()),
+          throwsA(
+            isA<SeedDecryptionException>().having(
+              (e) => e.message,
+              'message',
+              contains('authentication failed'),
+            ),
+          ),
         );
       });
 

--- a/test/packages/storage/secure_storage_static_test.dart
+++ b/test/packages/storage/secure_storage_static_test.dart
@@ -124,14 +124,30 @@ void main() {
         expect(a, isNot(b));
       });
 
-      test('decryptSeed with the wrong key throws', () {
+      test('decryptSeed with the wrong key throws a typed SeedDecryptionException', () {
         final correctKey = aesKey();
         final wrongKey = Uint8List.fromList(List.generate(32, (i) => 0xFF - i));
         final encoded = SecureStorage.encryptSeed(correctKey, 'secret');
 
+        // GCM tag mismatch surfaces as a typed exception, not a bare
+        // InvalidCipherTextException leaking out of the unlock path.
         expect(
           () => SecureStorage.decryptSeed(wrongKey, encoded),
-          throwsA(anything),
+          throwsA(isA<SeedDecryptionException>()),
+        );
+      });
+
+      test('decryptSeed with a tampered ciphertext throws a typed SeedDecryptionException', () {
+        final key = aesKey();
+        final encoded = SecureStorage.encryptSeed(key, 'secret');
+        // Flip the last character of the base64 ciphertext half so the GCM
+        // authentication tag no longer verifies.
+        final tampered = encoded.substring(0, encoded.length - 1) +
+            (encoded.endsWith('A') ? 'B' : 'A');
+
+        expect(
+          () => SecureStorage.decryptSeed(key, tampered),
+          throwsA(isA<SeedDecryptionException>()),
         );
       });
 
@@ -147,22 +163,48 @@ void main() {
         expect(parts[0], hasLength(16));
       });
 
-      test('decryptSeed with missing colon separator throws', () {
+      test('decryptSeed with missing colon separator throws a typed SeedDecryptionException', () {
         final key = aesKey();
 
+        // Previously an uncaught RangeError from `substring(0, -1)`; now a
+        // controlled, catchable failure.
         expect(
           () => SecureStorage.decryptSeed(key, 'noColonHere'),
-          throwsA(anything),
+          throwsA(isA<SeedDecryptionException>()),
         );
       });
 
-      test('decryptSeed with empty string throws', () {
+      test('decryptSeed with empty string throws a typed SeedDecryptionException', () {
         final key = aesKey();
 
         expect(
           () => SecureStorage.decryptSeed(key, ''),
-          throwsA(anything),
+          throwsA(isA<SeedDecryptionException>()),
         );
+      });
+
+      test('decryptSeed with a valid separator but non-base64 body throws a typed exception', () {
+        final key = aesKey();
+
+        // Colon present (clears the separator guard) but the ciphertext half
+        // is not valid base64 → exercises the FormatException branch.
+        expect(
+          () => SecureStorage.decryptSeed(key, 'AAAAAAAAAAAAAAAA:not*valid*base64'),
+          throwsA(isA<SeedDecryptionException>()),
+        );
+      });
+
+      test('SeedDecryptionException carries a descriptive message and toString', () {
+        SeedDecryptionException? caught;
+        try {
+          SecureStorage.decryptSeed(aesKey(), 'noColonHere');
+        } on SeedDecryptionException catch (e) {
+          caught = e;
+        }
+
+        expect(caught, isNotNull);
+        expect(caught!.message, contains('IV separator'));
+        expect(caught.toString(), 'SeedDecryptionException: ${caught.message}');
       });
     });
   });

--- a/test/screens/restore_wallet/restore_wallet_page_test.dart
+++ b/test/screens/restore_wallet/restore_wallet_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -90,6 +91,41 @@ void main() {
       );
       expect(find.byType(RestoreWalletInputField), findsOne);
       expect(find.byType(RestoreWalletButton), findsOne);
+    });
+
+    // The restore screen is where the user types their existing 12-word
+    // recovery phrase, so it handles real seed material like the sibling seed
+    // screens. It must block screenshots + the app-switcher snapshot on init
+    // and re-enable them on dispose so it never lands in the recents thumbnail
+    // or a screen recording.
+    testWidgets('disables screenshots on init and re-enables on dispose', (tester) async {
+      const channel = MethodChannel('com.flutterplaza.no_screenshot_methods');
+      final calls = <String>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        (call) async {
+          calls.add(call.method);
+          return true;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, null),
+      );
+
+      await tester.pumpApp(buildSubject(const RestoreWalletView()));
+      expect(
+        calls,
+        contains('screenshotOff'),
+        reason: 'the restore screen handles real seed words and must block screenshots on init',
+      );
+
+      // Replace the screen so RestoreWalletView is disposed.
+      await tester.pumpApp(buildSubject(const SizedBox.shrink()));
+      expect(
+        calls,
+        contains('screenshotOn'),
+        reason: 'leaving the restore screen must re-enable screenshots',
+      );
     });
 
     group('$RestoreWalletButton', () {

--- a/test/setup/lifecycle_initializer_test.dart
+++ b/test/setup/lifecycle_initializer_test.dart
@@ -70,19 +70,65 @@ void main() {
   // the source comment to catch a future regression at the call site.
 
   testWidgets(
-    'AppLifecycleState.paused does NOT lock the wallet — already covered by hidden',
+    'AppLifecycleState.paused arms the lock (covers a skipped/coalesced hidden)',
     (tester) async {
       await pumpLifecycle(tester);
 
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
       await tester.pump();
 
-      verifyNever(() => walletService.lockCurrentWallet());
+      // paused must now drop the mnemonic and arm the PIN gate too, so a
+      // platform that never emits `hidden` still locks.
+      verify(() => walletService.lockCurrentWallet()).called(1);
+      verify(() => pinAuthCubit.onAppHidden()).called(1);
+      // and it still cancels the balance sync it always did.
+      verify(() => balanceService.cancelSync()).called(1);
     },
   );
 
   testWidgets(
-    'AppLifecycleState.resumed does NOT call lockCurrentWallet',
+    'hidden + paused in one background episode lock exactly once (idempotent)',
+    (tester) async {
+      await pumpLifecycle(tester);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+
+      verify(() => walletService.lockCurrentWallet()).called(1);
+      verify(() => pinAuthCubit.onAppHidden()).called(1);
+    },
+  );
+
+  testWidgets(
+    'paused + hidden in the reverse order also lock exactly once',
+    (tester) async {
+      await pumpLifecycle(tester);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      await tester.pump();
+
+      verify(() => walletService.lockCurrentWallet()).called(1);
+      verify(() => pinAuthCubit.onAppHidden()).called(1);
+    },
+  );
+
+  testWidgets(
+    'AppLifecycleState.inactive does NOT lock (biometric/permission prompts raise it)',
+    (tester) async {
+      await pumpLifecycle(tester);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      await tester.pump();
+
+      verifyNever(() => walletService.lockCurrentWallet());
+      verifyNever(() => pinAuthCubit.onAppHidden());
+    },
+  );
+
+  testWidgets(
+    'AppLifecycleState.resumed does NOT lock and re-arms for the next background',
     (tester) async {
       when(() => appStore.primaryAddress).thenReturn('0xabc');
       when(() => balanceService.updateBalance(any())).thenAnswer((_) async {});
@@ -90,10 +136,47 @@ void main() {
 
       await pumpLifecycle(tester);
 
-      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      // The lifecycle machine only permits single-step moves along
+      // detached ↔ paused ↔ hidden ↔ inactive ↔ resumed, and the binding's
+      // state carries across tests in this file. Step along the chain from the
+      // current state so every transition is valid.
+      const chain = <AppLifecycleState>[
+        AppLifecycleState.detached,
+        AppLifecycleState.paused,
+        AppLifecycleState.hidden,
+        AppLifecycleState.inactive,
+        AppLifecycleState.resumed,
+      ];
+      void driveTo(AppLifecycleState target) {
+        if (tester.binding.lifecycleState == null) {
+          tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        }
+        var index = chain.indexOf(tester.binding.lifecycleState!);
+        final targetIndex = chain.indexOf(target);
+        while (index != targetIndex) {
+          index += index < targetIndex ? 1 : -1;
+          tester.binding.handleAppLifecycleStateChanged(chain[index]);
+        }
+      }
+
+      // Known foreground baseline.
+      driveTo(AppLifecycleState.resumed);
       await tester.pump();
 
-      verifyNever(() => walletService.lockCurrentWallet());
+      // First background episode locks once.
+      driveTo(AppLifecycleState.hidden);
+      await tester.pump();
+      verify(() => walletService.lockCurrentWallet()).called(1);
+
+      // Resume clears the arm guard and must not itself lock.
+      driveTo(AppLifecycleState.resumed);
+      await tester.pump();
+
+      // Second background episode locks again — only possible because resume
+      // reset the guard; without the reset the handler would be a no-op.
+      driveTo(AppLifecycleState.hidden);
+      await tester.pump();
+      verify(() => walletService.lockCurrentWallet()).called(1);
     },
   );
 }


### PR DESCRIPTION
Hardens the at-rest handling of seed and key material flagged by the source-level audit in #612, plus the related iOS-backup exposure NEW-20 from #298.

Refs #612
Refs #298 (NEW-20)

## Findings

| # | Sev | Decision | Fix | Test |
|---|-----|----------|-----|------|
| S1 | HIGH | **Scoped** screenshot protection, not app-wide `FLAG_SECURE` (rationale below); close the one remaining gap | `restore_wallet_view` (user types their existing 12 words) now blocks screenshots + the app-switcher snapshot on `initState` / re-enables on `dispose`, like the sibling seed screens | widget test asserts the `no_screenshot` channel gets `screenshotOff` on init, `screenshotOn` on dispose |
| S2 | HIGH | Already fixed on `staging` | `deleteCurrentWallet` → `purgeWallet` (seed row **and** mnemonic key) landed in #621; regenerate path still uses account-only delete | covered by existing `wallet_repository_test` / `wallet_service_test` |
| S3 | MED | Owned by #619 | — | — |
| S4 | MED | Arm the auto-lock on `paused` **and** `hidden`; **not** on `inactive` | `lifecycle_initializer` arms the mnemonic-drop + PIN re-lock from both `hidden` and `paused`, made idempotent per background episode | 6 widget tests (paused arms, hidden+paused / paused+hidden lock once, inactive inert, resume re-arms) |
| S5 | MED | **Deferred** — cannot verify a safe migration without on-device runs (details below) | runtime unchanged | — |
| S6 | LOW | Fail typed & gracefully | `decryptSeed` throws a typed `SeedDecryptionException` for a missing separator, invalid base64, or GCM auth failure instead of a raw `RangeError` / `InvalidCipherTextException` | static tests for each failure branch + toString |
| NEW-20 | — | Exclude the encrypted DB from iCloud **in place** (no move) | `NSURLIsExcludedFromBackupKey` set on the SQLCipher file + `-wal`/`-shm`/`-journal` sidecars via a method channel; wired into boot | `database_test` asserts the exact path set; adapter is the platform boundary |

## S1 — why scoped, not app-wide `FLAG_SECURE`

I inspected the `no_screenshot` **1.1.0** source (`com.flutterplaza.no_screenshot.NoScreenshotPlugin`): `screenshotOff()` calls `window.addFlags(FLAG_SECURE)` and `screenshotOn()` calls `clearFlags(FLAG_SECURE)`. `FLAG_SECURE` is exactly the OS mechanism that blanks the recents/app-switcher thumbnail **and** blocks OS/3rd-party screen recording. So on the seed screens where `screenshotOff()` is active, those vectors are already closed while the screen is mounted — correcting the finding's premise that `no_screenshot` covers only manual screenshots.

App-wide `FLAG_SECURE` in `MainActivity` was considered and **declined**:

- **Technical incompatibility.** `no_screenshot` toggles the *same* window `FLAG_SECURE`. A flag set globally in `MainActivity.onCreate` would be silently *cleared* by the `screenshotOn()` in any seed screen's `dispose`, leaving the whole app unprotected afterwards. Making app-wide work would require ripping `no_screenshot` out entirely — which directly collides with the in-flight #619 (adds `no_screenshot` to verify-seed).
- **Product stance.** The codebase deliberately keeps non-sensitive screens screenshot-able (e.g. receive-QR sharing); #619 reaffirms the per-screen pattern with the comment *"so non-sensitive screens stay screenshot-able."*

The residual risk in the scoped model is *completeness* — a screen that shows/handles seed words but forgets to opt in (exactly the S3 miss). Auditing the seed screens found `restore_wallet` unprotected (the user types their real recovery phrase there); this PR closes it. `create_wallet` and `settings_seed` were already protected; verify-seed is handled by #619.

If the team later wants belt-and-suspenders app-wide protection, the clean path is to drop `no_screenshot` and set `FLAG_SECURE` in `MainActivity`, accepting the loss of legitimate screenshots — a product call, out of scope here. iOS app-switcher blanking is not included (Android-focused finding; iOS would need a native cover-view — not cheap/clean).

## S4 — lock on `paused`/`hidden`, not `inactive`

Only `hidden` armed the auto-lock + mnemonic drop, so a platform that skips/coalesces `hidden` left `_lastBackgroundTime == null` and never force-locked. Now both `hidden` and `paused` arm it, guarded by a per-episode flag (reset on `resumed`) so the `hidden`+`paused` pair — and their double `lockCurrentWallet()`, which would otherwise double-decrement the active-unlock-holder count — locks exactly once.

`inactive` is intentionally **not** a trigger: on iOS it fires for transient, still-foreground interruptions — the biometric (Face ID/Touch ID) prompt, permission dialogs, the incoming-call banner, Control Center. The biometric unlock prompt in particular raises `inactive`, so locking there would drop the mnemonic and re-arm the PIN gate in the middle of the very unlock the user is completing.

## S5 — deferred, with recommendation

`const FlutterSecureStorage()` is constructed without hardened options (Android `encryptedSharedPreferences`, iOS `KeychainAccessibility`). It holds the SQLCipher DB key, the mnemonic AES key, and the PIN hash/lockout.

I am **not** changing this at runtime, because I cannot establish a verified-safe migration without on-device runs, and the downside is catastrophic: on `flutter_secure_storage` **9.2.4**, flipping Android to `encryptedSharedPreferences: true` switches the storage backend, and existing entries written by the legacy cipher backend can become **unreadable** — losing the mnemonic-decryption key would brick every existing wallet. A read-old → rewrite-new migration is possible in principle but must be validated on real Android/iOS devices with an upgrade-in-place install, which is outside this environment.

**Recommendation (follow-up):**
- Android: add `AndroidOptions(encryptedSharedPreferences: true)` behind a one-time, idempotent read-legacy → rewrite-hardened migration, gated on a persisted `migratedV2` marker; validate an upgrade-in-place install on-device before shipping.
- iOS: set `IOSOptions(accessibility: KeychainAccessibility.first_unlock_this_device)` so keys are not eligible for iCloud-Keychain/backup restore onto another device. Reads of existing items remain valid (accessibility governs *when* readable, not the lookup); still verify on-device.

## S6

`decryptSeed` now guards the missing-separator case and wraps base64/GCM failures in a typed `SeedDecryptionException`, so a corrupted `walletInfos.seed` row surfaces a catchable error on the unlock path instead of an uncaught `RangeError`. AES-GCM's rejection of tampered ciphertext is unchanged — only *typed*.

## NEW-20 (#298) — DB out of iCloud backup

The SQLCipher DB lives in `Documents/`, which iOS backs up to iCloud. The earlier move-based #293 was closed unmerged; note that `Library/Application Support/` is itself backed up by default, so a move alone would not have excluded it. This PR excludes the file **in place** via `NSURLIsExcludedFromBackupKey` (no move → no migration risk to a wallet-bearing file), covering the `-wal`/`-shm`/`-journal` sidecars too, idempotently on each launch. Android is unaffected (`android:allowBackup="false"`).

## Coordination

- No overlap with #757: it rewrites `verifyPin` (adds `PinVerificationResult`); this PR touches `decryptSeed` and the `FlutterSecureStorage` *nothing*, and the new `SeedDecryptionException` sits at the end of the file, away from #757's edits.
- S2 (#621) and S3 (#619) are noted above, not re-fixed.

## Tests

Targeted suites green on Flutter 3.41.6 (storage, repository, lifecycle, restore-wallet). `flutter analyze` clean on all changed files. Kotlin/Swift changes are minimal and not emulator-testable here; the Dart side is covered.


## Post-review corrections (2026-07-04)

- **S4 premise:** Flutter ≥3.13 synthesizes `hidden` before every `paused` (`ServicesBinding._generateStateTransitions`), so a platform delivering `paused` without `hidden` is unreachable and the described lock gap was theoretical. The change is still worthwhile for a different reason: the per-episode idempotence guard suppresses the duplicate `lockCurrentWallet()` the base code fired on every `hidden`+`paused` episode (double-decrementing the unlock-holder count).
- **NEW-20 sidecars:** the DB runs in default rollback-journal mode (no WAL pragma; drift 2.32.1 doesn't enable it), so `-wal`/`-shm` never exist and a live `-journal` is rolled back and deleted before the boot-time exclusion runs. The sidecar handling is forward-proofing only; the effective exclusion today is the main DB file. Recommended before/at merge: one on-device check that the xattr actually sticks on the main file (the exclusion call fails silently by design: `if let` + `try?` + `unawaited`).
