### PR TITLE
test(handbook): converge the reset-wallet checkbox instead of a single tap

### DIFF
--- a/.maestro/handbook/25-restore-wallet.yaml
+++ b/.maestro/handbook/25-restore-wallet.yaml
@@ -25,26 +25,25 @@
 # use the same pattern as the `wallet-logout-confirm-checkbox` and
 # `home-terms-link` Semantics ids elsewhere in the app.
 #
-# The checkbox is now wrapped in `Semantics(identifier:
-# 'wallet-logout-confirm-checkbox', toggled: …)` with a row-wide opaque
+# The checkbox is wrapped in `Semantics(identifier:
+# 'wallet-logout-confirm-checkbox', toggled: isChecked)` with a row-wide opaque
 # GestureDetector (see
-# lib/screens/settings/widgets/settings_confirm_logout_wallet_sheet.dart)
-# so Maestro can target it deterministically via `tapOn: id:` instead of the
+# lib/screens/settings/widgets/settings_confirm_logout_wallet_sheet.dart) so
+# Maestro can both target it by id and read its checked state — instead of the
 # previous wrap-sensitive `leftOf:` coordinate-tap that XCUITest silently
-# dropped on Apple Silicon + iOS 26 (mobile-dev-inc/maestro#3137) — that
-# silent loss is what caused the prior run to never check the box, leaving
-# "Zurücksetzen" disabled and every downstream step a no-op against the still
-# visible modal. We tap the checkbox once by id (a single deterministic
-# Semantics target with a full-row tap surface), then gate the "Zurücksetzen"
-# button tap on the modal still being visible — if "Zurücksetzen" was silently
-# dropped we re-tap until the modal closes. We deliberately do not loop the
-# checkbox itself: tapping it twice would toggle it back off again, since
-# the underlying `setState(() => isChecked = !isChecked)` is not idempotent.
-# If the checkbox tap is the one that's silently dropped, the next
-# `extendedWaitUntil notVisible "RealUnit Wallet zurücksetzen"` (with the
-# Zurücksetzen button still disabled) fails loudly rather than passing silently
-# downstream — and the same Semantics-id strategy that fixed flow 26's
-# Nutzungsbedingungen-link tap has been reliable enough since.
+# dropped on Apple Silicon + iOS 26 (mobile-dev-inc/maestro#3137).
+#
+# XCUITest still drops the occasional id-tap on that stack, and the checkbox is
+# a non-idempotent toggle (`setState(() => isChecked = !isChecked)`), so we can
+# neither trust a single tap nor blind-retry it — a second tap would toggle a
+# landed one back off. Instead we converge: tap the checkbox ONLY while it
+# still reports `checked: false`. A landed tap flips it to checked and ends the
+# loop; a dropped tap leaves it unchecked and is retried; a checked box is
+# never tapped again. `checked` mirrors the `toggled:` Semantics flag and is
+# present in the iOS view hierarchy Maestro reads. We then `assertVisible
+# checked: true`, so an all-dropped run fails loudly right here instead of
+# no-oping the disabled "Zurücksetzen" button through every downstream step and
+# failing confusingly on the modal-still-visible assertion far below.
 #
 # All tap-leading steps (Zurücksetzen, Start, Software-Wallet, Wallet
 # wiederherstellen) are gated on their target not yet showing and re-tapped
@@ -52,9 +51,21 @@
 # screen changes, so surplus iterations no-op.
 appId: swiss.realunit.app
 ---
-- tapOn:
+- repeat:
+    times: 4
+    commands:
+      - runFlow:
+          when:
+            visible:
+              id: 'wallet-logout-confirm-checkbox'
+              checked: false
+          commands:
+            - tapOn:
+                id: 'wallet-logout-confirm-checkbox'
+            - waitForAnimationToEnd
+- assertVisible:
     id: 'wallet-logout-confirm-checkbox'
-- waitForAnimationToEnd
+    checked: true
 - repeat:
     times: 3
     commands:

--- a/.maestro/handbook/25-restore-wallet.yaml
+++ b/.maestro/handbook/25-restore-wallet.yaml
@@ -40,15 +40,22 @@
 # still reports `checked: false`. A landed tap flips it to checked and ends the
 # loop; a dropped tap leaves it unchecked and is retried; a checked box is
 # never tapped again. `checked` mirrors the `toggled:` Semantics flag and is
-# present in the iOS view hierarchy Maestro reads. We then `assertVisible
-# checked: true`, so an all-dropped run fails loudly right here instead of
-# no-oping the disabled "Zurücksetzen" button through every downstream step and
-# failing confusingly on the modal-still-visible assertion far below.
+# present in the iOS view hierarchy Maestro reads. The `waitForAnimationToEnd`
+# after the tap is load-bearing (not decorative): it lets the toggle rebuild
+# settle so the next iteration's `checked` read is accurate — without it a
+# just-landed tap could still read `checked: false` and be tapped again,
+# toggling the box back off. `times: 4` (one more than the repo-standard 3) is
+# deliberate: unlike the later taps, a dropped checkbox tap can't be re-driven
+# downstream, so it gets one extra attempt. We then `assertVisible checked:
+# true`, so an all-dropped run fails loudly right here instead of no-oping the
+# disabled "Zurücksetzen" button through every downstream step and failing
+# confusingly on the modal-still-visible assertion far below.
 #
-# All tap-leading steps (Zurücksetzen, Start, Software-Wallet, Wallet
-# wiederherstellen) are gated on their target not yet showing and re-tapped
-# if one was silently dropped. Each gate stops its loop the instant the
-# screen changes, so surplus iterations no-op.
+# The remaining tap-leading steps are each gated and re-tapped if one was
+# silently dropped: Zurücksetzen on the reset modal still being visible, and
+# Start / Software-Wallet / Wallet-wiederherstellen on their next-screen target
+# not yet showing. Each gate stops its loop the instant the screen changes, so
+# surplus iterations no-op.
 appId: swiss.realunit.app
 ---
 - repeat:
@@ -62,6 +69,7 @@ appId: swiss.realunit.app
           commands:
             - tapOn:
                 id: 'wallet-logout-confirm-checkbox'
+                optional: true
             - waitForAnimationToEnd
 - assertVisible:
     id: 'wallet-logout-confirm-checkbox'


### PR DESCRIPTION
## What

Makes handbook flow `25-restore-wallet` robust against the silently-dropped
checkbox tap that turned the `staging → develop` promotion PR red.

## Root cause (verified against the failure artifact)

The flow tapped the "Ich habe meine Wiederherstellungsphrase gesichert."
checkbox **exactly once** (`tapOn: id: wallet-logout-confirm-checkbox`). On the
`macos-latest` runner (Apple Silicon + iOS 26) XCUITest silently drops the
occasional tap (`mobile-dev-inc/maestro#3137`) — the tap reports `COMPLETED`
but never lands. When the dropped tap is the checkbox, it stays unchecked, so
the "Zurücksetzen" button stays disabled (`onPressed: null`), the three gated
`Zurücksetzen` taps below all no-op against a disabled button, and the run
fails ~30 lines later on `notVisible "…Wallet zurücksetzen…"` — a confusing
symptom far from the cause. The failure screenshot shows exactly this: checkbox
empty, "Zurücksetzen" greyed out.

## Fix

The checkbox is a non-idempotent toggle (`setState(() => isChecked =
!isChecked)`), so a blind retry could toggle a *landed* tap back off — which is
why the previous version deliberately tapped once. Instead we **converge**: tap
the checkbox only while it still reports `checked: false`, so a landed tap ends
the loop, a dropped tap is retried, and a checked box is never tapped again.
The `checked` state mirrors the `Semantics(toggled: isChecked)` node and is
present in the iOS view hierarchy Maestro reads (confirmed in the failing run's
hierarchy dump: `resource-id: wallet-logout-confirm-checkbox, checked: false`).
Then `assertVisible checked: true` fails loudly right at the checkbox if every
tap was dropped, instead of no-oping downstream.

No app change — `SettingsConfirmLogoutWalletSheet` already exposes `toggled`
and disables the button correctly; this is a test-robustness fix only.

## Validation

Tier 3 handbook flows only run on `push: develop` or on a PR labelled
`tier3:full`. This PR carries that label so the full handbook suite (including
`25-restore-wallet`) runs against a fresh iOS simulator here before merge.
