### PR TITLE
docs(handbook): add App Store & Google Play production links to download section

### DIFF
--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2918,7 +2918,7 @@ Dieser Inhalt dient Werbezwecken. Die genehmigten Prospekte und weitere Unterlag
                 <div class="file">docs/handbook/de/index.html</div>
               </div>
               <div class="rhs">
-                <b>3 Plattformen</b>
+                <b>5 Zugänge</b>
                 <div class="links">
                   <a href="https://github.com/RealUnitCH/app/releases">Releases ↗</a>
                 </div>
@@ -2927,8 +2927,9 @@ Dieser Inhalt dient Werbezwecken. Die genehmigten Prospekte und weitere Unterlag
           </summary>
 
           <p class="spec-intro">
-            Die öffentlichen Test- und Download-Zugänge der RealUnit-App an einem Ort —
-            iOS über <b>TestFlight</b>, Android über den <b>offenen Test im Play Store</b>
+            Die öffentlichen Store- und Test-Zugänge der RealUnit-App an einem Ort —
+            iOS über den <b>App Store</b> oder <b>TestFlight</b>, Android über
+            <b>Google Play</b> (regulärer Eintrag oder <b>offener Test</b>)
             oder als <b>APK-Direkt-Download</b>. Die Links sind öffentlich und stabil und
             werden statisch hier im Handbook gepflegt; pro Zugang gibt es den Link, einen
             Kopier-Button und einen QR-Code zum Scannen mit dem Handy. Bei einem künftigen
@@ -2936,7 +2937,45 @@ Dieser Inhalt dient Werbezwecken. Die genehmigten Prospekte und weitere Unterlag
             Play-Test-Pfad) diese Sektion aktualisieren.
           </p>
 
-          <div class="tests cols-3">
+          <div class="tests cols-2">
+            <div class="test download" id="dl-appstore">
+              <div class="head">
+                <a class="name permalink" href="#dl-appstore">Apple App Store</a>
+                <span class="src">iOS</span>
+              </div>
+              <div class="dl-body">
+                <div class="dl-qr"><svg role="img" viewBox="0 0 41 41"><title>QR-Code: Apple App Store</title><path fill="#fff" d="M0 0h41v41h-41z"/><path stroke="#343233" d="M4 4.5h7m1 0h1m1 0h1m7 0h4m1 0h1m2 0h7m-33 1h1m5 0h1m1 0h2m1 0h1m2 0h1m2 0h1m3 0h1m1 0h1m2 0h1m5 0h1m-33 1h1m1 0h3m1 0h1m4 0h1m1 0h2m1 0h1m1 0h1m1 0h1m2 0h2m1 0h1m1 0h3m1 0h1m-33 1h1m1 0h3m1 0h1m1 0h5m2 0h1m2 0h2m1 0h1m1 0h1m2 0h1m1 0h3m1 0h1m-33 1h1m1 0h3m1 0h1m2 0h1m1 0h1m1 0h1m2 0h1m1 0h1m5 0h1m1 0h1m1 0h3m1 0h1m-33 1h1m5 0h1m2 0h1m4 0h3m1 0h1m3 0h3m1 0h1m5 0h1m-33 1h7m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h7m-25 1h2m1 0h2m2 0h5m2 0h1m-23 1h1m1 0h2m1 0h3m2 0h3m1 0h2m1 0h1m3 0h1m4 0h1m2 0h1m1 0h2m-33 1h2m2 0h1m2 0h2m1 0h1m2 0h2m1 0h9m1 0h2m1 0h2m1 0h1m-28 1h2m4 0h1m1 0h1m4 0h1m4 0h3m1 0h3m1 0h2m-30 1h1m1 0h1m2 0h1m1 0h2m4 0h2m4 0h2m2 0h2m1 0h1m-28 1h1m3 0h1m2 0h1m2 0h1m1 0h3m3 0h2m2 0h2m1 0h3m-30 1h2m1 0h1m1 0h1m3 0h3m1 0h2m5 0h1m1 0h1m7 0h2m-31 1h7m1 0h1m4 0h1m2 0h4m1 0h2m2 0h1m1 0h1m-29 1h1m4 0h1m1 0h1m1 0h7m5 0h1m1 0h4m2 0h2m-31 1h1m2 0h2m1 0h2m1 0h1m1 0h1m2 0h1m1 0h1m1 0h1m1 0h3m1 0h3m1 0h1m1 0h1m-30 1h2m5 0h2m1 0h2m1 0h2m4 0h1m2 0h4m1 0h2m1 0h2m-33 1h5m1 0h1m2 0h1m2 0h1m1 0h3m1 0h1m2 0h1m2 0h1m1 0h3m1 0h2m-32 1h2m1 0h3m1 0h1m6 0h1m2 0h3m3 0h1m1 0h2m1 0h1m2 0h2m-33 1h2m2 0h1m1 0h1m3 0h1m1 0h2m2 0h1m5 0h1m4 0h1m1 0h2m-31 1h2m1 0h1m1 0h1m1 0h2m1 0h2m3 0h2m3 0h2m1 0h2m1 0h1m2 0h2m1 0h1m-29 1h3m4 0h1m3 0h1m3 0h2m2 0h1m2 0h2m3 0h2m-32 1h1m1 0h1m1 0h1m2 0h3m2 0h3m2 0h1m1 0h1m1 0h1m6 0h1m-30 1h1m1 0h1m2 0h2m1 0h1m2 0h1m2 0h1m2 0h1m1 0h1m2 0h1m1 0h5m3 0h1m-25 1h1m4 0h4m2 0h3m2 0h1m3 0h2m-30 1h7m1 0h1m1 0h1m1 0h2m3 0h5m1 0h2m1 0h1m1 0h1m-29 1h1m5 0h1m1 0h1m1 0h2m4 0h3m1 0h1m2 0h2m3 0h3m1 0h1m-33 1h1m1 0h3m1 0h1m3 0h1m1 0h1m1 0h5m3 0h7m1 0h1m1 0h1m-33 1h1m1 0h3m1 0h1m1 0h1m5 0h1m1 0h2m1 0h1m1 0h2m4 0h1m1 0h4m-33 1h1m1 0h3m1 0h1m1 0h1m3 0h2m1 0h2m1 0h1m1 0h3m1 0h4m-28 1h1m5 0h1m2 0h2m1 0h3m2 0h1m2 0h1m4 0h4m3 0h1m-33 1h7m1 0h2m3 0h2m1 0h2m1 0h1m1 0h1m3 0h1m2 0h1m1 0h1"/></svg></div>
+                <p class="dl-desc">
+                  Regulärer, öffentlicher Store-Eintrag für iPhone &amp; iPad — der
+                  normale Weg für iOS. Link auf dem Gerät öffnen und die App über
+                  den App Store installieren — Updates kommen automatisch.
+                </p>
+                <div class="dl-actions">
+                  <a class="dl-btn" href="https://apps.apple.com/ch/app/realunit/id6759720010" target="_blank" rel="noopener">Öffnen ↗</a>
+                  <button class="copy-link" type="button" data-copy-url="https://apps.apple.com/ch/app/realunit/id6759720010" title="Link kopieren" aria-label="App-Store-Link kopieren">🔗 Link kopieren</button>
+                </div>
+                <code class="dl-url">https://apps.apple.com/ch/app/realunit/id6759720010</code>
+              </div>
+            </div>
+            <div class="test download" id="dl-playstore-prod">
+              <div class="head">
+                <a class="name permalink" href="#dl-playstore-prod">Google Play</a>
+                <span class="src">Android</span>
+              </div>
+              <div class="dl-body">
+                <div class="dl-qr"><svg role="img" viewBox="0 0 45 45"><title>QR-Code: Google Play</title><path fill="#fff" d="M0 0h45v45h-45z"/><path stroke="#343233" d="M4 4.5h7m1 0h2m2 0h2m4 0h2m2 0h3m1 0h3m1 0h7m-37 1h1m5 0h1m2 0h2m1 0h7m1 0h2m2 0h1m5 0h1m5 0h1m-37 1h1m1 0h3m1 0h1m2 0h1m1 0h3m1 0h7m1 0h2m1 0h1m3 0h1m1 0h3m1 0h1m-37 1h1m1 0h3m1 0h1m1 0h1m1 0h1m2 0h2m4 0h2m3 0h3m1 0h1m1 0h1m1 0h3m1 0h1m-37 1h1m1 0h3m1 0h1m1 0h2m2 0h1m5 0h1m2 0h3m2 0h3m1 0h1m1 0h3m1 0h1m-37 1h1m5 0h1m1 0h5m3 0h1m1 0h3m1 0h1m2 0h2m1 0h1m1 0h1m5 0h1m-37 1h7m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h7m-29 1h7m1 0h3m2 0h1m2 0h1m1 0h1m-27 1h1m3 0h1m1 0h3m1 0h1m1 0h1m1 0h1m3 0h2m1 0h4m2 0h1m1 0h5m2 0h1m-37 1h1m1 0h4m2 0h2m1 0h1m2 0h1m1 0h2m1 0h2m2 0h1m1 0h1m1 0h2m2 0h3m1 0h1m-34 1h7m1 0h4m2 0h1m1 0h1m1 0h2m1 0h1m1 0h3m1 0h1m1 0h4m-32 1h3m4 0h4m3 0h2m2 0h3m2 0h2m1 0h1m3 0h3m-34 1h1m1 0h3m2 0h2m2 0h1m1 0h3m1 0h1m1 0h4m4 0h2m2 0h4m-32 1h1m5 0h1m3 0h4m4 0h6m3 0h2m-32 1h1m2 0h2m1 0h1m1 0h1m2 0h4m1 0h1m2 0h1m1 0h2m1 0h2m2 0h5m-35 1h2m1 0h1m5 0h1m4 0h2m5 0h4m4 0h4m1 0h1m-35 1h1m1 0h6m2 0h2m1 0h1m1 0h2m2 0h6m1 0h1m1 0h3m2 0h2m-34 1h1m5 0h2m1 0h1m7 0h2m1 0h1m1 0h1m2 0h4m2 0h4m-34 1h2m1 0h3m1 0h3m2 0h2m1 0h3m3 0h1m2 0h3m1 0h3m1 0h1m-33 1h1m2 0h1m4 0h1m1 0h1m1 0h4m1 0h3m2 0h1m2 0h1m1 0h1m4 0h2m-36 1h1m2 0h1m1 0h2m1 0h1m2 0h1m5 0h1m3 0h2m1 0h1m2 0h1m1 0h3m1 0h2m-34 1h2m2 0h1m1 0h2m4 0h4m1 0h1m3 0h2m2 0h3m2 0h2m-31 1h2m2 0h2m1 0h1m3 0h1m1 0h1m1 0h1m2 0h2m1 0h7m1 0h4m-34 1h1m1 0h2m5 0h1m3 0h5m2 0h1m2 0h1m4 0h4m1 0h1m1 0h1m-36 1h1m2 0h3m1 0h2m1 0h2m1 0h2m2 0h3m1 0h3m2 0h1m1 0h2m2 0h3m-36 1h1m1 0h3m3 0h1m5 0h1m1 0h1m2 0h2m1 0h7m3 0h1m-31 1h1m1 0h1m1 0h1m1 0h1m1 0h5m1 0h3m3 0h2m2 0h2m1 0h1m1 0h1m-30 1h1m2 0h1m5 0h2m4 0h2m2 0h3m2 0h3m3 0h1m1 0h1m-35 1h3m3 0h1m1 0h4m1 0h3m1 0h1m2 0h3m1 0h1m1 0h1m1 0h7m-27 1h1m1 0h1m2 0h5m3 0h1m1 0h1m1 0h2m1 0h1m3 0h1m2 0h1m-36 1h7m1 0h1m4 0h1m1 0h1m2 0h1m1 0h1m2 0h2m3 0h1m1 0h1m1 0h1m2 0h1m-36 1h1m5 0h1m2 0h1m1 0h1m2 0h3m2 0h3m4 0h3m3 0h3m1 0h1m-37 1h1m1 0h3m1 0h1m1 0h1m2 0h1m1 0h2m1 0h1m3 0h1m1 0h1m5 0h7m1 0h1m-37 1h1m1 0h3m1 0h1m2 0h1m2 0h3m3 0h2m3 0h1m3 0h1m1 0h3m1 0h1m2 0h1m-37 1h1m1 0h3m1 0h1m2 0h1m1 0h2m2 0h1m1 0h2m1 0h2m1 0h1m1 0h3m2 0h1m-31 1h1m5 0h1m5 0h2m1 0h3m1 0h1m1 0h1m1 0h1m3 0h1m4 0h1m1 0h2m-36 1h7m1 0h4m5 0h1m1 0h3m2 0h1m2 0h1m1 0h3m2 0h3"/></svg></div>
+                <p class="dl-desc">
+                  Regulärer, öffentlicher Store-Eintrag — der normale Weg für
+                  Android. Link auf dem Gerät öffnen und die App über den Play
+                  Store installieren — Updates kommen automatisch.
+                </p>
+                <div class="dl-actions">
+                  <a class="dl-btn" href="https://play.google.com/store/apps/details?id=swiss.realunit.app&amp;hl=de_CH" target="_blank" rel="noopener">Öffnen ↗</a>
+                  <button class="copy-link" type="button" data-copy-url="https://play.google.com/store/apps/details?id=swiss.realunit.app&amp;hl=de_CH" title="Link kopieren" aria-label="Play-Store-Link kopieren">🔗 Link kopieren</button>
+                </div>
+                <code class="dl-url">https://play.google.com/store/apps/details?id=swiss.realunit.app&amp;hl=de_CH</code>
+              </div>
+            </div>
             <div class="test download" id="dl-testflight">
               <div class="head">
                 <a class="name permalink" href="#dl-testflight">Apple TestFlight</a>


### PR DESCRIPTION
## Was

Die App ist inzwischen produktiv in beiden Stores gelistet. Die Download-Sektion (`#spec-downloads`) wird um die beiden öffentlichen Produktions-Einträge erweitert:

- **Apple App Store**: https://apps.apple.com/ch/app/realunit/id6759720010
- **Google Play**: https://play.google.com/store/apps/details?id=swiss.realunit.app&hl=de_CH

Beide als neue Karten in der ersten Reihe — mit QR-Code, Kopier-Button und stabiler URL, im gleichen Stil wie die bestehenden Karten. TestFlight, Play Offener Test und APK-Direkt-Download bleiben als Test-Kanäle darunter erhalten.

## Details

- Karten-Grid von `cols-3` auf `cols-2` umgestellt (5 Karten: 2 Produktion / 2 Test / 1 APK)
- Intro-Text und Zugangs-Zähler ("5 Zugänge") aktualisiert
- QR-Codes im identischen Format wie die bestehenden generiert (node-qrcode, ECC M, relativer Pfad) und per Apple-Vision-Decoder verifiziert — beide decodieren exakt auf die Ziel-URL
- Nur `docs/handbook/de/index.html`, keine App-Änderung