### PR TITLE
docs(store): refresh release notes for the next public update

### DIFF
--- a/android/fastlane/metadata/android/de-DE/changelogs/default.txt
+++ b/android/fastlane/metadata/android/de-DE/changelogs/default.txt
@@ -1,1 +1,1 @@
-Erste Veröffentlichung der RealUnit Wallet App.
+Verbesserte Nutzerführung im Bereich der Registrierung.

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -3214,7 +3214,7 @@ Dieser Inhalt dient Werbezwecken. Die genehmigten Prospekte und weitere Unterlag
     <dt>Privacy-URL</dt><dd><a href="https://realunit.ch/datenschutz/">https://realunit.ch/datenschutz/</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/privacy_url.txt" title="Quelle: privacy_url.txt">↗</a></dd>
     <dt>Support-URL</dt><dd><a href="https://realunit.ch/kontakt/">https://realunit.ch/kontakt/</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/support_url.txt" title="Quelle: support_url.txt">↗</a></dd>
     <dt>Copyright</dt><dd>© 2026 RealUnit Schweiz AG <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/copyright.txt" title="Quelle: copyright.txt">↗</a></dd>
-    <dt>Release-Notes</dt><dd>Erste Veröffentlichung der RealUnit Wallet App. <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/release_notes.txt" title="Quelle: release_notes.txt">↗</a></dd>
+    <dt>Release-Notes</dt><dd>Verbesserte Nutzerführung im Bereich der Registrierung. <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/release_notes.txt" title="Quelle: release_notes.txt">↗</a></dd>
   </dl>
 
   <h4>Screenshots — iPhone 6.9 Display (1320×2868)</h4>
@@ -3265,7 +3265,7 @@ Die RealUnit Schweiz AG ist eine börsenkotierte Investmentgesellschaft, welche 
 Jetzt herunterladen und Ihre finanzielle Souveränität zurückgewinnen.
 
 Dieser Inhalt dient Werbezwecken. Die genehmigten Prospekte und weitere Unterlagen zur RealUnit Schweiz AG sind abrufbar unter: https://realunit.ch/ueber-uns/downloads/ (Schweiz) | https://realunit.de/ueber-uns/downloads/ (Deutschland/EU). Vergangene Wertentwicklung ist kein verlässlicher Indikator für zukünftige Ergebnisse.</div></dd>
-    <dt>Changelog</dt><dd>Erste Veröffentlichung der RealUnit Wallet App. <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/changelogs/default.txt" title="Quelle: changelogs/default.txt">↗</a></dd>
+    <dt>Changelog</dt><dd>Verbesserte Nutzerführung im Bereich der Registrierung. <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/android/fastlane/metadata/android/de-DE/changelogs/default.txt" title="Quelle: changelogs/default.txt">↗</a></dd>
   </dl>
 
   <h4>Feature Graphic (1024×500)</h4>

--- a/ios/fastlane/metadata/de-DE/release_notes.txt
+++ b/ios/fastlane/metadata/de-DE/release_notes.txt
@@ -1,1 +1,1 @@
-Erste Veröffentlichung der RealUnit Wallet App.
+Verbesserte Nutzerführung im Bereich der Registrierung.


### PR DESCRIPTION
## What

Replace the stale first-release text in both store-listing sources with the notes for the next public update:

> Verbesserte Nutzerführung im Bereich der Registrierung.

- `ios/fastlane/metadata/de-DE/release_notes.txt` — App Store "What's New" / *Über dieses Update*
- `android/fastlane/metadata/android/de-DE/changelogs/default.txt` — Play Store changelog
- `docs/handbook/de/index.html` — regenerated via `scripts/assemble-handbook-store-listing.py` so the derived store-listing block stays in sync (satisfies the `handbook-build-check` gate)

## Why

The next release is a public App Store / Play update over an already-live version, not a first release. `fastlane deliver`/`supply` push these files verbatim into the "What's New" / changelog fields (`skip_metadata: false`, `force: true`), so the previous "Erste Veröffentlichung …" text would otherwise appear as the update notes — and would overwrite any manual edit made in App Store Connect.

## Merge order

Merge this into `staging` **before** promote #796 (staging → develop) so the corrected notes are part of the build that `deliver` stages to App Store Connect.