### PR TITLE
fix(pin): unify best-effort lockout reset across both unlock paths

### DIFF
--- a/lib/packages/storage/secure_storage.dart
+++ b/lib/packages/storage/secure_storage.dart
@@ -111,8 +111,6 @@ class SecureStorage {
 
   Future<String?> getPinHash() => _secureStorage.read(key: _pinHashKey);
 
-  Future<void> setPinHash(String hash) => _secureStorage.write(key: _pinHashKey, value: hash);
-
   Future<bool> hasPinHash() async =>
       await _secureStorage.read(key: _pinCredentialKey) != null ||
       await _secureStorage.read(key: _pinHashKey) != null;
@@ -128,9 +126,6 @@ class SecureStorage {
     if (hex == null) return null;
     return hexToBytes(hex);
   }
-
-  Future<void> setPinSalt(Uint8List salt) =>
-      _secureStorage.write(key: _pinSaltKey, value: bytesToHex(salt));
 
   /// Writes the PIN salt+hash as a single atomic keychain entry.
   ///

--- a/lib/screens/pin/bloc/verify_pin/verify_pin_cubit.dart
+++ b/lib/screens/pin/bloc/verify_pin/verify_pin_cubit.dart
@@ -68,7 +68,7 @@ class VerifyPinCubit extends Cubit<VerifyPinState> {
       if (state is VerifyPinSuccess) return;
       switch (result) {
         case PinVerificationResult.correct:
-          if (enableLockout) await _secureStorage.resetPinLockout();
+          await _resetLockoutBestEffort();
           _safeEmit(VerifyPinSuccess(biometricStatus: biometricStatus));
         case PinVerificationResult.notVerifiable:
           // No stored hash/salt: no input could ever match. Steer to recovery
@@ -187,18 +187,7 @@ class VerifyPinCubit extends Cubit<VerifyPinState> {
     if (state is VerifyPinSuccess) return;
     switch (outcome) {
       case BiometricAuthOutcome.success:
-        if (enableLockout) {
-          try {
-            await _secureStorage.resetPinLockout();
-          } catch (_) {
-            // Best-effort cleanup: the scan already succeeded, so unlock even if
-            // clearing the counter fails — a stale count self-heals on the next
-            // successful check. Without this a keychain throw would skip the
-            // success emit (the wallet would stay locked after a valid scan) and,
-            // because every caller is fire-and-forget, surface as an unhandled
-            // async error. Mirrors _checkPin's defensive storage handling.
-          }
-        }
+        await _resetLockoutBestEffort();
         _safeEmit(VerifyPinSuccess(biometricStatus: state.biometricStatus));
       case BiometricAuthOutcome.failed:
         // Plain scan failure or user cancel: stay silent, keep the button.
@@ -211,6 +200,24 @@ class VerifyPinCubit extends Cubit<VerifyPinState> {
         _setBiometricStatus(BiometricStatus.notEnrolled);
       case BiometricAuthOutcome.unavailable:
         _setBiometricStatus(BiometricStatus.unavailable);
+    }
+  }
+
+  /// Clears the failed-attempt / lockout counters after a successful auth.
+  ///
+  /// Best-effort: the auth already succeeded (correct PIN or a valid biometric
+  /// scan), so a keychain failure while clearing the counters must not block the
+  /// unlock — a stale count self-heals on the next successful check. Without this
+  /// a throw would skip the success emit (the wallet would stay locked after a
+  /// valid auth) and, because callers are fire-and-forget, surface as an
+  /// unhandled async error. Both success paths (PIN and biometric) route through
+  /// here so they stay consistent.
+  Future<void> _resetLockoutBestEffort() async {
+    if (!enableLockout) return;
+    try {
+      await _secureStorage.resetPinLockout();
+    } catch (_) {
+      // Intentionally swallowed — see the doc comment above.
     }
   }
 

--- a/test/packages/storage/secure_storage_test.dart
+++ b/test/packages/storage/secure_storage_test.dart
@@ -91,12 +91,6 @@ void main() {
       expect(await secureStorage.getPinHash(), 'abc123');
     });
 
-    test('setPinHash writes the value under pin.hash', () async {
-      await secureStorage.setPinHash('hashed');
-
-      verify(() => mockStorage.write(key: 'pin.hash', value: 'hashed')).called(1);
-    });
-
     test('hasPinHash is true when only the atomic credential is present', () async {
       when(
         () => mockStorage.read(key: 'pin.credential'),
@@ -152,16 +146,6 @@ void main() {
 
       final decoded = await secureStorage.getPinSalt();
       expect(decoded, salt);
-    });
-
-    test('setPinSalt hex-encodes the bytes before writing', () async {
-      final salt = Uint8List.fromList([0xde, 0xad, 0xbe, 0xef]);
-
-      await secureStorage.setPinSalt(salt);
-
-      verify(
-        () => mockStorage.write(key: 'pin.salt', value: 'deadbeef'),
-      ).called(1);
     });
 
     test('setPinCredential writes saltHex:hash atomically and clears the legacy split keys',

--- a/test/screens/pin/setup_pin_cubit_test.dart
+++ b/test/screens/pin/setup_pin_cubit_test.dart
@@ -109,10 +109,8 @@ void main() {
       await completed.timeout(const Duration(seconds: 30));
 
       expect(cubit.state.isComplete, isTrue);
-      // One atomic write — never the legacy split pair.
+      // One atomic write.
       verify(() => secureStorage.setPinCredential(any(), any())).called(1);
-      verifyNever(() => secureStorage.setPinSalt(any()));
-      verifyNever(() => secureStorage.setPinHash(any()));
     });
 
     test('mismatching confirm-pin resets currentPin and sets mismatch=true', () async {

--- a/test/screens/pin/verify_pin_cubit_test.dart
+++ b/test/screens/pin/verify_pin_cubit_test.dart
@@ -136,6 +136,27 @@ void main() {
         verify(() => secureStorage.resetPinLockout()).called(1);
       });
 
+      test(
+        'correct pin still unlocks when the lockout reset throws (no unhandled error)',
+        () async {
+          // A keychain failure while clearing the counter must not skip the
+          // unlock: the PIN was correct. The best-effort reset swallows the
+          // throw so the wallet still opens — mirrors the biometric success path.
+          when(() => secureStorage.verifyPin(any()))
+              .thenAnswer((_) async => PinVerificationResult.correct);
+          when(() => secureStorage.resetPinLockout())
+              .thenThrow(Exception('keychain unavailable'));
+          final cubit = build();
+          final success = cubit.stream.firstWhere((s) => s is VerifyPinSuccess);
+
+          addPin(cubit, '123456');
+          await success.timeout(const Duration(seconds: 30));
+
+          expect(cubit.state, isA<VerifyPinSuccess>());
+          verify(() => secureStorage.resetPinLockout()).called(1);
+        },
+      );
+
       blocTest<VerifyPinCubit, VerifyPinState>(
         'emits VerifyPinVerifying (carrying the full pin) before VerifyPinSuccess',
         build: build,


### PR DESCRIPTION
Follow-up to #757 (merged), addressing two points from the post-merge self-review.

## Problem

**A correct PIN could fail to unlock.** #757 hardened the *biometric* success path so a keychain failure while clearing the lockout counter (`resetPinLockout()`) still unlocks the wallet — the scan already succeeded. The **PIN** success path was left unguarded: `resetPinLockout()` in `_checkPin`'s `correct` branch runs inside the outer `try`, so a keychain throw falls into the `catch` and emits a plain pad state instead of `VerifyPinSuccess`. The user is rejected despite a correct PIN, and stays blocked while the keychain error persists (biometrics still work). The two success paths handled the same failure inconsistently.

**Obsolete legacy setters.** After #757 made `setPinCredential` the single atomic writer, `setPinHash`/`setPinSalt` have no production caller. Leaving them public is a footgun: a stray `setPinHash` would write `pin.hash` without a matching salt — the exact torn write #757 eliminated — or be silently shadowed by the combined `pin.credential` key.

## Changes

- Extract a shared `_resetLockoutBestEffort()` helper and route **both** success paths (PIN and biometric) through it. A counter-reset failure can no longer block an unlock that already authenticated; a stale count self-heals on the next successful check.
- Remove the unused `setPinHash`/`setPinSalt` setters. The read-side `getPinHash`/`getPinSalt` stay for the legacy read fallback.

## Tests

- New: a correct PIN still unlocks when `resetPinLockout()` throws (mirrors the existing biometric test).
- Removed the obsolete setter unit tests and their `verifyNever` assertions.

`flutter analyze` clean, full suite green (`--exclude-tags golden`).
