### PR TITLE
ci: disable Actions cache for flutter-action on the self-hosted runner

### DIFF
--- a/.github/workflows/golden-regenerate.yaml
+++ b/.github/workflows/golden-regenerate.yaml
@@ -49,7 +49,13 @@ jobs:
         with:
           flutter-version: "3.41.6"
           channel: "stable"
-          cache: true
+          # Self-hosted runner already keeps the Flutter SDK persistently
+          # under `_work/_tool` across runs. The Actions cache restore on
+          # this runner stalls at 0.5-0.8 MB/s, times out after the 10
+          # minute segment timeout, falls back to a cache miss anyway,
+          # then burns ~8 minutes on a cache-save — ~18 minutes of pure
+          # overhead that returns nothing useful here.
+          cache: false
       - run: flutter pub get
       - run: dart run tool/generate_localization.dart
       - run: dart run tool/generate_release_info.dart

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -320,7 +320,13 @@ jobs:
         with:
           flutter-version: "3.41.6"
           channel: "stable"
-          cache: true
+          # Self-hosted runner already keeps the Flutter SDK persistently
+          # under `_work/_tool` across runs. The Actions cache restore on
+          # this runner stalls at 0.5-0.8 MB/s, times out after the 10
+          # minute segment timeout, falls back to a cache miss anyway,
+          # then burns ~8 minutes on a cache-save — ~18 minutes of pure
+          # overhead that returns nothing useful here.
+          cache: false
       - run: flutter pub get
       - run: dart run tool/generate_localization.dart
       - run: dart run tool/generate_release_info.dart


### PR DESCRIPTION
## Problem

The self-hosted runner (Mac Studio) keeps the Flutter SDK persistently under `_work/_tool/flutter` across runs, so `subosito/flutter-action@v2`'s `cache: true` has nothing useful to restore there. In practice:

- Cache restore stalls at 0.5-0.8 MB/s and hits the 10 minute segment timeout, then falls back to `Cache not found` anyway.
- Cache save afterwards costs another ~8 minutes.
- Net: ~18 minutes of overhead per job, on top of the ~30 seconds the actual golden tests take to run.
- Result: 20-30 minute job duration on a runner that has exactly one slot for this repo.

## Solution

Set `cache: false` on the two jobs that run on the self-hosted runner:

- `.github/workflows/pull-request.yaml` — `golden-tests` job ("Visual Regression")
- `.github/workflows/golden-regenerate.yaml` — `regenerate` job

Both changes are accompanied by an inline comment explaining the rationale, matching the existing comment style in these files. `flutter-version`, `channel`, and `timeout-minutes` are unchanged.

GitHub-hosted jobs (`build` in `pull-request.yaml`, `tier3-handbook.yaml`, `release.yaml`) keep `cache: true` — they run on ephemeral runners where the cache is actually useful.

## Expected effect

Self-hosted job duration should drop from 20-30 min to roughly 2 min, freeing up the single self-hosted runner slot much sooner for the next queued job.

## Risk

Low. `cache: false` only removes a cache-restore/save step; it does not change the Flutter SDK version, channel, or any test behavior. Worst case if the assumption about the persistent `_work/_tool` SDK turns out wrong: `flutter-action` falls back to a fresh SDK install on that job, which costs time but does not break correctness.