### PR TITLE
docs(handbook): stage the four no-registration web baselines (18 → 22)

### DIFF
--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -317,7 +317,7 @@ jobs:
       - name: Stage web e2e baselines from web repo
         env:
           WEB_DIR: _web-checkout
-          # RealUnitCH/web commits 18 Playwright visual baselines under
+          # RealUnitCH/web commits 22 Playwright visual baselines under
           # tests/__screenshots__/{desktop-chromium,tablet-chromium,mobile-safari}/.
           # `-ne` below fails the build on ANY drift (add OR remove) so a change
           # to the committed set upstream requires an explicit bump here AND a

--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -323,7 +323,7 @@ jobs:
           # to the committed set upstream requires an explicit bump here AND a
           # matching card edit in docs/handbook/de/index.html (#spec-web) in the
           # SAME change — same guard rationale as the api steps above.
-          EXPECTED_WEB_BASELINE_COUNT: 18
+          EXPECTED_WEB_BASELINE_COUNT: 22
         run: |
           set -euo pipefail
 

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -8183,6 +8183,76 @@
             </div>
           </div>
 
+          <h3>Adressbestätigung — keine Wallet-Registrierung <a class="src" href="https://github.com/RealUnitCH/web/tree/develop/tests/__screenshots__" title="Quelle: tests/__screenshots__/">↗</a></h3>
+          <div class="tests cols-2">
+            <div class="test" id="web-confirm-no-registration-desktop-de">
+              <div class="head">
+                <a class="name permalink" href="#web-confirm-no-registration-desktop-de">web-confirm-no-registration-desktop-de</a>
+                <button class="copy-link" type="button" data-target="web-confirm-no-registration-desktop-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">desktop-chromium/confirm-no-registration.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/desktop-chromium/confirm-no-registration.png"
+                  alt="Keine Wallet-Registrierung — Desktop (DE)"
+                />
+              </div>
+              <div class="desc">
+                Zustand, wenn die E-Mail-Adresse bestätigt ist, aber keine
+                Wallet-Registrierung zum Link gefunden wurde — permanenter
+                Zustand ohne Retry, Desktop, Deutsch.
+              </div>
+            </div>
+            <div class="test" id="web-confirm-no-registration-desktop-en">
+              <div class="head">
+                <a class="name permalink" href="#web-confirm-no-registration-desktop-en">web-confirm-no-registration-desktop-en</a>
+                <button class="copy-link" type="button" data-target="web-confirm-no-registration-desktop-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">desktop-chromium/confirm-no-registration-en.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/desktop-chromium/confirm-no-registration-en.png"
+                  alt="No wallet registration found — Desktop (EN)"
+                />
+              </div>
+              <div class="desc">
+                Derselbe Zustand auf Englisch.
+              </div>
+            </div>
+            <div class="test" id="web-confirm-no-registration-tablet">
+              <div class="head">
+                <a class="name permalink" href="#web-confirm-no-registration-tablet">web-confirm-no-registration-tablet</a>
+                <button class="copy-link" type="button" data-target="web-confirm-no-registration-tablet" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">tablet-chromium/confirm-no-registration.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/tablet-chromium/confirm-no-registration.png"
+                  alt="Keine Wallet-Registrierung — Tablet"
+                />
+              </div>
+              <div class="desc">
+                Zustand im Tablet-Layout.
+              </div>
+            </div>
+            <div class="test" id="web-confirm-no-registration-mobile">
+              <div class="head">
+                <a class="name permalink" href="#web-confirm-no-registration-mobile">web-confirm-no-registration-mobile</a>
+                <button class="copy-link" type="button" data-target="web-confirm-no-registration-mobile" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">mobile-safari/confirm-no-registration.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/mobile-safari/confirm-no-registration.png"
+                  alt="Keine Wallet-Registrierung — Mobile"
+                />
+              </div>
+              <div class="desc">
+                Zustand in der Mobile-Ansicht.
+              </div>
+            </div>
+          </div>
+
           <h3>Adressbestätigung — Dienst nicht verfügbar <a class="src" href="https://github.com/RealUnitCH/web/tree/develop/tests/__screenshots__" title="Quelle: tests/__screenshots__/">↗</a></h3>
           <div class="tests cols-2">
             <div class="test" id="web-confirm-unavailable-desktop-de">


### PR DESCRIPTION
## Why

RealUnitCH/web#23 adds a dedicated confirm-page end state (`no-registration`) with four new Playwright baselines (18 → 22 PNGs). The handbook deploy stages those baselines behind the `EXPECTED_WEB_BASELINE_COUNT` guard, which requires the count bump and the matching gallery cards in the same change.

## Changes

- `handbook.yaml`: `EXPECTED_WEB_BASELINE_COUNT` 18 → 22.
- `docs/handbook/de/index.html` (`#spec-web`): four cards for the new views (desktop de/en, tablet, mobile), mirroring the confirm-invalid card group.

## Coupling

Merge together with RealUnitCH/web#23 — the guard fails the next handbook deploy if either side lands alone. The PR-level `Handbook Build Check` does not stage web baselines, so this PR's CI is unaffected either way.