### PR TITLE
fix(buy/sell): round min amount display up to avoid off-by-one

### DIFF
--- a/lib/screens/buy/widgets/payment_additional_action_needed_button.dart
+++ b/lib/screens/buy/widgets/payment_additional_action_needed_button.dart
@@ -34,7 +34,7 @@ class PaymentAdditionalActionNeededButton extends StatelessWidget {
                     S
                         .of(context)
                         .buyMinAmount(
-                          '${state.minAmount.round()}',
+                          '${state.minAmount.ceil()}',
                           context.read<BuyConverterCubit>().state.currency.code,
                         ),
                     style: const TextStyle(

--- a/lib/screens/sell/widgets/sell_button.dart
+++ b/lib/screens/sell/widgets/sell_button.dart
@@ -99,7 +99,7 @@ class SellButton extends StatelessWidget {
                   S
                       .of(context)
                       .sellMinAmount(
-                        '${state.minAmount.round()}',
+                        '${state.minAmount.ceil()}',
                         state.currency.code,
                       ),
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(

--- a/test/screens/buy/buy_page_test.dart
+++ b/test/screens/buy/buy_page_test.dart
@@ -231,7 +231,10 @@ void main() {
     });
 
     testWidgets('renders correctly when min amount is not met', (tester) async {
-      final minAmount = 100.0;
+      // Non-integer min: the API returns the minimum in the input currency
+      // (e.g. 100 CHF ≈ 108.4 EUR). The displayed value must round UP so the
+      // shown amount always satisfies the server-side minimum.
+      final minAmount = 108.4;
       final currency = Currency.chf;
 
       when(() => buyPaymentInfoCubit.state).thenReturn(
@@ -250,7 +253,7 @@ void main() {
 
       expect(find.byType(PaymentActionRequired), findsNothing);
       expect(find.byType(PaymentInformation), findsOne);
-      expect(find.text(S.current.buyMinAmount('${minAmount.round()}', currency.code)), findsOne);
+      expect(find.text(S.current.buyMinAmount('${minAmount.ceil()}', currency.code)), findsOne);
       expect(
         find.byWidgetPredicate(
           (Widget widget) => widget is AppFilledButton && widget.onPressed == null,

--- a/test/screens/sell/sell_page_test.dart
+++ b/test/screens/sell/sell_page_test.dart
@@ -240,7 +240,9 @@ void main() {
       });
 
       testWidgets('is disabled button when minimum amount is not met', (tester) async {
-        final amount = 10.0;
+        // Non-integer min: the displayed value must round UP so the shown
+        // amount always satisfies the server-side minimum.
+        final amount = 10.4;
         final currency = Currency.chf;
 
         when(
@@ -255,7 +257,7 @@ void main() {
         await tester.pumpApp(buildSubject(const SellView()));
 
         expect(
-          find.text(S.current.sellMinAmount(amount.round().toString(), currency.code)),
+          find.text(S.current.sellMinAmount(amount.ceil().toString(), currency.code)),
           findsOne,
         );
         expect(


### PR DESCRIPTION
## Problem
On the **buy** (and **sell**) screen the minimum-amount hint rounds the API's `minVolume` with `.round()`. Concrete report: min is 100 CHF; switching the currency to EUR shows *"Mindestbetrag 108"*, but entering 108 is still rejected — the user has to enter **109**.

## Root cause
`minVolume` comes from the DFX backend in the input currency (100 CHF ≈ **108.4 EUR** at the current rate). The traded amount is **quantized to an integer** before it is sent to the backend:
- `buy_payment_info_cubit.dart` → `parsedAmount.round()`
- `sell_payment_info_cubit.dart` → `double.parse(amount).round()`

So the smallest whole amount that can actually pass is `ceil(minVolume)` = 109. `.round()` displayed **108**, which the backend rejects → off-by-one.

## Fix
Display the minimum with `.ceil()` instead of `.round()` in both `payment_additional_action_needed_button.dart` (buy) and `sell_button.dart` (sell). Pure rendering change — the authoritative `minVolume` is untouched (API-authority preserved).

## Tests
`buy_page_test.dart` / `sell_page_test.dart` now use a **non-integer** minimum (108.4 / 10.4) so they guard the rounding direction instead of passing trivially with an integer.

- `flutter analyze` (changed files): no issues
- `flutter test` buy/sell page tests: all green
- Golden tests unaffected (fixtures use integer `minAmount: 10`)