### PR TITLE
fix(handbook): retarget reset-wallet selectors to the RealUnit sheet title

### DIFF
--- a/.maestro/handbook/24-settings-delete-wallet.yaml
+++ b/.maestro/handbook/24-settings-delete-wallet.yaml
@@ -33,7 +33,7 @@ appId: swiss.realunit.app
       - runFlow:
           when:
             notVisible:
-              text: '.*REALU Wallet zurücksetzen.*'
+              text: '.*RealUnit Wallet zurücksetzen.*'
           commands:
             - tapOn:
                 text: '.*Wallet zurücksetzen.*'
@@ -41,5 +41,5 @@ appId: swiss.realunit.app
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible:
-      text: '.*REALU Wallet zurücksetzen.*'
+      text: '.*RealUnit Wallet zurücksetzen.*'
     timeout: 30000

--- a/.maestro/handbook/25-restore-wallet.yaml
+++ b/.maestro/handbook/25-restore-wallet.yaml
@@ -41,7 +41,7 @@
 # checkbox itself: tapping it twice would toggle it back off again, since
 # the underlying `setState(() => isChecked = !isChecked)` is not idempotent.
 # If the checkbox tap is the one that's silently dropped, the next
-# `extendedWaitUntil notVisible "REALU Wallet zurücksetzen"` (with the
+# `extendedWaitUntil notVisible "RealUnit Wallet zurücksetzen"` (with the
 # Zurücksetzen button still disabled) fails loudly rather than passing silently
 # downstream — and the same Semantics-id strategy that fixed flow 26's
 # Nutzungsbedingungen-link tap has been reliable enough since.
@@ -61,7 +61,7 @@ appId: swiss.realunit.app
       - runFlow:
           when:
             visible:
-              text: '.*REALU Wallet zurücksetzen.*'
+              text: '.*RealUnit Wallet zurücksetzen.*'
           commands:
             - tapOn:
                 text: 'Zurücksetzen'
@@ -69,7 +69,7 @@ appId: swiss.realunit.app
 - waitForAnimationToEnd
 - extendedWaitUntil:
     notVisible:
-      text: '.*REALU Wallet zurücksetzen.*'
+      text: '.*RealUnit Wallet zurücksetzen.*'
     timeout: 15000
 - repeat:
     times: 3


### PR DESCRIPTION
## What

`#725` renamed the reset-wallet confirmation sheet title from **"REALU Wallet zurücksetzen"** to **"RealUnit Wallet zurücksetzen"** (`realunitWalletLogout` in `strings_{de,en}.arb`) but left the two Tier-3 handbook flows that key off that title untouched. The post-merge **Tier 3 — Handbook flows** run on `develop` goes red on flow `24-settings-delete-wallet`, which surfaces on the open `develop → main` release PR #325.

## Root cause

- `24-settings-delete-wallet` asserts the reset sheet title is visible, so the stale selector fails loudly: `Assertion '.*REALU Wallet zurücksetzen.*' is visible' failed`.
- `25-restore-wallet` gates the "Zurücksetzen" tap on that same title being visible; with the stale selector the gate never fires, the modal never closes and the restore path stalls at the `Wiederherstellungs-Wörter` settle target.

The rename landed in `#725` without a matching update to `.maestro/handbook/24,25`; all other renamed strings in that PR are already covered by stable selectors (flows 1–23 pass). The remaining `REALU` occurrences in the ARBs are the token ticker symbol, unrelated to this sheet title and not referenced by any flow.

## Fix

Retarget both selectors (and the comment reference in flow 25) from `.*REALU Wallet zurücksetzen.*` to `.*RealUnit Wallet zurücksetzen.*`. No behavioural change to the flows: `.*RealUnit Wallet zurücksetzen.*` still matches the sheet title and still excludes the `settingsDeleteWallet` menu entry ("Wallet zurücksetzen").

## Testing

- **Full handbook suite, real CI** (`Tier 3 — Handbook flows`, `tier3:full`): green — all 26 flows pass, incl. `24-settings-delete-wallet` and `25-restore-wallet`.
- **Full handbook suite, local** against a freshly-erased iPhone 17 / iOS 26.5 simulator pinned to `de_CH`, Maestro `2.0.10` (mirrors the CI job): `run-handbook-flows.sh` exit code `0`; `24` passed in 22s, `25` in 38s, `26` in 16s, all on attempt 1.
