### PR TITLE
chore: bump version floor to 1.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # derived from the release tag (see tool/generate_release_info.dart). Local
 # builds carry `+0` so the settings footer shows `dev` instead of a stale
 # pinned build number.
-version: 1.1.0+0
+version: 1.2.0+0
 
 environment:
   sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
## What

Bump the marketing-version floor in `pubspec.yaml` from `1.1.0` to `1.2.0` (`1.1.0+0` → `1.2.0+0`).

## Why

Starts a new **MINOR** release train (1.1 → 1.2). Per [`CONTRIBUTING.md` → *Release Versioning*](../blob/develop/CONTRIBUTING.md), the `X.Y.Z` part of `pubspec.yaml`'s `version:` is the floor that [`auto-tag.yaml`](../blob/develop/.github/workflows/auto-tag.yaml) consults for MAJOR/MINOR jumps. Once this reaches `develop`, the next auto-tag cuts `v1.2.0` instead of another `v1.1.x` patch.

## Scope

- **One line changed.** The `+0` build sentinel is deliberately **untouched** — CI always overrides `--build-name`/`--build-number` from the release tag (`tool/generate_release_info.dart`), and local builds keep the `dev` footer.
- No code changes; no root `CHANGELOG` exists (per-release store changelogs under `android/fastlane/**` are maintained separately, out of scope here).

## How auto-tag resolves it

`auto-tag.yaml` reads `pubspec.yaml` via `cut -d+ -f1` → `1.2.0`, then `sort -V | tail -1` picks the higher of the patch-bumped latest tag vs. this floor → resolves the next tag to `v1.2.0`.

## Verification

```
$ grep '^version:' pubspec.yaml
version: 1.2.0+0
```
