### PR TITLE
feat(handbook): view transaction-receipt PDFs inline

### DIFF
--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2480,6 +2480,7 @@
               </div>
               <div class="downloads">
                 <span class="doc-title">Transaktionshistorie (Sammelbeleg)</span>
+                <a class="dl-btn" href="../receipts/transaction-history-de.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../receipts/transaction-history-de.pdf" download>PDF</a>
               </div>
             </div>
@@ -2491,6 +2492,7 @@
               </div>
               <div class="downloads">
                 <span class="doc-title">Transaction History</span>
+                <a class="dl-btn" href="../receipts/transaction-history-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../receipts/transaction-history-en.pdf" download>PDF</a>
               </div>
             </div>
@@ -2506,6 +2508,7 @@
               </div>
               <div class="downloads">
                 <span class="doc-title">Transaktionsbestätigung (Einzelbeleg)</span>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-de.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../receipts/transaction-confirmation-de.pdf" download>PDF</a>
               </div>
             </div>
@@ -2517,6 +2520,7 @@
               </div>
               <div class="downloads">
                 <span class="doc-title">Transaction Confirmation</span>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../receipts/transaction-confirmation-en.pdf" download>PDF</a>
               </div>
             </div>

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -78,6 +78,24 @@ server {
         return 302 /de/;
     }
 
+    # Transaction-receipt examples (/receipts/*.pdf) — staged into the image
+    # from the api repo's docs/examples/realunit-receipt/. Unlike the legal
+    # exports below, these are meant to be VIEWED inline in the browser, so they
+    # must not inherit the attachment disposition of the generic \.(pdf|docx)$
+    # location. `^~` makes this longest-prefix match win over that regex
+    # location, so /receipts/*.pdf is served inline while /legal/*.pdf keeps its
+    # download disposition. auth_basic is inherited — receipts stay behind the
+    # same Basic-Auth gate. add_header is all-or-nothing per location, so the
+    # server-level security headers are restated here.
+    location ^~ /receipts/ {
+        add_header Content-Disposition "inline" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Cache-Control "private, no-store" always;
+        try_files $uri =404;
+    }
+
     # Legal downloads (/legal/*.pdf, /legal/*.docx) — the derived PDF/DOCX export
     # of assets/legal/*.md. Force a download disposition (nginx's default
     # mime.types has no .docx mapping; it would otherwise serve as


### PR DESCRIPTION
## What

The transaction-receipt example PDFs in the handbook can now be **viewed inline** in the browser, not only downloaded.

## Why

The generic `\.(pdf|docx)$` nginx location forces `Content-Disposition: attachment`, so every handbook PDF — including the transaction receipts under `/receipts/` — is downloaded instead of opening. There was no way to simply look at a receipt in the browser.

## How

- **`handbook.nginx.conf`** — new `location ^~ /receipts/` that serves the receipt PDFs with `Content-Disposition: inline`. The `^~` longest-prefix match wins over the regex `\.(pdf|docx)$` location, so `/legal/*.pdf` keeps its download disposition unchanged. `auth_basic` is inherited (receipts stay behind the same Basic-Auth gate) and the server-level security headers are restated, since `add_header` is all-or-nothing per location.
- **`docs/handbook/de/index.html`** — an `Ansehen ↗` link next to the existing `PDF` download in each of the four receipt cards (`#spec-receipts`), reusing the established `dl-btn` + `target="_blank" rel="noopener"` pattern. The download button is left unchanged, so both options are available.

## Verification

Isolated nginx container test against the real config — 8/8 pass:

- `nginx -t` ok
- `/receipts/*.pdf` → `200`, `Content-Disposition: inline`, `Content-Type: application/pdf`
- `/legal/*.pdf` → `200`, `Content-Disposition: attachment` (precedence intact)
- `/de/` without credentials → `401`, `/healthz` → `200`

The `#spec-receipts` section is hand-written (not generator-managed), so the store-listing / legal-downloads staleness gates in `handbook-build-check.yaml` are unaffected.
