### PR TITLE
fix(handbook): follow api rename of portfolio-statement examples

### DIFF
--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -257,7 +257,7 @@ jobs:
         env:
           API_DIR: _api-checkout
           # The api repo commits two example portfolio-statement (Vermögensübersicht)
-          # PDFs under docs/examples/realunit-balance/: balance-report-{de,en}.pdf.
+          # PDFs under docs/examples/realunit-statement/: vermoegensuebersicht-{de,en}.pdf.
           # `-ne` below fails the build on ANY drift (add OR remove) so a change to
           # the committed set upstream requires an explicit bump here in the SAME
           # PR — same guard rationale as the receipt step above.
@@ -272,9 +272,9 @@ jobs:
           # _api-checkout/ from the mail step above. NOTE the SEPARATE dest dir
           # (docs/handbook/balance/, not receipts/) so the receipt step's
           # `rm -rf docs/handbook/receipts` cannot wipe these, and vice versa.
-          SRC_DIR="${API_DIR}/docs/examples/realunit-balance"
+          SRC_DIR="${API_DIR}/docs/examples/realunit-statement"
           if [ ! -d "${SRC_DIR}" ]; then
-            echo "::error::${SRC_DIR} not found in the api checkout — the committed example balance statements are missing upstream (DFXswiss/api docs/examples/realunit-balance/)."
+            echo "::error::${SRC_DIR} not found in the api checkout — the committed example balance statements are missing upstream (DFXswiss/api docs/examples/realunit-statement/)."
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ docs/handbook/receipts/
 # Staged at handbook build time from DFXswiss/api's committed example balance
 # statements (see .github/workflows/handbook.yaml — step "Stage RealUnit balance
 # examples from api repo"). Never commit; source of truth is the api repo
-# (docs/examples/realunit-balance/, rendered by BalancePdfService).
+# (docs/examples/realunit-statement/, rendered by BalancePdfService).
 docs/handbook/balance/
 
 # Assembled at handbook build time from test/goldens/screens/ via

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -208,7 +208,7 @@ Die Sektion **V — Vermögensübersicht** (`#spec-balance`) verlinkt zwei
 Muster-PDFs (DE + EN): die Vermögensübersicht weist den REALU-Bestand mit dem
 massgeblichen Steuerwert aus. Wie die Transaktionsbelege werden diese PDFs
 **nicht** hier generiert — sie liegen bereits committet im api-Repo unter
-`docs/examples/realunit-balance/` (gerendert vom `BalancePdfService` via
+`docs/examples/realunit-statement/` (gerendert vom `BalancePdfService` via
 `realunit-balance-example.spec.ts`) und werden beim Handbook-Build nur ins Image
 kopiert (Step "Stage RealUnit balance examples from api repo" in `handbook.yaml`;
 Zielverzeichnis `docs/handbook/balance/` ist gitignored). Single Source of Truth

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2590,12 +2590,12 @@
             <div class="spec-head">
               <div class="lhs">
                 <h2><span class="num">V</span>Vermögensübersicht</h2>
-                <div class="file">DFXswiss/api · docs/examples/realunit-balance/</div>
+                <div class="file">DFXswiss/api · docs/examples/realunit-statement/</div>
               </div>
               <div class="rhs">
                 <b>Live aus api-Repo</b>
                 <div class="links">
-                  <a href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-balance">im api-Repo ↗</a>
+                  <a href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-statement">im api-Repo ↗</a>
                 </div>
               </div>
             </div>
@@ -2609,35 +2609,35 @@
             <a href="https://github.com/DFXswiss/api">DFXswiss/api</a>-Repo
             (<code>src/subdomains/supporting/balance/services/balance-pdf.service.ts</code>);
             die verlinkten Muster-PDFs liegen dort als
-            <code>docs/examples/realunit-balance/*.pdf</code> und werden bei jedem
+            <code>docs/examples/realunit-statement/*.pdf</code> und werden bei jedem
             Handbook-Build automatisch ins Image gezogen — Single Source of Truth
             ist das api-Repo, dieses Handbook spiegelt nur den aktuellen Stand.
           </p>
 
-          <h3>Vermögensübersicht <a class="src" href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-balance" title="Quelle: docs/examples/realunit-balance/">↗</a></h3>
+          <h3>Vermögensübersicht <a class="src" href="https://github.com/DFXswiss/api/tree/develop/docs/examples/realunit-statement" title="Quelle: docs/examples/realunit-statement/">↗</a></h3>
           <div class="tests cols-2">
-            <div class="test legal-doc" id="balance-report-de">
+            <div class="test legal-doc" id="vermoegensuebersicht-de">
               <div class="head">
-                <a class="name permalink" href="#balance-report-de">balance_report_de</a>
-                <button class="copy-link" type="button" data-target="balance-report-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <a class="name permalink" href="#vermoegensuebersicht-de">vermoegensuebersicht_de</a>
+                <button class="copy-link" type="button" data-target="vermoegensuebersicht-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
                 <span class="src">de</span>
               </div>
               <div class="downloads">
                 <span class="doc-title">Vermögensübersicht (Steuerwert)</span>
-                <a class="dl-btn" href="../balance/balance-report-de.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
-                <a class="dl-btn" href="../balance/balance-report-de.pdf" download>PDF</a>
+                <a class="dl-btn" href="../balance/vermoegensuebersicht-de.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
+                <a class="dl-btn" href="../balance/vermoegensuebersicht-de.pdf" download>PDF</a>
               </div>
             </div>
-            <div class="test legal-doc" id="balance-report-en">
+            <div class="test legal-doc" id="vermoegensuebersicht-en">
               <div class="head">
-                <a class="name permalink" href="#balance-report-en">balance_report_en</a>
-                <button class="copy-link" type="button" data-target="balance-report-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <a class="name permalink" href="#vermoegensuebersicht-en">vermoegensuebersicht_en</a>
+                <button class="copy-link" type="button" data-target="vermoegensuebersicht-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
                 <span class="src">en</span>
               </div>
               <div class="downloads">
                 <span class="doc-title">Portfolio Statement (Tax Value)</span>
-                <a class="dl-btn" href="../balance/balance-report-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
-                <a class="dl-btn" href="../balance/balance-report-en.pdf" download>PDF</a>
+                <a class="dl-btn" href="../balance/vermoegensuebersicht-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
+                <a class="dl-btn" href="../balance/vermoegensuebersicht-en.pdf" download>PDF</a>
               </div>
             </div>
           </div>

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -97,7 +97,7 @@ server {
     }
 
     # Portfolio-statement examples (/balance/*.pdf) — staged into the image from
-    # the api repo's docs/examples/realunit-balance/, rendered by BalancePdfService.
+    # the api repo's docs/examples/realunit-statement/, rendered by BalancePdfService.
     # Same rationale as /receipts/ above: these are meant to be VIEWED inline in
     # the browser, so `^~` makes this longest-prefix match win over the generic
     # \.(pdf|docx)$ location and keeps them off the attachment disposition.


### PR DESCRIPTION
## What

Follow the api-side rename of the portfolio-statement (Vermögensübersicht) example PDFs, so the handbook deploy stops failing and dev-handbook serves the current version.

## Why

api #4128 re-rendered the portfolio statement ("receipt letter design") and **renamed** the committed examples:

`docs/examples/realunit-balance/balance-report-{de,en}.pdf` → `docs/examples/realunit-statement/vermoegensuebersicht-{de,en}.pdf`

`realunit-balance` no longer exists upstream. The handbook (added in #792) still pointed the balance staging step's `SRC_DIR` and the Vermögensübersicht cards at the old path, so:

- the next handbook deploy fails at `realunit-balance not found` (the deploy checks out `DFXswiss/api@develop`), and
- dev-handbook still serves the pre-rename PDF (old design).

## How

- **`.github/workflows/handbook.yaml`** (balance staging step): `SRC_DIR` + comment + error message `realunit-balance` → `realunit-statement`, `balance-report-{de,en}.pdf` → `vermoegensuebersicht-{de,en}.pdf`. `EXPECTED_PDF_COUNT: 2` unchanged.
- **`docs/handbook/de/index.html`** (`#spec-balance`): the two Vermögensübersicht cards, the section source link, the `file` label and the intro code path repoint to the new dir/filenames; the card anchors are renamed `balance-report-*` → `vermoegensuebersicht-*` for consistency.

The served URL path stays `/balance/` (nginx `^~ /balance/` location unchanged) — only the upstream source dir and the file names change.
