### PR TITLE
docs(handbook): document the tax-residence step and the open pickers

### DIFF
--- a/.github/workflows/handbook-build-check.yaml
+++ b/.github/workflows/handbook-build-check.yaml
@@ -68,8 +68,8 @@ jobs:
           set -euo pipefail
           bash scripts/assemble-handbook-screenshots.sh /tmp/handbook-shots
           count=$(ls -1 /tmp/handbook-shots/*.png | wc -l | tr -d ' ')
-          if [ "$count" != "53" ]; then
-            echo "expected 53 screenshots, got $count" >&2
+          if [ "$count" != "61" ]; then
+            echo "expected 61 screenshots, got $count" >&2
             exit 1
           fi
 
@@ -149,11 +149,11 @@ jobs:
             exit 1
           fi
 
-          # Screenshots dir must contain all 53 PNGs assembled from Goldens.
+          # Screenshots dir must contain all 61 PNGs assembled from Goldens.
           # Hit one of them through the auth gate to verify wiring end-to-end.
-          # Mix of original 01-26 range + new 27-53 range so a regression
+          # Mix of original 01-26 range + new 27-61 range so a regression
           # in either half surfaces here.
-          for name in 01-welcome 11-dashboard 26-terms 35-dashboard-with-balance 46-buy-kyc-required 52-sell-unknown-error 53-buy-payment-details; do
+          for name in 01-welcome 11-dashboard 26-terms 35-dashboard-with-balance 46-buy-kyc-required 52-sell-unknown-error 53-buy-payment-details 61-kyc-registration-tax-tin-error; do
             code=$(curl -s -o /dev/null -w '%{http_code}' -u "${HANDBOOK_USER:-x}:${HANDBOOK_PASS:-x}" "http://127.0.0.1:8080/screenshots/${name}.png")
             # 200 (auth happens to match) or 401 (auth fails but file exists)
             # both prove the file is on disk. 404 means it was not assembled.

--- a/Dockerfile.handbook
+++ b/Dockerfile.handbook
@@ -7,7 +7,7 @@
 # Build context is the repo root; only docs/handbook/, scripts/, and
 # test/goldens/ are copied in.
 #
-# The 52 screenshots (`screenshots/NN-name.png`) are assembled from the
+# The 61 screenshots (`screenshots/NN-name.png`) are assembled from the
 # visual-regression Golden baselines under `test/goldens/screens/` via
 # scripts/assemble-handbook-screenshots.sh — one Golden per handbook
 # entry, see the mapping in that script. `docs/handbook/screenshots/` is

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -73,7 +73,11 @@ mehr aus diesen Maestro-Läufen.)
 2. **Screenshot-Mapping**: in `scripts/assemble-handbook-screenshots.sh` eine neue
    Zeile in der `MAPPING`-Tabelle ergänzen — `"NN-<name>=<feature>/goldens/macos/<file>.png"`.
    Die Nummer NN ist der Sortierschlüssel im Handbook (keine direkte Bindung mehr
-   an einen Maestro-Flow).
+   an einen Maestro-Flow). Damit ändert sich die Screenshot-Anzahl: den
+   Count-Guard in `.github/workflows/handbook-build-check.yaml` (der
+   `if [ "$count" != "N" ]`-Check plus die `NN-…`-Kommentare/-Samples im
+   Smoke-Step) im selben Zug anpassen — analog zur `EXPECTED_PDF_COUNT`-Mechanik
+   weiter unten.
 3. **HTML**: in `docs/handbook/de/index.html` einen neuen `<div class="test">`-Block
    in die thematisch passende `<details id="spec-NN" class="spec">`-Sektion
    einfügen (Muster siehe spec-01). Die Screenshots sind in wenige thematische

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -21,7 +21,7 @@ deployten Image (`handbook.realunit.app` / `dev-handbook.realunit.app`).
 
 ## Screenshots regenerieren
 
-Es gibt keinen separaten Regeneration-Schritt: Die 52 Handbook-Screenshots
+Es gibt keinen separaten Regeneration-Schritt: Die 61 Handbook-Screenshots
 sind direkt die Golden-Baselines unter `test/goldens/screens/` (gemappt in
 `scripts/assemble-handbook-screenshots.sh`). Eine UI-Änderung an einer der
 gemappten Pages produziert beim `flutter test test/goldens` einen Diff —

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2100,7 +2100,7 @@
               </div>
               <div class="desc">
                 Persönliche-Daten-Schritt mit geöffnetem Länder-Picker: Der User wählt
-                seine Nationalität (Staatsbürgerschaft) aus der durchsuchbaren Länderliste.
+                seine Nationalität (Staatsbürgerschaft) aus der scrollbaren Länderliste.
               </div>
             </div>
             <div class="test" id="41-kyc-registration-address">
@@ -2136,7 +2136,7 @@
               </div>
               <div class="desc">
                 Adress-Schritt mit geöffnetem Länder-Picker: Hier wählt der User das Land
-                seines Wohnsitzes aus der durchsuchbaren Länderliste.
+                seines Wohnsitzes aus der scrollbaren Länderliste.
               </div>
             </div>
             <div class="test" id="56-kyc-registration-tax">
@@ -2172,7 +2172,7 @@
               </div>
               <div class="desc">
                 Geöffneter Länder-Picker des Steuer-Schritts. Der User wählt genau ein Land
-                des steuerlichen Wohnsitzes aus der durchsuchbaren Liste.
+                des steuerlichen Wohnsitzes aus der scrollbaren Liste.
               </div>
             </div>
             <div class="test" id="58-kyc-registration-tax-swiss">
@@ -2242,8 +2242,8 @@
               </div>
               <div class="desc">
                 Validierungsfehler bei ausländischem Steuerwohnsitz ohne TIN: Das
-                Pflicht-TIN-Feld wird mit rotem Rahmen und dem Hinweis „TIN ist
-                erforderlich" markiert.
+                Pflicht-TIN-Feld wird mit rotem Rahmen markiert, der Submit ist
+                blockiert.
               </div>
             </div>
           </div>

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -1999,15 +1999,18 @@
                 <div class="file">test/goldens/screens/kyc/</div>
               </div>
               <div class="rhs">
-                <b>5 Screens</b>
+                <b>13 Screens</b>
               </div>
             </div>
           </summary>
           <p class="spec-intro">
-            KYC-Onboarding für Buy/Sell — Pflicht ab definierten Volumen-Schwellen. Zwei
-            Stammdaten-Schritte (persönlich + Adresse) sowie ein E-Mail-Verifizierungs-Schritt
-            mit den Fehler-States <em>Loading</em>, <em>Mismatch</em> (eingegebener Code
-            stimmt nicht) und <em>Unknown Error</em> (Backend-Fehler).
+            KYC-Onboarding für Buy/Sell — Pflicht ab definierten Volumen-Schwellen. Der
+            Registrierungs-Wizard umfasst zwei Stammdaten-Schritte (persönlich + Adresse)
+            und als finalen Schritt die Steueransässigkeit; der Submit der KYC-Anfrage an
+            das DFX-Backend erfolgt erst auf diesem Steuer-Schritt. Dazu kommt der
+            E-Mail-Verifizierungs-Schritt mit den Fehler-States <em>Loading</em>,
+            <em>Mismatch</em> (eingegebener Code stimmt nicht) und <em>Unknown Error</em>
+            (Backend-Fehler).
           </p>
 
           <div class="tests cols-2">
@@ -2083,6 +2086,23 @@
                 validiert, der Weiter-CTA ist disabled bis die Eingabe vollständig ist.
               </div>
             </div>
+            <div class="test" id="54-kyc-registration-personal-dropdown">
+              <div class="head">
+                <a class="name permalink" href="#54-kyc-registration-personal-dropdown">54-kyc-registration-personal-dropdown</a>
+                <button class="copy-link" type="button" data-target="54-kyc-registration-personal-dropdown" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">kyc_registration_personal_step_dropdown_open.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../screenshots/54-kyc-registration-personal-dropdown.png"
+                  alt="KYC Registrierung — Nationalitäts-Auswahl"
+                />
+              </div>
+              <div class="desc">
+                Persönliche-Daten-Schritt mit geöffnetem Länder-Picker: Der User wählt
+                seine Nationalität (Staatsbürgerschaft) aus der durchsuchbaren Länderliste.
+              </div>
+            </div>
             <div class="test" id="41-kyc-registration-address">
               <div class="head">
                 <a class="name permalink" href="#41-kyc-registration-address">41-kyc-registration-address</a>
@@ -2096,9 +2116,134 @@
                 />
               </div>
               <div class="desc">
-                Adress-Schritt der KYC-Registrierung (Strasse, PLZ, Ort, Land). Bei
-                erfolgreichem Submit wird die KYC-Anfrage an das DFX-Backend übermittelt
-                und der User durchläuft anschliessend die Identitätsverifikation.
+                Adress-Schritt der KYC-Registrierung (Strasse, Nummer, PLZ, Ort, Land).
+                Der Schritt ist nicht mehr final: „Weiter" führt den User zum
+                abschliessenden Steueransässigkeits-Schritt — die KYC-Anfrage wird erst
+                dort an das DFX-Backend übermittelt.
+              </div>
+            </div>
+            <div class="test" id="55-kyc-registration-address-dropdown">
+              <div class="head">
+                <a class="name permalink" href="#55-kyc-registration-address-dropdown">55-kyc-registration-address-dropdown</a>
+                <button class="copy-link" type="button" data-target="55-kyc-registration-address-dropdown" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">kyc_registration_address_step_dropdown_open.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../screenshots/55-kyc-registration-address-dropdown.png"
+                  alt="KYC Registrierung — Wohnsitz-Land-Auswahl"
+                />
+              </div>
+              <div class="desc">
+                Adress-Schritt mit geöffnetem Länder-Picker: Hier wählt der User das Land
+                seines Wohnsitzes aus der durchsuchbaren Länderliste.
+              </div>
+            </div>
+            <div class="test" id="56-kyc-registration-tax">
+              <div class="head">
+                <a class="name permalink" href="#56-kyc-registration-tax">56-kyc-registration-tax</a>
+                <button class="copy-link" type="button" data-target="56-kyc-registration-tax" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">kyc_registration_tax_step_default.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../screenshots/56-kyc-registration-tax.png"
+                  alt="KYC Registrierung — Steueransässigkeit"
+                />
+              </div>
+              <div class="desc">
+                Abschliessender Schritt der Registrierung. Der Pflicht-Länder-Picker „Land
+                des steuerlichen Wohnsitzes" ist nicht vorbelegt — der User muss genau ein
+                Land wählen. Der „Abschliessen"-CTA übermittelt die vollständige KYC-Anfrage
+                an das DFX-Backend.
+              </div>
+            </div>
+            <div class="test" id="57-kyc-registration-tax-dropdown">
+              <div class="head">
+                <a class="name permalink" href="#57-kyc-registration-tax-dropdown">57-kyc-registration-tax-dropdown</a>
+                <button class="copy-link" type="button" data-target="57-kyc-registration-tax-dropdown" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">kyc_registration_tax_step_dropdown_open.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../screenshots/57-kyc-registration-tax-dropdown.png"
+                  alt="KYC Registrierung — Steuerland-Auswahl"
+                />
+              </div>
+              <div class="desc">
+                Geöffneter Länder-Picker des Steuer-Schritts. Der User wählt genau ein Land
+                des steuerlichen Wohnsitzes aus der durchsuchbaren Liste.
+              </div>
+            </div>
+            <div class="test" id="58-kyc-registration-tax-swiss">
+              <div class="head">
+                <a class="name permalink" href="#58-kyc-registration-tax-swiss">58-kyc-registration-tax-swiss</a>
+                <button class="copy-link" type="button" data-target="58-kyc-registration-tax-swiss" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">kyc_registration_tax_step_swiss.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../screenshots/58-kyc-registration-tax-swiss.png"
+                  alt="KYC Registrierung — Schweizer Steueransässigkeit"
+                />
+              </div>
+              <div class="desc">
+                Ist die Schweiz (CH) als steuerlicher Wohnsitz gewählt, entfällt die
+                TIN-Abfrage — der Schritt lässt sich direkt abschliessen.
+              </div>
+            </div>
+            <div class="test" id="59-kyc-registration-tax-non-swiss">
+              <div class="head">
+                <a class="name permalink" href="#59-kyc-registration-tax-non-swiss">59-kyc-registration-tax-non-swiss</a>
+                <button class="copy-link" type="button" data-target="59-kyc-registration-tax-non-swiss" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">kyc_registration_tax_step_non_swiss.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../screenshots/59-kyc-registration-tax-non-swiss.png"
+                  alt="KYC Registrierung — Ausländische Steueransässigkeit"
+                />
+              </div>
+              <div class="desc">
+                Bei einem Nicht-CH-Steuerwohnsitz erscheint zusätzlich das Pflichtfeld
+                „Steueridentifikationsnummer (TIN)", das zusammen mit dem gewählten Land
+                übermittelt wird.
+              </div>
+            </div>
+            <div class="test" id="60-kyc-registration-tax-country-error">
+              <div class="head">
+                <a class="name permalink" href="#60-kyc-registration-tax-country-error">60-kyc-registration-tax-country-error</a>
+                <button class="copy-link" type="button" data-target="60-kyc-registration-tax-country-error" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">kyc_registration_tax_step_country_error.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../screenshots/60-kyc-registration-tax-country-error.png"
+                  alt="KYC Registrierung — Fehlende Länderauswahl"
+                />
+              </div>
+              <div class="desc">
+                Validierungsfehler beim Abschliessen ohne gewähltes Land: Der
+                Pflicht-Länder-Picker wird mit rotem Rahmen markiert, der Submit ist
+                blockiert.
+              </div>
+            </div>
+            <div class="test" id="61-kyc-registration-tax-tin-error">
+              <div class="head">
+                <a class="name permalink" href="#61-kyc-registration-tax-tin-error">61-kyc-registration-tax-tin-error</a>
+                <button class="copy-link" type="button" data-target="61-kyc-registration-tax-tin-error" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">kyc_registration_tax_step_tin_error.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../screenshots/61-kyc-registration-tax-tin-error.png"
+                  alt="KYC Registrierung — Fehlende TIN"
+                />
+              </div>
+              <div class="desc">
+                Validierungsfehler bei ausländischem Steuerwohnsitz ohne TIN: Das
+                Pflicht-TIN-Feld wird mit rotem Rahmen und dem Hinweis „TIN ist
+                erforderlich" markiert.
               </div>
             </div>
           </div>

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -38,7 +38,7 @@ server {
     # any unauth client could pull them. `Vary: Authorization` doesn't
     # save us — Cloudflare ignores Vary on non-Enterprise plans. The
     # only safe answer for gated content on this plan is no-store. The
-    # handbook ships ~6 MB total (HTML + 26 PNG screenshots, ~225 KB
+    # handbook ships ~6 MB total (HTML + 61 PNG screenshots, ~35 KB
     # each); a hard-refresh re-pulls all of it from origin, but the
     # upstream hosts shrug at that, and the gate by design keeps the
     # audience tiny.

--- a/scripts/assemble-handbook-screenshots.sh
+++ b/scripts/assemble-handbook-screenshots.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Assemble the 53 handbook screenshots from the visual-regression Golden
+# Assemble the 61 handbook screenshots from the visual-regression Golden
 # baselines. The flat `NN-name.png` output layout matches what
 # docs/handbook/de/index.html links to (`<img src="../screenshots/NN-name.png">`
 # — the relative path resolves to `docs/handbook/screenshots/NN-name.png`).
@@ -88,6 +88,14 @@ MAPPING=(
   "51-sell-min-amount=sell/goldens/macos/sell_min_amount_not_met.png"
   "52-sell-unknown-error=sell/goldens/macos/sell_unknown_error.png"
   "53-buy-payment-details=buy/goldens/macos/buy_payment_details_default.png"
+  "54-kyc-registration-personal-dropdown=kyc/goldens/macos/kyc_registration_personal_step_dropdown_open.png"
+  "55-kyc-registration-address-dropdown=kyc/goldens/macos/kyc_registration_address_step_dropdown_open.png"
+  "56-kyc-registration-tax=kyc/goldens/macos/kyc_registration_tax_step_default.png"
+  "57-kyc-registration-tax-dropdown=kyc/goldens/macos/kyc_registration_tax_step_dropdown_open.png"
+  "58-kyc-registration-tax-swiss=kyc/goldens/macos/kyc_registration_tax_step_swiss.png"
+  "59-kyc-registration-tax-non-swiss=kyc/goldens/macos/kyc_registration_tax_step_non_swiss.png"
+  "60-kyc-registration-tax-country-error=kyc/goldens/macos/kyc_registration_tax_step_country_error.png"
+  "61-kyc-registration-tax-tin-error=kyc/goldens/macos/kyc_registration_tax_step_tin_error.png"
 )
 
 missing=()


### PR DESCRIPTION
Follow-up to #801: the handbook did not know the new tax-residence step yet, and the spec-14 description of the address step became wrong (it claimed the KYC request is submitted there — submission moved to the new final step).

## Changes

- **`scripts/assemble-handbook-screenshots.sh`**: 8 new mapping rows (54–61) for the goldens added by #801 — the three tax-step states (default, Swiss, non-Swiss with TIN), both validation-error states, and the open-picker views for nationality, residence country, and tax-residence country.
- **`docs/handbook/de/index.html`** (spec-14 only): section intro now describes the three-step wizard with the final tax-residence step carrying the submit; the screen counter goes 5 → 13; block 41's submit claim is corrected („Weiter" leads to the tax step); 8 new test blocks following the existing pattern (permalink anchor, copy-link button, screenshot, description). The open-residence-picker block (55) explicitly documents where the user selects their country of residence.

## Verification

`assemble-handbook-screenshots.sh` run against the mapping: exit 0, **61 screenshots assembled**, all 8 new PNGs resolve to non-empty files. Spec-14 div balance 57/57, 13 test blocks, all 13 `img` references resolve. Headless-Chrome load of the assembled page succeeds and renders the new block texts. No golden or production-code changes.
