### PR TITLE
test(pin): cover NumberPad digit/delete taps on setup PIN page

### DIFF
--- a/test/screens/pin/setup_pin_page_test.dart
+++ b/test/screens/pin/setup_pin_page_test.dart
@@ -80,6 +80,27 @@ void main() {
         expect(find.text(S.current.pinCreateDescription('$pinLength')), findsOne);
         expect(find.byType(NumberPad), findsOne);
       });
+
+      testWidgets('forwards digit and delete taps to the cubit', (tester) async {
+        when(() => setupPinCubit.state).thenReturn(const SetupPinState(mode: SetupPinMode.create));
+
+        await tester.pumpApp(buildSubject(const SetupPinView()));
+
+        // Tapping a digit runs the pad's onNumberPressed closure, which the
+        // other setup-pin specs (spinner / error / listener states) never
+        // exercise because they don't press the pad.
+        final seven = find.descendant(of: find.byType(NumberPad), matching: find.text('7'));
+        await tester.ensureVisible(seven);
+        await tester.tap(seven);
+        await tester.pump();
+        verify(() => setupPinCubit.addDigit(7)).called(1);
+
+        final delete = find.byIcon(Icons.arrow_back_ios_new);
+        await tester.ensureVisible(delete);
+        await tester.tap(delete);
+        await tester.pump();
+        verify(() => setupPinCubit.deleteDigit()).called(1);
+      });
     });
 
     group('${SetupPinMode.confirm}', () {


### PR DESCRIPTION
Follow-up to #757 (merged). That PR left the setup-pin page's NumberPad wiring uncovered by the non-golden specs: the `onNumberPressed` closure (`(digit) => context.read<SetupPinCubit>().addDigit(digit)` in `setup_pin_page.dart`) only runs when a digit is actually pressed, and the existing specs only assert rendering / spinner / error / BlocListener states.

Adds one create-mode `testWidgets` that taps a digit and the delete key and verifies they forward to `addDigit` / `deleteDigit`, mirroring the verify-pin page's pad-tap pattern (`ensureVisible` + `pump`).

Verified locally: `flutter analyze` clean and `flutter test test/screens/pin/setup_pin_page_test.dart` green (9/9); the closure lines now report as covered in lcov.