### PR TITLE
feat(kyc): default the tax residence to the address country

### DIFF
--- a/lib/screens/kyc/steps/registration/kyc_registration_page.dart
+++ b/lib/screens/kyc/steps/registration/kyc_registration_page.dart
@@ -273,10 +273,19 @@ class _KycRegistrationViewState extends State<KycRegistrationView> {
         );
 
       case KycRegistrationStep.taxResidence:
-        return KycRegistrationTaxStep(
-          taxCountryCtrl: taxCountryCtrl,
-          tinCtrl: tinCtrl,
-          onSubmit: _onSubmit,
+        // Default the tax-residence country to the residence country entered on
+        // the address step, rebuilding when it changes — most people are
+        // tax-resident where they live. The field stays editable; CountryField
+        // propagates the default into `taxCountryCtrl` and reveals the TIN for a
+        // non-Swiss default.
+        return ValueListenableBuilder<Country?>(
+          valueListenable: countryCtrl,
+          builder: (context, residenceCountry, _) => KycRegistrationTaxStep(
+            taxCountryCtrl: taxCountryCtrl,
+            tinCtrl: tinCtrl,
+            initialCountry: residenceCountry,
+            onSubmit: _onSubmit,
+          ),
         );
     }
   }

--- a/lib/screens/kyc/steps/registration/steps/kyc_registration_tax_step.dart
+++ b/lib/screens/kyc/steps/registration/steps/kyc_registration_tax_step.dart
@@ -10,11 +10,17 @@ class KycRegistrationTaxStep extends StatelessWidget {
   final TextEditingController tinCtrl;
   final Future<void> Function() onSubmit;
 
+  /// Pre-selects the tax-residence country — the residence country the user
+  /// entered on the address step (most people are tax-resident where they
+  /// live). Editable here; `null` falls back to an empty, mandatory picker.
+  final Country? initialCountry;
+
   KycRegistrationTaxStep({
     super.key,
     required this.taxCountryCtrl,
     required this.tinCtrl,
     required this.onSubmit,
+    this.initialCountry,
   });
   final _formKey = GlobalKey<FormState>();
 
@@ -31,17 +37,19 @@ class KycRegistrationTaxStep extends StatelessWidget {
             child: Column(
               spacing: 16,
               children: [
-                // The tax-residence country is mandatory: no initial value, so
-                // the user has to make an explicit choice (CountryField's own
-                // validator blocks submit while nothing is picked).
-                // `swissTaxResidence` is derived from this selection — a Swiss
-                // (CH) tax residence maps to Swiss-only, and the TIN is
-                // collected only for a non-Swiss tax residence, matching the
-                // backend contract (`swissTaxResidence` + optional
+                // The tax-residence country defaults to the residence country
+                // entered on the address step (via [initialCountry]) but stays
+                // editable and mandatory: with no residence to fall back on the
+                // picker is empty and CountryField's own validator blocks submit
+                // until a choice is made. `swissTaxResidence` is derived from
+                // this selection — a Swiss (CH) tax residence maps to Swiss-only,
+                // and the TIN is collected only for a non-Swiss tax residence,
+                // matching the backend contract (`swissTaxResidence` + optional
                 // `countryAndTINs`).
                 CountryField(
                   label: S.of(context).taxResidenceCountry,
                   purpose: CountryFieldPurpose.nationality,
+                  initialValue: initialCountry,
                   onChanged: (country) => taxCountryCtrl.value = country,
                 ),
                 ValueListenableBuilder<Country?>(

--- a/test/screens/kyc/steps/kyc_registration_page_test.dart
+++ b/test/screens/kyc/steps/kyc_registration_page_test.dart
@@ -651,6 +651,37 @@ void main() {
       ),
     );
 
+    // Same person but tax-resident abroad: nationality CH, residence DE. Proves
+    // the tax residence defaults from the ADDRESS country (not the nationality)
+    // and exercises the non-Swiss prefill end-to-end.
+    const initialUserDataDe = RealUnitUserDataDto(
+      email: 'a@b.com',
+      name: 'Ada Lovelace',
+      type: 'HUMAN',
+      phoneNumber: '+41 79 000 00 00',
+      birthday: '1815-12-10',
+      nationality: 'CH',
+      addressStreet: 'Bahnhofstrasse 1',
+      addressPostalCode: '8000',
+      addressCity: 'Berlin',
+      addressCountry: 'DE',
+      swissTaxResidence: true,
+      lang: 'de',
+      kycData: KycPersonalData(
+        accountType: KycAccountType.personal,
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+        phone: '+41 79 000 00 00',
+        address: KycAddress(
+          street: 'Bahnhofstrasse',
+          houseNumber: '1',
+          zip: '8000',
+          city: 'Berlin',
+          country: 55,
+        ),
+      ),
+    );
+
     setUp(() {
       // Land the pager on the final tax-residence step so its country picker is
       // in view once we jump the PageView to it.
@@ -691,9 +722,12 @@ void main() {
         )
         .first;
 
-    Future<void> showTaxStep(WidgetTester tester) async {
+    Future<void> showTaxStep(
+      WidgetTester tester, {
+      RealUnitUserDataDto dto = initialUserData,
+    }) async {
       await tester.pumpApp(
-        buildSubject(const KycRegistrationView(initialUserData: initialUserData)),
+        buildSubject(KycRegistrationView(initialUserData: dto)),
       );
       // Let the seeded country lookups resolve before we jump to the tax page.
       await tester.pumpAndSettle();
@@ -807,6 +841,31 @@ void main() {
         final captured = captureSubmit();
         expect(captured[0], isTrue);
         expect(captured[1], isNull);
+      },
+    );
+
+    testWidgets(
+      'sources the tax residence from a non-Swiss address country, revealing '
+      'the TIN and forwarding it without a manual pick',
+      (tester) async {
+        await showTaxStep(tester, dto: initialUserDataDe);
+
+        // The residence (DE) — not the nationality (CH) — pre-selected the tax
+        // residence, so the TIN is revealed with no manual pick and the derived
+        // non-Swiss result is forwarded.
+        final context = tester.element(find.byType(KycRegistrationTaxStep));
+        final tinField = find.widgetWithText(TextFormField, S.of(context).tinHint);
+        await tester.scrollUntilVisible(tinField, 100, scrollable: taxScrollable());
+        await tester.enterText(tinField, '12 345 678 901');
+        await tester.pump();
+
+        await tapComplete(tester);
+
+        final captured = captureSubmit();
+        expect(captured[0], isFalse);
+        final tins = captured[1] as List<CountryAndTin>;
+        expect(tins.single.country, 'DE');
+        expect(tins.single.tin, '12 345 678 901');
       },
     );
   });

--- a/test/screens/kyc/steps/kyc_registration_page_test.dart
+++ b/test/screens/kyc/steps/kyc_registration_page_test.dart
@@ -665,7 +665,7 @@ void main() {
       addressPostalCode: '8000',
       addressCity: 'Berlin',
       addressCountry: 'DE',
-      swissTaxResidence: true,
+      swissTaxResidence: false,
       lang: 'de',
       kycData: KycPersonalData(
         accountType: KycAccountType.personal,

--- a/test/screens/kyc/steps/kyc_registration_page_test.dart
+++ b/test/screens/kyc/steps/kyc_registration_page_test.dart
@@ -793,5 +793,21 @@ void main() {
         expect(tins.single.tin, '12 345 678 901');
       },
     );
+
+    testWidgets(
+      'defaults the tax residence to the address country, forwarding it without a manual pick',
+      (tester) async {
+        await showTaxStep(tester);
+
+        // No selectTaxCountry: the Swiss address country pre-selected the tax
+        // residence, so the mandatory field is already valid and submit forwards
+        // the derived Swiss-only result.
+        await tapComplete(tester);
+
+        final captured = captureSubmit();
+        expect(captured[0], isTrue);
+        expect(captured[1], isNull);
+      },
+    );
   });
 }

--- a/test/screens/kyc/steps/registration/steps/kyc_registration_tax_step_test.dart
+++ b/test/screens/kyc/steps/registration/steps/kyc_registration_tax_step_test.dart
@@ -224,6 +224,47 @@ void main() {
         expect(harness.submitCount, 1);
       },
     );
+
+    testWidgets(
+      're-defaults when the residence country changes, revealing the TIN',
+      (tester) async {
+        // Mirror the page wiring: the tax step is rebuilt via a
+        // ValueListenableBuilder on the residence, so changing the residence
+        // after the initial prefill must re-default the tax country.
+        final harness = _Harness();
+        final residence = ValueNotifier<Country?>(_switzerland);
+        addTearDown(residence.dispose);
+
+        await tester.pumpApp(
+          Scaffold(
+            body: ValueListenableBuilder<Country?>(
+              valueListenable: residence,
+              builder: (_, country, _) => KycRegistrationTaxStep(
+                taxCountryCtrl: harness.taxCountryCtrl,
+                tinCtrl: harness.tinCtrl,
+                initialCountry: country,
+                onSubmit: () async => harness.submitCount++,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Swiss residence: pre-selected, no TIN.
+        var context = tester.element(find.byType(KycRegistrationTaxStep));
+        expect(harness.taxCountryCtrl.value, _switzerland);
+        expect(find.text(S.of(context).taxIdentificationNumber), findsNothing);
+
+        // Residence switches to a non-Swiss country: the tax step re-defaults
+        // and reveals the required TIN without a manual pick.
+        residence.value = _germany;
+        await tester.pumpAndSettle();
+
+        context = tester.element(find.byType(KycRegistrationTaxStep));
+        expect(harness.taxCountryCtrl.value, _germany);
+        expect(find.text(S.of(context).taxIdentificationNumber), findsOneWidget);
+      },
+    );
   });
 }
 

--- a/test/screens/kyc/steps/registration/steps/kyc_registration_tax_step_test.dart
+++ b/test/screens/kyc/steps/registration/steps/kyc_registration_tax_step_test.dart
@@ -10,6 +10,11 @@ import 'package:realunit_wallet/widgets/buttons/app_filled_button.dart';
 import '../../../../../helper/country_fixture.dart';
 import '../../../../../helper/pump_app.dart';
 
+// Ids match the committed country fixture (Country equality is id-keyed), so an
+// initialCountry resolves against the list the real DfxCountryService loads.
+const _switzerland = Country(id: 41, symbol: 'CH', name: 'Switzerland', kycAllowed: true);
+const _germany = Country(id: 55, symbol: 'DE', name: 'Germany', kycAllowed: true);
+
 void main() {
   setUp(() {
     GetIt.instance.registerSingleton<DfxCountryService>(fixtureCountryService());
@@ -17,7 +22,7 @@ void main() {
 
   tearDown(() async => GetIt.instance.reset());
 
-  Future<_Harness> pump(WidgetTester tester) async {
+  Future<_Harness> pump(WidgetTester tester, {Country? initialCountry}) async {
     final harness = _Harness();
 
     await tester.pumpApp(
@@ -25,6 +30,7 @@ void main() {
         body: KycRegistrationTaxStep(
           taxCountryCtrl: harness.taxCountryCtrl,
           tinCtrl: harness.tinCtrl,
+          initialCountry: initialCountry,
           onSubmit: () async => harness.submitCount++,
         ),
       ),
@@ -177,6 +183,45 @@ void main() {
         await tester.pump();
 
         expect(tinFocus.hasFocus, isFalse);
+      },
+    );
+  });
+
+  group('$KycRegistrationTaxStep prefill', () {
+    testWidgets(
+      'pre-selects a non-Swiss initial country, propagating it and revealing the TIN',
+      (tester) async {
+        final harness = await pump(tester, initialCountry: _germany);
+
+        // The residence country handed in as initialCountry propagates into the
+        // controller (so the derived swissTaxResidence is set) and reveals the
+        // required TIN — without any manual pick.
+        expect(harness.taxCountryCtrl.value, _germany);
+        final context = tester.element(find.byType(KycRegistrationTaxStep));
+        expect(find.text(S.of(context).taxIdentificationNumber), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'pre-selects a Swiss initial country without a TIN',
+      (tester) async {
+        final harness = await pump(tester, initialCountry: _switzerland);
+
+        expect(harness.taxCountryCtrl.value, _switzerland);
+        final context = tester.element(find.byType(KycRegistrationTaxStep));
+        expect(find.text(S.of(context).taxIdentificationNumber), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'submits the pre-selected Swiss residence without a manual pick',
+      (tester) async {
+        final harness = await pump(tester, initialCountry: _switzerland);
+
+        // The prefill alone satisfies the mandatory country field.
+        await tapComplete(tester);
+
+        expect(harness.submitCount, 1);
       },
     );
   });


### PR DESCRIPTION
## What

The KYC tax-residence step now **pre-selects the residence country** the user entered on the address step, instead of opening with an empty (grey-placeholder) picker. Most people are tax-resident where they live, so this is the right default — and it removes the "is Switzerland already selected?" ambiguity of the empty state.

The field stays **editable and mandatory**:
- The `CountryField` propagates the default into `taxCountryCtrl` (which drives the derived `swissTaxResidence`) and reveals the required TIN when the default is non-Swiss — no manual pick needed.
- If there is no residence to fall back on, the picker is empty and its validator still blocks submit until the user chooses.

## How

Wired reactively: `_buildStep(taxResidence)` wraps the tax step in a `ValueListenableBuilder` on the residence controller (`countryCtrl`) and passes it as the new `KycRegistrationTaxStep.initialCountry`, so the step always reflects the latest address country.

## Scope

- **No API change** — the derived `swissTaxResidence` + optional `countryAndTINs` on the wire are unchanged.
- **No new golden** — the prefilled state is pixel-identical to the existing `swiss` / `non_swiss` tax-step baselines (a pre-selected country + TIN looks the same however it got there).

## Verification (m5me, Flutter 3.41.6 = CI)

- `flutter analyze`: clean.
- KYC suite green (incl. all goldens); existing tax-residence wiring tests unchanged and passing.
- New tests: tax-step widget prefill (non-Swiss → TIN revealed + propagated; Swiss → no TIN; Swiss → submits without a manual pick) + a page-level integration test (address country pre-selects the tax residence and forwards it without a manual pick).
- **100% line coverage** of the two touched lib files (`kyc_registration_tax_step.dart` 32/32, `kyc_registration_page.dart` 152/152).
