### PR TITLE
feat(error-handling): catch unhandled async errors via PlatformDispatcher.onError

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:developer' as developer;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -11,7 +9,7 @@ import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
 import 'package:realunit_wallet/screens/pin/bloc/auth/pin_auth_cubit.dart';
 import 'package:realunit_wallet/screens/settings/bloc/settings_bloc.dart';
 import 'package:realunit_wallet/setup/di.dart';
-import 'package:realunit_wallet/setup/error_handling/realunit_error_view.dart';
+import 'package:realunit_wallet/setup/error_handling/error_handlers.dart';
 import 'package:realunit_wallet/setup/lifecycle_initializer.dart';
 import 'package:realunit_wallet/setup/routing/boot_navigation.dart';
 import 'package:realunit_wallet/setup/routing/router_config.dart';
@@ -20,7 +18,7 @@ import 'package:realunit_wallet/styles/themes.dart';
 Future<void> main() async {
   final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
 
-  _installErrorHandlers();
+  installErrorHandlers();
 
   // only preserve splash screen for 3 seconds for release version
   if (kReleaseMode) {
@@ -39,25 +37,6 @@ Future<void> _initialize() async {
   runApp(
     const LifecycleInitializer(child: WalletApp()),
   );
-}
-
-/// Defense-in-depth against uncaught build/paint exceptions. Without this, a
-/// single throw inside a widget's `build` (e.g. the empty-BitBox-address
-/// `EthereumAddress.fromHex("")` crash) surfaces in release as a bare grey
-/// [ErrorWidget] with no branding and no signal to the user. We log every such
-/// error and replace the grey box with a minimal on-brand surface.
-void _installErrorHandlers() {
-  final defaultOnError = FlutterError.onError;
-  FlutterError.onError = (details) {
-    developer.log(
-      'uncaught Flutter error: ${details.exceptionAsString()}',
-      name: 'WalletApp',
-      error: details.exception,
-      stackTrace: details.stack,
-    );
-    defaultOnError?.call(details);
-  };
-  ErrorWidget.builder = (details) => RealUnitErrorView(details: details);
 }
 
 Future<void> _initializeWithSplashDuration() async {

--- a/lib/setup/error_handling/error_handlers.dart
+++ b/lib/setup/error_handling/error_handlers.dart
@@ -1,0 +1,58 @@
+import 'dart:developer' as developer;
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:realunit_wallet/setup/error_handling/realunit_error_view.dart';
+
+/// Wires up the three process-wide error surfaces. Called once from `main`
+/// before any other bootstrap step, so errors thrown during setup are covered.
+///
+/// - [FlutterError.onError] catches errors raised inside a Flutter callback
+///   (build, layout, paint). It logs and then delegates to the previously
+///   installed handler, which keeps the framework's own reporting intact.
+/// - [ErrorWidget.builder] replaces the bare grey error box with an on-brand
+///   surface; see [RealUnitErrorView].
+/// - [PlatformDispatcher.onError] catches everything with no Flutter callback
+///   on the stack — unhandled `Future`, `Stream` and `Timer` errors in the root
+///   isolate — which the two handlers above never see.
+///
+/// Both handlers log and then hand the error on rather than absorbing it, so
+/// nothing that reported an error before reports less of one now.
+///
+/// Scope, deliberately narrow: [developer.log] writes to the VM service stream,
+/// so these calls surface in the DevTools Logging view under the `WalletApp`
+/// tag in debug and profile builds only — the VM service is absent from a
+/// release build, where the call is compiled out. Returning `false` from
+/// [PlatformDispatcher.onError] is what carries release builds: it keeps the
+/// engine's own reporting running instead of suppressing it (returning `true`
+/// would claim the error as handled while our log is a no-op, i.e. total
+/// silence). So this makes async errors *reachable where a developer is already
+/// attached*; it adds no release-mode visibility on its own. Getting evidence
+/// off a customer's device needs a crash reporter or a persisted log sink —
+/// this handler body is the hook such a sink plugs into.
+///
+/// @no-integration-test: the engine-side fallback reporting that runs after
+/// [PlatformDispatcher.onError] returns false is embedder behaviour and is not
+/// observable from a Dart test; the handler contract itself is unit-tested.
+void installErrorHandlers() {
+  final defaultOnError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    developer.log(
+      'uncaught Flutter error: ${details.exceptionAsString()}',
+      name: 'WalletApp',
+      error: details.exception,
+      stackTrace: details.stack,
+    );
+    defaultOnError?.call(details);
+  };
+  ErrorWidget.builder = (details) => RealUnitErrorView(details: details);
+  PlatformDispatcher.instance.onError = (error, stack) {
+    developer.log(
+      'uncaught async error: $error',
+      name: 'WalletApp',
+      error: error,
+      stackTrace: stack,
+    );
+    return false;
+  };
+}

--- a/test/setup/error_handling/error_handlers_test.dart
+++ b/test/setup/error_handling/error_handlers_test.dart
@@ -1,0 +1,73 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:realunit_wallet/setup/error_handling/error_handlers.dart';
+import 'package:realunit_wallet/setup/error_handling/realunit_error_view.dart';
+
+void main() {
+  // `installErrorHandlers` mutates process-wide statics that the test binding
+  // also relies on, so every handler is captured before and restored after each
+  // test — otherwise a failure here would leak into unrelated suites.
+  late FlutterExceptionHandler? originalFlutterOnError;
+  late ErrorWidgetBuilder originalErrorWidgetBuilder;
+  late ErrorCallback? originalPlatformOnError;
+
+  setUp(() {
+    originalFlutterOnError = FlutterError.onError;
+    originalErrorWidgetBuilder = ErrorWidget.builder;
+    originalPlatformOnError = PlatformDispatcher.instance.onError;
+  });
+
+  tearDown(() {
+    FlutterError.onError = originalFlutterOnError;
+    ErrorWidget.builder = originalErrorWidgetBuilder;
+    PlatformDispatcher.instance.onError = originalPlatformOnError;
+  });
+
+  group('installErrorHandlers', () {
+    test('installs an async error handler that reports the error onwards', () {
+      installErrorHandlers();
+
+      final handler = PlatformDispatcher.instance.onError;
+      expect(handler, isNotNull, reason: 'async errors must not go unhandled');
+
+      // The contract that matters: the handler returns false, so the engine's
+      // fallback reporting still runs after we log. Returning true would claim
+      // the error as handled and suppress that reporting — and since our
+      // developer.log is compiled out of release builds, that would leave a
+      // release crash reported by nobody at all.
+      expect(handler!(Exception('async boom'), StackTrace.current), isFalse);
+    });
+
+    test('async handler tolerates an empty stack trace', () {
+      installErrorHandlers();
+
+      expect(
+        () => PlatformDispatcher.instance.onError!(Exception('boom'), StackTrace.empty),
+        returnsNormally,
+      );
+    });
+
+    test('Flutter error handler delegates to the previously installed handler', () {
+      final received = <FlutterErrorDetails>[];
+      FlutterError.onError = received.add;
+
+      installErrorHandlers();
+      final details = FlutterErrorDetails(exception: Exception('sync boom'));
+      FlutterError.onError!(details);
+
+      expect(received, [details], reason: 'the default reporting path must stay intact');
+    });
+
+    test('installs the on-brand error widget builder', () {
+      installErrorHandlers();
+
+      expect(
+        ErrorWidget.builder(FlutterErrorDetails(exception: Exception('boom'))),
+        isA<RealUnitErrorView>(),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

`FlutterError.onError` only sees errors raised inside a Flutter callback — build, layout, paint. Unhandled errors from a `Future`, `Stream` or `Timer` callback in the root isolate reach **no handler at all** today: `lib/main.dart` installs `FlutterError.onError` and `ErrorWidget.builder`, and nothing else. There is no `PlatformDispatcher.onError` and no `runZonedGuarded`.

This installs `PlatformDispatcher.onError` alongside the existing handlers and extracts the whole installation out of `main.dart` into `lib/setup/error_handling/error_handlers.dart`, next to the `RealUnitErrorView` it already uses — which is what makes the contract testable at all.

## Scope — please read before assuming this fixes field diagnostics

This does **not** deliver release-mode evidence, and the PR should not be merged under that belief.

`developer.log` writes to the VM service stream, so these calls surface in the DevTools Logging view under the `WalletApp` tag in **debug and profile builds only** — the VM service is absent from a release build. What this PR actually delivers:

- async errors become **reachable where a developer is already attached**, where today they reach nothing;
- the handler returns **`false`**, so the engine's own fallback reporting keeps running in release instead of being suppressed. Returning `true` would claim the error as handled while our log is a no-op in release — reported by nobody at all;
- the handler body is now **the hook a real sink plugs into**.

Getting evidence off a customer's device still needs a crash reporter or a persisted log sink. That is a separate change and the one that would actually close a silent-field-crash report.

## Why `false` and not `true`

This is the one design decision in the diff, so it is pinned by an assertion in the test rather than left to prose. `true` = "handled, stop reporting"; `false` = "log it, then let the engine report as it always did". Since the log is compiled out of release, `true` would convert a reported crash into total silence — the opposite of the intent.

## Test

`test/setup/error_handling/error_handlers_test.dart` — 4 cases: the async handler is installed and returns `false`; it tolerates an empty stack trace; the Flutter handler still delegates to the previously installed one (the default reporting path stays intact); the on-brand error widget builder is installed. Process-wide statics are captured in `setUp` and restored in `tearDown` so nothing leaks into other suites.

`// @no-integration-test:` annotation added per CONTRIBUTING:205 — the engine-side fallback reporting that runs after the handler returns `false` is embedder behaviour and is not observable from a Dart test.

## Verification

Draft PRs skip CI in this repo, so both runs are local and this is the only gate:

- `flutter analyze` → 1 issue, pre-existing, in generated/gitignored code (`lib/generated/i18n.dart:55` `override_on_non_overriding_member`).
- `flutter test` → `+3019 -4`. The 4 failures are **pre-existing golden failures** in `settings_user_data`, baseline-proven at `+3015 -4` without this change. Isolated: `flutter test test/setup/error_handling/` → `+6: All tests passed!`

## Context

Came out of a customer case where an Android BitBox setup failed with a repeated crash and we had **zero** diagnostic evidence to work from. The transport half of that case is #866. The missing crash reporting is the other half — this PR is the groundwork for it, not the fix.