### PR TITLE
docs(handbook): the tax-residence picker now defaults to the address country

### DIFF
--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -2153,9 +2153,12 @@
               </div>
               <div class="desc">
                 Abschliessender Schritt der Registrierung. Der Pflicht-Länder-Picker „Land
-                des steuerlichen Wohnsitzes" ist nicht vorbelegt — der User muss genau ein
-                Land wählen. Der „Abschliessen"-CTA übermittelt die vollständige KYC-Anfrage
-                an das DFX-Backend.
+                des steuerlichen Wohnsitzes" ist mit dem im Adress-Schritt erfassten
+                Wohnsitzland vorbelegt — die meisten Menschen sind steueransässig, wo sie
+                wohnen — bleibt aber frei änderbar. Die Abbildung zeigt den unbelegten
+                Fallback-Zustand (kein Wohnsitzland vorhanden), in dem der User genau ein
+                Land wählen muss. Der „Abschliessen"-CTA übermittelt die vollständige
+                KYC-Anfrage an das DFX-Backend.
               </div>
             </div>
             <div class="test" id="57-kyc-registration-tax-dropdown">


### PR DESCRIPTION
Follow-up to #810: handbook block 56 still claimed the tax-residence picker is "nicht vorbelegt" — since #810 it defaults to the residence country from the address step (editable; empty picker only as fallback). Text updated accordingly; the screenshot keeps showing the unprefilled fallback state and the caption now says so. Blocks 57–59 and the section intro verified — no other prefill claims. One file, +6/−3, wording verified against `kyc_registration_page.dart`/`kyc_registration_tax_step.dart`.