### PR TITLE
feat(app-links): reopen the app from the website via a custom URL scheme

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,9 +33,26 @@
             <meta-data
                     android:name="io.flutter.embedding.android.EnableImpeller"
                     android:value="false"/>
+            <!-- Forward the inbound custom-scheme URL to Flutter/go_router
+                 instead of the legacy platform channel, so the scheme redirect
+                 handles it. -->
+            <meta-data
+                android:name="flutter_deeplinking_enabled"
+                android:value="true"/>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <!-- Custom URL scheme (realunit-wallet://…, canonical
+                 realunit-wallet://open). Opening the app via the scheme only
+                 foregrounds it; go_router redirects any scheme URL to the normal
+                 entry. A custom scheme needs no autoVerify / Digital Asset
+                 Links. -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="realunit-wallet"/>
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/lib/setup/routing/router_config.dart
+++ b/lib/setup/routing/router_config.dart
@@ -45,6 +45,7 @@ import 'package:realunit_wallet/screens/transaction_history/transaction_history_
 import 'package:realunit_wallet/screens/verify_seed/verify_seed_page.dart';
 import 'package:realunit_wallet/screens/web_view/web_view_page.dart';
 import 'package:realunit_wallet/screens/welcome/welcome_page.dart';
+import 'package:realunit_wallet/setup/routing/routes/app_link_entry.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/setup/routing/routes/legal_routes.dart';
 import 'package:realunit_wallet/setup/routing/routes/onboarding_routes.dart';
@@ -54,6 +55,14 @@ import 'package:realunit_wallet/setup/routing/routes/support_routes.dart';
 
 final GoRouter routerConfig = GoRouter(
   initialLocation: '/home',
+  // Custom-scheme opens (realunit-wallet://…, canonical realunit-wallet://open)
+  // only foreground the app; they must not force any navigation. The redirect
+  // keeps the current in-app route (warm resume) or hands off to the normal
+  // boot entry (cold start). See app_link_entry.dart.
+  redirect: (context, state) => appLinkSchemeRedirect(
+    state,
+    routerConfig.routerDelegate.currentConfiguration.uri.toString(),
+  ),
   routes: <RouteBase>[
     GoRoute(
       name: AppRoutes.home,

--- a/lib/setup/routing/routes/app_link_entry.dart
+++ b/lib/setup/routing/routes/app_link_entry.dart
@@ -1,0 +1,37 @@
+import 'package:go_router/go_router.dart';
+
+/// Custom URL scheme the app is opened with. Registered in
+/// `ios/Runner/Info.plist` (`CFBundleURLSchemes`) and
+/// `android/app/src/main/AndroidManifest.xml` (VIEW intent-filter).
+const String appLinkScheme = 'realunit-wallet';
+
+/// Canonical button target the website links to. Any `realunit-wallet://…` URL
+/// works — this is just the agreed, stable one.
+const String appLinkUrl = 'realunit-wallet://open';
+
+/// Cold-start fallback location (see [appLinkSchemeRedirect]) — the router's
+/// normal entry, identical to `GoRouter.initialLocation`.
+const String appLinkColdStartLocation = '/home';
+
+/// Top-level go_router redirect for custom-scheme opens.
+///
+/// A `realunit-wallet://…` open (canonical `realunit-wallet://open`) only brings
+/// the app to the foreground — it must NOT force any in-app navigation. So on a
+/// warm resume it keeps the user exactly where they were: [currentLocation] is
+/// the router's current in-app route, returned unchanged (a no-op). On a cold
+/// start there is no prior in-app route (currentLocation is empty or the scheme
+/// URL itself), so it hands off to the normal boot entry and lets `main.dart`'s
+/// boot flow take over — the PIN gate and boot ordering stay untouched. Either
+/// way go_router never shows an error screen for a scheme URL that matches no
+/// path route. Non-scheme (in-app) navigation is left untouched (`null`).
+//
+// @no-integration-test: OS-level custom-scheme delivery and foregrounding can
+// only be exercised on a real device, and no integration_test/ harness exists
+// in this repo yet. The redirect itself is covered by widget tests in
+// app_link_entry_test.dart.
+String? appLinkSchemeRedirect(GoRouterState state, String currentLocation) {
+  if (state.uri.scheme != appLinkScheme) return null;
+  final current = Uri.parse(currentLocation);
+  final isInAppRoute = current.scheme.isEmpty && current.path.startsWith('/');
+  return isInAppRoute ? currentLocation : appLinkColdStartLocation;
+}

--- a/test/setup/routing/app_link_entry_test.dart
+++ b/test/setup/routing/app_link_entry_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:realunit_wallet/setup/routing/routes/app_link_entry.dart';
+
+void main() {
+  // A minimal router wired to the *production* [appLinkSchemeRedirect], exactly
+  // as router_config.dart wires it (current location read from the router's own
+  // delegate). `/home` is the normal cold-start entry; `/dashboard` and
+  // `/settings` stand in for arbitrary in-app routes a warm resume must preserve.
+  GoRouter buildRouter({String initialLocation = '/home'}) {
+    late final GoRouter router;
+    router = GoRouter(
+      initialLocation: initialLocation,
+      redirect: (context, state) => appLinkSchemeRedirect(
+        state,
+        router.routerDelegate.currentConfiguration.uri.toString(),
+      ),
+      routes: [
+        GoRoute(
+          path: '/home',
+          builder: (_, _) => const Scaffold(body: Text('HOME', key: Key('home'))),
+        ),
+        GoRoute(
+          path: '/dashboard',
+          builder: (_, _) => const Scaffold(body: Text('DASH', key: Key('dashboard'))),
+        ),
+        GoRoute(
+          path: '/settings',
+          builder: (_, _) => const Scaffold(body: Text('SET', key: Key('settings'))),
+        ),
+      ],
+    );
+    return router;
+  }
+
+  String currentPath(GoRouter router) => router.routerDelegate.currentConfiguration.uri.path;
+
+  Future<GoRouter> pump(WidgetTester tester, {String initial = '/home'}) async {
+    final router = buildRouter(initialLocation: initial);
+    addTearDown(router.dispose);
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+    return router;
+  }
+
+  test('scheme constants', () {
+    expect(appLinkScheme, 'realunit-wallet');
+    expect(appLinkUrl, 'realunit-wallet://open');
+    expect(appLinkColdStartLocation, '/home');
+  });
+
+  testWidgets('warm resume: a scheme open keeps the user on /dashboard', (
+    tester,
+  ) async {
+    final router = await pump(tester);
+    router.go('/dashboard');
+    await tester.pumpAndSettle();
+    expect(currentPath(router), '/dashboard');
+
+    // The scheme open must NOT force any navigation — no jump to /home.
+    router.go(appLinkUrl);
+    await tester.pumpAndSettle();
+
+    expect(currentPath(router), '/dashboard');
+    expect(find.byKey(const Key('dashboard')), findsOneWidget);
+    expect(find.byKey(const Key('home')), findsNothing);
+  });
+
+  testWidgets('warm resume: a scheme open keeps the user on any route', (
+    tester,
+  ) async {
+    final router = await pump(tester);
+    router.go('/settings');
+    await tester.pumpAndSettle();
+    expect(currentPath(router), '/settings');
+
+    router.go(appLinkUrl);
+    await tester.pumpAndSettle();
+
+    expect(currentPath(router), '/settings');
+    expect(find.byKey(const Key('settings')), findsOneWidget);
+  });
+
+  testWidgets('cold start on the scheme URL boots to the normal entry', (
+    tester,
+  ) async {
+    // Simulates the OS delivering `realunit-wallet://open` as the initial route
+    // on a fresh launch (no prior in-app route to preserve).
+    final router = await pump(tester, initial: appLinkUrl);
+
+    expect(currentPath(router), appLinkColdStartLocation);
+    expect(find.byKey(const Key('home')), findsOneWidget);
+  });
+
+  testWidgets(
+    'cold start on any scheme host/path boots without an error screen',
+    (tester) async {
+      for (final url in const [
+        'realunit-wallet://',
+        'realunit-wallet://open/foo?x=1',
+        'realunit-wallet://anything',
+      ]) {
+        final router = await pump(tester, initial: url);
+        expect(currentPath(router), appLinkColdStartLocation, reason: 'for $url');
+        expect(
+          find.byKey(const Key('home')),
+          findsOneWidget,
+          reason: 'for $url',
+        );
+      }
+    },
+  );
+
+  testWidgets(
+    'cold start on a crafted scheme URL to an auth path still boots to /home '
+    '(PIN gate not bypassed)',
+    (tester) async {
+      // `realunit-wallet://dashboard` must not open the authenticated dashboard;
+      // with no prior route it boots to /home and the real boot flow (PIN gate)
+      // in main.dart runs.
+      final router = await pump(tester, initial: 'realunit-wallet://dashboard');
+
+      expect(currentPath(router), appLinkColdStartLocation);
+      expect(find.byKey(const Key('dashboard')), findsNothing);
+      expect(find.byKey(const Key('home')), findsOneWidget);
+    },
+  );
+
+  testWidgets('in-app navigation is left untouched by the scheme redirect', (
+    tester,
+  ) async {
+    final router = await pump(tester);
+
+    router.go('/dashboard');
+    await tester.pumpAndSettle();
+    expect(currentPath(router), '/dashboard');
+    expect(find.byKey(const Key('dashboard')), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What & why

Let a button/link on the `realunit.app` website **reopen the installed app** —
nothing more. Reopening **only foregrounds** the app; it does **not** force any
in-app navigation.

The mechanism is a **custom URL scheme**: `realunit-wallet://`.

- **Canonical button target (from the website):** `realunit-wallet://open`
- **Warm resume** (app was backgrounded): the user stays **exactly where they
  were** — no navigation, no jump to `/home`.
- **Cold start** (app was closed): the normal boot flow runs — that is just a
  regular launch, not a state change.
- The scheme carries no in-app target and no confirmation.

## Why a custom scheme (not Universal / App Links)

We only have the one domain, `realunit.app`, and we are **not** introducing a
subdomain. A custom scheme is the correct, isolated mechanism here:

- **iOS same-domain limitation.** iOS only routes an `https://realunit.app/…`
  link into the app if the app claims `applinks:realunit.app` **and**
  `realunit.app` serves a matching `apple-app-site-association` file. But
  `realunit.app` must keep serving its web pages in the browser — most
  importantly the aktionariat confirmation at
  `realunit.app/confirm-aktionariat`, which runs on the website. Claiming the
  domain for the app would fight the web flow. So Universal Links **on
  `realunit.app` itself** are off the table.
- **A custom scheme is owned solely by the app.** `realunit-wallet://` coexists
  with every `https://realunit.app/…` URL, captures none of them, and needs **no
  domain-association files** (no AASA, no `assetlinks.json`) and no subdomain.
- The aktionariat confirmation link stays exactly as it is —
  `realunit.app/confirm-aktionariat`, opened in the browser. This PR does not
  touch it.

## Changes

**iOS**
- No change. The `realunit-wallet` scheme is already registered in
  `ios/Runner/Info.plist` (`CFBundleURLSchemes`), and `FlutterDeepLinkingEnabled`
  is already `true`. (Verified — nothing to add.)

**Android**
- `android/app/src/main/AndroidManifest.xml`: add a custom-scheme intent-filter
  on `MainActivity` (`VIEW` / `DEFAULT` / `BROWSABLE`,
  `<data android:scheme="realunit-wallet"/>`, **no** `autoVerify` — a custom
  scheme needs none). Add the `flutter_deeplinking_enabled` meta-data inside
  `<activity>` so Flutter forwards the inbound scheme URL to go_router. The
  `MAIN` / `LAUNCHER` filter is untouched.

**Dart routing**
- `lib/setup/routing/routes/app_link_entry.dart` (new): the scheme constants
  (`appLinkScheme = 'realunit-wallet'`, `appLinkUrl = 'realunit-wallet://open'`)
  and `appLinkSchemeRedirect(state, currentLocation)` — a top-level go_router
  redirect that, for **any** `realunit-wallet://…` URL, returns the **current
  in-app location** (a no-op → the user stays put on a warm resume) or, when
  there is no prior in-app route (cold start), hands off to the normal boot
  entry. Non-scheme (in-app) navigation is left untouched.
- `lib/setup/routing/router_config.dart`: wire the top-level `redirect`, reading
  the current location from the router's own delegate.

No i18n, DI, service, DTO or screen changes.

### Reopen semantics — foreground only, no forced navigation

A `realunit-wallet://` open must not move the user. The redirect implements
exactly that:

- **Warm resume → stay put.** The redirect returns the router's current in-app
  location, so go_router does not navigate. The user remains on whatever screen
  they were on. Verified empirically (see Testing): opening the scheme while on
  `/dashboard` (or any route) leaves the router on that route, never `/home`.
- **Cold start → normal boot.** With no prior in-app route, the redirect returns
  the normal boot entry (`/home`); `main.dart`'s existing boot flow then decides
  the real target. This is just a regular launch.
- **No go_router error screen.** A scheme URL matches no path route; the redirect
  always resolves it (to the current location or `/home`), so the error page is
  never shown.

### Boot / PIN gate (unchanged)

- **`main.dart` is byte-for-byte identical to `staging`** (`git diff staging --
  lib/main.dart` is empty). The redirect never touches the boot / PIN ordering.
- **The PIN gate cannot be bypassed.** Opening the app via the scheme first
  backgrounds whatever app the link was tapped in; backgrounding already drops
  the mnemonic and re-arms the PIN gate (`LifecycleInitializer` →
  `onAppHidden()` / `lockCurrentWallet()`), and on resume the standard flow
  enforces `/verifyPin`. On a cold start a crafted `realunit-wallet://dashboard`
  resolves to `/home` (no prior route), never the authenticated dashboard.

## What was removed (previous approach on this branch)

The branch was reset to the `staging` merge-base and rebuilt. Earlier iterations
tried to claim an `https://` host (first `realunit.app/confirm-aktionariat`, then
a dedicated `app.realunit.app` subdomain) via Universal / App Links and, in the
first iteration, perform the confirmation in-app with a boot-navigation rebuild.
All of that is gone:

- no `com.apple.developer.associated-domains` entitlement (iOS entitlements are
  back to the `staging` version — keychain group only);
- no `https` App Links intent-filter / `autoVerify` on Android;
- no in-app aktionariat confirmation service / DTO / screen / cubit and no
  `main.dart` boot rebuild.

## Testing (CI-matching runner, Flutter 3.41.6)

- `flutter analyze` → **No issues found.**
- `flutter test --exclude-tags golden` → **green** (incl. the new route tests).
- `flutter test test/goldens` → **green** (no UI added).

New tests (`test/setup/routing/app_link_entry_test.dart`):
- **warm resume: a scheme open keeps the user on `/dashboard`** (and on any other
  route) — no jump to `/home`;
- cold start on `realunit-wallet://open` boots to the normal entry (`/home`);
- any scheme host/path (`realunit-wallet://`, `…/open/foo?x=1`, `…/anything`)
  boots without an error screen;
- a crafted `realunit-wallet://dashboard` on cold start still boots to `/home`
  (PIN gate not bypassed);
- in-app navigation (`/dashboard`) is left untouched by the redirect.

The platform scheme-delivery path carries a `// @no-integration-test:`
annotation (no `integration_test/` harness exists yet); OS-level delivery must be
validated on a real device once one does.

## Go-live checklist (much simpler now)

1. **Ship the app version.** That's the only prerequisite — a custom scheme is
   self-contained. **No** `.well-known` files (no AASA, no `assetlinks.json`),
   **no** subdomain, no Apple portal capability.
2. **Website button** links to `realunit-wallet://open`. On a device without the
   app installed the OS shows the usual "no app to handle this link" behaviour —
   the button should therefore be shown where an install path already exists (or
   paired with a store link).
3. The aktionariat confirmation link stays `realunit.app/confirm-aktionariat`
   (browser, web flow) — unchanged by this PR.

## Notes

- **Base branch:** `staging`, per `CONTRIBUTING.md`'s
  `feature/* → staging → develop → main` flow.
- Draft — not for merge / not marked ready.
