### PR TITLE
chore(release): start 1.1.0 tag train to unblock store deploys

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # derived from the release tag (see tool/generate_release_info.dart). Local
 # builds carry `+0` so the settings footer shows `dev` instead of a stale
 # pinned build number.
-version: 1.0.15+0
+version: 1.1.0+0
 
 environment:
   sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
## Problem

`auto-tag.yaml` patch-bumps the latest tag on every push to `develop`, and `tool/generate_release_info.dart` hard-fails for `PATCH > 99` (versionCode schema `MAJOR*10_000_000 + MINOR*100_000 + PATCH*1_000 + 999`). The patch train overran that cap to `v1.0.100` / `v1.0.101`, so **`android-deploy` and `ios-deploy` crash on every release** at the codegen step:

```
RangeError: PATCH must be in 0..99 in tag: v1.0.101
  at _parseSegment (tool/generate_release_info.dart:88)
```

## Fix

Per `CONTRIBUTING.md` → **Release Versioning**: bump `pubspec.yaml`'s MINOR floor so the next `auto-tag` emits **`v1.1.0`** instead of `v1.0.102`, restarting the tag train inside the deployable `0..99` range.

- `v1.1.0` → versionCode `10_100_999`, strictly above the last shipped build (`v1.0.99` → `10_099_999`) — monotonic ✓
- `PATCH == 0` routes through the production-candidate release lane
- `+0` build sentinel untouched (CI overrides `--build-name` / `--build-number` from the tag)

## Rollout

1. Merge this into `staging`.
2. The `staging → develop` promotion PR carries it to `develop`.
3. On that push, `auto-tag` creates `v1.1.0` and the release pipeline deploys.

Subsequent auto-tags continue cleanly at `v1.1.1`, `v1.1.2`, …
