### PR TITLE
fix(ci): give the cold-start welcome assert head-room for iOS 26 hierarchy latency

### DIFF
--- a/.maestro/handbook/01-welcome.yaml
+++ b/.maestro/handbook/01-welcome.yaml
@@ -1,6 +1,22 @@
 # Tier-3 navigation smoke. The handbook screenshot for this flow is the
 # visual-regression Golden mapped in scripts/assemble-handbook-screenshots.sh;
 # this flow's diagnostic capture lands in build/handbook-captures/01-welcome.png.
+#
+# Timeout — why 120s here and not the suite-wide 30s:
+#   This is the FIRST flow, so it runs against a cold XCUITest driver on a
+#   freshly `simctl erase`-d device. On iOS 26 simulators, retrieving the
+#   view hierarchy of the deep Flutter semantics tree is pathologically slow
+#   when cold — a single snapshot has been observed taking 45-64s on a loaded
+#   `macos-latest` runner (see the driver post-mortem in a #824 run: the assert
+#   spent 64s inside one hierarchy fetch that only returned after the old 30s
+#   timeout had already elapsed, so it failed even though "Start" WAS in the
+#   tree). "Start" is a plain AppFilledButton label that is always present and
+#   accessible — the app is not slow, the XCUITest snapshot is. Every later
+#   flow reuses the now-warm driver (`--reinstall-driver=false`), so their 30s
+#   assertions retrieve the hierarchy fast enough; only this cold first fetch
+#   needs the head-room. 120s comfortably absorbs the worst observed single
+#   fetch while still failing a genuinely broken welcome screen well inside the
+#   flow's budget.
 appId: swiss.realunit.app
 ---
 - launchApp:
@@ -9,4 +25,4 @@ appId: swiss.realunit.app
 - waitForAnimationToEnd
 - extendedWaitUntil:
     visible: 'Start'
-    timeout: 30000
+    timeout: 120000


### PR DESCRIPTION
## Problem

The `01-welcome` Maestro handbook flow intermittently fails on CI with `Assert that "Start" is visible ... FAILED`, even though the welcome screen renders correctly and **"Start" is present in the accessibility tree** (verified from the failure artifact — the captured view-hierarchy contains `accessibilityText: "Start"`).

Root cause (from a #824 run's driver post-mortem): `01-welcome` runs first, against a **cold** XCUITest driver on a freshly `simctl erase`-d **iOS 26** simulator. Retrieving the deep Flutter semantics tree's view hierarchy is pathologically slow when cold — a single snapshot was observed taking **64s** on a loaded `macos-latest` runner. The assert's 30s timeout elapsed while still inside that first fetch, so it failed before it could ever evaluate a hierarchy that *did* contain "Start". The app is not slow; the XCUITest snapshot is.

Every later flow reuses the warmed driver (`--reinstall-driver=false`) and retrieves the hierarchy fast enough, so only this cold first fetch is affected — which is why the suite-wide 30s works everywhere else.

## Fix

Raise **only** the `01-welcome` assert timeout to **120s** (with an inline rationale), comfortably absorbing the worst observed cold single-fetch. A genuinely broken welcome screen still fails well inside the flow budget. No app/behaviour change — this is a test-infra robustness fix.

## Verification

Labelled `tier3:full` so the Tier-3 Maestro workflow runs on this PR; watching `01-welcome` pass.