### PR TITLE
docs(store): add App Store promotional text

### DIFF
--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -3190,6 +3190,7 @@
   <dl class="store-listing">
     <dt>App-Name (max 30)</dt><dd><code>RealUnit</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/name.txt" title="Quelle: name.txt">↗</a></dd>
     <dt>Untertitel (max 30)</dt><dd><code>Sicher. Einfach. Unabhängig.</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/subtitle.txt" title="Quelle: subtitle.txt">↗</a></dd>
+    <dt>Werbetext (max 170)</dt><dd>Kaufe, halte und verkaufe RealUnit Tokens sicher mit der RealUnit App <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/promotional_text.txt" title="Quelle: promotional_text.txt">↗</a></dd>
     <dt>Beschreibung (max 4000) <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/description.txt" title="Quelle: description.txt">↗</a></dt><dd><pre>Die offizielle App der RealUnit Schweiz AG – für den einfachen, sicheren Kauf und die bankenunabhängige Verwahrung der RealUnit Aktientoken. Direkt in Ihrer Hand.
 
 IHRE VORTEILE AUF EINEN BLICK

--- a/ios/fastlane/metadata/de-DE/promotional_text.txt
+++ b/ios/fastlane/metadata/de-DE/promotional_text.txt
@@ -1,0 +1,1 @@
+Kaufe, halte und verkaufe RealUnit Tokens sicher mit der RealUnit App

--- a/scripts/assemble-handbook-store-listing.py
+++ b/scripts/assemble-handbook-store-listing.py
@@ -161,6 +161,7 @@ def main() -> int:
     ctx = {
         "ios_name": html.escape(read(ios / "name.txt")),
         "ios_subtitle": html.escape(read(ios / "subtitle.txt")),
+        "ios_promotional_text": html.escape(read(ios / "promotional_text.txt")),
         "ios_description": html.escape(read(ios / "description.txt")),
         "ios_keywords": html.escape(read(ios / "keywords.txt")),
         "ios_marketing_url": html.escape(read(ios / "marketing_url.txt")),

--- a/scripts/templates/store-listing.html.tmpl
+++ b/scripts/templates/store-listing.html.tmpl
@@ -31,6 +31,7 @@
   <dl class="store-listing">
     <dt>App-Name (max 30)</dt><dd><code>{{ ios_name }}</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/name.txt" title="Quelle: name.txt">↗</a></dd>
     <dt>Untertitel (max 30)</dt><dd><code>{{ ios_subtitle }}</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/subtitle.txt" title="Quelle: subtitle.txt">↗</a></dd>
+    <dt>Werbetext (max 170)</dt><dd>{{ ios_promotional_text }} <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/promotional_text.txt" title="Quelle: promotional_text.txt">↗</a></dd>
     <dt>Beschreibung (max 4000) <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/description.txt" title="Quelle: description.txt">↗</a></dt><dd><pre>{{ ios_description }}</pre></dd>
     <dt>Schlagwörter (max 100, kommasepariert)</dt><dd><code>{{ ios_keywords }}</code> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/keywords.txt" title="Quelle: keywords.txt">↗</a></dd>
     <dt>Marketing-URL</dt><dd><a href="{{ ios_marketing_url }}">{{ ios_marketing_url }}</a> <a class="src" href="https://github.com/RealUnitCH/app/blob/develop/ios/fastlane/metadata/de-DE/marketing_url.txt" title="Quelle: marketing_url.txt">↗</a></dd>


### PR DESCRIPTION
## What

Two related commits:

1. **`docs(store)`** — populate the previously-empty `ios/fastlane/metadata/de-DE/promotional_text.txt`:
   > Kaufe, halte und verkaufe RealUnit Tokens sicher mit der RealUnit App

   (69 chars — within the 170-char App Store limit)
2. **`docs(handbook)`** — mirror that Promotional Text in the handbook store-listing (generator ctx + template + regenerated `docs/handbook/de/index.html`), between subtitle and description to match App Store Connect ordering.

## Why

`promotional_text.txt` has been 0 bytes since #644, so `fastlane deliver` loaded it on every run and pushed an **empty** Promotional Text to App Store Connect — and with `force: true` it also overwrote any value entered manually in ASC (same overwrite mechanism previously seen with the release notes). Commit 1 fixes the source; commit 2 keeps the handbook a faithful, complete mirror of what ships to the stores (it previously omitted this one field).

## Notes

- Promotional Text is not version-locked in App Store Connect, so `store-metadata.yaml` (main push, metadata paths) transmits it without needing a new app version.
- Aside found during audit: `android/fastlane/metadata/android/de-DE/video.txt` is also empty (Play promo-video URL) — most likely intentional (no video); left untouched.