### PR TITLE
test(kyc): restore 100% coverage for the legal-acceptance feature

### DIFF
--- a/test/packages/service/dfx/models/legal/real_unit_legal_agreement_test.dart
+++ b/test/packages/service/dfx/models/legal/real_unit_legal_agreement_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/packages/service/dfx/models/legal/real_unit_legal_agreement.dart';
+
+void main() {
+  group('RealUnitLegalAgreement', () {
+    test('value <-> fromValue round-trips every agreement', () {
+      for (final agreement in RealUnitLegalAgreement.values) {
+        expect(RealUnitLegalAgreementExtension.fromValue(agreement.value), agreement);
+      }
+    });
+
+    test('fromValue throws ArgumentError on an unknown value', () {
+      expect(
+        () => RealUnitLegalAgreementExtension.fromValue('NopeNotAnAgreement'),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
+++ b/test/screens/kyc/cubits/kyc/kyc_cubit_test.dart
@@ -1265,5 +1265,24 @@ void main() {
       act: (cubit) => cubit.acceptLegalDisclaimer(),
       expect: () => [isA<KycFailure>()],
     );
+
+    // A non-ApiException failure (network/parse error) also fails closed via the
+    // generic catch, surfacing as KycFailure rather than being swallowed.
+    blocTest<KycCubit, KycState>(
+      'emits KycFailure when acceptLegal throws a non-ApiException error',
+      setUp: () {
+        when(() => kycService.getKycStatus()).thenAnswer(
+          (_) async => _kycStatus(
+            level: KycLevel.level50,
+            processStatus: KycProcessStatus.completed,
+          ),
+        );
+        when(() => kycService.getUser()).thenAnswer((_) async => _user());
+        when(() => legalService.acceptLegal(any())).thenThrow(Exception('boom'));
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.acceptLegalDisclaimer(),
+      expect: () => [isA<KycFailure>()],
+    );
   });
 }


### PR DESCRIPTION
Fixes the **Coverage Floor Gate** that went red on the `staging → develop` promotion (#824) after #831 merged.

The 100% line-coverage floor dropped to 99.9% — exactly two uncovered lines, both from #831:
- the generic (non-`ApiException`) `catch` in `KycCubit.acceptLegalDisclaimer` (kyc_cubit.dart:295-296)
- the `fromValue` `ArgumentError` default in `RealUnitLegalAgreement` (real_unit_legal_agreement.dart:48)

Test-only, no production change:
- cubit test: `acceptLegal` throwing a non-`ApiException` error → `KycFailure`
- `RealUnitLegalAgreement` round-trip (`value`↔`fromValue` over all six) + unknown-value (`ArgumentError`) test

Verified on the build host: `flutter analyze` clean, the affected suites pass, and coverage of both files is back to 100% (the enum file: LF:15 / LH:15).