### PR TITLE
fix(support): route a known email to the merge-verification flow

### DIFF
--- a/assets/languages/strings_de.arb
+++ b/assets/languages/strings_de.arb
@@ -337,7 +337,6 @@
   "supportEmailCaptureContinue": "Weiter",
   "supportEmailCaptureDescription": "Um ein Support-Ticket zu erfassen, benötigen wir Ihre E-Mail-Adresse.",
   "supportEmailCaptureTitle": "E-Mail-Adresse hinzufügen",
-  "supportEmailMergeRequiresVerification": "Diese E-Mail-Adresse ist bereits einer anderen Wallet zugeordnet. Bitte wählen Sie eine andere Adresse oder kontaktieren Sie den Support per E-Mail.",
   "supportEnterMessage": "Nachricht eingeben",
   "supportGenericIssue": "Allgemeines Anliegen",
   "supportKycIssue": "KYC-Problem",

--- a/assets/languages/strings_en.arb
+++ b/assets/languages/strings_en.arb
@@ -337,7 +337,6 @@
   "supportEmailCaptureContinue": "Continue",
   "supportEmailCaptureDescription": "To open a support ticket, we need your email address.",
   "supportEmailCaptureTitle": "Add email address",
-  "supportEmailMergeRequiresVerification": "This email is already linked to another wallet. Please choose a different address or contact support by email.",
   "supportEnterMessage": "Enter message",
   "supportGenericIssue": "General issue",
   "supportKycIssue": "KYC issue",

--- a/lib/screens/support/cubits/support_email_capture/support_email_capture_cubit.dart
+++ b/lib/screens/support/cubits/support_email_capture/support_email_capture_cubit.dart
@@ -24,33 +24,18 @@ class SupportEmailCaptureCubit extends Cubit<SupportEmailCaptureState> {
         case RegistrationEmailStatus.emailRegistered:
           emit(const SupportEmailCaptureSuccess());
         case RegistrationEmailStatus.mergeRequested:
-          // The email-merge resolution path is a multi-step
-          // verification flow we don't want to drag into this minimal
-          // capture page. The user is told to pick a different
-          // address or contact support by email instead.
-          emit(
-            const SupportEmailCaptureFailure(
-              error: SupportEmailCaptureError.mergeRequested,
-              message: '',
-            ),
-          );
+          // The email is already known to DFX, so the API has sent an
+          // account-merge confirmation email. Signal the view to route to the
+          // shared email-verification flow so the user can confirm and link
+          // this wallet to the existing account.
+          emit(const SupportEmailCaptureMergeRequested());
       }
     } on ApiException catch (e) {
       developer.log(e.toString());
-      emit(
-        SupportEmailCaptureFailure(
-          error: SupportEmailCaptureError.unknown,
-          message: e.message,
-        ),
-      );
+      emit(SupportEmailCaptureFailure(e.message));
     } catch (e) {
       developer.log(e.toString());
-      emit(
-        SupportEmailCaptureFailure(
-          error: SupportEmailCaptureError.unknown,
-          message: e.toString(),
-        ),
-      );
+      emit(SupportEmailCaptureFailure(e.toString()));
     }
   }
 }

--- a/lib/screens/support/cubits/support_email_capture/support_email_capture_state.dart
+++ b/lib/screens/support/cubits/support_email_capture/support_email_capture_state.dart
@@ -19,17 +19,21 @@ class SupportEmailCaptureSuccess extends SupportEmailCaptureState {
   const SupportEmailCaptureSuccess();
 }
 
-enum SupportEmailCaptureError { mergeRequested, unknown }
+/// The email belongs to an existing account and the API has sent an
+/// account-merge confirmation email (register/email returns `merge_requested`).
+/// The user must confirm that email to link this wallet to the existing
+/// account — the view routes to the shared KYC email-verification flow, not to
+/// an error. Distinct from [SupportEmailCaptureFailure]: this is a normal,
+/// recoverable branch, not a failure.
+class SupportEmailCaptureMergeRequested extends SupportEmailCaptureState {
+  const SupportEmailCaptureMergeRequested();
+}
 
 class SupportEmailCaptureFailure extends SupportEmailCaptureState {
-  final SupportEmailCaptureError error;
   final String message;
 
-  const SupportEmailCaptureFailure({
-    required this.error,
-    required this.message,
-  });
+  const SupportEmailCaptureFailure(this.message);
 
   @override
-  List<Object?> get props => [error, message];
+  List<Object?> get props => [message];
 }

--- a/lib/screens/support/subpages/support_email_capture_page.dart
+++ b/lib/screens/support/subpages/support_email_capture_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
+import 'package:realunit_wallet/screens/kyc/steps/email/subpages/kyc_email_verification_page.dart';
 import 'package:realunit_wallet/screens/support/cubits/support_email_capture/support_email_capture_cubit.dart';
 import 'package:realunit_wallet/setup/di.dart';
 import 'package:realunit_wallet/styles/colors.dart';
@@ -64,7 +65,7 @@ class _SupportEmailCaptureFormState extends State<SupportEmailCaptureForm> {
   @override
   Widget build(BuildContext context) {
     return BlocListener<SupportEmailCaptureCubit, SupportEmailCaptureState>(
-      listener: (context, state) {
+      listener: (context, state) async {
         if (state is SupportEmailCaptureSuccess) {
           // Signal to the caller that the email is now set on the
           // user record so it can re-init its cubit and route to the
@@ -72,13 +73,29 @@ class _SupportEmailCaptureFormState extends State<SupportEmailCaptureForm> {
           Navigator.of(context).pop(true);
           return;
         }
+        if (state is SupportEmailCaptureMergeRequested) {
+          // The email belongs to an existing account and the API has already
+          // sent an account-merge confirmation email. Route to the same
+          // verification page the KYC email step uses so the user can confirm.
+          // On confirmation this wallet is linked to the existing account, so
+          // its primary email is now set — signal the caller exactly like a
+          // direct registration success. If the user backs out unconfirmed,
+          // stay on the form so they can retry.
+          final isConfirmed = await Navigator.push<bool>(
+            context,
+            MaterialPageRoute<bool>(
+              builder: (_) => const KycEmailVerificationPage(),
+            ),
+          );
+          if (isConfirmed == true && context.mounted) {
+            Navigator.of(context).pop(true);
+          }
+          return;
+        }
         if (state is SupportEmailCaptureFailure) {
-          final message = state.error == SupportEmailCaptureError.mergeRequested
-              ? S.of(context).supportEmailMergeRequiresVerification
-              : state.message;
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text(message),
+              content: Text(state.message),
               backgroundColor: RealUnitColors.status.red600,
             ),
           );

--- a/test/screens/support/cubits/support_email_capture/support_email_capture_cubit_test.dart
+++ b/test/screens/support/cubits/support_email_capture/support_email_capture_cubit_test.dart
@@ -41,24 +41,20 @@ void main() {
     );
 
     blocTest<SupportEmailCaptureCubit, SupportEmailCaptureState>(
-      'mergeRequested → Loading → Failure(mergeRequested)',
+      'mergeRequested → Loading → MergeRequested',
       setUp: () => when(() => service.registerEmail(any())).thenAnswer(
         (_) async => RegistrationEmailStatus.mergeRequested,
       ),
       build: build,
       act: (c) => c.submit('a@b.com'),
-      expect: () => [
-        const SupportEmailCaptureLoading(),
-        isA<SupportEmailCaptureFailure>().having(
-          (s) => s.error,
-          'error',
-          SupportEmailCaptureError.mergeRequested,
-        ),
+      expect: () => const [
+        SupportEmailCaptureLoading(),
+        SupportEmailCaptureMergeRequested(),
       ],
     );
 
     blocTest<SupportEmailCaptureCubit, SupportEmailCaptureState>(
-      'ApiException → Failure(unknown) carrying the api message',
+      'ApiException → Failure carrying the api message',
       setUp: () => when(() => service.registerEmail(any())).thenAnswer(
         (_) async => throw const ApiException(
           code: 'SOMETHING_ELSE',
@@ -70,13 +66,12 @@ void main() {
       expect: () => [
         const SupportEmailCaptureLoading(),
         isA<SupportEmailCaptureFailure>()
-            .having((s) => s.error, 'error', SupportEmailCaptureError.unknown)
             .having((s) => s.message, 'message', 'rejected by server'),
       ],
     );
 
     blocTest<SupportEmailCaptureCubit, SupportEmailCaptureState>(
-      'non-Api exception → Failure(unknown) carrying e.toString()',
+      'non-Api exception → Failure carrying e.toString()',
       setUp: () => when(() => service.registerEmail(any())).thenAnswer(
         (_) async => throw Exception('socket down'),
       ),
@@ -85,7 +80,6 @@ void main() {
       expect: () => [
         const SupportEmailCaptureLoading(),
         isA<SupportEmailCaptureFailure>()
-            .having((s) => s.error, 'error', SupportEmailCaptureError.unknown)
             .having((s) => s.message, 'message', contains('socket down')),
       ],
     );

--- a/test/screens/support/cubits/support_email_capture/support_email_capture_state_test.dart
+++ b/test/screens/support/cubits/support_email_capture/support_email_capture_state_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:realunit_wallet/screens/support/cubits/support_email_capture/support_email_capture_cubit.dart';
 
 void main() {
-  group('$SupportEmailCaptureInitial / Loading / Success', () {
+  group('$SupportEmailCaptureInitial / Loading / Success / MergeRequested', () {
     test('Initial: equal across instances, empty props', () {
       final a = SupportEmailCaptureInitial();
       final b = SupportEmailCaptureInitial();
@@ -26,51 +26,41 @@ void main() {
       expect(a, equals(b));
     });
 
-    test('Initial vs Loading vs Success are distinct (runtimeType)', () {
+    test('MergeRequested: equal across instances', () {
+      final a = SupportEmailCaptureMergeRequested();
+      final b = SupportEmailCaptureMergeRequested();
+      expect(a, equals(b));
+    });
+
+    test('Initial / Loading / Success / MergeRequested are all distinct', () {
       final i = SupportEmailCaptureInitial();
       final l = SupportEmailCaptureLoading();
       final s = SupportEmailCaptureSuccess();
+      final m = SupportEmailCaptureMergeRequested();
       expect(i, isNot(equals(l)));
       expect(l, isNot(equals(s)));
-      expect(i, isNot(equals(s)));
+      expect(s, isNot(equals(m)));
+      expect(m, isNot(equals(i)));
     });
   });
 
   group('$SupportEmailCaptureFailure', () {
-    test('same error + same message is equal', () {
-      final a = SupportEmailCaptureFailure(
-        error: SupportEmailCaptureError.unknown,
-        message: 'x',
-      );
-      final b = SupportEmailCaptureFailure(
-        error: SupportEmailCaptureError.unknown,
-        message: 'x',
-      );
+    test('same message is equal', () {
+      final a = SupportEmailCaptureFailure('x');
+      final b = SupportEmailCaptureFailure('x');
       expect(a, equals(b));
     });
 
-    test('different error is unequal', () {
-      final a = SupportEmailCaptureFailure(
-        error: SupportEmailCaptureError.unknown,
-        message: 'x',
-      );
-      final b = SupportEmailCaptureFailure(
-        error: SupportEmailCaptureError.mergeRequested,
-        message: 'x',
-      );
+    test('different message is unequal', () {
+      final a = SupportEmailCaptureFailure('x');
+      final b = SupportEmailCaptureFailure('y');
       expect(a, isNot(equals(b)));
     });
 
-    test('different message is unequal', () {
-      final a = SupportEmailCaptureFailure(
-        error: SupportEmailCaptureError.unknown,
-        message: 'x',
-      );
-      final b = SupportEmailCaptureFailure(
-        error: SupportEmailCaptureError.unknown,
-        message: 'y',
-      );
-      expect(a, isNot(equals(b)));
+    test('is distinct from MergeRequested', () {
+      final f = SupportEmailCaptureFailure('x');
+      final m = SupportEmailCaptureMergeRequested();
+      expect(f, isNot(equals(m)));
     });
   });
 }

--- a/test/screens/support/subpages/support_email_capture_page_test.dart
+++ b/test/screens/support/subpages/support_email_capture_page_test.dart
@@ -8,7 +8,10 @@ import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:realunit_wallet/generated/i18n.dart';
+import 'package:realunit_wallet/packages/service/dfx/dfx_widget_service.dart';
 import 'package:realunit_wallet/packages/service/dfx/real_unit_registration_service.dart';
+import 'package:realunit_wallet/screens/home/bloc/home_bloc.dart';
+import 'package:realunit_wallet/screens/kyc/steps/email/subpages/kyc_email_verification_page.dart';
 import 'package:realunit_wallet/screens/support/cubits/support_email_capture/support_email_capture_cubit.dart';
 import 'package:realunit_wallet/screens/support/subpages/support_email_capture_page.dart';
 import 'package:realunit_wallet/widgets/form/labeled_text_field.dart';
@@ -18,8 +21,39 @@ class _MockSupportEmailCaptureCubit extends MockCubit<SupportEmailCaptureState>
 
 class _MockRegistrationService extends Mock implements RealUnitRegistrationService {}
 
+class _MockDfxWidgetService extends Mock implements DfxWidgetService {}
+
+class _MockHomeBloc extends MockBloc<HomeEvent, HomeState> implements HomeBloc {}
+
+/// Pops the second pushed sub-route with [value]. The merge branch pushes the
+/// shared [KycEmailVerificationPage] on top of the capture page; this lets a
+/// test simulate the user confirming (`true`) — or backing out (`null`) — of
+/// that page without fully driving it. The root/home route
+/// (`previousRoute == null`) and the first sub-route (the capture page) are
+/// skipped; the pop happens on the next microtask so the verification route
+/// mounts first, matching a real user tapping "I've confirmed".
+class _AutoPopVerificationObserver extends NavigatorObserver {
+  _AutoPopVerificationObserver({this.value});
+
+  final Object? value;
+  int _subPushes = 0;
+  bool _popped = false;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    if (previousRoute == null) return; // root/home route
+    _subPushes++;
+    if (_subPushes == 2 && !_popped) {
+      _popped = true;
+      Future.microtask(() => route.navigator?.pop<bool>(value as bool?));
+    }
+  }
+}
+
 void main() {
   late SupportEmailCaptureCubit cubit;
+  late HomeBloc homeBloc;
 
   setUpAll(() {
     final getIt = GetIt.instance;
@@ -28,11 +62,18 @@ void main() {
         _MockRegistrationService(),
       );
     }
+    // The merge branch routes to KycEmailVerificationPage, which resolves its
+    // cubit's DFXAuthService from getIt<DfxWidgetService>.
+    if (!getIt.isRegistered<DfxWidgetService>()) {
+      getIt.registerSingleton<DfxWidgetService>(_MockDfxWidgetService());
+    }
   });
 
   setUp(() {
     cubit = _MockSupportEmailCaptureCubit();
     when(() => cubit.state).thenReturn(const SupportEmailCaptureInitial());
+    homeBloc = _MockHomeBloc();
+    when(() => homeBloc.state).thenReturn(const HomeState());
   });
 
   Widget pumpView() {
@@ -48,6 +89,35 @@ void main() {
       ),
     );
   }
+
+  // Hosts the capture page under a Navigator so the merge branch's
+  // Navigator.push (and the capture page's own pop) are observable, with
+  // HomeBloc provided above MaterialApp so the pushed verification page can
+  // read it.
+  Widget mergeHarness({
+    required List<NavigatorObserver> observers,
+    required Future<void> Function(BuildContext) onLaunch,
+  }) {
+    return BlocProvider<HomeBloc>.value(
+      value: homeBloc,
+      child: MaterialApp(
+        localizationsDelegates: const [
+          S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: S.delegate.supportedLocales,
+        navigatorObservers: observers,
+        home: _LauncherPage(onLaunch: onLaunch),
+      ),
+    );
+  }
+
+  Widget captureRoute() => BlocProvider<SupportEmailCaptureCubit>.value(
+        value: cubit,
+        child: const SupportEmailCaptureView(),
+      );
 
   group('$SupportEmailCapturePage', () {
     testWidgets('builds the view via BlocProvider create', (tester) async {
@@ -116,9 +186,24 @@ void main() {
 
       expect(find.byType(CupertinoActivityIndicator), findsOne);
     });
+
+    testWidgets('tapping the form background unfocuses the email field', (tester) async {
+      await tester.pumpWidget(pumpView());
+
+      await tester.tap(find.byType(TextFormField));
+      await tester.pump();
+      final field = tester.widget<EditableText>(find.byType(EditableText));
+      expect(field.focusNode.hasFocus, isTrue);
+
+      // The GestureDetector wrapping the form dismisses the keyboard.
+      await tester.tap(find.text(S.current.supportEmailCaptureDescription));
+      await tester.pump();
+
+      expect(field.focusNode.hasFocus, isFalse);
+    });
   });
 
-  group('$SupportEmailCaptureView pop & snackbar behavior', () {
+  group('$SupportEmailCaptureView navigation & snackbar behavior', () {
     testWidgets('Success state pops the route with true', (tester) async {
       // Wire the view inside a GoRouter so the page's
       // `Navigator.pop(true)` is observable via the parent
@@ -170,36 +255,97 @@ void main() {
       expect(popResult, isTrue);
     });
 
-    testWidgets('Failure with mergeRequested shows the merge-required snackbar', (tester) async {
+    testWidgets('MergeRequested routes to the email-verification page', (tester) async {
       whenListen(
         cubit,
-        Stream.fromIterable(const [
-          SupportEmailCaptureFailure(
-            error: SupportEmailCaptureError.mergeRequested,
-            message: '',
-          ),
-        ]),
+        Stream.fromIterable(const [SupportEmailCaptureMergeRequested()]),
         initialState: const SupportEmailCaptureInitial(),
       );
 
-      await tester.pumpWidget(pumpView());
-      await tester.pump();
-      await tester.pump();
-
-      expect(
-        find.text(S.current.supportEmailMergeRequiresVerification),
-        findsOne,
+      await tester.pumpWidget(
+        BlocProvider<HomeBloc>.value(
+          value: homeBloc,
+          child: MaterialApp(
+            localizationsDelegates: const [
+              S.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: S.delegate.supportedLocales,
+            home: captureRoute(),
+          ),
+        ),
       );
+      await tester.pumpAndSettle();
+
+      // The merge branch pushes the shared verification flow, not a red error.
+      expect(find.byType(KycEmailVerificationPage), findsOne);
     });
 
-    testWidgets('Failure with unknown error shows the raw error message', (tester) async {
+    testWidgets('MergeRequested + confirmation pops the capture route with true', (tester) async {
+      whenListen(
+        cubit,
+        Stream.fromIterable(const [SupportEmailCaptureMergeRequested()]),
+        initialState: const SupportEmailCaptureInitial(),
+      );
+      Object? popResult;
+
+      await tester.pumpWidget(
+        mergeHarness(
+          observers: [_AutoPopVerificationObserver(value: true)],
+          onLaunch: (ctx) async {
+            popResult = await Navigator.of(ctx).push<bool>(
+              MaterialPageRoute<bool>(builder: (_) => captureRoute()),
+            );
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('LAUNCH'));
+      await tester.pumpAndSettle();
+
+      expect(popResult, isTrue);
+    });
+
+    testWidgets('MergeRequested + back-out keeps the form and does not pop', (tester) async {
+      whenListen(
+        cubit,
+        Stream.fromIterable(const [SupportEmailCaptureMergeRequested()]),
+        initialState: const SupportEmailCaptureInitial(),
+      );
+      var capturePopped = false;
+
+      await tester.pumpWidget(
+        mergeHarness(
+          observers: [_AutoPopVerificationObserver(value: null)],
+          onLaunch: (ctx) async {
+            await Navigator.of(ctx).push<bool>(
+              MaterialPageRoute<bool>(builder: (_) => captureRoute()),
+            );
+            capturePopped = true; // only runs once the capture route pops
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('LAUNCH'));
+      await tester.pumpAndSettle();
+
+      // Verification was dismissed without confirmation (await returned null),
+      // so the confirm guard's false branch ran and the capture route did NOT
+      // pop — it stays on the stack (offstage beneath nothing now).
+      expect(find.byType(KycEmailVerificationPage), findsNothing);
+      expect(capturePopped, isFalse);
+      expect(find.byType(SupportEmailCaptureView, skipOffstage: false), findsOne);
+    });
+
+    testWidgets('Failure state shows the raw error message', (tester) async {
       whenListen(
         cubit,
         Stream.fromIterable(const [
-          SupportEmailCaptureFailure(
-            error: SupportEmailCaptureError.unknown,
-            message: 'something broke',
-          ),
+          SupportEmailCaptureFailure('something broke'),
         ]),
         initialState: const SupportEmailCaptureInitial(),
       );


### PR DESCRIPTION
## The bug
When a user enters an email that **already belongs to an existing DFX account** in the support/buy primary-email capture page, the API (`POST /v1/realunit/register/email`) returns `merge_requested` (HTTP **201**) *after having already sent an account-merge confirmation email* — see `realunit.service.ts` / `user-data.service.ts#checkMail` (a true dead-end is a **409**, not `merge_requested`).

The capture page treated `merge_requested` as a failure and showed a red SnackBar:

> „Diese E-Mail-Adresse ist bereits einer anderen Wallet zugeordnet. Bitte wählen Sie eine andere Adresse oder kontaktieren Sie den Support per E-Mail."

That is wrong: the user's own email **is** the right one, a confirmation mail was already sent, and telling them to pick a different address (or email support) is a dead end that **blocks existing customers** from onboarding via support or buy. The main KYC email step already handles this correctly.

## The fix
Mirror the canonical KYC email step:
- New `SupportEmailCaptureMergeRequested` state; the `SupportEmailCaptureError` enum is dropped (`Failure` now carries just its `message`).
- On `merge_requested`, route to the **shared `KycEmailVerificationPage`** ("we've emailed you — confirm to continue with your existing account"). On confirmation the wallet is linked to the existing account, so its primary email is now set — signal the caller with `pop(true)` exactly like a direct registration. On back-out, stay on the form so the user can retry.
- Remove the now-unused `supportEmailMergeRequiresVerification` string (de/en).

Both callers (`settings_contact`, buy `payment_action_button`) already treat the `true` pop / re-fetch as "proceed", so no caller change is needed.

## Tests
Cubit/state/page tests updated to the merge-verification behaviour, using an auto-pop `NavigatorObserver` (mirrors `kyc_email_page_test`) to simulate confirm / back-out without driving the verification page. Verified on the self-hosted-equivalent runner: `flutter analyze` clean, all support email-capture tests pass, and the page file stays at **100% line coverage** (63/63).