### PR TITLE
fix(kyc): return to the in-flight route after resume/PIN re-lock instead of the dashboard

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -136,7 +136,7 @@ class _WalletAppState extends State<WalletApp> {
     final homeState = getIt<HomeBloc>().state;
     final pin = getIt<PinAuthCubit>();
     final pinState = pin.state;
-    final current = routerConfig.routerDelegate.currentConfiguration.uri.toString();
+    final current = effectiveLocation(routerConfig.routerDelegate.currentConfiguration);
 
     final action = resolveBootNavigation(
       isLoadingWallet: homeState.isLoadingWallet,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,10 +13,9 @@ import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
 import 'package:realunit_wallet/setup/di.dart';
 import 'package:realunit_wallet/setup/error_handling/realunit_error_view.dart';
 import 'package:realunit_wallet/setup/lifecycle_initializer.dart';
+import 'package:realunit_wallet/setup/routing/boot_navigation.dart';
 import 'package:realunit_wallet/setup/routing/router_config.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
-import 'package:realunit_wallet/setup/routing/routes/onboarding_routes.dart';
-import 'package:realunit_wallet/setup/routing/routes/pin_routes.dart';
 import 'package:realunit_wallet/styles/themes.dart';
 
 Future<void> main() async {
@@ -136,34 +135,46 @@ class _WalletAppState extends State<WalletApp> {
 
   void _navigate() {
     final homeState = getIt<HomeBloc>().state;
-    final pinState = getIt<PinAuthCubit>().state;
+    final pin = getIt<PinAuthCubit>();
+    final pinState = pin.state;
+    final current = routerConfig.routerDelegate.currentConfiguration.uri.toString();
 
-    if (homeState.isLoadingWallet) return;
+    final action = resolveBootNavigation(
+      isLoadingWallet: homeState.isLoadingWallet,
+      softwareTermsAccepted: homeState.softwareTermsAccepted,
+      hasWallet: homeState.hasWallet,
+      onboardingCompleted: homeState.onboardingCompleted,
+      isPinSetup: pinState.isPinSetup,
+      isPinVerified: pinState.isPinVerified,
+      bitboxAddressRecoveryNeeded: homeState.bitboxAddressRecoveryNeeded,
+      walletLoaded: homeState.openWallet != null,
+      currentLocation: current,
+      resumeLocation: pin.peekResumeLocation(),
+    );
 
-    String targetRoute;
-    if (!homeState.softwareTermsAccepted) {
-      targetRoute = AppRoutes.home;
-    } else if (!homeState.hasWallet) {
-      targetRoute = OnboardingRoutes.welcome;
-    } else if (!homeState.onboardingCompleted) {
-      targetRoute = OnboardingRoutes.completed;
-    } else if (!pinState.isPinSetup) {
-      targetRoute = PinRoutes.setup;
-    } else if (!pinState.isPinVerified) {
-      targetRoute = PinRoutes.verify;
-    } else if (homeState.bitboxAddressRecoveryNeeded) {
-      // A BitBox wallet was persisted with an empty/invalid address — divert to
-      // the re-pairing recovery flow instead of loading it into the dashboard
-      // (which would crash the build via `EthereumAddress.fromHex("")`).
-      targetRoute = AppRoutes.bitboxAddressRecovery;
-    } else if (homeState.openWallet == null) {
-      // Wallet not loaded yet — trigger load and wait for HomeBloc update
-      _loadWalletIfNeeded();
-      return;
-    } else {
-      targetRoute = AppRoutes.dashboard;
+    switch (action) {
+      case BootNavWaitForLoad():
+        return;
+      case BootNavLoadWallet():
+        // Wallet not loaded yet — trigger load and wait for the HomeBloc update.
+        _loadWalletIfNeeded();
+        return;
+      case BootNavGoNamed(:final routeName):
+        // Reaching the dashboard is the final landing — drop any stale resume
+        // capture so a later benign emission can't bounce the user around.
+        if (routeName == AppRoutes.dashboard) pin.clearResumeLocation();
+        routerConfig.goNamed(routeName);
+        return;
+      case BootNavRestore(:final location):
+        // Return to the in-flight route the user was on before the re-lock,
+        // reached only after the PIN gate above has already passed.
+        pin.clearResumeLocation();
+        routerConfig.go(location);
+        return;
+      case BootNavStay():
+        // Already on a valid non-gate route — discard any stale capture.
+        pin.clearResumeLocation();
+        return;
     }
-
-    routerConfig.goNamed(targetRoute);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,6 @@ import 'package:realunit_wallet/setup/error_handling/realunit_error_view.dart';
 import 'package:realunit_wallet/setup/lifecycle_initializer.dart';
 import 'package:realunit_wallet/setup/routing/boot_navigation.dart';
 import 'package:realunit_wallet/setup/routing/router_config.dart';
-import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/styles/themes.dart';
 
 Future<void> main() async {
@@ -152,29 +151,11 @@ class _WalletAppState extends State<WalletApp> {
       resumeLocation: pin.peekResumeLocation(),
     );
 
-    switch (action) {
-      case BootNavWaitForLoad():
-        return;
-      case BootNavLoadWallet():
-        // Wallet not loaded yet — trigger load and wait for the HomeBloc update.
-        _loadWalletIfNeeded();
-        return;
-      case BootNavGoNamed(:final routeName):
-        // Reaching the dashboard is the final landing — drop any stale resume
-        // capture so a later benign emission can't bounce the user around.
-        if (routeName == AppRoutes.dashboard) pin.clearResumeLocation();
-        routerConfig.goNamed(routeName);
-        return;
-      case BootNavRestore(:final location):
-        // Return to the in-flight route the user was on before the re-lock,
-        // reached only after the PIN gate above has already passed.
-        pin.clearResumeLocation();
-        routerConfig.go(location);
-        return;
-      case BootNavStay():
-        // Already on a valid non-gate route — discard any stale capture.
-        pin.clearResumeLocation();
-        return;
-    }
+    applyBootNavAction(
+      action,
+      routerConfig,
+      onLoadWallet: _loadWalletIfNeeded,
+      onClearResume: pin.clearResumeLocation,
+    );
   }
 }

--- a/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
+++ b/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
@@ -61,6 +61,13 @@ class PinAuthCubit extends Cubit<PinAuthState> {
     final elapsed = clock.now().difference(lastBackground);
     if (elapsed >= lockoutDuration) {
       emit(state.copyWith(isPinVerified: false));
+    } else if (state.isPinVerified) {
+      // The episode ended without a re-lock — nothing will consume the capture,
+      // so drop it eagerly, or a much later unrelated re-lock could restore a
+      // route from a long-finished episode. Kept while the PIN gate is showing
+      // (isPinVerified == false): a short away-switch on `/verifyPin` is the
+      // nested re-lock whose in-flight capture must survive.
+      _resumeLocation = null;
     }
     _lastBackgroundTime = null;
   }

--- a/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
+++ b/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
@@ -33,13 +33,16 @@ class PinAuthCubit extends Cubit<PinAuthState> {
 
   void onPinVerified() => emit(state.copyWith(isPinVerified: true));
 
-  /// Captures the background timestamp (for the re-lock timeout) and, once per
-  /// background episode, the route the user was on so `_navigate` can restore
-  /// it after any resulting PIN re-lock. Both use `??=` so only the first
-  /// backgrounding in an episode wins.
+  /// Captures the background timestamp (for the re-lock timeout) and the route
+  /// to restore after any resulting PIN re-lock. The timestamp uses `??=` — only
+  /// the first backgrounding of an episode arms the timeout. The resume route
+  /// instead takes the freshest non-null value: the caller passes null when the
+  /// app is backgrounded on a gate route (see `lifecycle_initializer`), so a
+  /// nested re-lock — backgrounding again while `/verifyPin` is showing — keeps
+  /// the good in-flight capture instead of overwriting it with the gate.
   void onAppHidden(String? currentLocation) {
     _lastBackgroundTime ??= clock.now();
-    _resumeLocation ??= currentLocation;
+    if (currentLocation != null) _resumeLocation = currentLocation;
   }
 
   /// The captured pre-background route, or null. Read (not consumed) here; the

--- a/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
+++ b/lib/screens/pin/bloc/auth/pin_auth_cubit.dart
@@ -15,6 +15,7 @@ class PinAuthCubit extends Cubit<PinAuthState> {
   final SecureStorage _secureStorage;
 
   DateTime? _lastBackgroundTime;
+  String? _resumeLocation;
 
   Future<void> initialize() async {
     final isPinSetup = await _secureStorage.hasPinHash();
@@ -32,7 +33,21 @@ class PinAuthCubit extends Cubit<PinAuthState> {
 
   void onPinVerified() => emit(state.copyWith(isPinVerified: true));
 
-  void onAppHidden() => _lastBackgroundTime ??= clock.now();
+  /// Captures the background timestamp (for the re-lock timeout) and, once per
+  /// background episode, the route the user was on so `_navigate` can restore
+  /// it after any resulting PIN re-lock. Both use `??=` so only the first
+  /// backgrounding in an episode wins.
+  void onAppHidden(String? currentLocation) {
+    _lastBackgroundTime ??= clock.now();
+    _resumeLocation ??= currentLocation;
+  }
+
+  /// The captured pre-background route, or null. Read (not consumed) here; the
+  /// consumer (`_navigate`) clears it via [clearResumeLocation] once it has
+  /// either restored the route or reached a final landing.
+  String? peekResumeLocation() => _resumeLocation;
+
+  void clearResumeLocation() => _resumeLocation = null;
 
   void onAppResumed() {
     if (!state.isPinSetup) return;
@@ -53,6 +68,7 @@ class PinAuthCubit extends Cubit<PinAuthState> {
       _secureStorage.deleteBiometricEnabled(),
       _secureStorage.resetPinLockout(),
     ]);
+    _resumeLocation = null;
     emit(const PinAuthState());
   }
 }

--- a/lib/setup/lifecycle_initializer.dart
+++ b/lib/setup/lifecycle_initializer.dart
@@ -86,7 +86,9 @@ class _LifecycleInitializerState extends State<LifecycleInitializer> {
     if (_armedForBackground) return;
     _armedForBackground = true;
 
-    final location = routerConfig.routerDelegate.currentConfiguration.uri.toString();
+    // effectiveLocation, not currentConfiguration.uri: the KYC flow is pushed
+    // imperatively, and the raw uri would capture the base route underneath.
+    final location = effectiveLocation(routerConfig.routerDelegate.currentConfiguration);
     // Pass null for gate routes so a nested re-lock — backgrounded again while
     // the PIN gate is on screen — keeps the earlier in-flight capture instead
     // of clobbering it with the gate location.

--- a/lib/setup/lifecycle_initializer.dart
+++ b/lib/setup/lifecycle_initializer.dart
@@ -7,6 +7,7 @@ import 'package:realunit_wallet/packages/service/balance_service.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
 import 'package:realunit_wallet/setup/di.dart';
+import 'package:realunit_wallet/setup/routing/router_config.dart';
 
 class LifecycleInitializer extends StatefulWidget {
   final Widget child;
@@ -84,7 +85,9 @@ class _LifecycleInitializerState extends State<LifecycleInitializer> {
     if (_armedForBackground) return;
     _armedForBackground = true;
 
-    getIt<PinAuthCubit>().onAppHidden();
+    getIt<PinAuthCubit>().onAppHidden(
+      routerConfig.routerDelegate.currentConfiguration.uri.toString(),
+    );
     // Drop the mnemonic before the OS suspends the isolate. `lockCurrentWallet`
     // is defensive on its own — no try/catch / catchError by design, so a
     // Future.error surfaces in the Zone instead of being silently swallowed.

--- a/lib/setup/lifecycle_initializer.dart
+++ b/lib/setup/lifecycle_initializer.dart
@@ -89,12 +89,7 @@ class _LifecycleInitializerState extends State<LifecycleInitializer> {
     // effectiveLocation, not currentConfiguration.uri: the KYC flow is pushed
     // imperatively, and the raw uri would capture the base route underneath.
     final location = effectiveLocation(routerConfig.routerDelegate.currentConfiguration);
-    // Pass null for gate routes so a nested re-lock — backgrounded again while
-    // the PIN gate is on screen — keeps the earlier in-flight capture instead
-    // of clobbering it with the gate location.
-    getIt<PinAuthCubit>().onAppHidden(
-      isGateLocation(location) ? null : location,
-    );
+    getIt<PinAuthCubit>().onAppHidden(resumeCaptureFor(location));
     // Drop the mnemonic before the OS suspends the isolate. `lockCurrentWallet`
     // is defensive on its own — no try/catch / catchError by design, so a
     // Future.error surfaces in the Zone instead of being silently swallowed.

--- a/lib/setup/lifecycle_initializer.dart
+++ b/lib/setup/lifecycle_initializer.dart
@@ -7,6 +7,7 @@ import 'package:realunit_wallet/packages/service/balance_service.dart';
 import 'package:realunit_wallet/packages/service/wallet_service.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
 import 'package:realunit_wallet/setup/di.dart';
+import 'package:realunit_wallet/setup/routing/boot_navigation.dart';
 import 'package:realunit_wallet/setup/routing/router_config.dart';
 
 class LifecycleInitializer extends StatefulWidget {
@@ -85,8 +86,12 @@ class _LifecycleInitializerState extends State<LifecycleInitializer> {
     if (_armedForBackground) return;
     _armedForBackground = true;
 
+    final location = routerConfig.routerDelegate.currentConfiguration.uri.toString();
+    // Pass null for gate routes so a nested re-lock — backgrounded again while
+    // the PIN gate is on screen — keeps the earlier in-flight capture instead
+    // of clobbering it with the gate location.
     getIt<PinAuthCubit>().onAppHidden(
-      routerConfig.routerDelegate.currentConfiguration.uri.toString(),
+      isGateLocation(location) ? null : location,
     );
     // Drop the mnemonic before the OS suspends the isolate. `lockCurrentWallet`
     // is defensive on its own — no try/catch / catchError by design, so a

--- a/lib/setup/routing/boot_navigation.dart
+++ b/lib/setup/routing/boot_navigation.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:go_router/go_router.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/setup/routing/routes/onboarding_routes.dart';
@@ -13,32 +15,32 @@ sealed class BootNavAction {
 
 /// The wallet is still loading — do not navigate yet, wait for the next
 /// emission that flips `isLoadingWallet` off.
-class BootNavWaitForLoad extends BootNavAction {
+final class BootNavWaitForLoad extends BootNavAction {
   const BootNavWaitForLoad();
 }
 
 /// All gates passed but the wallet is not in memory yet — trigger the load and
 /// wait for the resulting HomeBloc emission.
-class BootNavLoadWallet extends BootNavAction {
+final class BootNavLoadWallet extends BootNavAction {
   const BootNavLoadWallet();
 }
 
 /// Navigate to a gate / landing route by its go_router name.
-class BootNavGoNamed extends BootNavAction {
+final class BootNavGoNamed extends BootNavAction {
   final String routeName;
   const BootNavGoNamed(this.routeName);
 }
 
 /// Restore the in-flight (non-gate) route the user was on before the background
 /// lock / re-lock, addressed by its location (path).
-class BootNavRestore extends BootNavAction {
+final class BootNavRestore extends BootNavAction {
   final String location;
   const BootNavRestore(this.location);
 }
 
 /// All gates passed and the user is already on a valid non-gate route — leave
 /// them exactly where they are, never yank them to the dashboard.
-class BootNavStay extends BootNavAction {
+final class BootNavStay extends BootNavAction {
   const BootNavStay();
 }
 
@@ -59,9 +61,9 @@ String effectiveLocation(RouteMatchList configuration) {
 
 /// Locations that are boot/lock gates: `_navigate` re-derives them from state
 /// and must never treat one as an in-flight route to restore. What *is*
-/// restorable is governed by the [kRestorableLocations] allowlist below — not
+/// restorable is governed by the [restorableLocations] allowlist below — not
 /// by "anything that is not a gate".
-const Set<String> kGateLocations = {
+const Set<String> gateLocations = {
   '/home',
   '/welcome',
   '/createWallet',
@@ -75,9 +77,9 @@ const Set<String> kGateLocations = {
   '/debugAuth',
 };
 
-/// Whether [loc] resolves to one of the [kGateLocations] gates. Compares the
+/// Whether [loc] resolves to one of the [gateLocations] gates. Compares the
 /// path only, so a query string cannot defeat the check.
-bool isGateLocation(String loc) => kGateLocations.contains(Uri.parse(loc).path);
+bool isGateLocation(String loc) => gateLocations.contains(Uri.parse(loc).path);
 
 /// Non-gate locations safe to restore after a resume / re-lock: they rebuild
 /// from a bare path (no required `extra`) and sit behind no secondary PIN gate.
@@ -85,7 +87,7 @@ bool isGateLocation(String loc) => kGateLocations.contains(Uri.parse(loc).path);
 /// behaviour), so a newly added route can never silently become restorable (and
 /// crash on a missing `extra`) or surface a PIN-gated screen. Matched by exact
 /// path: `/settings/seed` != `/settings`, `/buyPaymentDetails` != `/buy`.
-const Set<String> kRestorableLocations = {
+const Set<String> restorableLocations = {
   '/kyc',
   '/dashboard',
   '/buy',
@@ -95,9 +97,9 @@ const Set<String> kRestorableLocations = {
   '/support',
 };
 
-/// Whether [loc]'s path is in the [kRestorableLocations] allowlist (query
+/// Whether [loc]'s path is in the [restorableLocations] allowlist (query
 /// string ignored).
-bool isRestorableLocation(String loc) => kRestorableLocations.contains(Uri.parse(loc).path);
+bool isRestorableLocation(String loc) => restorableLocations.contains(Uri.parse(loc).path);
 
 /// Pure boot/lock routing decision, evaluated on every HomeBloc / PinAuthCubit
 /// emission.
@@ -105,7 +107,7 @@ bool isRestorableLocation(String loc) => kRestorableLocations.contains(Uri.parse
 /// The gate ladder is evaluated top to bottom, so a restore can only ever be
 /// returned by the final branch — after `!isPinVerified` has already diverted
 /// to the PIN gate. A [BootNavRestore] is additionally limited to the
-/// [kRestorableLocations] allowlist, so it never re-enters a gate route, never
+/// [restorableLocations] allowlist, so it never re-enters a gate route, never
 /// bypasses the PIN gate, and never targets a route that needs `extra`.
 BootNavAction resolveBootNavigation({
   required bool isLoadingWallet,
@@ -169,9 +171,18 @@ void applyBootNavAction(
       return;
     case BootNavRestore(:final location):
       // Return to the in-flight route the user was on before the re-lock,
-      // reached only after the PIN gate above has already passed.
+      // reached only after the PIN gate above has already passed. Rebuild the
+      // real entry shape — dashboard as base, flow pushed on top — so the
+      // flow's pop-based exits (Close buttons, AppBar auto-back) keep working;
+      // a bare `go` would strand the restored route as the only match with
+      // nothing underneath to pop back to.
       onClearResume();
-      router.go(location);
+      if (Uri.parse(location).path == '/dashboard') {
+        router.go(location);
+      } else {
+        router.goNamed(AppRoutes.dashboard);
+        unawaited(router.push(location));
+      }
       return;
     case BootNavStay():
       // Already on a valid non-gate route — discard any stale capture.

--- a/lib/setup/routing/boot_navigation.dart
+++ b/lib/setup/routing/boot_navigation.dart
@@ -42,6 +42,21 @@ class BootNavStay extends BootNavAction {
   const BootNavStay();
 }
 
+/// The location the user actually sees, including imperatively pushed routes.
+///
+/// `RouteMatchList.uri` only reflects declarative (`go`) matches — after a
+/// `push` (how the KYC flow is entered from Buy/Sell) it still reports the
+/// base route underneath. Everything that judges or captures "where the user
+/// is" (the boot machine's `currentLocation`, the background capture, the
+/// scheme-open redirect) must read this helper instead, or a pushed flow is
+/// invisible to it.
+String effectiveLocation(RouteMatchList configuration) {
+  final matches = configuration.matches;
+  final last = matches.isEmpty ? null : matches.last;
+  if (last is ImperativeRouteMatch) return last.matches.uri.toString();
+  return configuration.uri.toString();
+}
+
 /// Locations that are boot/lock gates: `_navigate` re-derives them from state
 /// and must never treat one as an in-flight route to restore. What *is*
 /// restorable is governed by the [kRestorableLocations] allowlist below — not

--- a/lib/setup/routing/boot_navigation.dart
+++ b/lib/setup/routing/boot_navigation.dart
@@ -81,6 +81,12 @@ const Set<String> gateLocations = {
 /// path only, so a query string cannot defeat the check.
 bool isGateLocation(String loc) => gateLocations.contains(Uri.parse(loc).path);
 
+/// Maps the location the app was backgrounded on to what the resume capture
+/// should store: gate locations map to null so a nested re-lock — backgrounded
+/// again while the PIN gate is showing — keeps the earlier in-flight capture
+/// instead of clobbering it with the gate.
+String? resumeCaptureFor(String location) => isGateLocation(location) ? null : location;
+
 /// Non-gate locations safe to restore after a resume / re-lock: they rebuild
 /// from a bare path (no required `extra`) and sit behind no secondary PIN gate.
 /// Fail-closed — anything not listed falls back to the dashboard (the pre-fix

--- a/lib/setup/routing/boot_navigation.dart
+++ b/lib/setup/routing/boot_navigation.dart
@@ -1,0 +1,105 @@
+import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
+import 'package:realunit_wallet/setup/routing/routes/onboarding_routes.dart';
+import 'package:realunit_wallet/setup/routing/routes/pin_routes.dart';
+
+/// Pure, router-agnostic decision for the boot/lock navigation state machine
+/// driven by `main.dart`'s `_navigate`. Deliberately free of `go_router` and
+/// `getIt` so the whole gate ladder can be unit-tested exhaustively.
+sealed class BootNavAction {
+  const BootNavAction();
+}
+
+/// The wallet is still loading — do not navigate yet, wait for the next
+/// emission that flips `isLoadingWallet` off.
+class BootNavWaitForLoad extends BootNavAction {
+  const BootNavWaitForLoad();
+}
+
+/// All gates passed but the wallet is not in memory yet — trigger the load and
+/// wait for the resulting HomeBloc emission.
+class BootNavLoadWallet extends BootNavAction {
+  const BootNavLoadWallet();
+}
+
+/// Navigate to a gate / landing route by its go_router name.
+class BootNavGoNamed extends BootNavAction {
+  final String routeName;
+  const BootNavGoNamed(this.routeName);
+}
+
+/// Restore the in-flight (non-gate) route the user was on before the background
+/// lock / re-lock, addressed by its location (path).
+class BootNavRestore extends BootNavAction {
+  final String location;
+  const BootNavRestore(this.location);
+}
+
+/// All gates passed and the user is already on a valid non-gate route — leave
+/// them exactly where they are, never yank them to the dashboard.
+class BootNavStay extends BootNavAction {
+  const BootNavStay();
+}
+
+/// Locations that are boot/lock gates and must never be restored: re-entering
+/// one after a resume would either bypass a gate or be pointless. Every other
+/// location is an in-app route worth restoring.
+const Set<String> kGateLocations = {
+  '/home',
+  '/welcome',
+  '/createWallet',
+  '/restoreWallet',
+  '/verifySeed',
+  '/onboardingComplete',
+  '/pinGate',
+  '/setupPin',
+  '/verifyPin',
+  '/bitboxAddressRecovery',
+  '/debugAuth',
+};
+
+/// Whether [loc] resolves to one of the [kGateLocations] gates. Compares the
+/// path only, so a query string cannot defeat the check.
+bool isGateLocation(String loc) => kGateLocations.contains(Uri.parse(loc).path);
+
+/// Pure boot/lock routing decision, evaluated on every HomeBloc / PinAuthCubit
+/// emission.
+///
+/// The gate ladder is evaluated top to bottom, so a restore can only ever be
+/// returned by the final branch — after `!isPinVerified` has already diverted
+/// to the PIN gate. A [BootNavRestore] therefore never re-enters a gate route
+/// and never bypasses the PIN gate.
+BootNavAction resolveBootNavigation({
+  required bool isLoadingWallet,
+  required bool softwareTermsAccepted,
+  required bool hasWallet,
+  required bool onboardingCompleted,
+  required bool isPinSetup,
+  required bool isPinVerified,
+  required bool bitboxAddressRecoveryNeeded,
+  required bool walletLoaded,
+  required String currentLocation,
+  required String? resumeLocation,
+}) {
+  if (isLoadingWallet) return const BootNavWaitForLoad();
+  if (!softwareTermsAccepted) return const BootNavGoNamed(AppRoutes.home);
+  if (!hasWallet) return const BootNavGoNamed(OnboardingRoutes.welcome);
+  if (!onboardingCompleted) {
+    return const BootNavGoNamed(OnboardingRoutes.completed);
+  }
+  if (!isPinSetup) return const BootNavGoNamed(PinRoutes.setup);
+  if (!isPinVerified) return const BootNavGoNamed(PinRoutes.verify);
+  if (bitboxAddressRecoveryNeeded) {
+    // A BitBox wallet was persisted with an empty/invalid address — divert to
+    // the re-pairing recovery flow instead of loading it into the dashboard
+    // (which would crash the build via `EthereumAddress.fromHex("")`).
+    return const BootNavGoNamed(AppRoutes.bitboxAddressRecovery);
+  }
+  if (!walletLoaded) return const BootNavLoadWallet();
+
+  // All gates passed.
+  if (!isGateLocation(currentLocation)) return const BootNavStay();
+  if (resumeLocation != null && !isGateLocation(resumeLocation)) {
+    return BootNavRestore(resumeLocation);
+  }
+  return const BootNavGoNamed(AppRoutes.dashboard);
+}

--- a/lib/setup/routing/boot_navigation.dart
+++ b/lib/setup/routing/boot_navigation.dart
@@ -1,10 +1,12 @@
+import 'package:go_router/go_router.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/setup/routing/routes/onboarding_routes.dart';
 import 'package:realunit_wallet/setup/routing/routes/pin_routes.dart';
 
-/// Pure, router-agnostic decision for the boot/lock navigation state machine
-/// driven by `main.dart`'s `_navigate`. Deliberately free of `go_router` and
-/// `getIt` so the whole gate ladder can be unit-tested exhaustively.
+/// The outcome of the boot/lock navigation decision (see
+/// [resolveBootNavigation]) driven by `main.dart`'s `_navigate`. The decision
+/// itself is `getIt`-free so the whole gate ladder can be unit-tested
+/// exhaustively; [applyBootNavAction] below performs the go_router side effect.
 sealed class BootNavAction {
   const BootNavAction();
 }
@@ -40,9 +42,10 @@ class BootNavStay extends BootNavAction {
   const BootNavStay();
 }
 
-/// Locations that are boot/lock gates and must never be restored: re-entering
-/// one after a resume would either bypass a gate or be pointless. Every other
-/// location is an in-app route worth restoring.
+/// Locations that are boot/lock gates: `_navigate` re-derives them from state
+/// and must never treat one as an in-flight route to restore. What *is*
+/// restorable is governed by the [kRestorableLocations] allowlist below — not
+/// by "anything that is not a gate".
 const Set<String> kGateLocations = {
   '/home',
   '/welcome',
@@ -61,13 +64,34 @@ const Set<String> kGateLocations = {
 /// path only, so a query string cannot defeat the check.
 bool isGateLocation(String loc) => kGateLocations.contains(Uri.parse(loc).path);
 
+/// Non-gate locations safe to restore after a resume / re-lock: they rebuild
+/// from a bare path (no required `extra`) and sit behind no secondary PIN gate.
+/// Fail-closed — anything not listed falls back to the dashboard (the pre-fix
+/// behaviour), so a newly added route can never silently become restorable (and
+/// crash on a missing `extra`) or surface a PIN-gated screen. Matched by exact
+/// path: `/settings/seed` != `/settings`, `/buyPaymentDetails` != `/buy`.
+const Set<String> kRestorableLocations = {
+  '/kyc',
+  '/dashboard',
+  '/buy',
+  '/sell',
+  '/receive',
+  '/settings',
+  '/support',
+};
+
+/// Whether [loc]'s path is in the [kRestorableLocations] allowlist (query
+/// string ignored).
+bool isRestorableLocation(String loc) => kRestorableLocations.contains(Uri.parse(loc).path);
+
 /// Pure boot/lock routing decision, evaluated on every HomeBloc / PinAuthCubit
 /// emission.
 ///
 /// The gate ladder is evaluated top to bottom, so a restore can only ever be
 /// returned by the final branch — after `!isPinVerified` has already diverted
-/// to the PIN gate. A [BootNavRestore] therefore never re-enters a gate route
-/// and never bypasses the PIN gate.
+/// to the PIN gate. A [BootNavRestore] is additionally limited to the
+/// [kRestorableLocations] allowlist, so it never re-enters a gate route, never
+/// bypasses the PIN gate, and never targets a route that needs `extra`.
 BootNavAction resolveBootNavigation({
   required bool isLoadingWallet,
   required bool softwareTermsAccepted,
@@ -98,8 +122,45 @@ BootNavAction resolveBootNavigation({
 
   // All gates passed.
   if (!isGateLocation(currentLocation)) return const BootNavStay();
-  if (resumeLocation != null && !isGateLocation(resumeLocation)) {
+  if (resumeLocation != null && isRestorableLocation(resumeLocation)) {
     return BootNavRestore(resumeLocation);
   }
   return const BootNavGoNamed(AppRoutes.dashboard);
+}
+
+/// Executes a [resolveBootNavigation] decision against [router]. Split out from
+/// `main.dart`'s `_navigate` so the routing side effects can be driven against a
+/// real [GoRouter] in a widget test (the decision itself is covered by the pure
+/// table). [onLoadWallet] triggers the wallet load; [onClearResume] drops the
+/// captured resume location once it is spent.
+void applyBootNavAction(
+  BootNavAction action,
+  GoRouter router, {
+  required void Function() onLoadWallet,
+  required void Function() onClearResume,
+}) {
+  switch (action) {
+    case BootNavWaitForLoad():
+      return;
+    case BootNavLoadWallet():
+      // Wallet not loaded yet — trigger load and wait for the HomeBloc update.
+      onLoadWallet();
+      return;
+    case BootNavGoNamed(:final routeName):
+      // Reaching the dashboard is the final landing — drop any stale resume
+      // capture so a later benign emission can't bounce the user around.
+      if (routeName == AppRoutes.dashboard) onClearResume();
+      router.goNamed(routeName);
+      return;
+    case BootNavRestore(:final location):
+      // Return to the in-flight route the user was on before the re-lock,
+      // reached only after the PIN gate above has already passed.
+      onClearResume();
+      router.go(location);
+      return;
+    case BootNavStay():
+      // Already on a valid non-gate route — discard any stale capture.
+      onClearResume();
+      return;
+  }
 }

--- a/lib/setup/routing/router_config.dart
+++ b/lib/setup/routing/router_config.dart
@@ -45,6 +45,7 @@ import 'package:realunit_wallet/screens/transaction_history/transaction_history_
 import 'package:realunit_wallet/screens/verify_seed/verify_seed_page.dart';
 import 'package:realunit_wallet/screens/web_view/web_view_page.dart';
 import 'package:realunit_wallet/screens/welcome/welcome_page.dart';
+import 'package:realunit_wallet/setup/routing/boot_navigation.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_link_entry.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/setup/routing/routes/legal_routes.dart';
@@ -56,13 +57,16 @@ import 'package:realunit_wallet/setup/routing/routes/support_routes.dart';
 final GoRouter routerConfig = GoRouter(
   initialLocation: '/home',
   // Custom-scheme opens (realunit-wallet://…, canonical realunit-wallet://open)
-  // only foreground the app; they must not force any navigation. The redirect
-  // keeps the current in-app route (warm resume) or hands off to the normal
-  // boot entry (cold start). See app_link_entry.dart.
+  // only foreground the app; they must not force any navigation. Cold start:
+  // the redirect hands off to the normal boot entry. Warm resume: the redirect
+  // lets the scheme URL fall through unmatched and onException keeps the
+  // current configuration — the only true no-op that survives imperatively
+  // pushed routes (e.g. the KYC flow). See app_link_entry.dart.
   redirect: (context, state) => appLinkSchemeRedirect(
     state,
-    routerConfig.routerDelegate.currentConfiguration.uri.toString(),
+    effectiveLocation(routerConfig.routerDelegate.currentConfiguration),
   ),
+  onException: appLinkOnException,
   routes: <RouteBase>[
     GoRoute(
       name: AppRoutes.home,

--- a/lib/setup/routing/routes/app_link_entry.dart
+++ b/lib/setup/routing/routes/app_link_entry.dart
@@ -24,24 +24,35 @@ const String appLinkColdStartLocation = '/home';
 /// `main.dart`'s boot flow take over — the PIN gate and boot ordering stay
 /// untouched.
 ///
-/// Warm resume: it returns `null` so the scheme URL stays unmatched and falls
-/// through to [appLinkOnException], which keeps the current route configuration
-/// untouched — a true no-op. Returning a location string here instead would be
-/// applied as a `go` and REPLACE the whole match list: an imperatively pushed
-/// route (the KYC flow from Buy/Sell) would be dropped together with its
-/// page-scoped state, its `extra`, and the back stack underneath it.
+/// Warm resume, canonical path-less open (`realunit-wallet://open`): it returns
+/// `null` so the scheme URL stays unmatched and falls through to
+/// [appLinkOnException], which keeps the current route configuration untouched
+/// — a true no-op. Returning a location string here instead would be applied as
+/// a `go` and REPLACE the whole match list: an imperatively pushed route (the
+/// KYC flow from Buy/Sell) would be dropped together with its page-scoped
+/// state, its `extra`, and the back stack underneath it.
+///
+/// Warm resume, scheme URL CARRYING a path: go_router matches on `uri.path`
+/// alone, so `realunit-wallet://open/settings/seed` would match — and with a
+/// `null` return it would navigate, straight past flow-level gates (the seed
+/// page's PIN gate lives in the settings navigation path, not on the route).
+/// Such crafted URLs are pinned to [currentLocation] instead: that `go` may
+/// rebuild a pushed route as the base match, but a crafted URL is not worth
+/// preserving a pushed stack for — never navigating anywhere new wins.
 ///
 /// Non-scheme (in-app) navigation is left untouched (`null`).
 //
 // @no-integration-test: OS-level custom-scheme delivery and foregrounding can
 // only be exercised on a real device, and no integration_test/ harness exists
-// in this repo yet. The redirect + exception handler pair is covered by widget
-// tests in app_link_entry_test.dart.
+// in this repo yet. The redirect is covered by widget tests in
+// app_link_entry_test.dart.
 String? appLinkSchemeRedirect(GoRouterState state, String currentLocation) {
   if (state.uri.scheme != appLinkScheme) return null;
   final current = Uri.parse(currentLocation);
   final isInAppRoute = current.scheme.isEmpty && current.path.startsWith('/');
-  return isInAppRoute ? null : appLinkColdStartLocation;
+  if (!isInAppRoute) return appLinkColdStartLocation;
+  final hasPath = state.uri.path.isNotEmpty && state.uri.path != '/';
+  return hasPath ? currentLocation : null;
 }
 
 /// go_router exception handler paired with [appLinkSchemeRedirect].
@@ -54,6 +65,11 @@ String? appLinkSchemeRedirect(GoRouterState state, String currentLocation) {
 /// and it is the only variant that survives imperatively pushed routes.
 /// Cold-start scheme opens never reach this handler; the redirect already
 /// mapped them to [appLinkColdStartLocation].
+//
+// @no-integration-test: OS-level custom-scheme delivery and foregrounding can
+// only be exercised on a real device, and no integration_test/ harness exists
+// in this repo yet. The handler is covered by widget tests in
+// app_link_entry_test.dart.
 void appLinkOnException(BuildContext context, GoRouterState state, GoRouter router) {
   if (state.uri.scheme == appLinkScheme) return;
   // A non-scheme URL that matches no route is a programming error. Installing

--- a/lib/setup/routing/routes/app_link_entry.dart
+++ b/lib/setup/routing/routes/app_link_entry.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
 /// Custom URL scheme the app is opened with. Registered in
@@ -16,22 +17,48 @@ const String appLinkColdStartLocation = '/home';
 /// Top-level go_router redirect for custom-scheme opens.
 ///
 /// A `realunit-wallet://…` open (canonical `realunit-wallet://open`) only brings
-/// the app to the foreground — it must NOT force any in-app navigation. So on a
-/// warm resume it keeps the user exactly where they were: [currentLocation] is
-/// the router's current in-app route, returned unchanged (a no-op). On a cold
-/// start there is no prior in-app route (currentLocation is empty or the scheme
-/// URL itself), so it hands off to the normal boot entry and lets `main.dart`'s
-/// boot flow take over — the PIN gate and boot ordering stay untouched. Either
-/// way go_router never shows an error screen for a scheme URL that matches no
-/// path route. Non-scheme (in-app) navigation is left untouched (`null`).
+/// the app to the foreground — it must NOT force any in-app navigation.
+///
+/// Cold start: there is no prior in-app route ([currentLocation] is empty or
+/// the scheme URL itself), so it hands off to the normal boot entry and lets
+/// `main.dart`'s boot flow take over — the PIN gate and boot ordering stay
+/// untouched.
+///
+/// Warm resume: it returns `null` so the scheme URL stays unmatched and falls
+/// through to [appLinkOnException], which keeps the current route configuration
+/// untouched — a true no-op. Returning a location string here instead would be
+/// applied as a `go` and REPLACE the whole match list: an imperatively pushed
+/// route (the KYC flow from Buy/Sell) would be dropped together with its
+/// page-scoped state, its `extra`, and the back stack underneath it.
+///
+/// Non-scheme (in-app) navigation is left untouched (`null`).
 //
 // @no-integration-test: OS-level custom-scheme delivery and foregrounding can
 // only be exercised on a real device, and no integration_test/ harness exists
-// in this repo yet. The redirect itself is covered by widget tests in
-// app_link_entry_test.dart.
+// in this repo yet. The redirect + exception handler pair is covered by widget
+// tests in app_link_entry_test.dart.
 String? appLinkSchemeRedirect(GoRouterState state, String currentLocation) {
   if (state.uri.scheme != appLinkScheme) return null;
   final current = Uri.parse(currentLocation);
   final isInAppRoute = current.scheme.isEmpty && current.path.startsWith('/');
-  return isInAppRoute ? currentLocation : appLinkColdStartLocation;
+  return isInAppRoute ? null : appLinkColdStartLocation;
+}
+
+/// go_router exception handler paired with [appLinkSchemeRedirect].
+///
+/// With an `onException` handler installed, go_router keeps the current route
+/// configuration whenever a URL matches no route (go_router `router.dart`:
+/// "Avoid updating GoRouterDelegate if onException is provided"). A warm
+/// custom-scheme open is exactly that case — [appLinkSchemeRedirect] lets it
+/// fall through unmatched — so doing nothing here IS the foregrounding no-op,
+/// and it is the only variant that survives imperatively pushed routes.
+/// Cold-start scheme opens never reach this handler; the redirect already
+/// mapped them to [appLinkColdStartLocation].
+void appLinkOnException(BuildContext context, GoRouterState state, GoRouter router) {
+  if (state.uri.scheme == appLinkScheme) return;
+  // A non-scheme URL that matches no route is a programming error. Installing
+  // onException removes go_router's default error screen, so fail loud where
+  // tests and debug builds can see it; in release the user stays on the
+  // current screen instead of landing on an error page.
+  assert(false, 'No route matches ${state.uri}');
 }

--- a/lib/setup/routing/routes/app_link_entry.dart
+++ b/lib/setup/routing/routes/app_link_entry.dart
@@ -36,9 +36,13 @@ const String appLinkColdStartLocation = '/home';
 /// alone, so `realunit-wallet://open/settings/seed` would match — and with a
 /// `null` return it would navigate, straight past flow-level gates (the seed
 /// page's PIN gate lives in the settings navigation path, not on the route).
-/// Such crafted URLs are pinned to [currentLocation] instead: that `go` may
-/// rebuild a pushed route as the base match, but a crafted URL is not worth
-/// preserving a pushed stack for — never navigating anywhere new wins.
+/// Returning the current location instead would be no safer: applied as a
+/// `go`, it rebuilds a pushed `extra`-required route (`/buyPaymentDetails`,
+/// `/webView`, …) with a null `extra` and crashes its builder cast. So crafted
+/// path-carrying URLs are rewritten to the canonical [appLinkUrl]: the
+/// redirect runs once more on that path-less form, falls through unmatched,
+/// and [appLinkOnException] keeps the configuration — the same true no-op as
+/// the canonical open, with no rebuild at all.
 ///
 /// Non-scheme (in-app) navigation is left untouched (`null`).
 //
@@ -52,7 +56,7 @@ String? appLinkSchemeRedirect(GoRouterState state, String currentLocation) {
   final isInAppRoute = current.scheme.isEmpty && current.path.startsWith('/');
   if (!isInAppRoute) return appLinkColdStartLocation;
   final hasPath = state.uri.path.isNotEmpty && state.uri.path != '/';
-  return hasPath ? currentLocation : null;
+  return hasPath ? appLinkUrl : null;
 }
 
 /// go_router exception handler paired with [appLinkSchemeRedirect].

--- a/lib/setup/routing/routes/app_link_entry.dart
+++ b/lib/setup/routing/routes/app_link_entry.dart
@@ -39,8 +39,9 @@ const String appLinkColdStartLocation = '/home';
 /// Returning the current location instead would be no safer: applied as a
 /// `go`, it rebuilds a pushed `extra`-required route (`/buyPaymentDetails`,
 /// `/webView`, …) with a null `extra` and crashes its builder cast. So crafted
-/// path-carrying URLs are rewritten to the canonical [appLinkUrl]: the
-/// redirect runs once more on that path-less form, falls through unmatched,
+/// path-carrying URLs are rewritten to the canonical [appLinkUrl]: go_router
+/// resolves the rewritten URL to an unmatched (error) match list and
+/// short-circuits before any further redirect pass, so the chain terminates
 /// and [appLinkOnException] keeps the configuration — the same true no-op as
 /// the canonical open, with no rebuild at all.
 ///

--- a/test/screens/pin/pin_auth_cubit_test.dart
+++ b/test/screens/pin/pin_auth_cubit_test.dart
@@ -75,7 +75,7 @@ void main() {
     });
 
     test('onAppResumed when PIN not setup is a no-op (no emit)', () async {
-      final cubit = build()..onAppHidden();
+      final cubit = build()..onAppHidden(null);
       final before = cubit.state;
       cubit.onAppResumed();
       expect(cubit.state, before);
@@ -93,7 +93,7 @@ void main() {
         // lockoutDuration constant pin below — flipping that constant or the
         // comparator surfaces in the auth flow's own tests.
         cubit
-          ..onAppHidden()
+          ..onAppHidden(null)
           ..onAppResumed();
 
         expect(cubit.state.isPinVerified, isTrue);
@@ -110,7 +110,7 @@ void main() {
           final cubit = build()..onPinSetupComplete();
           expect(cubit.state.isPinVerified, isTrue);
 
-          cubit.onAppHidden();
+          cubit.onAppHidden(null);
           async.elapse(lockoutDuration + const Duration(seconds: 1));
           cubit.onAppResumed();
 
@@ -129,6 +129,67 @@ void main() {
       // The behaviour depends on this exact constant — pin it so changes
       // surface in this file rather than only in the auth flow.
       expect(lockoutDuration, const Duration(minutes: 5));
+    });
+  });
+
+  group('resume location capture', () {
+    test('onAppHidden captures the location once (??=)', () {
+      final cubit = build()
+        ..onAppHidden('/kyc')
+        ..onAppHidden('/dashboard');
+      expect(cubit.peekResumeLocation(), '/kyc');
+    });
+
+    test('a null first capture does not lock out a later real location', () {
+      final cubit = build()
+        ..onAppHidden(null)
+        ..onAppHidden('/kyc');
+      expect(cubit.peekResumeLocation(), '/kyc');
+    });
+
+    test('clearResumeLocation drops the capture', () {
+      final cubit = build()..onAppHidden('/kyc');
+      expect(cubit.peekResumeLocation(), '/kyc');
+      cubit.clearResumeLocation();
+      expect(cubit.peekResumeLocation(), isNull);
+    });
+
+    test('a long hide keeps the resume location for the consumer', () {
+      // The re-lock (isPinVerified -> false) and the resume-location capture
+      // are independent: on relock we still hand the captured route to
+      // `_navigate`, which restores it after the PIN gate and clears it there.
+      fakeAsync((async) {
+        final cubit = build()
+          ..onPinSetupComplete()
+          ..onAppHidden('/kyc');
+        async.elapse(lockoutDuration + const Duration(seconds: 1));
+        cubit.onAppResumed();
+
+        expect(cubit.state.isPinVerified, isFalse);
+        expect(cubit.peekResumeLocation(), '/kyc');
+        cubit.close();
+      });
+    });
+
+    test('a short hide also keeps the resume location for the consumer', () {
+      final cubit = build()
+        ..onPinSetupComplete()
+        ..onAppHidden('/kyc')
+        ..onAppResumed();
+
+      expect(cubit.state.isPinVerified, isTrue);
+      expect(cubit.peekResumeLocation(), '/kyc');
+    });
+
+    test('reset clears the captured resume location', () async {
+      when(() => storage.deletePinHash()).thenAnswer((_) async {});
+      when(() => storage.deleteBiometricEnabled()).thenAnswer((_) async {});
+      when(() => storage.resetPinLockout()).thenAnswer((_) async {});
+
+      final cubit = build()..onAppHidden('/kyc');
+      expect(cubit.peekResumeLocation(), '/kyc');
+      await cubit.reset();
+      expect(cubit.peekResumeLocation(), isNull);
     });
   });
 

--- a/test/screens/pin/pin_auth_cubit_test.dart
+++ b/test/screens/pin/pin_auth_cubit_test.dart
@@ -133,10 +133,21 @@ void main() {
   });
 
   group('resume location capture', () {
-    test('onAppHidden captures the location once (??=)', () {
+    test('a fresh non-gate capture replaces the previous one', () {
+      // Freshest non-null (non-gate) location wins: backgrounding again on a
+      // different in-flight route updates the restore target.
       final cubit = build()
         ..onAppHidden('/kyc')
-        ..onAppHidden('/dashboard');
+        ..onAppHidden('/settings');
+      expect(cubit.peekResumeLocation(), '/settings');
+    });
+
+    test('a null (gate) background keeps the earlier in-flight capture', () {
+      // The caller passes null for gate routes; a nested re-lock must not
+      // clobber the good `/kyc` capture with the gate.
+      final cubit = build()
+        ..onAppHidden('/kyc')
+        ..onAppHidden(null);
       expect(cubit.peekResumeLocation(), '/kyc');
     });
 

--- a/test/screens/pin/pin_auth_cubit_test.dart
+++ b/test/screens/pin/pin_auth_cubit_test.dart
@@ -182,14 +182,38 @@ void main() {
       });
     });
 
-    test('a short hide also keeps the resume location for the consumer', () {
+    test('a short hide in the verified state clears the capture eagerly', () {
+      // The episode ended without a re-lock: nothing consumes the capture, so
+      // it is dropped here — a much later, unrelated re-lock must not restore
+      // a route from a long-finished episode.
       final cubit = build()
         ..onPinSetupComplete()
         ..onAppHidden('/kyc')
         ..onAppResumed();
 
       expect(cubit.state.isPinVerified, isTrue);
-      expect(cubit.peekResumeLocation(), '/kyc');
+      expect(cubit.peekResumeLocation(), isNull);
+    });
+
+    test('a short hide while the PIN gate is showing keeps the capture', () {
+      // Nested re-lock: a short away-switch on /verifyPin (isPinVerified is
+      // still false) must not lose the in-flight capture the pending unlock is
+      // about to restore.
+      fakeAsync((async) {
+        final cubit = build()
+          ..onPinSetupComplete()
+          ..onAppHidden('/kyc');
+        async.elapse(lockoutDuration + const Duration(seconds: 1));
+        cubit.onAppResumed(); // re-lock: isPinVerified -> false
+
+        cubit
+          ..onAppHidden(null) // backgrounded again on the gate route
+          ..onAppResumed(); // short: no lockout elapsed
+
+        expect(cubit.state.isPinVerified, isFalse);
+        expect(cubit.peekResumeLocation(), '/kyc');
+        cubit.close();
+      });
     });
 
     test('reset clears the captured resume location', () async {

--- a/test/setup/lifecycle_initializer_test.dart
+++ b/test/setup/lifecycle_initializer_test.dart
@@ -39,12 +39,11 @@ void main() {
 
   tearDown(() => GetIt.instance.reset());
 
-  Future<void> pumpLifecycle(WidgetTester tester) =>
-      tester.pumpWidget(
-        const LifecycleInitializer(
-          child: SizedBox.shrink(),
-        ),
-      );
+  Future<void> pumpLifecycle(WidgetTester tester) => tester.pumpWidget(
+    const LifecycleInitializer(
+      child: SizedBox.shrink(),
+    ),
+  );
 
   testWidgets(
     'AppLifecycleState.hidden drops the mnemonic via WalletService.lockCurrentWallet',
@@ -80,7 +79,7 @@ void main() {
       // paused must now drop the mnemonic and arm the PIN gate too, so a
       // platform that never emits `hidden` still locks.
       verify(() => walletService.lockCurrentWallet()).called(1);
-      verify(() => pinAuthCubit.onAppHidden()).called(1);
+      verify(() => pinAuthCubit.onAppHidden(any())).called(1);
       // and it still cancels the balance sync it always did.
       verify(() => balanceService.cancelSync()).called(1);
     },
@@ -96,7 +95,7 @@ void main() {
       await tester.pump();
 
       verify(() => walletService.lockCurrentWallet()).called(1);
-      verify(() => pinAuthCubit.onAppHidden()).called(1);
+      verify(() => pinAuthCubit.onAppHidden(any())).called(1);
     },
   );
 
@@ -110,7 +109,7 @@ void main() {
       await tester.pump();
 
       verify(() => walletService.lockCurrentWallet()).called(1);
-      verify(() => pinAuthCubit.onAppHidden()).called(1);
+      verify(() => pinAuthCubit.onAppHidden(any())).called(1);
     },
   );
 
@@ -123,7 +122,7 @@ void main() {
       await tester.pump();
 
       verifyNever(() => walletService.lockCurrentWallet());
-      verifyNever(() => pinAuthCubit.onAppHidden());
+      verifyNever(() => pinAuthCubit.onAppHidden(any()));
     },
   );
 

--- a/test/setup/routing/app_link_entry_test.dart
+++ b/test/setup/routing/app_link_entry_test.dart
@@ -3,21 +3,24 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:realunit_wallet/setup/routing/boot_navigation.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_link_entry.dart';
 
 void main() {
-  // A minimal router wired to the *production* [appLinkSchemeRedirect], exactly
-  // as router_config.dart wires it (current location read from the router's own
-  // delegate). `/home` is the normal cold-start entry; `/dashboard` and
-  // `/settings` stand in for arbitrary in-app routes a warm resume must preserve.
+  // A minimal router wired to the *production* scheme handling — the
+  // [appLinkSchemeRedirect] + [appLinkOnException] pair with the push-aware
+  // [effectiveLocation], exactly as router_config.dart wires it. `/home` is the
+  // normal cold-start entry; `/dashboard` and `/settings` stand in for
+  // arbitrary in-app routes a warm resume must preserve.
   GoRouter buildRouter({String initialLocation = '/home'}) {
     late final GoRouter router;
     router = GoRouter(
       initialLocation: initialLocation,
       redirect: (context, state) => appLinkSchemeRedirect(
         state,
-        router.routerDelegate.currentConfiguration.uri.toString(),
+        effectiveLocation(router.routerDelegate.currentConfiguration),
       ),
+      onException: appLinkOnException,
       routes: [
         GoRoute(
           path: '/home',
@@ -147,6 +150,25 @@ void main() {
           reason: 'for $url',
         );
       }
+    },
+  );
+
+  testWidgets(
+    'warm resume: a crafted scheme URL to an auth path is a no-op '
+    '(no navigation, PIN gate not bypassed)',
+    (tester) async {
+      final router = await pump(tester);
+      router.go('/settings');
+      await tester.pumpAndSettle();
+
+      // `realunit-wallet://dashboard` must not navigate anywhere on a warm
+      // resume either — same no-op as the canonical open.
+      router.go('realunit-wallet://dashboard');
+      await tester.pumpAndSettle();
+
+      expect(currentPath(router), '/settings');
+      expect(find.byKey(const Key('settings')), findsOneWidget);
+      expect(find.byKey(const Key('dashboard')), findsNothing);
     },
   );
 

--- a/test/setup/routing/app_link_entry_test.dart
+++ b/test/setup/routing/app_link_entry_test.dart
@@ -34,6 +34,13 @@ void main() {
           path: '/settings',
           builder: (_, _) => const Scaffold(body: Text('SET', key: Key('settings'))),
         ),
+        GoRoute(
+          path: '/details',
+          // Mirrors the real extra-required builders (/buyPaymentDetails,
+          // /webView, …): rebuilding this route from a bare path throws.
+          builder: (_, state) =>
+              Scaffold(body: Text(state.extra! as String, key: const Key('details'))),
+        ),
       ],
     );
     return router;
@@ -188,6 +195,35 @@ void main() {
       expect(currentPath(router), '/dashboard');
       expect(find.byKey(const Key('dashboard')), findsOneWidget);
       expect(find.byKey(const Key('settings')), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'warm resume: a crafted path-carrying scheme URL over a pushed '
+    'extra-required route neither navigates nor crashes',
+    (tester) async {
+      final router = await pump(tester);
+      router.go('/dashboard');
+      await tester.pumpAndSettle();
+
+      // Backgrounding on a pushed extra-required route is the everyday case
+      // (e.g. /buyPaymentDetails while paying in the banking app).
+      unawaited(router.push('/details', extra: 'payment'));
+      await tester.pumpAndSettle();
+      expect(find.text('payment'), findsOneWidget);
+
+      // The crafted URL is rewritten to the canonical path-less open and ends
+      // in the onException no-op. A currentLocation pin instead would rebuild
+      // /details via `go` with a null extra and crash the builder cast.
+      router.go('realunit-wallet://open/settings');
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('payment'), findsOneWidget);
+      expect(router.canPop(), isTrue);
+      router.pop();
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('dashboard')), findsOneWidget);
     },
   );
 

--- a/test/setup/routing/app_link_entry_test.dart
+++ b/test/setup/routing/app_link_entry_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -81,6 +83,42 @@ void main() {
     expect(currentPath(router), '/settings');
     expect(find.byKey(const Key('settings')), findsOneWidget);
   });
+
+  testWidgets(
+    'warm resume: a scheme open keeps the user on a PUSHED route '
+    '(how /kyc is reached from Buy/Sell)',
+    (tester) async {
+      final router = await pump(tester);
+      router.go('/dashboard');
+      await tester.pumpAndSettle();
+
+      // The KYC flow is entered imperatively — context.pushNamed(AppRoutes.kyc)
+      // from the Buy/Sell buttons — so the flow route sits ON TOP of the base
+      // route instead of replacing it. /settings stands in for the pushed flow.
+      unawaited(router.push('/settings'));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('settings')), findsOneWidget);
+
+      // Same promise as for go-routes above: the scheme open must NOT force
+      // any navigation. The pushed route (and with it any page-scoped state,
+      // e.g. the KycCubit) must survive the open.
+      router.go(appLinkUrl);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('settings')), findsOneWidget);
+      expect(find.byKey(const Key('dashboard')), findsNothing);
+
+      // A true no-op also preserves the imperative stack itself — the pushed
+      // route must still pop back to the base route it was pushed from. This
+      // guards against "fixes" that rebuild the page as a new base route
+      // (which would drop page-scoped state, `state.extra`, and the back
+      // stack while leaving the same page visible).
+      expect(router.canPop(), isTrue);
+      router.pop();
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('dashboard')), findsOneWidget);
+    },
+  );
 
   testWidgets('cold start on the scheme URL boots to the normal entry', (
     tester,

--- a/test/setup/routing/app_link_entry_test.dart
+++ b/test/setup/routing/app_link_entry_test.dart
@@ -173,6 +173,25 @@ void main() {
   );
 
   testWidgets(
+    'warm resume: a crafted scheme URL carrying a real path does not navigate '
+    '(flow-level gates not bypassed)',
+    (tester) async {
+      final router = await pump(tester);
+      router.go('/dashboard');
+      await tester.pumpAndSettle();
+
+      // go_router matches on uri.path alone, so this WOULD match /settings if
+      // the redirect let it fall through like the canonical path-less open.
+      router.go('realunit-wallet://open/settings');
+      await tester.pumpAndSettle();
+
+      expect(currentPath(router), '/dashboard');
+      expect(find.byKey(const Key('dashboard')), findsOneWidget);
+      expect(find.byKey(const Key('settings')), findsNothing);
+    },
+  );
+
+  testWidgets(
     'cold start on a crafted scheme URL to an auth path still boots to /home '
     '(PIN gate not bypassed)',
     (tester) async {

--- a/test/setup/routing/boot_navigation_apply_test.dart
+++ b/test/setup/routing/boot_navigation_apply_test.dart
@@ -125,19 +125,44 @@ void main() {
       // Fail-closed: not on the allowlist -> dashboard, never the crashing route.
       expect((action as BootNavGoNamed).routeName, AppRoutes.dashboard);
 
+      var cleared = false;
       applyBootNavAction(
         action,
         router,
         onLoadWallet: () {},
-        onClearResume: () {},
+        onClearResume: () => cleared = true,
       );
       await tester.pumpAndSettle();
 
       expect(tester.takeException(), isNull);
       expect(find.text('dashboard'), findsOneWidget);
       expect(locationOf(router), '/dashboard');
+      // The dashboard is a final landing — the stale capture must be dropped.
+      expect(cleared, isTrue);
     },
   );
+
+  testWidgets('navigating to a gate keeps the capture for the pending unlock', (
+    tester,
+  ) async {
+    final router = buildRouter();
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    // A re-lock diverts to the PIN gate. Clearing here would silently degrade
+    // the post-unlock restore to the dashboard fallback.
+    var cleared = false;
+    applyBootNavAction(
+      const BootNavGoNamed(PinRoutes.verify),
+      router,
+      onLoadWallet: () {},
+      onClearResume: () => cleared = true,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('verify'), findsOneWidget);
+    expect(cleared, isFalse);
+  });
 
   testWidgets(
     'premise guard: restoring /buyPaymentDetails from a bare path really throws',

--- a/test/setup/routing/boot_navigation_apply_test.dart
+++ b/test/setup/routing/boot_navigation_apply_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -118,6 +120,29 @@ void main() {
       router.go('/buyPaymentDetails');
       await tester.pumpAndSettle();
       expect(tester.takeException(), isNotNull);
+    },
+  );
+
+  testWidgets(
+    'effectiveLocation reports a pushed route where the raw uri stays on the base',
+    (tester) async {
+      final router = buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      router.go('/dashboard');
+      await tester.pumpAndSettle();
+      expect(effectiveLocation(router.routerDelegate.currentConfiguration), '/dashboard');
+
+      // The KYC flow is entered exactly like this: an imperative push on top
+      // of the dashboard.
+      unawaited(router.push('/kyc'));
+      await tester.pumpAndSettle();
+
+      // Premise guard for every effectiveLocation call site: the raw uri is
+      // blind to the push — the helper is not.
+      expect(locationOf(router), '/dashboard');
+      expect(effectiveLocation(router.routerDelegate.currentConfiguration), '/kyc');
     },
   );
 }

--- a/test/setup/routing/boot_navigation_apply_test.dart
+++ b/test/setup/routing/boot_navigation_apply_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:realunit_wallet/setup/routing/boot_navigation.dart';
+import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
+import 'package:realunit_wallet/setup/routing/routes/pin_routes.dart';
+
+// Drives the real `_navigate` wiring — `resolveBootNavigation` + the go_router
+// side effect `applyBootNavAction` — against a real [GoRouter]. This is the seam
+// the pure-function table and the cubit tests can't reach: it proves the
+// decision is actually enacted on a router, and that a resume of an
+// `extra`-required route lands on the dashboard WITHOUT building (and crashing
+// on) that route. Pumping the full `WalletApp` is impractical (it depends on the
+// whole DI graph + the global router building real, service-backed pages), so we
+// exercise the smallest faithful seam instead.
+void main() {
+  // Only the routes this seam touches. `/buyPaymentDetails` mirrors the real
+  // builder's non-nullable `extra` cast, so building it from a bare path throws
+  // — exactly the crash the restore allowlist must prevent.
+  GoRouter buildRouter() => GoRouter(
+    initialLocation: '/verifyPin',
+    routes: [
+      GoRoute(
+        name: PinRoutes.verify,
+        path: '/verifyPin',
+        builder: (_, _) => const Text('verify'),
+      ),
+      GoRoute(
+        name: AppRoutes.dashboard,
+        path: '/dashboard',
+        builder: (_, _) => const Text('dashboard'),
+      ),
+      GoRoute(
+        name: AppRoutes.kyc,
+        path: '/kyc',
+        builder: (_, _) => const Text('kyc'),
+      ),
+      GoRoute(
+        name: AppRoutes.buyPaymentDetails,
+        path: '/buyPaymentDetails',
+        builder: (_, state) => Text('buy ${state.extra as Object}'),
+      ),
+    ],
+  );
+
+  // Fully-passed post-gate input: the router is on the PIN gate right after a
+  // re-lock, so a captured non-gate route can be restored.
+  BootNavAction resolveAfterRelock(String? resumeLocation) => resolveBootNavigation(
+    isLoadingWallet: false,
+    softwareTermsAccepted: true,
+    hasWallet: true,
+    onboardingCompleted: true,
+    isPinSetup: true,
+    isPinVerified: true,
+    bitboxAddressRecoveryNeeded: false,
+    walletLoaded: true,
+    currentLocation: '/verifyPin',
+    resumeLocation: resumeLocation,
+  );
+
+  String locationOf(GoRouter router) => router.routerDelegate.currentConfiguration.uri.toString();
+
+  testWidgets('re-lock -> PIN -> restore lands on the captured /kyc route', (
+    tester,
+  ) async {
+    final router = buildRouter();
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    var cleared = false;
+    applyBootNavAction(
+      resolveAfterRelock('/kyc'),
+      router,
+      onLoadWallet: () {},
+      onClearResume: () => cleared = true,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('kyc'), findsOneWidget);
+    expect(locationOf(router), '/kyc');
+    expect(cleared, isTrue);
+  });
+
+  testWidgets(
+    'resuming an extra-required route lands on /dashboard without throwing',
+    (tester) async {
+      final router = buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      final action = resolveAfterRelock('/buyPaymentDetails');
+      // Fail-closed: not on the allowlist -> dashboard, never the crashing route.
+      expect((action as BootNavGoNamed).routeName, AppRoutes.dashboard);
+
+      applyBootNavAction(
+        action,
+        router,
+        onLoadWallet: () {},
+        onClearResume: () {},
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('dashboard'), findsOneWidget);
+      expect(locationOf(router), '/dashboard');
+    },
+  );
+
+  testWidgets(
+    'premise guard: restoring /buyPaymentDetails from a bare path really throws',
+    (tester) async {
+      final router = buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      // Proves the crash the allowlist prevents is real: navigating to the
+      // extra-required route without `extra` surfaces an exception.
+      router.go('/buyPaymentDetails');
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNotNull);
+    },
+  );
+}

--- a/test/setup/routing/boot_navigation_apply_test.dart
+++ b/test/setup/routing/boot_navigation_apply_test.dart
@@ -62,25 +62,56 @@ void main() {
 
   String locationOf(GoRouter router) => router.routerDelegate.currentConfiguration.uri.toString();
 
-  testWidgets('re-lock -> PIN -> restore lands on the captured /kyc route', (
+  testWidgets(
+    're-lock -> PIN -> restore lands on the captured /kyc route with the '
+    'dashboard underneath (pop-based exits keep working)',
+    (tester) async {
+      final router = buildRouter();
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+
+      var cleared = false;
+      applyBootNavAction(
+        resolveAfterRelock('/kyc'),
+        router,
+        onLoadWallet: () {},
+        onClearResume: () => cleared = true,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('kyc'), findsOneWidget);
+      expect(effectiveLocation(router.routerDelegate.currentConfiguration), '/kyc');
+      expect(cleared, isTrue);
+
+      // The restore rebuilds the real entry shape (dashboard base + pushed
+      // flow), so the flow's pop-based exits (Close buttons, AppBar auto-back)
+      // still have somewhere to go — a bare `go` restore would strand them.
+      expect(router.canPop(), isTrue);
+      router.pop();
+      await tester.pumpAndSettle();
+      expect(find.text('dashboard'), findsOneWidget);
+      expect(locationOf(router), '/dashboard');
+    },
+  );
+
+  testWidgets('restoring /dashboard itself stays a plain go (nothing to pop)', (
     tester,
   ) async {
     final router = buildRouter();
     await tester.pumpWidget(MaterialApp.router(routerConfig: router));
     await tester.pumpAndSettle();
 
-    var cleared = false;
     applyBootNavAction(
-      resolveAfterRelock('/kyc'),
+      resolveAfterRelock('/dashboard'),
       router,
       onLoadWallet: () {},
-      onClearResume: () => cleared = true,
+      onClearResume: () {},
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('kyc'), findsOneWidget);
-    expect(locationOf(router), '/kyc');
-    expect(cleared, isTrue);
+    expect(find.text('dashboard'), findsOneWidget);
+    expect(locationOf(router), '/dashboard');
+    expect(router.canPop(), isFalse);
   });
 
   testWidgets(

--- a/test/setup/routing/boot_navigation_test.dart
+++ b/test/setup/routing/boot_navigation_test.dart
@@ -164,7 +164,7 @@ void main() {
   });
 
   group('isGateLocation', () {
-    for (final loc in kGateLocations) {
+    for (final loc in gateLocations) {
       test('$loc is a gate', () => expect(isGateLocation(loc), isTrue));
     }
 
@@ -184,7 +184,7 @@ void main() {
   });
 
   group('isRestorableLocation', () {
-    for (final loc in kRestorableLocations) {
+    for (final loc in restorableLocations) {
       test(
         '$loc is restorable',
         () => expect(isRestorableLocation(loc), isTrue),

--- a/test/setup/routing/boot_navigation_test.dart
+++ b/test/setup/routing/boot_navigation_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/setup/routing/boot_navigation.dart';
+import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
+import 'package:realunit_wallet/setup/routing/routes/onboarding_routes.dart';
+import 'package:realunit_wallet/setup/routing/routes/pin_routes.dart';
+
+void main() {
+  // A fully-passed, steady-state input where the user sits on a non-gate route
+  // (/kyc). Individual tests flip exactly one field to exercise one branch.
+  BootNavAction resolve({
+    bool isLoadingWallet = false,
+    bool softwareTermsAccepted = true,
+    bool hasWallet = true,
+    bool onboardingCompleted = true,
+    bool isPinSetup = true,
+    bool isPinVerified = true,
+    bool bitboxAddressRecoveryNeeded = false,
+    bool walletLoaded = true,
+    String currentLocation = '/kyc',
+    String? resumeLocation,
+  }) => resolveBootNavigation(
+    isLoadingWallet: isLoadingWallet,
+    softwareTermsAccepted: softwareTermsAccepted,
+    hasWallet: hasWallet,
+    onboardingCompleted: onboardingCompleted,
+    isPinSetup: isPinSetup,
+    isPinVerified: isPinVerified,
+    bitboxAddressRecoveryNeeded: bitboxAddressRecoveryNeeded,
+    walletLoaded: walletLoaded,
+    currentLocation: currentLocation,
+    resumeLocation: resumeLocation,
+  );
+
+  group('resolveBootNavigation gate ladder', () {
+    test('isLoadingWallet short-circuits to wait, ignoring everything else', () {
+      expect(
+        resolve(
+          isLoadingWallet: true,
+          softwareTermsAccepted: false,
+          resumeLocation: '/kyc',
+        ),
+        isA<BootNavWaitForLoad>(),
+      );
+    });
+
+    test('missing software terms -> home', () {
+      final action = resolve(softwareTermsAccepted: false);
+      expect((action as BootNavGoNamed).routeName, AppRoutes.home);
+    });
+
+    test('no wallet -> welcome', () {
+      final action = resolve(hasWallet: false);
+      expect((action as BootNavGoNamed).routeName, OnboardingRoutes.welcome);
+    });
+
+    test('onboarding not completed -> onboarding completed screen', () {
+      final action = resolve(onboardingCompleted: false);
+      expect((action as BootNavGoNamed).routeName, OnboardingRoutes.completed);
+    });
+
+    test('pin not set up -> setup pin', () {
+      final action = resolve(isPinSetup: false);
+      expect((action as BootNavGoNamed).routeName, PinRoutes.setup);
+    });
+
+    test('pin not verified -> verify pin', () {
+      final action = resolve(isPinVerified: false);
+      expect((action as BootNavGoNamed).routeName, PinRoutes.verify);
+    });
+
+    test('bitbox address recovery needed -> recovery flow', () {
+      final action = resolve(bitboxAddressRecoveryNeeded: true);
+      expect(
+        (action as BootNavGoNamed).routeName,
+        AppRoutes.bitboxAddressRecovery,
+      );
+    });
+
+    test('wallet not loaded -> load wallet', () {
+      expect(resolve(walletLoaded: false), isA<BootNavLoadWallet>());
+    });
+  });
+
+  group('resolveBootNavigation gate precedence over restore (security)', () {
+    test(
+      'an un-verified PIN wins over a pending restore: never bypasses the gate',
+      () {
+        // The router is on the PIN gate and a restorable /kyc is captured, but
+        // isPinVerified is false -> we MUST go to the PIN gate, never restore.
+        final action = resolve(
+          isPinVerified: false,
+          currentLocation: '/verifyPin',
+          resumeLocation: '/kyc',
+        );
+        expect((action as BootNavGoNamed).routeName, PinRoutes.verify);
+      },
+    );
+  });
+
+  group('resolveBootNavigation post-gate landing', () {
+    test('already on a valid non-gate route -> stay put (never yank)', () {
+      // Even with a stale capture present, an active non-gate route is kept.
+      expect(
+        resolve(currentLocation: '/kyc', resumeLocation: '/settings'),
+        isA<BootNavStay>(),
+      );
+    });
+
+    test('on the dashboard steady state -> stay put', () {
+      expect(resolve(currentLocation: '/dashboard'), isA<BootNavStay>());
+    });
+
+    test('core scenario: relocked on the PIN gate, restore the captured /kyc', () {
+      final action = resolve(
+        currentLocation: '/verifyPin',
+        resumeLocation: '/kyc',
+      );
+      expect((action as BootNavRestore).location, '/kyc');
+    });
+
+    test('on a gate route with no capture -> dashboard fallback', () {
+      final action = resolve(currentLocation: '/verifyPin', resumeLocation: null);
+      expect((action as BootNavGoNamed).routeName, AppRoutes.dashboard);
+    });
+
+    test('a gate resume location is NOT restored -> dashboard fallback', () {
+      // The captured route is itself a gate (e.g. /setupPin): restoring it
+      // would be pointless / unsafe, so fall back to the dashboard.
+      final action = resolve(
+        currentLocation: '/verifyPin',
+        resumeLocation: '/setupPin',
+      );
+      expect((action as BootNavGoNamed).routeName, AppRoutes.dashboard);
+    });
+
+    test('restore preserves a resume path that carries a query string', () {
+      final action = resolve(
+        currentLocation: '/verifyPin',
+        resumeLocation: '/transactionHistory?filter=buy',
+      );
+      expect(
+        (action as BootNavRestore).location,
+        '/transactionHistory?filter=buy',
+      );
+    });
+  });
+
+  group('isGateLocation', () {
+    for (final loc in kGateLocations) {
+      test('$loc is a gate', () => expect(isGateLocation(loc), isTrue));
+    }
+
+    test('a non-gate app route is not a gate', () {
+      expect(isGateLocation('/kyc'), isFalse);
+      expect(isGateLocation('/dashboard'), isFalse);
+      expect(isGateLocation('/settings/security'), isFalse);
+    });
+
+    test('a query string does not defeat the gate check', () {
+      expect(isGateLocation('/verifyPin?x=1'), isTrue);
+    });
+
+    test('a query string does not turn a non-gate into a gate', () {
+      expect(isGateLocation('/kyc?context=buy'), isFalse);
+    });
+  });
+}

--- a/test/setup/routing/boot_navigation_test.dart
+++ b/test/setup/routing/boot_navigation_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:realunit_wallet/setup/routing/boot_navigation.dart';
+import 'package:realunit_wallet/setup/routing/router_config.dart';
 import 'package:realunit_wallet/setup/routing/routes/app_routes.dart';
 import 'package:realunit_wallet/setup/routing/routes/onboarding_routes.dart';
 import 'package:realunit_wallet/setup/routing/routes/pin_routes.dart';
@@ -211,6 +213,36 @@ void main() {
 
     test('a query string does not defeat the allowlist match', () {
       expect(isRestorableLocation('/kyc?context=buy'), isTrue);
+    });
+  });
+
+  group('drift pin against the real route table', () {
+    // Both sets duplicate path literals from router_config.dart. A path rename
+    // there would otherwise drift silently: an unrecognized gate strands the
+    // user on the gate screen (BootNavStay instead of the dashboard fallback),
+    // an unrecognized restorable route silently degrades to the dashboard.
+    Set<String> collectPaths(List<RouteBase> routes, String prefix) {
+      final paths = <String>{};
+      for (final route in routes) {
+        var next = prefix;
+        if (route is GoRoute) {
+          next = route.path.startsWith('/')
+              ? route.path
+              : '${prefix == '/' ? '' : prefix}/${route.path}';
+          paths.add(next);
+        }
+        paths.addAll(collectPaths(route.routes, next));
+      }
+      return paths;
+    }
+
+    test('every gate and restorable location is a real route path', () {
+      // Constructing GoRouter never invokes page builders, so walking the real
+      // routerConfig needs neither DI nor pumpWidget.
+      final realPaths = collectPaths(routerConfig.configuration.routes, '');
+
+      expect(gateLocations.difference(realPaths), isEmpty);
+      expect(restorableLocations.difference(realPaths), isEmpty);
     });
   });
 }

--- a/test/setup/routing/boot_navigation_test.dart
+++ b/test/setup/routing/boot_navigation_test.dart
@@ -7,6 +7,11 @@ import 'package:realunit_wallet/setup/routing/routes/onboarding_routes.dart';
 import 'package:realunit_wallet/setup/routing/routes/pin_routes.dart';
 
 void main() {
+  // The drift-pin group below constructs the real global GoRouter; initialize
+  // the test binding up front, matching the repo convention for plain-test
+  // files that touch framework globals.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   // A fully-passed, steady-state input where the user sits on a non-gate route
   // (/kyc). Individual tests flip exactly one field to exercise one branch.
   BootNavAction resolve({
@@ -178,6 +183,14 @@ void main() {
 
     test('a query string does not defeat the gate check', () {
       expect(isGateLocation('/verifyPin?x=1'), isTrue);
+    });
+
+    test('resumeCaptureFor maps gates to null and keeps in-flight routes', () {
+      expect(resumeCaptureFor('/verifyPin'), isNull);
+      expect(resumeCaptureFor('/pinGate'), isNull);
+      expect(resumeCaptureFor('/kyc'), '/kyc');
+      expect(resumeCaptureFor('/kyc?context=buy'), '/kyc?context=buy');
+      expect(resumeCaptureFor(''), '');
     });
 
     test('a query string does not turn a non-gate into a gate', () {

--- a/test/setup/routing/boot_navigation_test.dart
+++ b/test/setup/routing/boot_navigation_test.dart
@@ -136,12 +136,30 @@ void main() {
     test('restore preserves a resume path that carries a query string', () {
       final action = resolve(
         currentLocation: '/verifyPin',
-        resumeLocation: '/transactionHistory?filter=buy',
+        resumeLocation: '/kyc?context=buy',
       );
-      expect(
-        (action as BootNavRestore).location,
-        '/transactionHistory?filter=buy',
+      expect((action as BootNavRestore).location, '/kyc?context=buy');
+    });
+
+    test('an extra-required resume route is NOT restored -> dashboard', () {
+      // `/buyPaymentDetails` rebuilds via `state.extra as BuyPaymentDetailsParams`
+      // (non-nullable): restoring it from a bare path would crash, so it is not
+      // on the allowlist and falls back to the dashboard (fail-closed).
+      final action = resolve(
+        currentLocation: '/verifyPin',
+        resumeLocation: '/buyPaymentDetails',
       );
+      expect((action as BootNavGoNamed).routeName, AppRoutes.dashboard);
+    });
+
+    test('a PIN-gated settings subroute is NOT restored -> dashboard', () {
+      // `/settings/seed` sits behind a secondary PIN gate; exact-path matching
+      // (`/settings/seed` != `/settings`) keeps it off the allowlist.
+      final action = resolve(
+        currentLocation: '/verifyPin',
+        resumeLocation: '/settings/seed',
+      );
+      expect((action as BootNavGoNamed).routeName, AppRoutes.dashboard);
     });
   });
 
@@ -162,6 +180,37 @@ void main() {
 
     test('a query string does not turn a non-gate into a gate', () {
       expect(isGateLocation('/kyc?context=buy'), isFalse);
+    });
+  });
+
+  group('isRestorableLocation', () {
+    for (final loc in kRestorableLocations) {
+      test(
+        '$loc is restorable',
+        () => expect(isRestorableLocation(loc), isTrue),
+      );
+    }
+
+    test('an extra-required route is not restorable', () {
+      expect(isRestorableLocation('/buyPaymentDetails'), isFalse);
+      expect(isRestorableLocation('/sellBitbox'), isFalse);
+      expect(isRestorableLocation('/legalDocument'), isFalse);
+      expect(isRestorableLocation('/webView'), isFalse);
+    });
+
+    test('a PIN-gated / sensitive subroute is not restorable', () {
+      expect(isRestorableLocation('/settings/seed'), isFalse);
+      expect(isRestorableLocation('/settings/security'), isFalse);
+      expect(isRestorableLocation('/settings/security/changePin'), isFalse);
+    });
+
+    test('a gate route is not restorable', () {
+      expect(isRestorableLocation('/verifyPin'), isFalse);
+      expect(isRestorableLocation('/home'), isFalse);
+    });
+
+    test('a query string does not defeat the allowlist match', () {
+      expect(isRestorableLocation('/kyc?context=buy'), isTrue);
     });
   });
 }


### PR DESCRIPTION
## Problem

Starting a KYC flow (e.g. from Buy/Sell) pushes `/kyc` imperatively and builds a
page-scoped `KycCubit`. Leaving the app and coming back then dropped the user on
the **dashboard** instead of the KYC step they were on. The most visible case is
the new confirm-email step: the user opens the confirmation mail, taps the
website's "Back to the app" button (`realunit-wallet://open`), and finds the
dashboard rather than the flow continuing.

## Root cause — three independent paths, one shared blind spot

`routerConfig.routerDelegate.currentConfiguration.uri` does **not** reflect
imperatively pushed routes (go_router 14.x): after `pushNamed('/kyc')` it still
reports the base route underneath (`/dashboard`). Every consumer of that value
judged "where the user is" wrong for pushed flows:

1. **Warm scheme open (any background duration).** The scheme redirect's
   "stay where you were" contract returned that location as a no-op. go_router
   applies a redirect result as a `go`, which **replaces the whole match list**
   — the pushed `/kyc` route was dropped together with its page-scoped cubit,
   its `extra`, and the back stack. Pinned red-first by the new
   `app_link_entry_test.dart` case before the fix landed.
2. **PIN re-lock (>= 5 min background).** `_navigate()` is a boot state machine
   with no notion of the in-flight route; after re-lock + PIN entry it landed on
   `goNamed(dashboard)` unconditionally. Fixed by the capture/restore machinery
   (`resolveBootNavigation`), but the capture initially read the same blind
   source — a pushed `/kyc` was captured as `/dashboard`.
3. **Warm balance emission.** Any `HomeBloc` emission on resume re-ran
   `_navigate()` into the unconditional dashboard branch. Fixed by `BootNavStay`
   (an active non-gate route is never clobbered).

## Fix

- **New pure function** `resolveBootNavigation` + sealed `BootNavAction`
  (`lib/setup/routing/boot_navigation.dart`): the whole gate ladder extracted as
  a `getIt`/`go_router`-free decision, exhaustively unit-tested.
- **Restore allowlist** `restorableLocations` (fail-closed): only routes that
  rebuild from a bare path and sit behind no secondary gate are ever restored;
  everything else falls back to the dashboard. A restore can only be returned by
  the final ladder branch, after the PIN gate has already diverted — **the PIN
  gate is never bypassed.**
- **Push-aware location source** `effectiveLocation(RouteMatchList)`: resolves
  the last `ImperativeRouteMatch` when present. Used by the boot machine's
  `currentLocation`, the background capture in `lifecycle_initializer`, and the
  scheme redirect wiring — a pushed flow is no longer invisible.
- **True no-op for warm scheme opens** — canonical path-less open only: the
  redirect returns `null` for a warm `realunit-wallet://open` so the URL stays
  unmatched, and a new `onException` handler keeps the current configuration
  untouched (go_router skips the delegate update when `onException` is
  installed). This is the only variant that survives pushed routes — returning
  *any* location string would replace the match list. Scheme URLs **carrying a
  path** are rewritten to the canonical path-less open: go_router matches on
  `uri.path` alone, so a crafted `realunit-wallet://open/settings/seed` would
  otherwise match and navigate straight past flow-level gates — and pinning the
  current location instead would rebuild a pushed `extra`-required route
  (`/buyPaymentDetails`, …) with a null `extra` and crash its builder cast. The
  rewritten URL resolves to an unmatched (error) match list and go_router
  short-circuits before any further redirect pass, ending in the same no-op.
  Cold start keeps the existing `/home` handoff. Non-scheme match
  failures now `assert` in debug instead of showing go_router's error screen;
  in release the user stays on the current screen.
- **Restores rebuild the real entry shape**: dashboard as base + the flow
  pushed on top (a bare `go` would strand the restored route as the only match
  — pop-based exits like the KYC "Close" button or the AppBar auto-back would
  be dead). Restoring `/dashboard` itself stays a plain `go`.
- **Capture hygiene**: `PinAuthCubit.onAppHidden(location)` arms the timeout
  once per background episode (`??=`) while the resume location takes the
  freshest non-null value; gate locations are captured as `null` so a nested
  re-lock keeps the earlier in-flight capture; the capture is cleared once
  spent or once a final landing is reached; and an episode that ends
  **without** a re-lock drops its capture eagerly — a much later unrelated
  re-lock can never restore a route from a long-finished episode.

## Known limitation

Restores replay the **path** only, not `state.extra` — for KYC that means the
`kycContext` from Buy/Sell is not restored. Irrelevant for the confirm-email
resume: `checkKyc()` without a context yields the same "email already confirmed
-> advance" path. Extra-requiring routes are excluded from the allowlist
entirely (they would crash on a bare-path rebuild — covered by a premise test).

## Tests

- `test/setup/routing/app_link_entry_test.dart` — the pushed-route scheme-open
  case (red before the fix): pushed page survives the open **and** can still
  pop back to its base route (guards against match-list-replacing "fixes");
  warm crafted-scheme URLs in both forms — host form
  (`realunit-wallet://dashboard`) and path form
  (`realunit-wallet://open/settings`) — do not navigate, including over a
  pushed `extra`-required route (no navigation, no builder-cast crash); all
  existing warm/cold cases unchanged and green.
- `test/setup/routing/boot_navigation_test.dart` — exhaustive table for the
  gate ladder, allowlist, and restore/stay/fallback semantics, plus a drift pin
  asserting every gate/restorable location is a real `router_config` path.
- `test/setup/routing/boot_navigation_apply_test.dart` — the real-router seam:
  re-lock -> PIN -> restore lands on `/kyc` **with the dashboard underneath**
  (canPop + pop back works; `/dashboard` restore stays a plain go); an
  `extra`-required route falls back to the dashboard without throwing (plus the
  premise guard that it really throws); `effectiveLocation` reports the pushed
  route where the raw uri stays on the base.
- `test/screens/pin/pin_auth_cubit_test.dart` — capture semantics with a fake
  clock: freshest-non-null capture, gate-capture keeps the in-flight route,
  eager clear when an episode ends without a re-lock vs. kept while the PIN
  gate is showing, peek/clear/reset.
- `test/setup/lifecycle_initializer_test.dart` — lock/idempotency behaviour
  with the new capture signature.

`flutter analyze` -> no issues in changed code. kyc/pin/home golden suites
unchanged (no UI change).
