### PR TITLE
feat(buy): show a dedicated minimum-purchase error on confirm rejection

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -29,6 +29,7 @@
   "buyPaymentConfirm": "Jetzt verbindlich kaufen",
   "buyPaymentConfirmFailed": "Es gibt ein technisches Problem. Bitte versuchen Sie es später erneut. Falls der Fehler weiterhin besteht, kontaktieren Sie unseren Support.",
   "buyPaymentConfirmFailedAktionariat": "Es gibt ein technisches Problem. Bitte überprüfen Sie Ihr E-Mail-Postfach, möglicherweise fehlt noch eine Bestätigung Ihrer Blockchain-Adresse. Andernfalls versuchen Sie es später erneut. Falls der Fehler weiterhin besteht, kontaktieren Sie unseren Support.",
+  "buyPaymentConfirmFailedAmountTooLow": "Der Betrag liegt unter dem Mindestbetrag für den Kauf. Bitte erhöhen Sie den Betrag und versuchen Sie es erneut.",
   "buyPaymentDetailsTitle": "Zahlungsdetails",
   "buyPaymentInstructionEmail": "Bitte überweisen Sie den Kaufbetrag mittels Banktransaktion. Die folgende Zahlungsanweisung haben wir Ihnen soeben auch per E-Mail zugestellt.",
   "buyPaymentPurposeHint": "Hinweis: Der Verwendungszweck ist wichtig! Vergessen Sie nicht, ihn als Zahlungsmitteilung zu erfassen.",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -29,6 +29,7 @@
   "buyPaymentConfirm": "Buy now bindingly",
   "buyPaymentConfirmFailed": "There is a technical problem. Please try again later. If the error persists, contact our support team.",
   "buyPaymentConfirmFailedAktionariat": "There is a technical problem. Please check your email inbox — you may still need to confirm your blockchain address. Otherwise, please try again later. If the error persists, contact our support team.",
+  "buyPaymentConfirmFailedAmountTooLow": "The amount is below the minimum purchase amount. Please increase the amount and try again.",
   "buyPaymentDetailsTitle": "Payment details",
   "buyPaymentInstructionEmail": "Please transfer the purchase amount via bank transfer. We have just sent you the following payment instructions by email as well.",
   "buyPaymentPurposeHint": "Note: The purpose of payment is important! Don't forget to enter it as the payment reference.",

--- a/lib/screens/buy/cubits/buy_confirm/buy_confirm_cubit.dart
+++ b/lib/screens/buy/cubits/buy_confirm/buy_confirm_cubit.dart
@@ -7,6 +7,11 @@ import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_
 
 part 'buy_confirm_state.dart';
 
+// Backend error code for a confirm rejected by Aktionariat because the
+// purchase is below its minimum (HTTP 400). Dispatch on the code, not the
+// message text — the message is Aktionariat's and may change.
+const String _errorCodeAmountTooLow = 'AmountTooLow';
+
 class BuyConfirmCubit extends Cubit<BuyConfirmState> {
   final RealUnitBuyPaymentInfoService _buyPaymentInfoService;
 
@@ -27,11 +32,12 @@ class BuyConfirmCubit extends Cubit<BuyConfirmState> {
       );
     } on ApiException catch (e) {
       developer.log(e.toString());
-      emit(
-        BuyConfirmFailure(
-          e.statusCode == 503 ? BuyConfirmError.aktionariat : BuyConfirmError.unknown,
-        ),
-      );
+      final error = e.statusCode == 503
+          ? BuyConfirmError.aktionariat
+          : e.code == _errorCodeAmountTooLow
+          ? BuyConfirmError.amountTooLow
+          : BuyConfirmError.unknown;
+      emit(BuyConfirmFailure(error));
     } catch (e) {
       developer.log(e.toString());
       emit(const BuyConfirmFailure(BuyConfirmError.unknown));

--- a/lib/screens/buy/cubits/buy_confirm/buy_confirm_state.dart
+++ b/lib/screens/buy/cubits/buy_confirm/buy_confirm_state.dart
@@ -1,6 +1,6 @@
 part of 'buy_confirm_cubit.dart';
 
-enum BuyConfirmError { aktionariat, unknown }
+enum BuyConfirmError { aktionariat, amountTooLow, unknown }
 
 abstract class BuyConfirmState extends Equatable {
   const BuyConfirmState();

--- a/lib/screens/buy/widgets/buy_confirm_button.dart
+++ b/lib/screens/buy/widgets/buy_confirm_button.dart
@@ -64,6 +64,7 @@ class BuyConfirmButtonView extends StatelessWidget {
         if (state is BuyConfirmFailure) {
           final text = switch (state.error) {
             BuyConfirmError.aktionariat => S.of(context).buyPaymentConfirmFailedAktionariat,
+            BuyConfirmError.amountTooLow => S.of(context).buyPaymentConfirmFailedAmountTooLow,
             BuyConfirmError.unknown => S.of(context).buyPaymentConfirmFailed,
           };
           ScaffoldMessenger.of(context).showSnackBar(

--- a/test/screens/buy/cubits/buy_confirm_cubit_test.dart
+++ b/test/screens/buy/cubits/buy_confirm_cubit_test.dart
@@ -95,6 +95,27 @@ void main() {
       expect((cubit.state as BuyConfirmFailure).error, BuyConfirmError.amountTooLow);
     });
 
+    test('confirmPayment prefers aktionariat over amountTooLow when a 503 also '
+        'carries code AmountTooLow', () async {
+      // 503 keeps precedence over the AmountTooLow code — pins the branch order
+      // so a future refactor can't surface a min-purchase message for a genuine
+      // service outage.
+      when(() => service.confirmPayment(any())).thenAnswer(
+        (_) async => throw const ApiException(
+          statusCode: 503,
+          code: 'AmountTooLow',
+          message: 'Aktionariat down',
+        ),
+      );
+
+      final cubit = BuyConfirmCubit(service);
+      final done = cubit.stream.firstWhere((s) => s is BuyConfirmFailure);
+      await cubit.confirmPayment(7);
+      await done;
+
+      expect((cubit.state as BuyConfirmFailure).error, BuyConfirmError.aktionariat);
+    });
+
     test('confirmPayment emits Failure(unknown) on other ApiException', () async {
       when(() => service.confirmPayment(any())).thenAnswer(
         (_) async => throw const ApiException(

--- a/test/screens/buy/cubits/buy_confirm_cubit_test.dart
+++ b/test/screens/buy/cubits/buy_confirm_cubit_test.dart
@@ -77,6 +77,24 @@ void main() {
       expect((cubit.state as BuyConfirmFailure).error, BuyConfirmError.aktionariat);
     });
 
+    test('confirmPayment emits Failure(amountTooLow) on ApiException 400 with '
+        'code AmountTooLow', () async {
+      when(() => service.confirmPayment(any())).thenAnswer(
+        (_) async => throw const ApiException(
+          statusCode: 400,
+          code: 'AmountTooLow',
+          message: 'Purchases by bank transfer require a minimum of 100 nominal in base currency',
+        ),
+      );
+
+      final cubit = BuyConfirmCubit(service);
+      final done = cubit.stream.firstWhere((s) => s is BuyConfirmFailure);
+      await cubit.confirmPayment(7);
+      await done;
+
+      expect((cubit.state as BuyConfirmFailure).error, BuyConfirmError.amountTooLow);
+    });
+
     test('confirmPayment emits Failure(unknown) on other ApiException', () async {
       when(() => service.confirmPayment(any())).thenAnswer(
         (_) async => throw const ApiException(

--- a/test/screens/buy/widgets/buy_confirm_button_test.dart
+++ b/test/screens/buy/widgets/buy_confirm_button_test.dart
@@ -144,6 +144,22 @@ void main() {
       expect(find.text(S.current.buyPaymentConfirmFailedAktionariat), findsOneWidget);
     });
 
+    testWidgets('shows the minimum-purchase error on an amount-too-low failure',
+        (tester) async {
+      whenListen(
+        cubit,
+        Stream.fromIterable([
+          const BuyConfirmFailure(BuyConfirmError.amountTooLow),
+        ]),
+        initialState: const BuyConfirmInitial(),
+      );
+
+      await tester.pumpWidget(host());
+      await tester.pump();
+
+      expect(find.text(S.current.buyPaymentConfirmFailedAmountTooLow), findsOneWidget);
+    });
+
     GoRouter detailsRouter({BuyPaymentInfo info = _info}) => GoRouter(
           initialLocation: '/buy',
           routes: [

--- a/test/screens/buy_sell_converter_confirm_states_test.dart
+++ b/test/screens/buy_sell_converter_confirm_states_test.dart
@@ -73,10 +73,13 @@ void main() {
       expect(a, isNot(c));
     });
 
-    test('BuyConfirmError enum has exactly aktionariat + unknown', () {
+    test('BuyConfirmError enum has exactly aktionariat + amountTooLow + unknown', () {
       // Pin the variants — the listener in BuyButton switches on these.
-      expect(BuyConfirmError.values.toSet(),
-          {BuyConfirmError.aktionariat, BuyConfirmError.unknown});
+      expect(BuyConfirmError.values.toSet(), {
+        BuyConfirmError.aktionariat,
+        BuyConfirmError.amountTooLow,
+        BuyConfirmError.unknown,
+      });
     });
 
     test('Initial and Loading are distinct singletons (by value)', () {


### PR DESCRIPTION
## What

The buy-confirm endpoint (`PUT /v1/realunit/buy/:id/confirm`) will start rejecting purchases below Aktionariat's minimum with HTTP 400 and a structured error code `AmountTooLow` in the response body (same coded-error shape as `KYC_LEVEL_REQUIRED` / `REGISTRATION_REQUIRED`, which `ApiException.fromJson` already parses). Today such a rejection arrives as a 503 (the API maps every Aktionariat failure to service-unavailable), so the app shows the Aktionariat copy — the "check your email / confirm your blockchain address" message — which is misleading for what is really an amount problem.

- `BuyConfirmCubit`: dispatch on `ApiException.code == 'AmountTooLow'` to a new `BuyConfirmError.amountTooLow` state. The existing `503 -> aktionariat` mapping is unchanged and keeps precedence; `unknown` remains the fallback.
- `BuyConfirmButtonView`: new snackbar copy for the amount-too-low case (en + de). The copy stays generic — the minimum is Aktionariat's and can change, so no number is hardcoded.
- Tests: cubit mapping (400 + `AmountTooLow` -> `amountTooLow`, 503 -> `aktionariat`, `503`-carrying-`AmountTooLow` -> `aktionariat` precedence, other -> `unknown`), enum pin, and snackbar widget test.

## Notes

- Dispatch is on the error `code` field, not the message text or the HTTP status, matching the existing `PRICE_SOURCE_UNAVAILABLE` handling in `BuyPaymentInfoCubit`.
- Companion to the dfx-api change that introduces the `AmountTooLow` code on buy confirm. Safe to merge independently: until the API ships the code, such rejections keep arriving as 503 and show the Aktionariat copy; afterwards they show the dedicated minimum-purchase copy.
