### PR TITLE
ci: lower self-hosted job timeout from 30 to 15 minutes

### DIFF
--- a/.github/workflows/golden-regenerate.yaml
+++ b/.github/workflows/golden-regenerate.yaml
@@ -37,7 +37,13 @@ jobs:
   regenerate:
     name: Regenerate golden baselines
     runs-on: [self-hosted, macOS, ARM64, m3-ultra, realunit-app]
-    timeout-minutes: 30
+    # Same reasoning as `golden-tests` in `pull-request.yaml`: the old 30 was
+    # sized for the cache era (~18 minutes of stalled Actions-cache overhead).
+    # Regeneration is that same workload plus a commit+push, so 15 minutes
+    # still leaves room for a cold Flutter SDK download, and it frees this
+    # repo's single self-hosted slot far sooner when a run wedges. Keep the
+    # two jobs' timeouts in sync, like the rest of their setup.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -313,7 +313,16 @@ jobs:
     name: Visual Regression
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: [self-hosted, macOS, ARM64, m3-ultra, realunit-app]
-    timeout-minutes: 30
+    # 30 was sized for the era when `subosito/flutter-action@v2` still pulled
+    # the SDK through the Actions cache and burned ~18 minutes on a stalled
+    # restore plus the trailing cache-save. Without that overhead the job
+    # finishes in ~1 minute, so 15 is generous headroom — it still covers the
+    # worst normal case, where the SDK is absent from the runner's persistent
+    # tool cache and has to be downloaded from scratch. The lower ceiling is
+    # what matters here: the self-hosted runner has exactly ONE slot for this
+    # repo, so a wedged job blocks every other PR until it is killed. 15 hands
+    # the slot back twice as fast as 30.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Problem

Both jobs that run on the self-hosted Mac Studio carry `timeout-minutes: 30`:

| Workflow | Job | |
|---|---|---|
| `pull-request.yaml` | `golden-tests` (Visual Regression) | 30 |
| `golden-regenerate.yaml` | `regenerate` (Regenerate golden baselines) | 30 |

That 30 was sized for the cache era: `subosito/flutter-action@v2` pulled the SDK through the Actions cache, where the restore stalls at 0.5–0.8 MB/s, times out, misses anyway, and then burns ~8 more minutes on a cache save — roughly 18 minutes of pure overhead. A 20–30 minute job needed a 30 minute ceiling.

That premise is gone with #849.

## Measurement

With the Actions cache disabled on the self-hosted runner (#849), the same `golden-tests` job ran in **54 seconds** on the runner — `12:02:24Z → 12:03:18Z`, measured in a real CI run, not estimated.

## Change

`30 → 15` on both self-hosted jobs. Nothing else is touched — no `cache:` change, no reformatting.

Explicitly **unchanged**: `build` / Analyze & Test (30, GitHub-hosted `macos-latest`, legitimately slower), `coverage-floor` (5), `bitbox-audit` (10).

## Why 15, and not 5 or 30

The job runs in ~1 minute, so 15 is a ~15x margin — it will never fire in normal operation. It still absorbs the worst *legitimate* case: a runner whose persistent tool cache (`_work/_tool`) has been wiped, so the Flutter SDK has to be downloaded from scratch. 15 covers that comfortably while still being a real ceiling.

The ceiling is the point. The self-hosted runner has exactly **one** slot for this repo. A wedged job (hung `flutter test`, stuck simulator, dead network mid-download) does not just fail slowly — it holds the only slot and blocks every other PR behind it. At 30 that is a half-hour outage of the visual-regression lane; at 15 the slot comes back twice as fast. `golden-regenerate` is the same workload plus a commit+push on the same single slot, so it moves in lockstep.

## Risk

Low, and one-directional: the only way this bites is a job that legitimately needs more than 15 minutes. Post-#849 the job needs ~1. If the tool cache is ever cold *and* the download is pathologically slow, the job fails with a clear timeout rather than silently occupying the slot — a better failure mode than the status quo.

> [!IMPORTANT]
> **Do not let this PR's CI run before #849 is in its base.** The constraint is about CI order, not just merge order.
>
> This branch carries `timeout-minutes: 15` while `staging` still has `cache: true` in both self-hosted jobs (#849 is what removes it). Flipping this PR out of draft is what first exercises the new cap — against the cache era it exists to retire. Of the 14 completed `Visual Regression` runs of the last two days, **7 exceeded 15 minutes**, three of them as *green* runs (19.5 / 19.6 / 20.9 min): the stalled cache restore and the trailing cache save vary independently, so a run over the cap is roughly a coin flip. The job would be killed at 15 minutes, red-lining this PR's own gating check and holding the single self-hosted slot for the full 15 minutes.
>
> Correct order: merge #849 into `staging` first, **then** mark this ready. No rebase is needed — the two PRs touch different lines, so once #849 lands the recomputed merge ref carries `cache: false` on its own. Until then this stays a draft, and `golden-regenerate` must not be dispatched on this branch.