### PR TITLE
fix(buy/sell): round min amount hint up to avoid off-by-one rejection

### DIFF
--- a/lib/screens/buy/widgets/payment_action_button.dart
+++ b/lib/screens/buy/widgets/payment_action_button.dart
@@ -44,7 +44,7 @@ class PaymentActionButton extends StatelessWidget {
                     S
                         .of(context)
                         .buyMinAmount(
-                          '${state.minAmount.round()}',
+                          '${state.minAmount.ceil()}',
                           context.read<BuyConverterCubit>().state.currency.code,
                         ),
                     style: const TextStyle(

--- a/lib/screens/sell/widgets/sell_button.dart
+++ b/lib/screens/sell/widgets/sell_button.dart
@@ -110,7 +110,7 @@ class SellButton extends StatelessWidget {
                   S
                       .of(context)
                       .sellMinAmount(
-                        '${state.minAmount.round()}',
+                        '${state.minAmount.ceil()}',
                         state.currency.code,
                       ),
                   style: Theme.of(context).textTheme.bodyMedium?.copyWith(

--- a/test/screens/buy/buy_page_test.dart
+++ b/test/screens/buy/buy_page_test.dart
@@ -195,12 +195,12 @@ void main() {
     });
 
     testWidgets('renders correctly when min amount is not met', (tester) async {
-      // Non-integer min: the API returns the minimum in the input currency
-      // (e.g. 100 CHF ~ 108.4 EUR). The traded amount is quantized with
-      // .round() before it is sent, so the displayed value must round UP to
+      // Non-integer min: the API returns the minimum in the input currency, so
+      // a 100 CHF minimum shown in EUR is ~108.4. The traded amount is quantized
+      // with .round() before it is sent, so the displayed value must round UP to
       // the smallest whole amount that still satisfies the server-side minimum.
       final minAmount = 108.4;
-      final currency = Currency.chf;
+      final currency = Currency.eur;
 
       when(() => buyPaymentInfoCubit.state).thenReturn(
         BuyPaymentInfoMinAmountNotMetFailure(

--- a/test/screens/buy/buy_page_test.dart
+++ b/test/screens/buy/buy_page_test.dart
@@ -195,7 +195,11 @@ void main() {
     });
 
     testWidgets('renders correctly when min amount is not met', (tester) async {
-      final minAmount = 100.0;
+      // Non-integer min: the API returns the minimum in the input currency
+      // (e.g. 100 CHF ~ 108.4 EUR). The traded amount is quantized with
+      // .round() before it is sent, so the displayed value must round UP to
+      // the smallest whole amount that still satisfies the server-side minimum.
+      final minAmount = 108.4;
       final currency = Currency.chf;
 
       when(() => buyPaymentInfoCubit.state).thenReturn(
@@ -214,7 +218,7 @@ void main() {
 
       expect(find.byType(PaymentActionRequired), findsNothing);
       expect(find.byType(PaymentInformation), findsOne);
-      expect(find.text(S.current.buyMinAmount('${minAmount.round()}', currency.code)), findsOne);
+      expect(find.text(S.current.buyMinAmount('${minAmount.ceil()}', currency.code)), findsOne);
       expect(
         find.byWidgetPredicate(
           (Widget widget) => widget is AppFilledButton && widget.onPressed == null,

--- a/test/screens/buy/buy_page_test.dart
+++ b/test/screens/buy/buy_page_test.dart
@@ -196,9 +196,10 @@ void main() {
 
     testWidgets('renders correctly when min amount is not met', (tester) async {
       // Non-integer min: the API returns the minimum in the input currency, so
-      // a 100 CHF minimum shown in EUR is ~108.4. The traded amount is quantized
-      // with .round() before it is sent, so the displayed value must round UP to
-      // the smallest whole amount that still satisfies the server-side minimum.
+      // a CHF-denominated minimum shown in EUR comes back fractional (here 108.4).
+      // The traded amount is quantized with .round() before it is sent, so the
+      // displayed value must round UP to the smallest whole amount that still
+      // satisfies the server-side minimum.
       final minAmount = 108.4;
       final currency = Currency.eur;
 

--- a/test/screens/sell/sell_page_test.dart
+++ b/test/screens/sell/sell_page_test.dart
@@ -243,14 +243,14 @@ void main() {
         // Non-integer min: the traded amount is quantized with .round() before
         // it is sent, so the displayed value must round UP to the smallest
         // whole amount that still satisfies the server-side minimum.
-        final amount = 10.4;
+        final minAmount = 10.4;
         final currency = Currency.chf;
 
         when(
           () => sellPaymentInfoCubit.state,
         ).thenReturn(
           SellPaymentInfoMinAmountNotMet(
-            minAmount: amount,
+            minAmount: minAmount,
             currency: currency,
           ),
         );
@@ -258,7 +258,7 @@ void main() {
         await tester.pumpApp(buildSubject(const SellView()));
 
         expect(
-          find.text(S.current.sellMinAmount(amount.ceil().toString(), currency.code)),
+          find.text(S.current.sellMinAmount(minAmount.ceil().toString(), currency.code)),
           findsOne,
         );
         expect(

--- a/test/screens/sell/sell_page_test.dart
+++ b/test/screens/sell/sell_page_test.dart
@@ -240,7 +240,10 @@ void main() {
       });
 
       testWidgets('is disabled button when minimum amount is not met', (tester) async {
-        final amount = 10.0;
+        // Non-integer min: the traded amount is quantized with .round() before
+        // it is sent, so the displayed value must round UP to the smallest
+        // whole amount that still satisfies the server-side minimum.
+        final amount = 10.4;
         final currency = Currency.chf;
 
         when(
@@ -255,7 +258,7 @@ void main() {
         await tester.pumpApp(buildSubject(const SellView()));
 
         expect(
-          find.text(S.current.sellMinAmount(amount.round().toString(), currency.code)),
+          find.text(S.current.sellMinAmount(amount.ceil().toString(), currency.code)),
           findsOne,
         );
         expect(

--- a/test/screens/sell/sell_page_test.dart
+++ b/test/screens/sell/sell_page_test.dart
@@ -258,7 +258,7 @@ void main() {
         await tester.pumpApp(buildSubject(const SellView()));
 
         expect(
-          find.text(S.current.sellMinAmount(minAmount.ceil().toString(), currency.code)),
+          find.text(S.current.sellMinAmount('${minAmount.ceil()}', currency.code)),
           findsOne,
         );
         expect(


### PR DESCRIPTION
## Problem

On the **buy** and **sell** screens the minimum-amount hint rounds the API's `minVolume` with `.round()`. Concrete report: the minimum is 100 CHF; switching the input currency to EUR shows *"Mindestbetrag 108"*, but entering 108 is still rejected — the user has to enter **109**.

## Root cause

`minVolume` is returned by the API in the input currency (100 CHF ≈ **108.4 EUR** at the current rate). The traded amount is **quantized to an integer before it is sent**:

- `buy_payment_info_cubit.dart` → `parsedAmount.round()`
- `sell_payment_info_cubit.dart` → `double.parse(amount).round()`

So the smallest whole amount the backend accepts is `ceil(minVolume)` = 109. When the fractional part of `minVolume` is ≤ 0.5, `.round()` renders a value **one unit below** the accepted minimum → off-by-one.

## Fix

Render the hint with `.ceil()` instead of `.round()` in `payment_action_button.dart` (buy) and `sell_button.dart` (sell).

This is a **display-formatting change only** — the authoritative `minVolume` is untouched, so the API stays the decision authority (per the "API as Decision Authority" contributing rule; display formatting is an explicit UI concern).

## Tests

`buy_page_test.dart` / `sell_page_test.dart` now use a **non-integer** minimum (108.4 / 10.4) so they guard the rounding *direction* instead of passing trivially with an integer.

- `flutter analyze`: no new issues
- buy/sell page tests: green
- Golden tests unaffected (fixtures use integer minimums)

Related: #785 (same fix; that branch was cut from a stale commit and targeted `develop`, so it no longer applies cleanly — this reworks it onto current `staging`).
