### PR TITLE
fix(store-metadata): set iOS App Store name to "RealUnit"

### DIFF
--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2555,7 +2555,7 @@
   <!-- iOS section -->
   <h3>Apple App Store (de-DE)</h3>
   <dl class="store-listing">
-    <dt>App-Name (max 30)</dt><dd><code>RealUnit Wallet</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/name.txt" title="Quelle: name.txt">↗</a></dd>
+    <dt>App-Name (max 30)</dt><dd><code>RealUnit</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/name.txt" title="Quelle: name.txt">↗</a></dd>
     <dt>Untertitel (max 30)</dt><dd><code>Sicher. Einfach. Unabhängig.</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/subtitle.txt" title="Quelle: subtitle.txt">↗</a></dd>
     <dt>Beschreibung (max 4000) <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/description.txt" title="Quelle: description.txt">↗</a></dt><dd><pre>Die offizielle App der RealUnit Schweiz AG – für den einfachen, sicheren Kauf und die bankenunabhängige Verwahrung der RealUnit Aktientoken. Direkt in Ihrer Hand.
 

--- a/ios/fastlane/metadata/de-DE/name.txt
+++ b/ios/fastlane/metadata/de-DE/name.txt
@@ -1,1 +1,1 @@
-RealUnit Wallet
+RealUnit


### PR DESCRIPTION
## What
- `ios/fastlane/metadata/de-DE/name.txt`: "RealUnit Wallet" → "RealUnit"
- `docs/handbook/de/index.html`: regenerated via `scripts/assemble-handbook-store-listing.py` so the derived store-listing block stays in sync (enforced by the `handbook-build-check` CI gate).

## Why
"RealUnit Wallet" is already taken by another app in the Apple App Store — App Store Connect rejects it ("the entered App name is already used"). The live app name is "RealUnit". Aligning the fastlane metadata source of truth with the published listing prevents a future `fastlane deliver` / `store_metadata` run from hard-failing on the name conflict.

## Scope — iOS-only, deliberate
Only the **iOS** App Store name has the collision. The Android `title.txt` ("RealUnit Wallet") lives in a separate Play Store namespace with no such conflict and is intentionally left unchanged here. A cross-platform brand alignment (including prose in release notes / changelog / handbook title) is a separate product decision, not part of this conflict fix.

`scripts/check-store-metadata.sh` passes locally.