### PR TITLE
fix(kyc): follow-up to #808 — contract docs, fail-loud date parse, gate-edge tests

### DIFF
--- a/docs/screens.md
+++ b/docs/screens.md
@@ -85,6 +85,7 @@ Column meaning:
 | KYC | `KycNationalityPage` | — | — | — |
 | KYC | `KycEmailPage` | — | — | — |
 | KYC | `KycEmailVerificationPage` | — | — | — |
+| KYC | `KycConfirmEmailPage` | — | — | — |
 | KYC | `Kyc2faPage` | — | — | — |
 | KYC | `KycIdentPage` | — | — | — |
 | KYC | `KycFinancialDataPage` | — | — | — |

--- a/docs/screens.md
+++ b/docs/screens.md
@@ -98,7 +98,7 @@ Column meaning:
 | KYC | `KycFailurePage` | — | — | — |
 | KYC | `KycAccountMergePage` | — | — | — |
 
-65 screens — 40 routed (`GoRoute`) + 25 non-routed.
+66 screens — 40 routed (`GoRoute`) + 26 non-routed.
 
 ## Notes
 

--- a/lib/packages/service/dfx/models/wallet/real_unit_registration_info_dto.dart
+++ b/lib/packages/service/dfx/models/wallet/real_unit_registration_info_dto.dart
@@ -11,10 +11,12 @@ class RealUnitRegistrationInfoDto {
   final RealUnitUserDataDto? realUnitUserDataDto;
 
   /// Whether the API has confirmed the account e-mail address for this wallet.
-  /// Nullable on purpose: absent on pre-rollout backends and for grandfathered
-  /// accounts. `KycCubit` treats `null` as "no confirmation gate" and proceeds
-  /// as before — only an explicit `false` routes to the confirm step. See
-  /// CONTRIBUTING.md "API as Decision Authority" (legacy backend tolerance).
+  /// Nullable on purpose: `null` means a pre-rollout backend (the field does
+  /// not exist yet) or no registration at all — grandfathered accounts (in
+  /// existence before the rollout) report an explicit `true`, never `null`.
+  /// `KycCubit` treats `null` as "no confirmation gate" and proceeds as before —
+  /// only an explicit `false` routes to the confirm step. See CONTRIBUTING.md
+  /// "API as Decision Authority" (legacy backend tolerance).
   final bool? emailConfirmed;
 
   /// Timestamp of the confirmation, when the API reports one. Not consumed for
@@ -29,14 +31,15 @@ class RealUnitRegistrationInfoDto {
   });
 
   factory RealUnitRegistrationInfoDto.fromJson(Map<String, dynamic> json) {
-    final confirmedDateRaw = json['confirmedDate'] as String?;
     return RealUnitRegistrationInfoDto(
       state: RealUnitRegistrationState.fromJson(json['state'] as String),
       realUnitUserDataDto: json['userData'] != null
           ? RealUnitUserDataDto.fromJson(json['userData'] as Map<String, dynamic>)
           : null,
       emailConfirmed: json['emailConfirmed'] as bool?,
-      confirmedDate: confirmedDateRaw != null ? DateTime.tryParse(confirmedDateRaw) : null,
+      confirmedDate: json['confirmedDate'] != null
+          ? DateTime.parse(json['confirmedDate'] as String)
+          : null,
     );
   }
 }

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -128,10 +128,11 @@ class KycCubit extends Cubit<KycState> {
       switch (registrationInfo.state) {
         case RealUnitRegistrationState.alreadyRegistered:
           // The API owns the confirmation gate. When it reports the account
-          // e-mail is not yet confirmed, route to the confirm step. `null`
-          // (pre-rollout backend / grandfathered account) and `true` both mean
-          // "no gate" — proceed exactly as before. Purely additive, API-driven;
-          // see CONTRIBUTING.md "API as Decision Authority" (legacy tolerance).
+          // e-mail is not yet confirmed, route to the confirm step. `true`
+          // (confirmed, or a grandfathered account) and `null` (pre-rollout
+          // backend) both mean "no gate" — proceed exactly as before. Purely
+          // additive, API-driven; see CONTRIBUTING.md "API as Decision
+          // Authority" (legacy tolerance).
           if (registrationInfo.emailConfirmed == false) {
             emit(const KycSuccess(currentStep: KycStep.confirmEmail));
             return;
@@ -143,6 +144,10 @@ class KycCubit extends Cubit<KycState> {
           // Forward the server-supplied userData so `KycLinkWalletPage` does
           // not have to re-fetch — see CONTRIBUTING.md "Single round-trip per
           // decision". The backend always populates this for `AddWallet`.
+          // `emailConfirmed` is deliberately not gated here: in `AddWallet` it
+          // describes the *other* wallet's registration, not this one. After the
+          // link-wallet round-trip `checkKyc()` re-fetches and the gate then
+          // applies to the resulting `AlreadyRegistered` registration.
           emit(
             KycSuccess(
               currentStep: KycStep.linkWallet,

--- a/lib/screens/kyc/steps/confirm_email/cubits/kyc_confirm_email_cubit.dart
+++ b/lib/screens/kyc/steps/confirm_email/cubits/kyc_confirm_email_cubit.dart
@@ -8,8 +8,10 @@ part 'kyc_confirm_email_state.dart';
 /// wallet. The gate is API-driven: `KycCubit` routes here only when
 /// `getRegistrationInfo().emailConfirmed == false`, and this cubit re-fetches
 /// the same fact when the user reports they clicked the confirmation link. When
-/// the backend flips the flag (or no longer reports one — legacy/grandfathered,
-/// `null`), the flow proceeds. See CONTRIBUTING.md "API as Decision Authority".
+/// the backend reports the address is confirmed (an explicit `true`, including
+/// grandfathered accounts) or no longer reports the flag at all (a pre-rollout
+/// backend, `null`), the flow proceeds. See CONTRIBUTING.md "API as Decision
+/// Authority".
 class KycConfirmEmailCubit extends Cubit<KycConfirmEmailState> {
   // Mirrors `KycCubit._checkKycTimeout`: the same `getRegistrationInfo()`
   // call is watch-dogged so a stalled request (socket up, backend never

--- a/test/packages/service/dfx/models/aggregate_dtos_test.dart
+++ b/test/packages/service/dfx/models/aggregate_dtos_test.dart
@@ -249,16 +249,16 @@ void main() {
       expect(dto.confirmedDate, isNull);
     });
 
-    test('guards an unparseable confirmedDate → null', () {
-      final dto = RealUnitRegistrationInfoDto.fromJson({
-        'state': 'AlreadyRegistered',
-        'userData': null,
-        'emailConfirmed': true,
-        'confirmedDate': 'not-a-date',
-      });
-
-      expect(dto.emailConfirmed, isTrue);
-      expect(dto.confirmedDate, isNull);
+    test('throws on a present but unparseable confirmedDate (fail loud)', () {
+      expect(
+        () => RealUnitRegistrationInfoDto.fromJson({
+          'state': 'AlreadyRegistered',
+          'userData': null,
+          'emailConfirmed': true,
+          'confirmedDate': 'not-a-date',
+        }),
+        throwsA(isA<FormatException>()),
+      );
     });
   });
 

--- a/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
+++ b/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
@@ -371,8 +371,8 @@ void main() {
 
     // Email-confirmation gate (API-driven). Only an explicit
     // `emailConfirmed == false` on an already-registered wallet routes to the
-    // confirm step; `true` and `null` (legacy / grandfathered) proceed as
-    // before.
+    // confirm step; `true` (confirmed, or grandfathered) and `null` (pre-rollout
+    // backend) proceed as before.
     blocTest<KycCubit, KycState>(
       'emits KycSuccess(confirmEmail) when AlreadyRegistered and emailConfirmed=false',
       setUp: () {
@@ -439,7 +439,8 @@ void main() {
           ),
         );
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
-        // Explicit null — the pre-rollout backend / grandfathered account case.
+        // Explicit null — the pre-rollout backend case (grandfathered accounts
+        // report an explicit `true`, never `null`).
         when(() => registrationService.getRegistrationInfo()).thenAnswer(
           (_) async => _walletStatus(
             RealUnitRegistrationState.alreadyRegistered,
@@ -454,6 +455,39 @@ void main() {
       expect: () => [
         const KycLoading(),
         const KycCompleted(),
+      ],
+    );
+
+    // The confirm gate is scoped to `alreadyRegistered`. In `addWallet`,
+    // `emailConfirmed` describes the other wallet's registration, so an explicit
+    // `false` must NOT route to the confirm step — the user proceeds to link the
+    // wallet and the gate is re-evaluated on the fresh registration afterwards.
+    blocTest<KycCubit, KycState>(
+      'does NOT gate on emailConfirmed=false when AddWallet (routes to linkWallet)',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(level: KycLevel.level20),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+        when(() => registrationService.getRegistrationInfo()).thenAnswer(
+          (_) async => _walletStatus(
+            RealUnitRegistrationState.addWallet,
+            userData: _fixtureUserData,
+            emailConfirmed: false,
+          ),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        cubit.markLegalDisclaimerAccepted();
+        await cubit.checkKyc();
+      },
+      expect: () => [
+        const KycLoading(),
+        const KycSuccess(
+          currentStep: KycStep.linkWallet,
+          realUnitUserData: _fixtureUserData,
+        ),
       ],
     );
 

--- a/test/screens/kyc/steps/confirm_email/kyc_confirm_email_cubit_test.dart
+++ b/test/screens/kyc/steps/confirm_email/kyc_confirm_email_cubit_test.dart
@@ -147,5 +147,50 @@ void main() {
         });
       },
     );
+
+    // A late response from a superseded `recheck()` must not overwrite the
+    // fresh state of a newer one. The first call hangs on a `Completer`; a
+    // second call resolves immediately to `Confirmed`; when the first call's
+    // response finally arrives (still `false`) its generation no longer matches,
+    // so it emits nothing. Two back-to-back `Loading`s collapse to one via
+    // Equatable, so the expected sequence is `[Loading, Confirmed]`. Mirrors the
+    // `KycCubit` generation-counter regression test.
+    test(
+      'a late response from a superseded recheck does NOT overwrite the fresh Confirmed state',
+      () async {
+        final call1Completer = Completer<RealUnitRegistrationInfoDto>();
+        var firstCall = true;
+        when(() => registrationService.getRegistrationInfo()).thenAnswer((_) {
+          if (firstCall) {
+            firstCall = false;
+            return call1Completer.future;
+          }
+          return Future.value(_info(emailConfirmed: true));
+        });
+
+        final cubit = build();
+        final states = <KycConfirmEmailState>[];
+        final sub = cubit.stream.listen(states.add);
+
+        final call1Future = cubit.recheck();
+
+        await Future<void>.delayed(Duration.zero);
+
+        await cubit.recheck();
+
+        call1Completer.complete(_info(emailConfirmed: false));
+        await call1Future;
+        await Future<void>.delayed(Duration.zero);
+
+        await sub.cancel();
+        await cubit.close();
+
+        expect(states, const [
+          KycConfirmEmailLoading(),
+          KycConfirmEmailConfirmed(),
+        ]);
+        expect(cubit.state, const KycConfirmEmailConfirmed());
+      },
+    );
   });
 }


### PR DESCRIPTION
## What

Post-merge follow-up to #808 (email-confirmation step). No runtime behaviour change apart from one parsing hardening; the bulk is contract documentation, test pinning, and inventory upkeep.

- **Correct the `emailConfirmed` contract docs** (DTO, `KycCubit` gate comment, `KycConfirmEmailCubit` class doc, two test comments): grandfathered registrations report an explicit `true` — `null` means a pre-rollout backend (field absent) or no registration. The previous comments conflated the two. Behaviour is unchanged (`true` and `null` both proceed); only the documented meaning was wrong.
- **Fail-loud date parsing**: `confirmedDate` now uses the repo-wide `json[...] != null ? DateTime.parse(...) : null` pattern instead of `DateTime.tryParse`, which silently swallowed an unparseable value. The DTO test pinning the silent fallback is replaced by one pinning the `FormatException`.
- **Pin two gate edges with tests**:
  - `AddWallet` + `emailConfirmed=false` must NOT route to the confirm step (the flag describes the *other* wallet's registration there; the gate re-applies after the link-wallet round-trip) — now tested and documented in the `addWallet` case.
  - Generation-counter regression test for `KycConfirmEmailCubit.recheck()`: a late response from a superseded call must not overwrite the fresh state — mirrors the existing `KycCubit` regression test.
- **`docs/screens.md`**: add the missing `KycConfirmEmailPage` inventory row and update the tally.

## Verification (m5me, Flutter 3.41.6)

- `flutter analyze`: clean.
- `flutter test --coverage`: **2788 passed, 0 failed**; goldens unchanged.
- Changed lib files at 100 % line coverage (`real_unit_registration_info_dto.dart` 9/9, `kyc_cubit.dart` 93/93, `kyc_confirm_email_cubit.dart` 15/15).
