### PR TITLE
feat(kyc): drive the legal-disclaimer gate from the API

### DIFF
--- a/lib/packages/service/dfx/models/legal/dto/real_unit_legal_agreement_status_dto.dart
+++ b/lib/packages/service/dfx/models/legal/dto/real_unit_legal_agreement_status_dto.dart
@@ -1,0 +1,28 @@
+import 'package:realunit_wallet/packages/service/dfx/models/legal/real_unit_legal_agreement.dart';
+
+/// Per-agreement acceptance status as reported by `GET /v1/realunit/legal`.
+/// `accepted` is the API's own verdict (current version vs. accepted version) —
+/// the app renders it 1:1 and never re-derives it from the version fields. The
+/// version fields are carried for completeness/display only.
+class RealUnitLegalAgreementStatusDto {
+  final RealUnitLegalAgreement agreement;
+  final String currentVersion;
+  final String? acceptedVersion;
+  final bool accepted;
+
+  const RealUnitLegalAgreementStatusDto({
+    required this.agreement,
+    required this.currentVersion,
+    this.acceptedVersion,
+    required this.accepted,
+  });
+
+  factory RealUnitLegalAgreementStatusDto.fromJson(Map<String, dynamic> json) {
+    return RealUnitLegalAgreementStatusDto(
+      agreement: RealUnitLegalAgreementExtension.fromValue(json['agreement'] as String),
+      currentVersion: json['currentVersion'] as String,
+      acceptedVersion: json['acceptedVersion'] as String?,
+      accepted: json['accepted'] as bool,
+    );
+  }
+}

--- a/lib/packages/service/dfx/models/legal/dto/real_unit_legal_info_dto.dart
+++ b/lib/packages/service/dfx/models/legal/dto/real_unit_legal_info_dto.dart
@@ -1,0 +1,31 @@
+import 'package:realunit_wallet/packages/service/dfx/models/legal/dto/real_unit_legal_agreement_status_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal/real_unit_legal_agreement.dart';
+
+/// Server-side legal-acceptance state for the current wallet, returned by both
+/// `GET` and `PUT /v1/realunit/legal`. `allAccepted` is the authoritative gate
+/// for the legal disclaimer in `KycCubit` — see CONTRIBUTING.md "API as
+/// Decision Authority".
+class RealUnitLegalInfoDto {
+  final List<RealUnitLegalAgreementStatusDto> agreements;
+  final bool allAccepted;
+
+  const RealUnitLegalInfoDto({
+    required this.agreements,
+    required this.allAccepted,
+  });
+
+  /// The agreements the user has not yet accepted at the current version.
+  /// Forwarded verbatim to `PUT /v1/realunit/legal` so the app records exactly
+  /// what the server still needs.
+  List<RealUnitLegalAgreement> get outstandingAgreements =>
+      agreements.where((a) => !a.accepted).map((a) => a.agreement).toList();
+
+  factory RealUnitLegalInfoDto.fromJson(Map<String, dynamic> json) {
+    return RealUnitLegalInfoDto(
+      agreements: (json['agreements'] as List<dynamic>)
+          .map((e) => RealUnitLegalAgreementStatusDto.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      allAccepted: json['allAccepted'] as bool,
+    );
+  }
+}

--- a/lib/packages/service/dfx/models/legal/real_unit_legal_agreement.dart
+++ b/lib/packages/service/dfx/models/legal/real_unit_legal_agreement.dart
@@ -1,0 +1,51 @@
+/// Mirror of the server-side `RealUnitLegalAgreement` enum on
+/// `GET`/`PUT /v1/realunit/legal`. The API owns which agreements exist and
+/// which are still outstanding for a wallet; the app forwards them 1:1 — see
+/// CONTRIBUTING.md "API as Decision Authority". Mirrors the `.value` /
+/// `fromValue` shape of `KycStepName` in `models/kyc/kyc_level.dart`.
+enum RealUnitLegalAgreement {
+  residenceConfirmation,
+  taxDomicileSelfCertification,
+  realUnitPrivacyPolicy,
+  realUnitRegistrationAgreement,
+  aktionariatTermsOfService,
+  dfxTermsAndConditions,
+}
+
+extension RealUnitLegalAgreementExtension on RealUnitLegalAgreement {
+  String get value {
+    switch (this) {
+      case RealUnitLegalAgreement.residenceConfirmation:
+        return 'ResidenceConfirmation';
+      case RealUnitLegalAgreement.taxDomicileSelfCertification:
+        return 'TaxDomicileSelfCertification';
+      case RealUnitLegalAgreement.realUnitPrivacyPolicy:
+        return 'RealUnitPrivacyPolicy';
+      case RealUnitLegalAgreement.realUnitRegistrationAgreement:
+        return 'RealUnitRegistrationAgreement';
+      case RealUnitLegalAgreement.aktionariatTermsOfService:
+        return 'AktionariatTermsOfService';
+      case RealUnitLegalAgreement.dfxTermsAndConditions:
+        return 'DfxTermsAndConditions';
+    }
+  }
+
+  static RealUnitLegalAgreement fromValue(String value) {
+    switch (value) {
+      case 'ResidenceConfirmation':
+        return RealUnitLegalAgreement.residenceConfirmation;
+      case 'TaxDomicileSelfCertification':
+        return RealUnitLegalAgreement.taxDomicileSelfCertification;
+      case 'RealUnitPrivacyPolicy':
+        return RealUnitLegalAgreement.realUnitPrivacyPolicy;
+      case 'RealUnitRegistrationAgreement':
+        return RealUnitLegalAgreement.realUnitRegistrationAgreement;
+      case 'AktionariatTermsOfService':
+        return RealUnitLegalAgreement.aktionariatTermsOfService;
+      case 'DfxTermsAndConditions':
+        return RealUnitLegalAgreement.dfxTermsAndConditions;
+      default:
+        throw ArgumentError('Unknown RealUnitLegalAgreement value: $value');
+    }
+  }
+}

--- a/lib/packages/service/dfx/real_unit_legal_service.dart
+++ b/lib/packages/service/dfx/real_unit_legal_service.dart
@@ -1,0 +1,54 @@
+import 'dart:convert';
+
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal/dto/real_unit_legal_info_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal/real_unit_legal_agreement.dart';
+
+class RealUnitLegalService extends DFXAuthService {
+  RealUnitLegalService(super.appStore, super.walletService);
+
+  static const _legalPath = '/v1/realunit/legal';
+
+  /// Fetches the API-side legal-acceptance state for the current wallet. The
+  /// backend owns which agreements exist, their current version, and whether
+  /// each is already accepted; the disclaimer gate in `KycCubit` renders
+  /// `allAccepted` 1:1 instead of a local session flag — see CONTRIBUTING.md
+  /// "API as Decision Authority".
+  Future<RealUnitLegalInfoDto> getLegalInfo() async {
+    final uri = buildUri(host, _legalPath);
+    final response = await authenticatedGet(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+    );
+
+    if (response.statusCode != 200) {
+      final errorJson = jsonDecode(response.body) as Map<String, dynamic>;
+      throw ApiException.fromJson(errorJson, httpStatusCode: response.statusCode);
+    }
+
+    return RealUnitLegalInfoDto.fromJson(jsonDecode(response.body));
+  }
+
+  /// Durably records acceptance of [agreements] for the current wallet. The
+  /// backend stamps the current version and returns the refreshed info; the
+  /// call is idempotent.
+  Future<RealUnitLegalInfoDto> acceptLegal(List<RealUnitLegalAgreement> agreements) async {
+    final uri = buildUri(host, _legalPath);
+    final response = await authenticatedPut(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'agreements': agreements.map((a) => a.value).toList(),
+      }),
+    );
+
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      final errorJson = jsonDecode(response.body) as Map<String, dynamic>;
+      throw ApiException.fromJson(errorJson, httpStatusCode: response.statusCode);
+    }
+
+    return RealUnitLegalInfoDto.fromJson(jsonDecode(response.body));
+  }
+}

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -8,9 +8,11 @@ import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_level_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal/real_unit_legal_agreement.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/user/dto/real_unit_user_data_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/user/dto/user_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_registration_state.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_legal_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 
@@ -21,11 +23,24 @@ class KycCubit extends Cubit<KycState> {
 
   final DfxKycService _kycService;
   final RealUnitRegistrationService _registrationService;
+  final RealUnitLegalService _legalService;
   final AppStore _appStore;
 
+  /// Offline fallback ONLY. The legal disclaimer gate is server-driven via
+  /// `_legalService.getLegalInfo()`; this per-session flag is used solely when
+  /// that endpoint is unreachable (pre-rollout backend or outage) so the
+  /// disclaimer is not re-shown for the rest of the session — see the gate in
+  /// `_runCheckKyc` and CONTRIBUTING.md "API as Decision Authority" (legacy
+  /// tolerance).
   bool _legalDisclaimerAccepted = false;
   bool _emailRegistrationAttempted = false;
   String? _kycContext;
+
+  /// Agreements the server last reported as outstanding, remembered so
+  /// `acceptLegalDisclaimer` records exactly those on `PUT /v1/realunit/legal`.
+  /// `null` until the first successful `getLegalInfo()` — the accept path then
+  /// falls back to all agreements.
+  List<RealUnitLegalAgreement>? _outstandingLegalAgreements;
 
   // `Future.timeout` does not cancel the underlying work, so a late HTTP
   // response from an earlier call can still resume and emit state after a
@@ -37,9 +52,11 @@ class KycCubit extends Cubit<KycState> {
   KycCubit(
     DfxKycService kycService,
     RealUnitRegistrationService registrationService,
+    RealUnitLegalService legalService,
     AppStore appStore,
   ) : _kycService = kycService,
       _registrationService = registrationService,
+      _legalService = legalService,
       _appStore = appStore,
       super(const KycInitial());
 
@@ -94,11 +111,26 @@ class KycCubit extends Cubit<KycState> {
         return;
       }
 
-      // Disclaimer is a local session gate that must precede every sensitive
-      // call. It does not encode business routing — the API does — it just
-      // enforces a per-session ceremony on this device before the cubit
-      // forwards anything that requires a signed user identity.
-      if (!_legalDisclaimerAccepted) {
+      // The legal disclaimer gate is server-driven: the API is the single
+      // source of truth for whether this user still has outstanding agreements
+      // to accept — see CONTRIBUTING.md "API as Decision Authority". A 404 means
+      // the `/legal` endpoint is not deployed yet (pre-rollout backend): fall
+      // back to the local per-session `_legalDisclaimerAccepted` ceremony
+      // (legacy tolerance, mirrors the `emailConfirmed` gate below). Any OTHER
+      // error must fail closed on this compliance gate — rethrow so it surfaces
+      // as a KycFailure instead of silently letting the user past the disclaimer.
+      bool showDisclaimer;
+      try {
+        final legalInfo = await _legalService.getLegalInfo();
+        if (isClosed || generation != _runGeneration) return;
+        showDisclaimer = !legalInfo.allAccepted;
+        _outstandingLegalAgreements = legalInfo.outstandingAgreements;
+      } on ApiException catch (e) {
+        if (isClosed || generation != _runGeneration) return;
+        if (e.statusCode != 404) rethrow;
+        showDisclaimer = !_legalDisclaimerAccepted;
+      }
+      if (showDisclaimer) {
         emit(const KycSuccess(currentStep: KycStep.legalDisclaimer));
         return;
       }
@@ -238,8 +270,23 @@ class KycCubit extends Cubit<KycState> {
     }
   }
 
-  void markLegalDisclaimerAccepted() {
+  /// Records acceptance of the legal disclaimer. Sets the local per-session
+  /// flag first as the offline fallback (so the disclaimer is not re-shown this
+  /// session even if the backend is unreachable), then durably records
+  /// acceptance server-side via `PUT /v1/realunit/legal` for whatever the
+  /// server last reported as outstanding (all agreements when we never got a
+  /// successful `getLegalInfo()`). The server round-trip is best-effort: an
+  /// error is swallowed because the local flag already unblocks the session and
+  /// the following `checkKyc()` re-reads the authoritative server state, which
+  /// then drives the next routing decision.
+  Future<void> acceptLegalDisclaimer() async {
     _legalDisclaimerAccepted = true;
+    try {
+      await _legalService.acceptLegal(
+        _outstandingLegalAgreements ?? RealUnitLegalAgreement.values,
+      );
+    } catch (_) {}
+    await checkKyc();
   }
 
   /// should only be called after realunit registration was completed

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -271,21 +271,29 @@ class KycCubit extends Cubit<KycState> {
   }
 
   /// Records acceptance of the legal disclaimer. Sets the local per-session
-  /// flag first as the offline fallback (so the disclaimer is not re-shown this
-  /// session even if the backend is unreachable), then durably records
-  /// acceptance server-side via `PUT /v1/realunit/legal` for whatever the
-  /// server last reported as outstanding (all agreements when we never got a
-  /// successful `getLegalInfo()`). The server round-trip is best-effort: an
-  /// error is swallowed because the local flag already unblocks the session and
-  /// the following `checkKyc()` re-reads the authoritative server state, which
-  /// then drives the next routing decision.
+  /// flag first (the offline fallback for a pre-rollout backend), then durably
+  /// records acceptance server-side via `PUT /v1/realunit/legal` for whatever
+  /// the server last reported as outstanding (all agreements when we never got
+  /// a successful `getLegalInfo()`). A 404 (endpoint not deployed yet) is
+  /// tolerated — the local flag carries the session; any other PUT failure
+  /// surfaces as `KycFailure` rather than being swallowed into a silent
+  /// re-prompt loop. On success the following `checkKyc()` re-reads the
+  /// authoritative server state, which drives the next routing decision.
   Future<void> acceptLegalDisclaimer() async {
     _legalDisclaimerAccepted = true;
     try {
       await _legalService.acceptLegal(
         _outstandingLegalAgreements ?? RealUnitLegalAgreement.values,
       );
-    } catch (_) {}
+    } on ApiException catch (e) {
+      if (e.statusCode != 404) {
+        emit(KycFailure(e.toString()));
+        return;
+      }
+    } catch (e) {
+      emit(KycFailure(e.toString()));
+      return;
+    }
     await checkKyc();
   }
 

--- a/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
+++ b/lib/screens/kyc/cubits/kyc/kyc_cubit.dart
@@ -286,11 +286,13 @@ class KycCubit extends Cubit<KycState> {
         _outstandingLegalAgreements ?? RealUnitLegalAgreement.values,
       );
     } on ApiException catch (e) {
+      if (isClosed) return;
       if (e.statusCode != 404) {
         emit(KycFailure(e.toString()));
         return;
       }
     } catch (e) {
+      if (isClosed) return;
       emit(KycFailure(e.toString()));
       return;
     }

--- a/lib/screens/kyc/kyc_page_manager.dart
+++ b/lib/screens/kyc/kyc_page_manager.dart
@@ -4,6 +4,7 @@ import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/app_store.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_kyc_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_legal_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
 import 'package:realunit_wallet/screens/kyc/cubits/kyc/kyc_cubit.dart';
 import 'package:realunit_wallet/screens/kyc/steps/2fa/kyc_2fa_page.dart';
@@ -35,6 +36,7 @@ class KycPageManager extends StatelessWidget {
       create: (_) => KycCubit(
         getIt<DfxKycService>(),
         getIt<RealUnitRegistrationService>(),
+        getIt<RealUnitLegalService>(),
         getIt<AppStore>(),
       )..checkKyc(context: kycContext),
       child: const KycViewManager(),
@@ -65,8 +67,9 @@ class KycViewManager extends StatelessWidget {
             KycStep.confirmEmail => const KycConfirmEmailPage(),
             KycStep.legalDisclaimer => LegalDisclaimerPage(
               onCompleted: () {
-                context.read<KycCubit>().markLegalDisclaimerAccepted();
-                context.read<KycCubit>().checkKyc();
+                // Records acceptance server-side and re-runs `checkKyc()`
+                // internally, so the API drives the next routing decision.
+                context.read<KycCubit>().acceptLegalDisclaimer();
               },
             ),
             KycStep.registration => KycRegistrationPage(initialUserData: realUnitUserData),

--- a/lib/setup/di.dart
+++ b/lib/setup/di.dart
@@ -30,6 +30,7 @@ import 'package:realunit_wallet/packages/service/dfx/dfx_support_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_account_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_service.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_legal_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_pdf_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_sell_payment_info_service.dart';
@@ -180,6 +181,9 @@ void setupServices() {
   getIt.registerFactory(() => RealUnitAccountService(getIt<AppStore>()));
   getIt.registerFactory(
     () => RealUnitBuyPaymentInfoService(getIt<AppStore>(), getIt<WalletService>()),
+  );
+  getIt.registerFactory(
+    () => RealUnitLegalService(getIt<AppStore>(), getIt<WalletService>()),
   );
   getIt.registerFactory(
     () => RealUnitPdfService(getIt<AppStore>(), getIt<WalletService>()),

--- a/test/packages/service/dfx/real_unit_legal_service_test.dart
+++ b/test/packages/service/dfx/real_unit_legal_service_test.dart
@@ -1,0 +1,171 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:realunit_wallet/packages/config/api_config.dart';
+import 'package:realunit_wallet/packages/config/network_mode.dart';
+import 'package:realunit_wallet/packages/repository/cache_repository.dart';
+import 'package:realunit_wallet/packages/service/app_store.dart';
+import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal/real_unit_legal_agreement.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_legal_service.dart';
+import 'package:realunit_wallet/packages/service/session_cache.dart';
+import 'package:realunit_wallet/packages/service/wallet_service.dart';
+import 'package:realunit_wallet/packages/wallet/wallet.dart';
+import 'package:realunit_wallet/packages/wallet/wallet_account.dart';
+
+class _MockAppStore extends Mock implements AppStore {}
+
+class _MockWallet extends Mock implements AWallet {}
+
+class _MockAccount extends Mock implements AWalletAccount {}
+
+class _MockCacheRepository extends Mock implements CacheRepository {}
+
+class _MockWalletService extends Mock implements WalletService {}
+
+void main() {
+  late _MockAppStore appStore;
+  late _MockWallet wallet;
+  late _MockAccount account;
+  late _MockWalletService walletService;
+  late SessionCache session;
+
+  setUp(() {
+    appStore = _MockAppStore();
+    wallet = _MockWallet();
+    account = _MockAccount();
+    walletService = _MockWalletService();
+    session = SessionCache(_MockCacheRepository());
+    session.setAuthToken('jwt-1');
+
+    when(() => appStore.apiConfig).thenReturn(const ApiConfig(networkMode: NetworkMode.mainnet));
+    when(() => appStore.sessionCache).thenReturn(session);
+    when(() => appStore.wallet).thenReturn(wallet);
+    when(() => wallet.primaryAccount).thenReturn(account);
+    when(() => walletService.ensureCurrentWalletUnlocked()).thenAnswer((_) async {});
+    when(() => walletService.lockCurrentWallet()).thenAnswer((_) async {});
+  });
+
+  RealUnitLegalService build(http.Client client) {
+    when(() => appStore.httpClient).thenReturn(client);
+    return RealUnitLegalService(appStore, walletService);
+  }
+
+  // The per-service wiring (401-retry etc.) is covered in dfx_auth_service_test;
+  // the "Bearer JWT" assertion below proves the call routes through the
+  // authenticated client.
+  group('$RealUnitLegalService.getLegalInfo', () {
+    test('GETs /v1/realunit/legal with the Bearer JWT and parses the info', () async {
+      String? path;
+      String? method;
+      String? auth;
+      final client = MockClient((request) async {
+        path = request.url.path;
+        method = request.method;
+        auth = request.headers['Authorization'];
+        return http.Response(
+          jsonEncode({
+            'agreements': [
+              {
+                'agreement': 'DfxTermsAndConditions',
+                'currentVersion': '20260712',
+                'acceptedVersion': '20260712',
+                'accepted': true,
+              },
+              {
+                'agreement': 'ResidenceConfirmation',
+                'currentVersion': '20260712',
+                'acceptedVersion': null,
+                'accepted': false,
+              },
+            ],
+            'allAccepted': false,
+          }),
+          200,
+        );
+      });
+
+      final info = await build(client).getLegalInfo();
+
+      expect(method, 'GET');
+      expect(path, '/v1/realunit/legal');
+      expect(auth, 'Bearer jwt-1');
+      expect(info.allAccepted, isFalse);
+      expect(info.agreements, hasLength(2));
+      // Only the not-yet-accepted agreement is outstanding.
+      expect(info.outstandingAgreements, [RealUnitLegalAgreement.residenceConfirmation]);
+    });
+
+    test('throws ApiException on a non-200 response', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'statusCode': 500, 'code': 'SERVER_ERROR', 'message': 'boom'}),
+          500,
+        ),
+      );
+
+      expect(() => build(client).getLegalInfo(), throwsA(isA<ApiException>()));
+    });
+  });
+
+  group('$RealUnitLegalService.acceptLegal', () {
+    test('PUTs /v1/realunit/legal with the agreement values and parses the info', () async {
+      String? path;
+      String? method;
+      String? auth;
+      Map<String, dynamic>? body;
+      final client = MockClient((request) async {
+        path = request.url.path;
+        method = request.method;
+        auth = request.headers['Authorization'];
+        body = jsonDecode(request.body) as Map<String, dynamic>;
+        return http.Response(
+          jsonEncode({'agreements': <dynamic>[], 'allAccepted': true}),
+          200,
+        );
+      });
+
+      final info = await build(client).acceptLegal([
+        RealUnitLegalAgreement.dfxTermsAndConditions,
+        RealUnitLegalAgreement.residenceConfirmation,
+      ]);
+
+      expect(method, 'PUT');
+      expect(path, '/v1/realunit/legal');
+      expect(auth, 'Bearer jwt-1');
+      // The PascalCase server values go on the wire, in order.
+      expect(body!['agreements'], ['DfxTermsAndConditions', 'ResidenceConfirmation']);
+      expect(info.allAccepted, isTrue);
+    });
+
+    test('accepts a 201 Created response as success', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'agreements': <dynamic>[], 'allAccepted': true}),
+          201,
+        ),
+      );
+
+      final info = await build(client).acceptLegal([RealUnitLegalAgreement.dfxTermsAndConditions]);
+
+      expect(info.allAccepted, isTrue);
+    });
+
+    test('throws ApiException on a non-2xx response', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'statusCode': 400, 'code': 'BAD', 'message': 'nope'}),
+          400,
+        ),
+      );
+
+      expect(
+        () => build(client).acceptLegal([RealUnitLegalAgreement.dfxTermsAndConditions]),
+        throwsA(isA<ApiException>()),
+      );
+    });
+  });
+}

--- a/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
+++ b/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
@@ -11,12 +11,16 @@ import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_level_dt
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_session_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_step_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal/dto/real_unit_legal_agreement_status_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal/dto/real_unit_legal_info_dto.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal/real_unit_legal_agreement.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/registration_email_status.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/registration/kyc/kyc_personal_data.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/user/dto/real_unit_user_data_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/user/dto/user_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_registration_info_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_registration_state.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_legal_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/screens/kyc/cubits/kyc/kyc_cubit.dart';
@@ -24,6 +28,8 @@ import 'package:realunit_wallet/screens/kyc/cubits/kyc/kyc_cubit.dart';
 class _MockDfxKycService extends Mock implements DfxKycService {}
 
 class _MockRealUnitRegistrationService extends Mock implements RealUnitRegistrationService {}
+
+class _MockRealUnitLegalService extends Mock implements RealUnitLegalService {}
 
 class _MockAppStore extends Mock implements AppStore {}
 
@@ -98,6 +104,20 @@ RealUnitRegistrationInfoDto _walletStatus(
   emailConfirmed: emailConfirmed,
 );
 
+// Single-agreement legal info. `allAccepted:false` leaves the one agreement
+// outstanding (so `outstandingAgreements` == [residenceConfirmation]).
+RealUnitLegalInfoDto _legalInfo({bool allAccepted = true}) => RealUnitLegalInfoDto(
+  agreements: [
+    RealUnitLegalAgreementStatusDto(
+      agreement: RealUnitLegalAgreement.residenceConfirmation,
+      currentVersion: '20260712',
+      acceptedVersion: allAccepted ? '20260712' : null,
+      accepted: allAccepted,
+    ),
+  ],
+  allAccepted: allAccepted,
+);
+
 const _kycPersonalData = KycPersonalData(
   accountType: KycAccountType.personal,
   firstName: 'Ada',
@@ -125,12 +145,18 @@ const _fixtureUserData = RealUnitUserDataDto(
 void main() {
   late DfxKycService kycService;
   late RealUnitRegistrationService registrationService;
+  late RealUnitLegalService legalService;
   late AppStore appStore;
   late AWallet wallet;
+
+  setUpAll(() {
+    registerFallbackValue(<RealUnitLegalAgreement>[]);
+  });
 
   setUp(() {
     kycService = _MockDfxKycService();
     registrationService = _MockRealUnitRegistrationService();
+    legalService = _MockRealUnitLegalService();
     appStore = _MockAppStore();
     wallet = _MockAWallet();
     when(() => appStore.wallet).thenReturn(wallet);
@@ -142,9 +168,13 @@ void main() {
     when(() => registrationService.getRegistrationInfo()).thenAnswer(
       (_) async => _walletStatus(RealUnitRegistrationState.alreadyRegistered),
     );
+    // Default: the server reports all legal agreements accepted, so the
+    // disclaimer gate passes and tests exercise downstream routing. Tests that
+    // exercise the gate itself override this per-test.
+    when(() => legalService.getLegalInfo()).thenAnswer((_) async => _legalInfo());
   });
 
-  KycCubit buildCubit() => KycCubit(kycService, registrationService, appStore);
+  KycCubit buildCubit() => KycCubit(kycService, registrationService, legalService, appStore);
 
   group('$KycCubit checkKyc', () {
     blocTest<KycCubit, KycState>(
@@ -185,11 +215,39 @@ void main() {
       },
     );
 
+    // Legal disclaimer gate is server-driven: the API is the single source of
+    // truth for whether outstanding agreements remain. `allAccepted:false`
+    // routes to the disclaimer step.
     blocTest<KycCubit, KycState>(
-      'emits KycSuccess(legalDisclaimer) when disclaimer not yet accepted',
+      'emits KycSuccess(legalDisclaimer) when the server reports outstanding agreements',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
           (_) async => _kycStatus(level: KycLevel.level20),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+        when(() => legalService.getLegalInfo()).thenAnswer(
+          (_) async => _legalInfo(allAccepted: false),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.checkKyc(),
+      expect: () => [
+        const KycLoading(),
+        const KycSuccess(currentStep: KycStep.legalDisclaimer),
+      ],
+    );
+
+    // `allAccepted:true` (default stub) passes the gate without ever showing
+    // the disclaimer — the once-per-session ceremony is gone; the server
+    // decides.
+    blocTest<KycCubit, KycState>(
+      'proceeds past the disclaimer gate when the server reports allAccepted',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(
+            level: KycLevel.level50,
+            processStatus: KycProcessStatus.completed,
+          ),
         );
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
@@ -197,7 +255,53 @@ void main() {
       act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
+        const KycCompleted(),
+      ],
+    );
+
+    // Legacy tolerance (mirrors the `emailConfirmed` gate): a 404 means the
+    // legal endpoint is not deployed yet (pre-rollout backend), so the gate
+    // falls back to the local per-session flag. With nothing accepted yet the
+    // flag is `false`, so the disclaimer is shown — identical to the previous
+    // behaviour.
+    blocTest<KycCubit, KycState>(
+      'falls back to the local session gate (shows disclaimer) when getLegalInfo returns 404',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(level: KycLevel.level20),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+        when(() => legalService.getLegalInfo()).thenThrow(
+          const ApiException(statusCode: 404, code: 'NOT_FOUND', message: ''),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.checkKyc(),
+      expect: () => [
+        const KycLoading(),
         const KycSuccess(currentStep: KycStep.legalDisclaimer),
+      ],
+    );
+
+    // Fail closed: any non-404 error on the compliance gate must surface as a
+    // KycFailure — never silently degrade to the local flag (no silent fallback
+    // on a legal gate).
+    blocTest<KycCubit, KycState>(
+      'emits KycFailure when getLegalInfo fails with a non-404 error',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(level: KycLevel.level20),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+        when(() => legalService.getLegalInfo()).thenThrow(
+          const ApiException(statusCode: 500, code: 'SERVER_ERROR', message: 'boom'),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.checkKyc(),
+      expect: () => [
+        const KycLoading(),
+        isA<KycFailure>(),
       ],
     );
 
@@ -221,10 +325,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycSuccess(
@@ -246,10 +347,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycSuccess(currentStep: KycStep.registration),
@@ -271,10 +369,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycSuccess(
@@ -306,10 +401,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycSignatureUnsupportedFailure(),
@@ -332,10 +424,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycSignatureUnsupportedFailure(),
@@ -359,10 +448,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycCompleted(),
@@ -391,10 +477,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycSuccess(currentStep: KycStep.confirmEmail),
@@ -419,10 +502,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycCompleted(),
@@ -448,10 +528,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycCompleted(),
@@ -478,10 +555,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycSuccess(
@@ -507,10 +581,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         isA<KycFailure>(),
@@ -534,10 +605,7 @@ void main() {
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycAccountMergeRequested(),
@@ -559,10 +627,7 @@ void main() {
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [const KycLoading(), const KycCompleted()],
     );
 
@@ -578,10 +643,7 @@ void main() {
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [const KycLoading(), const KycMergeProcessing()],
     );
 
@@ -600,10 +662,7 @@ void main() {
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [const KycLoading(), const KycPending(KycStep.ident)],
     );
 
@@ -625,10 +684,7 @@ void main() {
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycUnsupportedStepFailure(null),
@@ -658,10 +714,7 @@ void main() {
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycUnsupportedStepFailure(KycStepName.additionalDocuments),
@@ -683,10 +736,7 @@ void main() {
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [const KycLoading(), const KycPending(KycStep.dfxApproval)],
     );
 
@@ -712,10 +762,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycSuccess(
@@ -744,10 +791,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycUnsupportedStepFailure(KycStepName.personalData),
@@ -776,10 +820,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
         const KycUnsupportedStepFailure(null),
@@ -798,10 +839,7 @@ void main() {
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [const KycLoading(), isA<KycFailure>()],
     );
 
@@ -822,10 +860,7 @@ void main() {
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       verify: (cubit) {
         final state = cubit.state as KycFailure;
         expect(state.message, 'KYC terminated');
@@ -836,8 +871,12 @@ void main() {
       ],
     );
 
+    // Previously a returning user was always re-shown the disclaimer (the flag
+    // reset on every cubit construction). Now the server drives the gate: an
+    // already-accepted returning user (`allAccepted:true`, the default stub)
+    // skips the disclaimer entirely and lands on completed.
     blocTest<KycCubit, KycState>(
-      'returning user at completed processStatus still routes through the disclaimer first',
+      'returning user with all agreements accepted skips the disclaimer and lands on completed',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
           (_) async => _kycStatus(
@@ -848,12 +887,10 @@ void main() {
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
       },
       build: buildCubit,
-      act: (cubit) async {
-        await cubit.checkKyc();
-      },
+      act: (cubit) => cubit.checkKyc(),
       expect: () => [
         const KycLoading(),
-        const KycSuccess(currentStep: KycStep.legalDisclaimer),
+        const KycCompleted(),
       ],
     );
 
@@ -996,8 +1033,9 @@ void main() {
         });
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
 
-        final cubit = KycCubit(kycService, registrationService, appStore)
-          ..markLegalDisclaimerAccepted();
+        // Server reports all agreements accepted (default stub), so the
+        // disclaimer gate passes and both runs reach the completed state.
+        final cubit = KycCubit(kycService, registrationService, legalService, appStore);
 
         final states = <KycState>[];
         final sub = cubit.stream.listen(states.add);
@@ -1089,10 +1127,7 @@ void main() {
         );
       },
       build: buildCubit,
-      act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc(context: 'RealunitBuy');
-      },
+      act: (cubit) => cubit.checkKyc(context: 'RealunitBuy'),
       expect: () => [
         const KycLoading(),
         const KycSuccess(
@@ -1119,7 +1154,6 @@ void main() {
       },
       build: buildCubit,
       act: (cubit) async {
-        cubit.markLegalDisclaimerAccepted();
         // First call sets the context.
         await cubit.checkKyc(context: 'RealunitBuy');
         // Second call omits context — should reuse 'RealunitBuy'.
@@ -1137,9 +1171,13 @@ void main() {
     );
   });
 
-  group('$KycCubit markLegalDisclaimerAccepted', () {
+  group('$KycCubit acceptLegalDisclaimer', () {
+    // Happy path: the user accepts on the disclaimer page. `acceptLegalDisclaimer`
+    // records acceptance server-side (`acceptLegal` with the outstanding
+    // agreements), then re-runs `checkKyc()`; the server now reports
+    // `allAccepted`, so the gate passes and the API drives the next routing.
     blocTest<KycCubit, KycState>(
-      'progresses through disclaimer gate and lets API drive the next routing decision',
+      'records acceptance server-side, then re-checks and lets the API drive the next routing decision',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
           (_) async => _kycStatus(
@@ -1148,12 +1186,56 @@ void main() {
           ),
         );
         when(() => kycService.getUser()).thenAnswer((_) async => _user());
+        // Outstanding before acceptance, all-accepted afterwards — mirrors the
+        // server stamping the version on PUT.
+        var accepted = false;
+        when(() => legalService.getLegalInfo()).thenAnswer(
+          (_) async => accepted ? _legalInfo() : _legalInfo(allAccepted: false),
+        );
+        when(() => legalService.acceptLegal(any())).thenAnswer((_) async {
+          accepted = true;
+          return _legalInfo();
+        });
       },
       build: buildCubit,
       act: (cubit) async {
-        await cubit.checkKyc(); // expects legalDisclaimer
-        cubit.markLegalDisclaimerAccepted();
-        await cubit.checkKyc(); // expects KycCompleted (AlreadyRegistered + processStatus=Completed)
+        await cubit.checkKyc(); // outstanding -> disclaimer
+        await cubit.acceptLegalDisclaimer(); // records + re-checks -> completed
+      },
+      expect: () => [
+        const KycLoading(),
+        const KycSuccess(currentStep: KycStep.legalDisclaimer),
+        const KycLoading(),
+        const KycCompleted(),
+      ],
+      verify: (_) {
+        verify(() => legalService.acceptLegal(any())).called(1);
+      },
+    );
+
+    // Offline path: both the acceptance PUT and the subsequent GET fail. The
+    // local per-session flag (set to true inside `acceptLegalDisclaimer`) then
+    // carries the session so the re-check passes the gate — the server error is
+    // swallowed and never surfaces to the user.
+    blocTest<KycCubit, KycState>(
+      'falls back to the local session flag when the server round-trip fails',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(
+            level: KycLevel.level50,
+            processStatus: KycProcessStatus.completed,
+          ),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+        when(() => legalService.getLegalInfo()).thenThrow(
+          const ApiException(statusCode: 404, code: 'NOT_FOUND', message: ''),
+        );
+        when(() => legalService.acceptLegal(any())).thenThrow(Exception('legal endpoint down'));
+      },
+      build: buildCubit,
+      act: (cubit) async {
+        await cubit.checkKyc(); // gate falls back to local flag (false) -> disclaimer
+        await cubit.acceptLegalDisclaimer(); // sets local flag -> re-check passes -> completed
       },
       expect: () => [
         const KycLoading(),

--- a/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
+++ b/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
@@ -1000,10 +1000,7 @@ void main() {
           );
         },
         build: buildCubit,
-        act: (cubit) async {
-          cubit.markLegalDisclaimerAccepted();
-          await cubit.checkKyc();
-        },
+        act: (cubit) => cubit.checkKyc(),
         expect: () => [
           const KycLoading(),
           KycSuccess(currentStep: expected, urlOrToken: 'https://example.com/step'),
@@ -1213,12 +1210,12 @@ void main() {
       },
     );
 
-    // Offline path: both the acceptance PUT and the subsequent GET fail. The
-    // local per-session flag (set to true inside `acceptLegalDisclaimer`) then
-    // carries the session so the re-check passes the gate — the server error is
-    // swallowed and never surfaces to the user.
+    // Pre-rollout path: both the acceptance PUT and the subsequent GET return
+    // 404 (endpoint not deployed). The local per-session flag (set inside
+    // `acceptLegalDisclaimer`) carries the session so the re-check passes the
+    // gate — the tolerated 404 never surfaces to the user.
     blocTest<KycCubit, KycState>(
-      'falls back to the local session flag when the server round-trip fails',
+      'falls back to the local session flag when the endpoint returns 404',
       setUp: () {
         when(() => kycService.getKycStatus()).thenAnswer(
           (_) async => _kycStatus(
@@ -1230,7 +1227,9 @@ void main() {
         when(() => legalService.getLegalInfo()).thenThrow(
           const ApiException(statusCode: 404, code: 'NOT_FOUND', message: ''),
         );
-        when(() => legalService.acceptLegal(any())).thenThrow(Exception('legal endpoint down'));
+        when(() => legalService.acceptLegal(any())).thenThrow(
+          const ApiException(statusCode: 404, code: 'NOT_FOUND', message: ''),
+        );
       },
       build: buildCubit,
       act: (cubit) async {
@@ -1243,6 +1242,28 @@ void main() {
         const KycLoading(),
         const KycCompleted(),
       ],
+    );
+
+    // Fail closed: a non-404 PUT failure (endpoint live but the write errors)
+    // surfaces as KycFailure instead of being silently swallowed into a
+    // re-prompt loop.
+    blocTest<KycCubit, KycState>(
+      'emits KycFailure when acceptLegal fails with a non-404 error',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(
+            level: KycLevel.level50,
+            processStatus: KycProcessStatus.completed,
+          ),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+        when(() => legalService.acceptLegal(any())).thenThrow(
+          const ApiException(statusCode: 500, code: 'SERVER_ERROR', message: 'boom'),
+        );
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.acceptLegalDisclaimer(),
+      expect: () => [isA<KycFailure>()],
     );
   });
 }

--- a/test/screens/kyc/kyc_page_manager_test.dart
+++ b/test/screens/kyc/kyc_page_manager_test.dart
@@ -27,8 +27,7 @@ import '../../helper/helper.dart';
 
 class _MockDfxKycService extends Mock implements DfxKycService {}
 
-class _MockRealUnitRegistrationService extends Mock
-    implements RealUnitRegistrationService {}
+class _MockRealUnitRegistrationService extends Mock implements RealUnitRegistrationService {}
 
 class _MockRealUnitLegalService extends Mock implements RealUnitLegalService {}
 
@@ -41,8 +40,7 @@ class _MockKycCubit extends MockCubit<KycState> implements KycCubit {}
 UserKycDto _kycHeader({KycLevel level = KycLevel.level0}) =>
     UserKycDto(hash: 'h', level: level, dataComplete: false);
 
-UserDto _user({String? mail = 'test@example.com'}) =>
-    UserDto(mail: mail, kyc: _kycHeader());
+UserDto _user({String? mail = 'test@example.com'}) => UserDto(mail: mail, kyc: _kycHeader());
 
 KycLevelDto _kycStatus({
   required KycLevel level,
@@ -161,6 +159,7 @@ void main() {
       final getIt = GetIt.instance;
       getIt.registerSingleton<DfxKycService>(kycService);
       getIt.registerSingleton<RealUnitRegistrationService>(registrationService);
+      getIt.registerSingleton<RealUnitLegalService>(legalService);
       getIt.registerSingleton<AppStore>(appStore);
       addTearDown(() async => getIt.reset());
 
@@ -202,15 +201,16 @@ void main() {
   );
 
   // The legalDisclaimer arm wires LegalDisclaimerPage.onCompleted to
-  // markLegalDisclaimerAccepted + checkKyc; drive that callback directly.
+  // acceptLegalDisclaimer (which records acceptance server-side and re-checks);
+  // drive that callback directly.
   testWidgets(
-    'KycViewManager legalDisclaimer onCompleted marks acceptance and re-checks',
+    'KycViewManager legalDisclaimer onCompleted records acceptance',
     (tester) async {
       final cubit = _MockKycCubit();
       when(() => cubit.state).thenReturn(
         const KycSuccess(currentStep: KycStep.legalDisclaimer),
       );
-      when(() => cubit.checkKyc()).thenAnswer((_) async {});
+      when(() => cubit.acceptLegalDisclaimer()).thenAnswer((_) async {});
 
       await tester.pumpApp(viewWithState(cubit));
       await tester.pumpAndSettle();
@@ -220,8 +220,7 @@ void main() {
       final page = tester.widget<LegalDisclaimerPage>(find.byType(LegalDisclaimerPage));
       page.onCompleted!();
 
-      verify(() => cubit.markLegalDisclaimerAccepted()).called(1);
-      verify(() => cubit.checkKyc()).called(1);
+      verify(() => cubit.acceptLegalDisclaimer()).called(1);
     },
   );
 }

--- a/test/screens/kyc/kyc_page_manager_test.dart
+++ b/test/screens/kyc/kyc_page_manager_test.dart
@@ -10,9 +10,11 @@ import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_level_dt
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_session_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/dto/kyc_step_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/kyc/kyc_level.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal/dto/real_unit_legal_info_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/user/dto/user_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_registration_info_dto.dart';
 import 'package:realunit_wallet/packages/service/dfx/models/wallet/real_unit_registration_state.dart';
+import 'package:realunit_wallet/packages/service/dfx/real_unit_legal_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
 import 'package:realunit_wallet/packages/wallet/wallet.dart';
 import 'package:realunit_wallet/screens/kyc/cubits/kyc/kyc_cubit.dart';
@@ -27,6 +29,8 @@ class _MockDfxKycService extends Mock implements DfxKycService {}
 
 class _MockRealUnitRegistrationService extends Mock
     implements RealUnitRegistrationService {}
+
+class _MockRealUnitLegalService extends Mock implements RealUnitLegalService {}
 
 class _MockAppStore extends Mock implements AppStore {}
 
@@ -74,12 +78,14 @@ KycStepSessionDto _currentStep(
 void main() {
   late _MockDfxKycService kycService;
   late _MockRealUnitRegistrationService registrationService;
+  late _MockRealUnitLegalService legalService;
   late _MockAppStore appStore;
   late _MockAWallet wallet;
 
   setUp(() {
     kycService = _MockDfxKycService();
     registrationService = _MockRealUnitRegistrationService();
+    legalService = _MockRealUnitLegalService();
     appStore = _MockAppStore();
     wallet = _MockAWallet();
     when(() => appStore.wallet).thenReturn(wallet);
@@ -88,6 +94,11 @@ void main() {
       (_) async => RealUnitRegistrationInfoDto(
         state: RealUnitRegistrationState.alreadyRegistered,
       ),
+    );
+    // Default: server reports all legal agreements accepted, so the disclaimer
+    // gate passes and tests exercise downstream routing.
+    when(() => legalService.getLegalInfo()).thenAnswer(
+      (_) async => const RealUnitLegalInfoDto(agreements: [], allAccepted: true),
     );
   });
 
@@ -112,7 +123,7 @@ void main() {
         ),
       );
 
-      final cubit = KycCubit(kycService, registrationService, appStore);
+      final cubit = KycCubit(kycService, registrationService, legalService, appStore);
       await tester.pumpApp(
         BlocProvider<KycCubit>.value(
           value: cubit,
@@ -120,7 +131,8 @@ void main() {
         ),
       );
 
-      cubit.markLegalDisclaimerAccepted();
+      // Server reports all agreements accepted (default stub), so the disclaimer
+      // gate passes and the cubit reaches the dfxApproval routing under test.
       await cubit.checkKyc();
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
## What

Makes the KYC legal-disclaimer gate server-driven via the new DFX API `GET`/`PUT /v1/realunit/legal` capability, replacing the per-session in-memory flag `_legalDisclaimerAccepted` that reset on every KYC entry.

## Why

The disclaimer was gated on a local `KycCubit` field that is `false` on every fresh cubit, so it re-appeared on every KYC (re)entry (the reported bug). The API is now the single source of truth for whether the user still has outstanding agreements to accept — per CONTRIBUTING "API as Decision Authority".

## How

- `RealUnitLegalService` (`getLegalInfo` / `acceptLegal`) + DTOs + a `RealUnitLegalAgreement` enum mirror
- `KycCubit` gate: shows the disclaimer only when `getLegalInfo().allAccepted` is false; disclaimer completion records acceptance via `PUT` (the outstanding agreements) and re-checks so the API drives the next routing
- Fail-closed: a **404** means the endpoint is not deployed yet (pre-rollout) and falls back to the local per-session flag; **any other error** surfaces as `KycFailure` — no silent fallback on a compliance gate
- version fields are strings (`YYYYMMDD`)

## ⛔ Blocked — pair PR

Depends on the API PR **DFXswiss/api#4183** (the `/v1/realunit/legal` endpoint + versioned acceptance store). Keep this as a **draft** until that merges to `develop` and reaches DEV; opening it ready before then would have the app hit a 404 and fall through to the local flag.

## Verification (m5me, Flutter 3.41.6)

- `flutter analyze` — No issues found
- `flutter test` (kyc_cubit + kyc_page_manager) — all pass, incl. the new fail-closed test (non-404 → `KycFailure`), the 404 pre-rollout fallback test, and the accept/re-check path
- `dart format` clean
