### PR TITLE
fix(kyc): sign the server-provided registration date, not the device date

### DIFF
--- a/lib/packages/service/dfx/real_unit_registration_service.dart
+++ b/lib/packages/service/dfx/real_unit_registration_service.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:intl/intl.dart';
 import 'package:realunit_wallet/packages/config/api_config.dart';
 import 'package:realunit_wallet/packages/service/dfx/dfx_auth_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/exceptions/api_exception.dart';
@@ -22,6 +21,7 @@ class RealUnitRegistrationService extends DFXAuthService {
   RealUnitRegistrationService(super.appStore, super.walletService);
 
   static const _registrationInfoPath = '/v1/realunit/registration';
+  static const _registerDatePath = '/v1/realunit/register/date';
   static const _registerEmailPath = '/v1/realunit/register/email';
   static const _registerCompletionPath = '/v1/realunit/register/complete';
   static const _registerWalletPath = '/v1/realunit/register/wallet';
@@ -46,6 +46,35 @@ class RealUnitRegistrationService extends DFXAuthService {
     }
 
     return RealUnitRegistrationInfoDto.fromJson(jsonDecode(response.body));
+  }
+
+  /// Fetches the registration date to sign from the API. `registrationDate` is
+  /// part of the EIP-712 signed registration envelope and the backend validates
+  /// it against its own clock, so the value must be the server's date — never
+  /// the device's local date. A device in a timezone ahead of UTC would
+  /// otherwise sign tomorrow's date and be rejected by the backend. Fetched
+  /// immediately before signing so it is always fresh.
+  Future<String> getRegistrationDate() async {
+    final uri = buildUri(host, _registerDatePath);
+    final response = await authenticatedGet(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+    );
+
+    if (response.statusCode != 200) {
+      final errorJson = jsonDecode(response.body) as Map<String, dynamic>;
+      throw ApiException.fromJson(errorJson, httpStatusCode: response.statusCode);
+    }
+
+    final date = (jsonDecode(response.body) as Map<String, dynamic>)['date'];
+    if (date is! String) {
+      throw ApiException(
+        statusCode: response.statusCode,
+        code: 'UNKNOWN',
+        message: 'Missing registration date in API response',
+      );
+    }
+    return date;
   }
 
   /// registers an email on the wallet. Should always be called first when registering
@@ -103,7 +132,9 @@ class RealUnitRegistrationService extends DFXAuthService {
     );
     final addressPostalCode = toBitboxSafeAscii(registration.addressPostalCode);
     final addressCity = toBitboxSafeAscii(registration.addressCity);
-    final registrationDate = DateFormat('yyyy-MM-dd').format(DateTime.now());
+    // The registration date is a signed field the backend validates against
+    // its own clock — take it from the API, never the device's local date.
+    final registrationDate = await getRegistrationDate();
     final signature = await Eip712Signer.signRegistration(
       credentials: credentials,
       chainId: _chainId,
@@ -185,7 +216,8 @@ class RealUnitRegistrationService extends DFXAuthService {
 
   Future<RegistrationStatus> _registerWallet(RealUnitUserDataDto userData) async {
     final credentials = appStore.wallet.primaryAccount.primaryAddress;
-    final registrationDate = DateFormat('yyyy-MM-dd').format(DateTime.now());
+    // Server-provided registration date (signed field) — see completeRegistration.
+    final registrationDate = await getRegistrationDate();
     // Same ASCII guard as completeRegistration — see comment there.
     final signature = await Eip712Signer.signRegistration(
       credentials: credentials,

--- a/lib/packages/service/dfx/real_unit_registration_service.dart
+++ b/lib/packages/service/dfx/real_unit_registration_service.dart
@@ -102,19 +102,23 @@ class RealUnitRegistrationService extends DFXAuthService {
 
   /// registers a wallet and and adds the wallet to the new user
   Future<RegistrationStatus> completeRegistration(Registration registration) async {
+    // Fetch the server-provided signing date BEFORE unlocking the wallet: it
+    // only needs the JWT, not the private key, so a slow or failing fetch must
+    // not hold the decrypted key resident (and a failure aborts before unlock).
+    final registrationDate = await getRegistrationDate();
     // EIP-712 registration signature requires the private key — promote the
     // view-wallet (if any) to a fully unlocked SoftwareWallet first, then
     // lock back down in the finally so a throw mid-sequence doesn't leave the
     // key resident.
     await walletService.ensureCurrentWalletUnlocked();
     try {
-      return await _completeRegistration(registration);
+      return await _completeRegistration(registration, registrationDate);
     } finally {
       await walletService.lockCurrentWallet();
     }
   }
 
-  Future<RegistrationStatus> _completeRegistration(Registration registration) async {
+  Future<RegistrationStatus> _completeRegistration(Registration registration, String registrationDate) async {
     final credentials = appStore.wallet.primaryAccount.primaryAddress;
     // BitBox firmware rejects non-ASCII bytes in EIP-712 string fields.
     // Transliterate everything that goes into the signed envelope AND the
@@ -132,9 +136,6 @@ class RealUnitRegistrationService extends DFXAuthService {
     );
     final addressPostalCode = toBitboxSafeAscii(registration.addressPostalCode);
     final addressCity = toBitboxSafeAscii(registration.addressCity);
-    // The registration date is a signed field the backend validates against
-    // its own clock — take it from the API, never the device's local date.
-    final registrationDate = await getRegistrationDate();
     final signature = await Eip712Signer.signRegistration(
       credentials: credentials,
       chainId: _chainId,
@@ -206,18 +207,18 @@ class RealUnitRegistrationService extends DFXAuthService {
   Future<RegistrationStatus> registerWallet(
     RealUnitUserDataDto userData,
   ) async {
+    // Fetch the signed date before unlocking — see completeRegistration.
+    final registrationDate = await getRegistrationDate();
     await walletService.ensureCurrentWalletUnlocked();
     try {
-      return await _registerWallet(userData);
+      return await _registerWallet(userData, registrationDate);
     } finally {
       await walletService.lockCurrentWallet();
     }
   }
 
-  Future<RegistrationStatus> _registerWallet(RealUnitUserDataDto userData) async {
+  Future<RegistrationStatus> _registerWallet(RealUnitUserDataDto userData, String registrationDate) async {
     final credentials = appStore.wallet.primaryAccount.primaryAddress;
-    // Server-provided registration date (signed field) — see completeRegistration.
-    final registrationDate = await getRegistrationDate();
     // Same ASCII guard as completeRegistration — see comment there.
     final signature = await Eip712Signer.signRegistration(
       credentials: credentials,

--- a/test/integration/link_wallet_connect_flow_test.dart
+++ b/test/integration/link_wallet_connect_flow_test.dart
@@ -109,7 +109,10 @@ void main() {
       () async {
         credentials.behavior = FakeBitboxBehavior.disconnect;
         var posts = 0;
-        final client = MockClient((_) async {
+        final client = MockClient((request) async {
+          if (request.url.path == '/v1/realunit/register/date') {
+            return http.Response(jsonEncode({'date': '2026-07-13'}), 200);
+          }
           posts++;
           return http.Response(jsonEncode({'status': 'completed'}), 201);
         });
@@ -122,7 +125,7 @@ void main() {
         expect(
           posts,
           0,
-          reason: 'the EIP-712 sign throws BitboxNotConnectedException before the POST',
+          reason: 'the EIP-712 sign throws BitboxNotConnectedException before the register POST',
         );
         // The wallet is unlocked for the ceremony and re-locked in the finally
         // even though signing throws.
@@ -138,6 +141,9 @@ void main() {
         Uri? sentUri;
         Map<String, dynamic>? body;
         final client = MockClient((request) async {
+          if (request.url.path == '/v1/realunit/register/date') {
+            return http.Response(jsonEncode({'date': '2026-07-13'}), 200);
+          }
           sentUri = request.url;
           body = jsonDecode(request.body) as Map<String, dynamic>;
           return http.Response(jsonEncode({'status': 'completed'}), 201);
@@ -152,7 +158,8 @@ void main() {
         expect(body!['walletAddress'], credentials.address.hexEip55);
         // 65-byte ECDSA signature → 0x + 130 hex chars.
         expect((body!['signature'] as String).length, 132);
-        expect((body!['registrationDate'] as String).length, 10);
+        // The signed registrationDate is the server-provided date.
+        expect(body!['registrationDate'], '2026-07-13');
       },
     );
 
@@ -161,6 +168,9 @@ void main() {
       () async {
         Uri? sentUri;
         final client = MockClient((request) async {
+          if (request.url.path == '/v1/realunit/register/date') {
+            return http.Response(jsonEncode({'date': '2026-07-13'}), 200);
+          }
           sentUri = request.url;
           return http.Response(jsonEncode({'status': 'completed'}), 201);
         });

--- a/test/packages/service/dfx/real_unit_registration_service_happy_test.dart
+++ b/test/packages/service/dfx/real_unit_registration_service_happy_test.dart
@@ -135,6 +135,9 @@ void main() {
         Map<String, dynamic>? body;
         Map<String, String>? headers;
         final client = MockClient((request) async {
+          if (request.url.path == '/v1/realunit/register/date') {
+            return http.Response(jsonEncode({'date': '2026-07-13'}), 200);
+          }
           sentUri = request.url;
           body = jsonDecode(request.body) as Map<String, dynamic>;
           headers = request.headers;
@@ -146,6 +149,10 @@ void main() {
         expect(status, RegistrationStatus.completed);
         expect(sentUri!.path, '/v1/realunit/register/complete');
         expect(headers!['authorization'], 'Bearer jwt-1');
+
+        // The signed registrationDate must be the server-provided date, not a
+        // locally-derived one — the whole point of the /register/date fetch.
+        expect(body!['registrationDate'], '2026-07-13');
 
         // Signed envelope copy — must be ASCII-transliterated to match what
         // BitBox firmware would have signed.
@@ -183,6 +190,9 @@ void main() {
         Uri? sentUri;
         Map<String, dynamic>? body;
         final client = MockClient((request) async {
+          if (request.url.path == '/v1/realunit/register/date') {
+            return http.Response(jsonEncode({'date': '2026-07-13'}), 200);
+          }
           sentUri = request.url;
           body = jsonDecode(request.body) as Map<String, dynamic>;
           return http.Response(jsonEncode({'status': 'completed'}), 201);
@@ -224,7 +234,10 @@ void main() {
         // sibling file short-circuits before the HTTP call, so the wire
         // error path stays uncovered without this.
         var calls = 0;
-        final client = MockClient((_) async {
+        final client = MockClient((request) async {
+          if (request.url.path == '/v1/realunit/register/date') {
+            return http.Response(jsonEncode({'date': '2026-07-13'}), 200);
+          }
           calls++;
           return http.Response(
             jsonEncode({
@@ -256,7 +269,10 @@ void main() {
       () async {
         // Coverage pin for the matching branch in `_registerWallet`.
         var calls = 0;
-        final client = MockClient((_) async {
+        final client = MockClient((request) async {
+          if (request.url.path == '/v1/realunit/register/date') {
+            return http.Response(jsonEncode({'date': '2026-07-13'}), 200);
+          }
           calls++;
           return http.Response(
             jsonEncode({
@@ -286,6 +302,9 @@ void main() {
         Uri? sentUri;
         Map<String, dynamic>? body;
         final client = MockClient((request) async {
+          if (request.url.path == '/v1/realunit/register/date') {
+            return http.Response(jsonEncode({'date': '2026-07-13'}), 200);
+          }
           sentUri = request.url;
           body = jsonDecode(request.body) as Map<String, dynamic>;
           return http.Response(jsonEncode({'status': 'completed'}), 201);
@@ -297,9 +316,52 @@ void main() {
         expect(sentUri!.path, '/v1/realunit/register/wallet');
         expect(body!['walletAddress'], _privKey.address.hexEip55);
         expect((body!['signature'] as String).length, 132);
-        // YYYY-MM-DD shape, length 10.
-        expect((body!['registrationDate'] as String).length, 10);
+        // The signed registrationDate must be the server-provided date.
+        expect(body!['registrationDate'], '2026-07-13');
       },
     );
+  });
+
+  group('getRegistrationDate', () {
+    test('GETs /v1/realunit/register/date and returns the server date', () async {
+      Uri? sentUri;
+      String? method;
+      final client = MockClient((request) async {
+        sentUri = request.url;
+        method = request.method;
+        return http.Response(jsonEncode({'date': '2026-07-13'}), 200);
+      });
+
+      final date = await build(client).getRegistrationDate();
+
+      expect(date, '2026-07-13');
+      expect(method, 'GET');
+      expect(sentUri!.path, '/v1/realunit/register/date');
+    });
+
+    test('rewraps a non-200 response as ApiException carrying the backend status', () async {
+      final client = MockClient((_) async {
+        return http.Response(
+          jsonEncode({'statusCode': 503, 'code': 'UNAVAILABLE', 'message': 'down'}),
+          503,
+        );
+      });
+
+      await expectLater(
+        () => build(client).getRegistrationDate(),
+        throwsA(isA<ApiException>()),
+      );
+    });
+
+    test('throws when the response omits the date field (no silent fallback)', () async {
+      final client = MockClient((_) async {
+        return http.Response(jsonEncode({'notDate': true}), 200);
+      });
+
+      await expectLater(
+        () => build(client).getRegistrationDate(),
+        throwsA(isA<ApiException>()),
+      );
+    });
   });
 }

--- a/test/packages/service/dfx/real_unit_registration_service_test.dart
+++ b/test/packages/service/dfx/real_unit_registration_service_test.dart
@@ -204,7 +204,14 @@ void main() {
       when(() => account.primaryAddress).thenReturn(
         FakeBitboxCredentials(behavior: FakeBitboxBehavior.disconnect)..bitboxManager = null,
       );
-      final client = MockClient((_) async => http.Response('{}', 201));
+      // The date fetch happens before signing, so it must succeed for the flow
+      // to reach the signing step where the disconnected BitBox surfaces.
+      final client = MockClient((request) async {
+        if (request.url.path == '/v1/realunit/register/date') {
+          return http.Response('{"date":"2026-07-13"}', 200);
+        }
+        return http.Response('{}', 201);
+      });
 
       expect(
         () => build(client).completeRegistration(buildRegistration()),
@@ -245,7 +252,14 @@ void main() {
       when(() => account.primaryAddress).thenReturn(
         FakeBitboxCredentials(behavior: FakeBitboxBehavior.disconnect)..bitboxManager = null,
       );
-      final client = MockClient((_) async => http.Response('{}', 201));
+      // The date fetch happens before signing, so it must succeed for the flow
+      // to reach the signing step where the disconnected BitBox surfaces.
+      final client = MockClient((request) async {
+        if (request.url.path == '/v1/realunit/register/date') {
+          return http.Response('{"date":"2026-07-13"}', 200);
+        }
+        return http.Response('{}', 201);
+      });
 
       expect(
         () => build(client).registerWallet(buildUserData()),


### PR DESCRIPTION
## Problem

The registration date is a signed EIP-712 field the backend validates against its own **UTC** clock. The app derived it from the **device's local date** (`DateFormat('yyyy-MM-dd').format(DateTime.now())`), so a device in a timezone ahead of UTC — e.g. Europe/Zurich just after local midnight — signed **tomorrow's** date relative to the server and every registration failed:

> RealUnitApiException: Registration date must be today (code: UNKNOWN, statusCode: 400)

(Reproduced on the tax-residence "Abschliessen" step around 00:36 local.)

## Fix

- Fetch the date from the new **`GET /v1/realunit/register/date`** immediately before signing, in both `_completeRegistration` and `_registerWallet`.
- Drop the now-unused `intl` `DateFormat` import.

The server is now the single source of truth for the signed date, so the device timezone can no longer push it out of the accepted window.

## Tests

- `getRegistrationDate`: GETs the endpoint and returns the date; non-200 and a missing `date` field both throw (no silent fallback).
- Registration/​add-wallet happy paths assert the **server-provided** date lands in the signed body; error and BitBox-disconnect paths updated for the extra fetch.

## Pair PR

Consumes DFXswiss/api#4186 (`GET /realunit/register/date` + one-day UTC tolerance). Merge the API PR first.