### PR TITLE
docs(handbook): add portfolio-statement & sale-confirmation examples

### DIFF
--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -217,13 +217,13 @@ jobs:
       - name: Stage RealUnit receipt examples from api repo
         env:
           API_DIR: _api-checkout
-          # The api repo commits six example receipt PDFs under
-          # docs/examples/realunit-receipt/: transaction-{confirmation,history}-{de,en}.pdf
-          # plus transaction-confirmation-sale-de.pdf and transaction-transfer-de.pdf.
+          # The api repo commits eight example receipt PDFs under
+          # docs/examples/realunit-receipt/, each type in DE and EN:
+          # transaction-{confirmation,confirmation-sale,history,transfer}-{de,en}.pdf.
           # `-ne` below fails the build on ANY drift (add OR remove) so a change to
           # the committed set upstream requires an explicit bump here in the SAME
           # PR — same guard rationale as EXPECTED_HTML_COUNT above.
-          EXPECTED_PDF_COUNT: 6
+          EXPECTED_PDF_COUNT: 8
         run: |
           set -euo pipefail
 

--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -217,12 +217,13 @@ jobs:
       - name: Stage RealUnit receipt examples from api repo
         env:
           API_DIR: _api-checkout
-          # The api repo commits four example receipt PDFs under
-          # docs/examples/realunit-receipt/: transaction-{confirmation,history}-{de,en}.pdf.
+          # The api repo commits six example receipt PDFs under
+          # docs/examples/realunit-receipt/: transaction-{confirmation,history}-{de,en}.pdf
+          # plus transaction-confirmation-sale-de.pdf and transaction-transfer-de.pdf.
           # `-ne` below fails the build on ANY drift (add OR remove) so a change to
           # the committed set upstream requires an explicit bump here in the SAME
           # PR — same guard rationale as EXPECTED_HTML_COUNT above.
-          EXPECTED_PDF_COUNT: 4
+          EXPECTED_PDF_COUNT: 6
         run: |
           set -euo pipefail
 
@@ -251,6 +252,46 @@ jobs:
 
           ls -la docs/handbook/receipts/ | head -20
           echo "Staged $(ls docs/handbook/receipts/*.pdf | wc -l | tr -d ' ') receipt example PDFs"
+
+      - name: Stage RealUnit balance examples from api repo
+        env:
+          API_DIR: _api-checkout
+          # The api repo commits two example portfolio-statement (Vermögensübersicht)
+          # PDFs under docs/examples/realunit-balance/: balance-report-{de,en}.pdf.
+          # `-ne` below fails the build on ANY drift (add OR remove) so a change to
+          # the committed set upstream requires an explicit bump here in the SAME
+          # PR — same guard rationale as the receipt step above.
+          EXPECTED_PDF_COUNT: 2
+        run: |
+          set -euo pipefail
+
+          # Like the receipt examples, these PDFs are already committed in the api
+          # repo (rendered by BalancePdfService via the api-side spec
+          # realunit-balance-example.spec.ts), so no generator / npm run is needed
+          # here — we only copy them into the build context. Reuses the same
+          # _api-checkout/ from the mail step above. NOTE the SEPARATE dest dir
+          # (docs/handbook/balance/, not receipts/) so the receipt step's
+          # `rm -rf docs/handbook/receipts` cannot wipe these, and vice versa.
+          SRC_DIR="${API_DIR}/docs/examples/realunit-balance"
+          if [ ! -d "${SRC_DIR}" ]; then
+            echo "::error::${SRC_DIR} not found in the api checkout — the committed example balance statements are missing upstream (DFXswiss/api docs/examples/realunit-balance/)."
+            exit 1
+          fi
+
+          PDF_COUNT=$(ls "${SRC_DIR}"/*.pdf 2>/dev/null | wc -l | tr -d ' ')
+          if [ "${PDF_COUNT}" -ne "${EXPECTED_PDF_COUNT}" ]; then
+            echo "::error::Expected exactly ${EXPECTED_PDF_COUNT} balance PDFs in ${SRC_DIR}, got ${PDF_COUNT}. If this drift is intentional (example added/removed upstream), update EXPECTED_PDF_COUNT in this workflow in the same PR."
+            exit 1
+          fi
+
+          # Fresh staging dir (defensive, mirrors the receipt step) so a stale PDF
+          # from a previous local run cannot survive into the build context.
+          rm -rf docs/handbook/balance
+          mkdir -p docs/handbook/balance
+          cp "${SRC_DIR}"/*.pdf docs/handbook/balance/
+
+          ls -la docs/handbook/balance/ | head -20
+          echo "Staged $(ls docs/handbook/balance/*.pdf | wc -l | tr -d ' ') balance example PDFs"
 
       # Cleanup runs even when the generator step above (or any other step
       # between staging and `docker build`) fails. Without `if: always()`, a

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,12 @@ docs/handbook/mails/
 # (docs/examples/realunit-receipt/, rendered by SwissQRService).
 docs/handbook/receipts/
 
+# Staged at handbook build time from DFXswiss/api's committed example balance
+# statements (see .github/workflows/handbook.yaml — step "Stage RealUnit balance
+# examples from api repo"). Never commit; source of truth is the api repo
+# (docs/examples/realunit-balance/, rendered by BalancePdfService).
+docs/handbook/balance/
+
 # Assembled at handbook build time from test/goldens/screens/ via
 # scripts/assemble-handbook-screenshots.sh (see Dockerfile.handbook).
 # Source of truth are the Golden baselines under test/goldens/; this

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -174,8 +174,9 @@ Vorab-Anschauen während eines Template-Refactors.)
 
 ## Transaktionsbelege
 
-Die Sektion **B — Transaktionsbelege** verlinkt vier Muster-PDFs, die das
-Backend erzeugt (Transaktionshistorie + Transaktionsbestätigung, je DE/EN).
+Die Sektion **B — Transaktionsbelege** verlinkt sechs Muster-PDFs, die das
+Backend erzeugt: Transaktionshistorie und Transaktionsbestätigung (je DE/EN)
+sowie Verkauf-Bestätigung und Übertragung (je DE).
 Anders als die Mail-Previews werden diese PDFs **nicht** hier generiert — sie
 liegen bereits committet im api-Repo unter `docs/examples/realunit-receipt/`
 (gerendert vom `SwissQRService` via `realunit-receipt-example.spec.ts`) und
@@ -200,6 +201,20 @@ open docs/handbook/de/index.html   # Sektion "B — Transaktionsbelege"
 
 Zum Regenerieren der Muster-PDFs selbst siehe das api-Repo
 (`GENERATE_RECEIPT_EXAMPLES=true npx jest realunit-receipt-example`).
+
+## Vermögensübersicht
+
+Die Sektion **V — Vermögensübersicht** (`#spec-balance`) verlinkt zwei
+Muster-PDFs (DE + EN): die Vermögensübersicht weist den REALU-Bestand mit dem
+massgeblichen Steuerwert aus. Wie die Transaktionsbelege werden diese PDFs
+**nicht** hier generiert — sie liegen bereits committet im api-Repo unter
+`docs/examples/realunit-balance/` (gerendert vom `BalancePdfService` via
+`realunit-balance-example.spec.ts`) und werden beim Handbook-Build nur ins Image
+kopiert (Step "Stage RealUnit balance examples from api repo" in `handbook.yaml`;
+Zielverzeichnis `docs/handbook/balance/` ist gitignored). Single Source of Truth
+ist das api-Repo. Kommt upstream ein Beispiel hinzu oder weg, failt der Build am
+eigenen `EXPECTED_PDF_COUNT`-Guard des balance-Steps — dann die Zahl in
+`handbook.yaml` und die Download-Karten in `#spec-balance` im selben Zug anpassen.
 
 ## Beziehung zu den Tier-0/Tier-1-Tests
 

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -174,9 +174,9 @@ Vorab-Anschauen während eines Template-Refactors.)
 
 ## Transaktionsbelege
 
-Die Sektion **B — Transaktionsbelege** verlinkt sechs Muster-PDFs, die das
-Backend erzeugt: Transaktionshistorie und Transaktionsbestätigung (je DE/EN)
-sowie Verkauf-Bestätigung und Übertragung (je DE).
+Die Sektion **B — Transaktionsbelege** verlinkt acht Muster-PDFs, die das
+Backend erzeugt — Transaktionshistorie, Transaktionsbestätigung,
+Verkauf-Bestätigung und Übertragung, jeweils in DE und EN.
 Anders als die Mail-Previews werden diese PDFs **nicht** hier generiert — sie
 liegen bereits committet im api-Repo unter `docs/examples/realunit-receipt/`
 (gerendert vom `SwissQRService` via `realunit-receipt-example.spec.ts`) und

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2538,6 +2538,17 @@
                 <a class="dl-btn" href="../receipts/transaction-confirmation-sale-de.pdf" download>PDF</a>
               </div>
             </div>
+            <div class="test legal-doc" id="receipt-confirmation-sale-en">
+              <div class="head">
+                <a class="name permalink" href="#receipt-confirmation-sale-en">transaction_confirmation_sale_en</a>
+                <button class="copy-link" type="button" data-target="receipt-confirmation-sale-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">en</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Sale Confirmation</span>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-sale-en.pdf" download>PDF</a>
+              </div>
+            </div>
           </div>
 
           <h3>Übertragung <a class="src" href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-receipt" title="Quelle: docs/examples/realunit-receipt/">↗</a></h3>
@@ -2551,6 +2562,17 @@
               <div class="downloads">
                 <span class="doc-title">Übertragung (Einzelbeleg)</span>
                 <a class="dl-btn" href="../receipts/transaction-transfer-de.pdf" download>PDF</a>
+              </div>
+            </div>
+            <div class="test legal-doc" id="receipt-transfer-en">
+              <div class="head">
+                <a class="name permalink" href="#receipt-transfer-en">transaction_transfer_en</a>
+                <button class="copy-link" type="button" data-target="receipt-transfer-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">en</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Transfer</span>
+                <a class="dl-btn" href="../receipts/transaction-transfer-en.pdf" download>PDF</a>
               </div>
             </div>
           </div>

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -826,6 +826,9 @@
               <a href="#spec-receipts"><span class="spec-num">B</span>Transaktionsbelege</a>
             </li>
             <li>
+              <a href="#spec-balance"><span class="spec-num">V</span>Vermögensübersicht</a>
+            </li>
+            <li>
               <a href="#spec-store-listing"><span class="spec-num">S</span>Store-Listing</a>
             </li>
             <li>
@@ -2522,6 +2525,73 @@
                 <span class="doc-title">Transaction Confirmation</span>
                 <a class="dl-btn" href="../receipts/transaction-confirmation-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../receipts/transaction-confirmation-en.pdf" download>PDF</a>
+              </div>
+            </div>
+            <div class="test legal-doc" id="receipt-confirmation-sale-de">
+              <div class="head">
+                <a class="name permalink" href="#receipt-confirmation-sale-de">transaction_confirmation_sale_de</a>
+                <button class="copy-link" type="button" data-target="receipt-confirmation-sale-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">de</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Verkauf-Bestätigung (Einzelbeleg)</span>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-sale-de.pdf" download>PDF</a>
+              </div>
+            </div>
+          </div>
+        </details>
+
+        <details id="spec-balance" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">V</span>Vermögensübersicht</h2>
+                <div class="file">DFXswiss/api · docs/examples/realunit-balance/</div>
+              </div>
+              <div class="rhs">
+                <b>Live aus api-Repo</b>
+                <div class="links">
+                  <a href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-balance">im api-Repo ↗</a>
+                </div>
+              </div>
+            </div>
+          </summary>
+
+          <p class="spec-intro">
+            Beispiel-Beleg, den das Backend als PDF erzeugt: die
+            <b>Vermögensübersicht</b> weist den REALU-Bestand mit dem massgeblichen
+            <b>Steuerwert</b> aus (im Muster 350 REALU per 31.12.2025). Der Renderer
+            lebt im
+            <a href="https://github.com/DFXswiss/api">DFXswiss/api</a>-Repo
+            (<code>src/subdomains/supporting/balance/services/balance-pdf.service.ts</code>);
+            die verlinkten Muster-PDFs liegen dort als
+            <code>docs/examples/realunit-balance/*.pdf</code> und werden bei jedem
+            Handbook-Build automatisch ins Image gezogen — Single Source of Truth
+            ist das api-Repo, dieses Handbook spiegelt nur den aktuellen Stand.
+          </p>
+
+          <h3>Vermögensübersicht <a class="src" href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-balance" title="Quelle: docs/examples/realunit-balance/">↗</a></h3>
+          <div class="tests cols-2">
+            <div class="test legal-doc" id="balance-report-de">
+              <div class="head">
+                <a class="name permalink" href="#balance-report-de">balance_report_de</a>
+                <button class="copy-link" type="button" data-target="balance-report-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">de</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Vermögensübersicht (Steuerwert)</span>
+                <a class="dl-btn" href="../balance/balance-report-de.pdf" download>PDF</a>
+              </div>
+            </div>
+            <div class="test legal-doc" id="balance-report-en">
+              <div class="head">
+                <a class="name permalink" href="#balance-report-en">balance_report_en</a>
+                <button class="copy-link" type="button" data-target="balance-report-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">en</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Portfolio Statement (Tax Value)</span>
+                <a class="dl-btn" href="../balance/balance-report-en.pdf" download>PDF</a>
               </div>
             </div>
           </div>

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2539,6 +2539,21 @@
               </div>
             </div>
           </div>
+
+          <h3>Übertragung <a class="src" href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-receipt" title="Quelle: docs/examples/realunit-receipt/">↗</a></h3>
+          <div class="tests cols-2">
+            <div class="test legal-doc" id="receipt-transfer-de">
+              <div class="head">
+                <a class="name permalink" href="#receipt-transfer-de">transaction_transfer_de</a>
+                <button class="copy-link" type="button" data-target="receipt-transfer-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">de</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Übertragung (Einzelbeleg)</span>
+                <a class="dl-btn" href="../receipts/transaction-transfer-de.pdf" download>PDF</a>
+              </div>
+            </div>
+          </div>
         </details>
 
         <details id="spec-balance" class="spec" open>

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2535,6 +2535,7 @@
               </div>
               <div class="downloads">
                 <span class="doc-title">Verkauf-Bestätigung (Einzelbeleg)</span>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-sale-de.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../receipts/transaction-confirmation-sale-de.pdf" download>PDF</a>
               </div>
             </div>
@@ -2546,6 +2547,7 @@
               </div>
               <div class="downloads">
                 <span class="doc-title">Sale Confirmation</span>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-sale-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../receipts/transaction-confirmation-sale-en.pdf" download>PDF</a>
               </div>
             </div>
@@ -2561,6 +2563,7 @@
               </div>
               <div class="downloads">
                 <span class="doc-title">Übertragung (Einzelbeleg)</span>
+                <a class="dl-btn" href="../receipts/transaction-transfer-de.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../receipts/transaction-transfer-de.pdf" download>PDF</a>
               </div>
             </div>
@@ -2572,6 +2575,7 @@
               </div>
               <div class="downloads">
                 <span class="doc-title">Transfer</span>
+                <a class="dl-btn" href="../receipts/transaction-transfer-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../receipts/transaction-transfer-en.pdf" download>PDF</a>
               </div>
             </div>
@@ -2617,6 +2621,7 @@
               </div>
               <div class="downloads">
                 <span class="doc-title">Vermögensübersicht (Steuerwert)</span>
+                <a class="dl-btn" href="../balance/balance-report-de.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../balance/balance-report-de.pdf" download>PDF</a>
               </div>
             </div>
@@ -2628,6 +2633,7 @@
               </div>
               <div class="downloads">
                 <span class="doc-title">Portfolio Statement (Tax Value)</span>
+                <a class="dl-btn" href="../balance/balance-report-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../balance/balance-report-en.pdf" download>PDF</a>
               </div>
             </div>

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2462,8 +2462,11 @@
           <p class="spec-intro">
             Beispiel-Belege, die das Backend als PDF erzeugt: die
             <b>Transaktionshistorie</b> (Sammelbeleg über mehrere Transaktionen,
-            per Klick auf „Transaktionshistorie") und die
-            <b>Transaktionsbestätigung</b> (Einzelbeleg für eine Transaktion). Der
+            per Klick auf „Transaktionshistorie"), die
+            <b>Transaktionsbestätigung</b> (Einzelbeleg für eine Kauftransaktion),
+            die <b>Verkauf-Bestätigung</b> (Einzelbeleg für eine
+            Verkaufstransaktion) und die <b>Übertragung</b> (Einzelbeleg für eine
+            Wallet-zu-Wallet-Übertragung). Der
             Renderer lebt im
             <a href="https://github.com/DFXswiss/api">DFXswiss/api</a>-Repo
             (<code>src/subdomains/supporting/payment/services/swiss-qr.service.ts</code>);

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -96,6 +96,23 @@ server {
         try_files $uri =404;
     }
 
+    # Portfolio-statement examples (/balance/*.pdf) — staged into the image from
+    # the api repo's docs/examples/realunit-balance/, rendered by BalancePdfService.
+    # Same rationale as /receipts/ above: these are meant to be VIEWED inline in
+    # the browser, so `^~` makes this longest-prefix match win over the generic
+    # \.(pdf|docx)$ location and keeps them off the attachment disposition.
+    # auth_basic is inherited — they stay behind the same Basic-Auth gate.
+    # add_header is all-or-nothing per location, so the server-level security
+    # headers are restated here.
+    location ^~ /balance/ {
+        add_header Content-Disposition "inline" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Cache-Control "private, no-store" always;
+        try_files $uri =404;
+    }
+
     # Legal downloads (/legal/*.pdf, /legal/*.docx) — the derived PDF/DOCX export
     # of assets/legal/*.md. Force a download disposition (nginx's default
     # mime.types has no .docx mapping; it would otherwise serve as


### PR DESCRIPTION
## What

Adds two more backend-generated example documents to the RealUnit handbook, staged from the DFXswiss/api repo at build time (that repo stays the single source of truth), and fixes the receipt staging guard that the upstream example set had outgrown.

### Handbook content (`docs/handbook/de/index.html`)
- **Vermögensübersicht (portfolio statement)** — new `spec-balance` section with the DE and EN report and a matching nav entry. Staged from `docs/examples/realunit-balance/` into a dedicated `docs/handbook/balance/` directory with its own count guard (expects 2), kept separate from `receipts/` so neither staging step's `rm -rf` can clobber the other.
- **Verkauf-Bestätigung (sale confirmation, DE)** — new block in the existing transaction-confirmation subsection, linking the staged `transaction-confirmation-sale-de.pdf` (no EN sale receipt exists upstream).

### CI fix (`.github/workflows/handbook.yaml`)
- New "Stage RealUnit balance examples from api repo" step (own dir, guard = 2), mirroring the existing receipt-staging step.
- Bump the receipt staging guard `EXPECTED_PDF_COUNT` **4 → 6**. The api repo grew its committed receipt set to six PDFs (adding `transaction-confirmation-sale-de.pdf` and `transaction-transfer-de.pdf`); the still-4 guard rejected the drift and broke the DEV handbook deploy — the last `Handbook CI/CD` staging run failed with `Expected exactly 4 receipt PDFs … got 6`. Six is exactly what the guard's own drift message prescribes.

## Verification

Replicated the workflow's staging logic against `DFXswiss/api@develop` and built `Dockerfile.handbook`: both guards pass (6 receipt PDFs, 2 balance PDFs), the image builds, `/healthz` returns 200, and the staged PDFs plus the new `spec-balance` / `receipt-confirmation-sale-de` blocks and nav entry are present in the final rendered `index.html`. The authoritative check remains the `Handbook CI/CD` deploy that runs on merge to `staging`.
