### PR TITLE
fix(handbook): add sale & transfer receipt examples, bump PDF guard to 8

### DIFF
--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -217,12 +217,13 @@ jobs:
       - name: Stage RealUnit receipt examples from api repo
         env:
           API_DIR: _api-checkout
-          # The api repo commits four example receipt PDFs under
-          # docs/examples/realunit-receipt/: transaction-{confirmation,history}-{de,en}.pdf.
+          # The api repo commits eight example receipt PDFs under
+          # docs/examples/realunit-receipt/:
+          # transaction-{confirmation,confirmation-sale,transfer,history}-{de,en}.pdf.
           # `-ne` below fails the build on ANY drift (add OR remove) so a change to
           # the committed set upstream requires an explicit bump here in the SAME
           # PR — same guard rationale as EXPECTED_HTML_COUNT above.
-          EXPECTED_PDF_COUNT: 4
+          EXPECTED_PDF_COUNT: 8
         run: |
           set -euo pipefail
 

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2459,8 +2459,9 @@
           <p class="spec-intro">
             Beispiel-Belege, die das Backend als PDF erzeugt: die
             <b>Transaktionshistorie</b> (Sammelbeleg über mehrere Transaktionen,
-            per Klick auf „Transaktionshistorie") und die
-            <b>Transaktionsbestätigung</b> (Einzelbeleg für eine Transaktion). Der
+            per Klick auf „Transaktionshistorie") und die Einzelbelege je
+            Transaktion — die <b>Transaktionsbestätigung</b> für Kauf und Verkauf
+            sowie die <b>Übertragung</b> (Wallet-zu-Wallet, ohne Kauf/Verkauf). Der
             Renderer lebt im
             <a href="https://github.com/DFXswiss/api">DFXswiss/api</a>-Repo
             (<code>src/subdomains/supporting/payment/services/swiss-qr.service.ts</code>);
@@ -2498,7 +2499,7 @@
             </div>
           </div>
 
-          <h3>Transaktionsbestätigung <a class="src" href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-receipt" title="Quelle: docs/examples/realunit-receipt/">↗</a></h3>
+          <h3>Transaktionsbestätigung – Kauf <a class="src" href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-receipt" title="Quelle: docs/examples/realunit-receipt/">↗</a></h3>
           <div class="tests cols-2">
             <div class="test legal-doc" id="receipt-confirmation-de">
               <div class="head">
@@ -2507,7 +2508,7 @@
                 <span class="src">de</span>
               </div>
               <div class="downloads">
-                <span class="doc-title">Transaktionsbestätigung (Einzelbeleg)</span>
+                <span class="doc-title">Transaktionsbestätigung Kauf (Einzelbeleg)</span>
                 <a class="dl-btn" href="../receipts/transaction-confirmation-de.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../receipts/transaction-confirmation-de.pdf" download>PDF</a>
               </div>
@@ -2519,9 +2520,65 @@
                 <span class="src">en</span>
               </div>
               <div class="downloads">
-                <span class="doc-title">Transaction Confirmation</span>
+                <span class="doc-title">Transaction Confirmation (Purchase)</span>
                 <a class="dl-btn" href="../receipts/transaction-confirmation-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../receipts/transaction-confirmation-en.pdf" download>PDF</a>
+              </div>
+            </div>
+          </div>
+
+          <h3>Transaktionsbestätigung – Verkauf <a class="src" href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-receipt" title="Quelle: docs/examples/realunit-receipt/">↗</a></h3>
+          <div class="tests cols-2">
+            <div class="test legal-doc" id="receipt-confirmation-sale-de">
+              <div class="head">
+                <a class="name permalink" href="#receipt-confirmation-sale-de">transaction_confirmation_sale_de</a>
+                <button class="copy-link" type="button" data-target="receipt-confirmation-sale-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">de</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Transaktionsbestätigung Verkauf (Einzelbeleg)</span>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-sale-de.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-sale-de.pdf" download>PDF</a>
+              </div>
+            </div>
+            <div class="test legal-doc" id="receipt-confirmation-sale-en">
+              <div class="head">
+                <a class="name permalink" href="#receipt-confirmation-sale-en">transaction_confirmation_sale_en</a>
+                <button class="copy-link" type="button" data-target="receipt-confirmation-sale-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">en</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Transaction Confirmation (Sale)</span>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-sale-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
+                <a class="dl-btn" href="../receipts/transaction-confirmation-sale-en.pdf" download>PDF</a>
+              </div>
+            </div>
+          </div>
+
+          <h3>Übertragung <a class="src" href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-receipt" title="Quelle: docs/examples/realunit-receipt/">↗</a></h3>
+          <div class="tests cols-2">
+            <div class="test legal-doc" id="receipt-transfer-de">
+              <div class="head">
+                <a class="name permalink" href="#receipt-transfer-de">transaction_transfer_de</a>
+                <button class="copy-link" type="button" data-target="receipt-transfer-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">de</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Übertragung (Wallet-zu-Wallet)</span>
+                <a class="dl-btn" href="../receipts/transaction-transfer-de.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
+                <a class="dl-btn" href="../receipts/transaction-transfer-de.pdf" download>PDF</a>
+              </div>
+            </div>
+            <div class="test legal-doc" id="receipt-transfer-en">
+              <div class="head">
+                <a class="name permalink" href="#receipt-transfer-en">transaction_transfer_en</a>
+                <button class="copy-link" type="button" data-target="receipt-transfer-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">en</span>
+              </div>
+              <div class="downloads">
+                <span class="doc-title">Transfer (wallet-to-wallet)</span>
+                <a class="dl-btn" href="../receipts/transaction-transfer-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
+                <a class="dl-btn" href="../receipts/transaction-transfer-en.pdf" download>PDF</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## What

Add the two new receipt example types to the handbook and bump the receipt-staging guard to match the upstream set.

## Why

The api repo now ships **8** example receipt PDFs under `docs/examples/realunit-receipt/` — a sale confirmation and a plain wallet-to-wallet transfer were added upstream (DE/EN each) — but the handbook deploy workflow pins `EXPECTED_PDF_COUNT: 4`. The receipt-staging guard fails with `Expected exactly 4 receipt PDFs …, got 8` and aborts the build before it starts, so **every handbook deploy to DEV/PRD has been red** since that upstream change (the #790 and #791 merges both failed to deploy). The DEV/PRD handbook therefore still serves the pre-change build.

## How

- **`.github/workflows/handbook.yaml`** — `EXPECTED_PDF_COUNT` 4 → 8, comment updated to list the new file set.
- **`docs/handbook/de/index.html`** (`#spec-receipts`) — four new download cards: `Transaktionsbestätigung – Verkauf` (DE/EN) and `Übertragung` (DE/EN), each with the inline `Ansehen ↗` + `PDF` links introduced in #791. The existing confirmation cards are relabelled `– Kauf` to distinguish a purchase from a sale, and the section intro now names all three single-receipt types.

The 8 card references match the 8 committed api PDFs 1:1.
