### PR TITLE
ci: skip duplicate pull_request run for staging->develop auto-PR

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -17,11 +17,17 @@ name: RealUnit Build
 #    push-vs-pull_request events, so allowing both would double
 #    self-hosted-runner load for no signal. The mechanical difference
 #    is that develop → main can be filtered via `branches-ignore: [main]`
-#    on the trigger (nothing else targets `main` as a PR base here);
-#    staging → develop cannot, because `develop` is also the legitimate
-#    target of real feature PRs that need their own CI run — so this
-#    one is filtered by HEAD branch in the job-level `if:` guards
-#    (skip when `github.head_ref` is `staging`) instead.
+#    on the trigger (nothing legitimately targets `main` as a PR base);
+#    staging → develop cannot, because `develop` is the default branch
+#    and can still receive ad-hoc or accidentally-mistargeted PRs that
+#    need full CI — so the filter is surgical and sits in the job-level
+#    `if:` guards instead. Those guards identify the trusted same-repo
+#    auto-PR by head-repo identity, head branch `staging`, and base
+#    branch `develop` together (not branch name alone): a fork PR whose
+#    head branch happens to be named `staging` must not skip required
+#    checks, since a job skipped via job-level `if:` counts as satisfying
+#    a required check and a fork-authored SHA has no corresponding
+#    `push: staging` run in the base repo.
 #  - `ready_for_review` makes the workflow fire the moment a draft PR
 #    is marked ready — drafts themselves skip via the `if:` guard
 #    below (saves macOS-runner minutes while work is still in progress).
@@ -67,7 +73,12 @@ jobs:
     # `push` (post-merge gate) and `workflow_dispatch` (manual override)
     # always run — the condition is "anything that isn't a PR, or a PR
     # that isn't a draft".
-    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.head_ref != 'staging'
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && !(github.event_name == 'pull_request'
+           && github.event.pull_request.head.repo.full_name == github.repository
+           && github.head_ref == 'staging'
+           && github.base_ref == 'develop')
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -235,7 +246,12 @@ jobs:
     # Same draft guard as `build`: skip drafts, always run on push/dispatch.
     # `build` already enforces this, but mirroring it here keeps the gate's
     # behaviour locally readable instead of inferred from `needs:`.
-    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.head_ref != 'staging'
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && !(github.event_name == 'pull_request'
+           && github.event.pull_request.head.repo.full_name == github.repository
+           && github.head_ref == 'staging'
+           && github.base_ref == 'develop')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -322,7 +338,12 @@ jobs:
   # baselines in the same PR (see `docs/visual-regression-tests.md`).
   golden-tests:
     name: Visual Regression
-    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.head_ref != 'staging'
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && !(github.event_name == 'pull_request'
+           && github.event.pull_request.head.repo.full_name == github.repository
+           && github.head_ref == 'staging'
+           && github.base_ref == 'develop')
     runs-on: [self-hosted, macOS, ARM64, m3-ultra, realunit-app]
     timeout-minutes: 30
     steps:
@@ -353,7 +374,12 @@ jobs:
   bitbox-audit:
     name: BitBox quirks audit
     # Same guard pattern as `build`: skip drafts, always run on push/dispatch.
-    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.head_ref != 'staging'
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && !(github.event_name == 'pull_request'
+           && github.event.pull_request.head.repo.full_name == github.repository
+           && github.head_ref == 'staging'
+           && github.base_ref == 'develop')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -11,6 +11,17 @@ name: RealUnit Build
 #    commit landed, and concurrency groups don't dedupe across
 #    push-vs-pull_request events, so allowing both would double
 #    macOS-runner load on the release lane for no signal.
+#    Auto-PRs staging → develop (opened by `auto-staging-pr.yaml`) are
+#    the same situation for a different lane: `push: staging` already
+#    covered the same SHA, and concurrency groups don't dedupe across
+#    push-vs-pull_request events, so allowing both would double
+#    self-hosted-runner load for no signal. The mechanical difference
+#    is that develop → main can be filtered via `branches-ignore: [main]`
+#    on the trigger (nothing else targets `main` as a PR base here);
+#    staging → develop cannot, because `develop` is also the legitimate
+#    target of real feature PRs that need their own CI run — so this
+#    one is filtered by HEAD branch in the job-level `if:` guards
+#    (skip when `github.head_ref` is `staging`) instead.
 #  - `ready_for_review` makes the workflow fire the moment a draft PR
 #    is marked ready — drafts themselves skip via the `if:` guard
 #    below (saves macOS-runner minutes while work is still in progress).
@@ -56,7 +67,7 @@ jobs:
     # `push` (post-merge gate) and `workflow_dispatch` (manual override)
     # always run — the condition is "anything that isn't a PR, or a PR
     # that isn't a draft".
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.head_ref != 'staging'
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -224,7 +235,7 @@ jobs:
     # Same draft guard as `build`: skip drafts, always run on push/dispatch.
     # `build` already enforces this, but mirroring it here keeps the gate's
     # behaviour locally readable instead of inferred from `needs:`.
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.head_ref != 'staging'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -311,7 +322,7 @@ jobs:
   # baselines in the same PR (see `docs/visual-regression-tests.md`).
   golden-tests:
     name: Visual Regression
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.head_ref != 'staging'
     runs-on: [self-hosted, macOS, ARM64, m3-ultra, realunit-app]
     timeout-minutes: 30
     steps:
@@ -342,7 +353,7 @@ jobs:
   bitbox-audit:
     name: BitBox quirks audit
     # Same guard pattern as `build`: skip drafts, always run on push/dispatch.
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.head_ref != 'staging'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Problem

For roughly 94% of `staging` commits, two CI runs fire on the same SHA:

1. The `push: staging` run.
2. The `pull_request` run of the permanently open, non-draft auto-PR `staging -> develop` (opened by `auto-staging-pr.yaml`).

Concurrency groups cannot dedupe these two runs, because `push` and `pull_request` events fall into different concurrency groups. Cost: roughly 9 hours of duplicate self-hosted runner time per week.

## Solution

Extend all four job-level `if:` guards in `.github/workflows/pull-request.yaml` (`build`, `coverage-floor`, `golden-tests`, `bitbox-audit`) so they skip only the trusted same-repo auto-PR `staging -> develop`:

```yaml
if: >-
  (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
  && !(github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name == github.repository
       && github.head_ref == 'staging'
       && github.base_ref == 'develop')
```

That clause identifies the real auto-PR by event type, head-repo identity, head branch name, and base branch name together. `push` and `workflow_dispatch` still run (the inner parenthesized clause is false when there is no pull_request event). Draft PRs still skip. Genuine feature PRs still run — whether they target `staging` (the normal base per CONTRIBUTING.md) or accidentally target `develop`, and whether they come from the same repo or a fork — because they fail at least one of the identity checks above. For the real same-repo auto-PR, `push: staging` already verified that SHA, so the `pull_request` run is redundant and is skipped.

This mirrors the existing rationale already documented for excluding the `develop -> main` release PR, with one mechanical difference: `develop -> main` is filtered via `branches-ignore: [main]` on the trigger, because nothing legitimately targets `main` as a PR base here. `staging -> develop` cannot be filtered the same way, because `develop` is the default branch and can still receive ad-hoc or accidentally-mistargeted PRs that need full CI — so the filter is surgical and sits in the job-level `if:` guards instead. A comment paragraph explaining this was added to the trigger-model header, alongside (not replacing) the existing `develop -> main` explanation.

The `on:` trigger block and the `concurrency:` block are untouched.

### Why not branch name alone

A bare `github.head_ref == 'staging'` match would be exploitable in this public repo with forking enabled. A fork PR whose head branch is named `staging` would match the same string, and because GitHub treats a job skipped via job-level `if:` as satisfying a required status check, all four required-check-backing jobs would report as satisfied without ever running — a CI bypass. For a fork-authored SHA there is also no corresponding `push: staging` run in the base repo that would have supplied a real, independently computed check result. That is why the guard also requires `github.event.pull_request.head.repo.full_name == github.repository` (rules out forks) and `github.base_ref == 'develop'` (rules out feature PRs targeting `staging`) in addition to the head branch name check.

## Expected effect

Eliminates the duplicate self-hosted-runner run for ~94% of `staging` commits, recovering roughly 9 hours/week of runner time.

## Required status checks / risk

Ruleset "PRs" (id `11317379`) applies to `~DEFAULT_BRANCH` (= `develop`), `refs/heads/main`, and `refs/heads/staging`, with required status checks `Analyze & Test`, `Visual Regression`, `Coverage Floor Gate`. The auto-PR `staging -> develop` is #841 ("Promote: staging -> develop"), targets `develop`, is non-draft, and therefore falls under this ruleset.

Precedent, verified empirically on the most recently merged `develop -> main` release PR, #325 (head SHA `39783bdc`):

- `gh api "repos/RealUnitCH/app/actions/runs?head_sha=39783bdc"` — the only "RealUnit Build" run on this SHA is a **push** run (run #2228, conclusion `success`). No `pull_request` run exists, because `branches-ignore: [main]` suppresses it.
- `gh api "repos/RealUnitCH/app/commits/39783bdc/check-runs?per_page=100"` — `Analyze & Test = success`, `Visual Regression = success`, `Coverage Floor Gate = success`.
- PR #325 merged normally. Check runs are bound to the commit SHA, not to a specific workflow run: the `push` run's checks satisfied the required checks of a PR that itself never had its own run.

The same mechanism applies to `staging -> develop`: `push: staging` lands the same three checks on the identical SHA that PR #841 carries as its HEAD.

Additional safeguard: a job skipped via a job-level `if:` still produces a check run, with conclusion `skipped`, and GitHub counts `skipped` as satisfying a required status check (not as a failure) — unlike a job that never appears at all (e.g. filtered out via `on: paths:`), which would stay `expected` indefinitely and block merge. That's why gating with a job-level `if:` (as this PR does), rather than removing the trigger, is the correct mechanism here. The same skip-as-success mechanism is precisely why the guard must also verify fork identity (`head.repo.full_name == github.repository`) and not rely on branch name alone: otherwise a fork PR with head branch `staging` could satisfy required checks without any job ever running.

A reviewer can reproduce both data points directly:

```
gh api "repos/RealUnitCH/app/actions/runs?head_sha=39783bdc"
gh api "repos/RealUnitCH/app/commits/39783bdc/check-runs?per_page=100"
```

Risk: low overall (four identical, additive `if:` conditions), but this is the one part of the change worth a reviewer's explicit sign-off, since it touches required-check semantics on an auto-managed PR rather than a purely cosmetic CI change.
