### PR TITLE
ci(golden-regenerate): checkout live branch head instead of pinned dispatch sha

### DIFF
--- a/.github/workflows/golden-regenerate.yaml
+++ b/.github/workflows/golden-regenerate.yaml
@@ -45,6 +45,13 @@ jobs:
           # this, checkout still works but the remote is configured with no
           # credential helper and the push fails with HTTP 403.
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Single-slot runner can start minutes after dispatch. Default
+          # checkout pins github.sha (stale by then); render against that
+          # tree and the later push is rejected because the branch tip has
+          # moved. Checkout the live head instead (github.ref_name — the
+          # dispatched branch; workflow_dispatch always runs with --ref
+          # <branch>) so baselines match the tree they get committed to.
+          ref: ${{ github.ref_name }}
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: "3.41.6"
@@ -81,9 +88,13 @@ jobs:
             exit 0
           fi
           git commit -m "test(goldens): regenerate baselines on the self-hosted runner"
-          # On protected branches (develop/main) this fails by design.
-          # The next step uploads the PNGs as an artifact so the user can
-          # still recover the regen output.
+          # Protected branches (develop/main): fails by design — no force-push,
+          # no bypass. Feature branches: after the ref: fix above this should
+          # normally succeed. If the branch still moves between checkout and
+          # push (now a seconds-wide window), fail loud; the fallback artifact
+          # step below still uploads the PNGs. Recovery: re-dispatch (cheap).
+          # Do NOT rebase or force-push — that would publish baselines that no
+          # longer match the tree head they were rendered against.
           git push
 
       # Runs only if the push step failed. Uploads the regenerated PNGs so


### PR DESCRIPTION
## Problem

The `regenerate` job in `golden-regenerate.yaml` checks out the default `github.sha`, which GitHub pins at dispatch time. The self-hosted runner this workflow uses only has a single execution slot, so the job can sit queued for many minutes after `workflow_dispatch` before it actually starts. By the time it runs, the dispatched branch has frequently moved on past the pinned sha.

The job then regenerates golden baselines against that stale tree and tries to push the result back onto the branch. Since the branch tip has advanced, the push is rejected with `! [rejected] (fetch first)`, and the whole run — including the ~costly golden regeneration on the self-hosted runner — is wasted. This is a documented, reproduced failure mode (run 29259187838).

The comment that previously sat above `git push` attributed this to protected-branch behavior ("On protected branches (develop/main) this fails by design"). That's a misdiagnosis for this failure: the observed rejections were on a feature branch, caused by the branch moving during the queue wait, not by branch protection.

## Fix

Add `ref: ${{ github.ref_name }}` to the `actions/checkout@v4` step so it checks out the live head of the dispatched branch at checkout time, instead of the sha pinned at dispatch time. This way the goldens are always rendered against the exact tree the commit will land on, regardless of how long the job sat in the runner queue.

The push-step comment is reworded to separate the two distinct cases clearly:
- Protected branch (develop/main): push fails by design, no force-push or bypass — unchanged.
- Feature branch: after this fix, the checkout/push window is a matter of seconds rather than minutes, so this should normally succeed. If the branch still moves in that narrow window, the push still fails loudly, and the existing fallback artifact upload still recovers the regenerated PNGs. The fix for that case is simply to re-dispatch the workflow.

## Why not a rebase/retry instead

An alternative would have been to `git pull --rebase` (or force-push) before the push and retry. That was deliberately not done: rebasing the commit would let baselines rendered against one tree get published against a different, newer tree they were never actually validated against — a correctness hazard, not just a convenience issue. Keeping the push fail-loud, with re-dispatch as the recovery path, guarantees committed baselines always match the tree they were rendered from.

## Risk

The remaining race window (checkout to push) shrinks from potentially many minutes to roughly the job's own runtime (about a minute), so a residual failure is unlikely but not impossible. If it still happens, the push fails loudly as before and the fallback artifact upload (`if-no-files-found: error`) still preserves the regenerated baselines for manual recovery.