### PR TITLE
fix(bitbox): sign the registration with a chainId-extended EIP-712 domain

### DIFF
--- a/lib/packages/wallet/eip712_signer.dart
+++ b/lib/packages/wallet/eip712_signer.dart
@@ -29,7 +29,7 @@ class Eip712Signer {
     // hardware wallets sign with the chainId-extended domain. Software wallets
     // keep the legacy chainId-less domain until Aktionariat has confirmed its
     // signature re-verification accepts the extended variant — the API
-    // accepts both (pair PR DFXswiss/api#4354).
+    // accepts both (pair PR DFXswiss/api#4542).
     final includeChainIdInDomain = credentials is BitboxCredentials;
 
     final Map<String, dynamic> typedDataMap = {

--- a/lib/packages/wallet/eip712_signer.dart
+++ b/lib/packages/wallet/eip712_signer.dart
@@ -24,11 +24,20 @@ class Eip712Signer {
     required bool swissTaxResidence,
     required String registrationDate,
   }) {
+    // The BitBox02 firmware refuses to sign typed data whose EIP712Domain has
+    // no chainId ("typed data has no chain ID" shown on the device), so
+    // hardware wallets sign with the chainId-extended domain. Software wallets
+    // keep the legacy chainId-less domain until Aktionariat has confirmed its
+    // signature re-verification accepts the extended variant — the API
+    // accepts both (pair PR DFXswiss/api#4354).
+    final includeChainIdInDomain = credentials is BitboxCredentials;
+
     final Map<String, dynamic> typedDataMap = {
       'types': {
         'EIP712Domain': [
           {'name': 'name', 'type': 'string'},
           {'name': 'version', 'type': 'string'},
+          if (includeChainIdInDomain) {'name': 'chainId', 'type': 'uint256'},
         ],
         'RealUnitUser': [
           {'name': 'email', 'type': 'string'},
@@ -47,7 +56,11 @@ class Eip712Signer {
         ],
       },
       'primaryType': 'RealUnitUser',
-      'domain': {'name': 'RealUnitUser', 'version': '1'},
+      'domain': {
+        'name': 'RealUnitUser',
+        'version': '1',
+        if (includeChainIdInDomain) 'chainId': chainId,
+      },
       'message': {
         'email': email,
         'name': name,

--- a/test/packages/wallet/eip712_signer_bitbox_test.dart
+++ b/test/packages/wallet/eip712_signer_bitbox_test.dart
@@ -57,7 +57,8 @@ void main() {
     // Signs with a non-default chainId so a hardcoded value cannot pass, and asserts the
     // EIP712Domain member list exactly: the domain typehash covers the names, their types
     // and their order, so any of those drifting changes the digest and the API recovers a
-    // foreign address. Mirrors the chainId-wiring pin in eip712_delegation_bitbox_test.dart.
+    // foreign address. Mirrors the chainId-wiring pin in
+    // test/integration/eip7702_delegation_bitbox_test.dart.
     for (final chainId in const [1, 11155111]) {
       test('signs with the chainId-extended EIP-712 domain (chainId $chainId)', () async {
         when(
@@ -66,9 +67,10 @@ void main() {
 
         await signRegistration(chainId: chainId);
 
-        final captured = verify(
+        // called(1): a second sign would mean a second on-device confirmation prompt.
+        final captured = (verify(
           () => manager.signETHTypedMessage(captureAny(), any(), captureAny()),
-        ).captured;
+        )..called(1)).captured;
         final typedData = jsonDecode(utf8.decode(captured[1] as Uint8List)) as Map<String, dynamic>;
 
         expect(captured[0], chainId);

--- a/test/packages/wallet/eip712_signer_bitbox_test.dart
+++ b/test/packages/wallet/eip712_signer_bitbox_test.dart
@@ -24,9 +24,9 @@ void main() {
   BitboxCredentials connected() =>
       BitboxCredentials('0x000000000000000000000000000000000000dead')..setBitbox(manager);
 
-  Future<String> signRegistration() => Eip712Signer.signRegistration(
+  Future<String> signRegistration({int chainId = 1}) => Eip712Signer.signRegistration(
     credentials: connected(),
-    chainId: 1,
+    chainId: chainId,
     email: 'jk@dfx.swiss',
     name: 'Joshua',
     type: 'human',
@@ -54,22 +54,32 @@ void main() {
     // registrations must sign the chainId-extended domain. The software-wallet
     // path keeps the legacy domain (pinned by the golden signature in
     // eip712_signer_test.dart).
-    test('signs with the chainId-extended EIP-712 domain', () async {
-      when(
-        () => manager.signETHTypedMessage(any(), any(), any()),
-      ).thenAnswer((_) async => Uint8List.fromList([0x01]));
+    // Signs with a non-default chainId so a hardcoded value cannot pass, and asserts the
+    // EIP712Domain member list exactly: the domain typehash covers the names, their types
+    // and their order, so any of those drifting changes the digest and the API recovers a
+    // foreign address. Mirrors the chainId-wiring pin in eip712_delegation_bitbox_test.dart.
+    for (final chainId in const [1, 11155111]) {
+      test('signs with the chainId-extended EIP-712 domain (chainId $chainId)', () async {
+        when(
+          () => manager.signETHTypedMessage(any(), any(), any()),
+        ).thenAnswer((_) async => Uint8List.fromList([0x01]));
 
-      await signRegistration();
+        await signRegistration(chainId: chainId);
 
-      final jsonMessage =
-          verify(() => manager.signETHTypedMessage(any(), any(), captureAny())).captured.single as Uint8List;
-      final typedData = jsonDecode(utf8.decode(jsonMessage)) as Map<String, dynamic>;
-      expect(typedData['domain']['chainId'], 1);
-      expect(
-        (typedData['types']['EIP712Domain'] as List).map((e) => e['name']),
-        containsAll(['name', 'version', 'chainId']),
-      );
-    });
+        final captured = verify(
+          () => manager.signETHTypedMessage(captureAny(), any(), captureAny()),
+        ).captured;
+        final typedData = jsonDecode(utf8.decode(captured[1] as Uint8List)) as Map<String, dynamic>;
+
+        expect(captured[0], chainId);
+        expect(typedData['domain']['chainId'], chainId);
+        expect(typedData['types']['EIP712Domain'], [
+          {'name': 'name', 'type': 'string'},
+          {'name': 'version', 'type': 'string'},
+          {'name': 'chainId', 'type': 'uint256'},
+        ]);
+      });
+    }
 
     test('throws SigningCancelledException on empty signature', () async {
       when(

--- a/test/packages/wallet/eip712_signer_bitbox_test.dart
+++ b/test/packages/wallet/eip712_signer_bitbox_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:bitbox_flutter/bitbox_manager.dart';
@@ -46,6 +47,28 @@ void main() {
         () => manager.signETHTypedMessage(any(), any(), any()),
       ).thenAnswer((_) async => Uint8List.fromList([0xCA, 0xFE, 0xBA, 0xBE]));
       expect(await signRegistration(), '0xcafebabe');
+    });
+
+    // The BitBox02 firmware rejects typed data whose EIP712Domain has no
+    // chainId ("typed data has no chain ID" on the device) — hardware-wallet
+    // registrations must sign the chainId-extended domain. The software-wallet
+    // path keeps the legacy domain (pinned by the golden signature in
+    // eip712_signer_test.dart).
+    test('signs with the chainId-extended EIP-712 domain', () async {
+      when(
+        () => manager.signETHTypedMessage(any(), any(), any()),
+      ).thenAnswer((_) async => Uint8List.fromList([0x01]));
+
+      await signRegistration();
+
+      final jsonMessage =
+          verify(() => manager.signETHTypedMessage(any(), any(), captureAny())).captured.single as Uint8List;
+      final typedData = jsonDecode(utf8.decode(jsonMessage)) as Map<String, dynamic>;
+      expect(typedData['domain']['chainId'], 1);
+      expect(
+        (typedData['types']['EIP712Domain'] as List).map((e) => e['name']),
+        containsAll(['name', 'version', 'chainId']),
+      );
     });
 
     test('throws SigningCancelledException on empty signature', () async {


### PR DESCRIPTION
## Problem

BitBox users cannot complete the RealUnit registration: on submit, the BitBox02 (Nova) rejects the signing request and shows **"typed data has no chain ID"** on the device (first affected customer: userData 412822, 23.07.). The firmware requires a `chainId` member in the EIP712Domain; our registration payload signs the chainId-less domain `{ name: 'RealUnitUser', version: '1' }`. Software wallets sign it regardless, which is why this never surfaced.

## Change

- `Eip712Signer.signRegistration` includes `chainId` (value: `apiConfig.asset.chainId`, already plumbed through) in the EIP712Domain **for BitboxCredentials only**.
- Software wallets keep the legacy domain — pinned by the existing golden-signature test, so this path provably does not change.

## Pair PR

**DFXswiss/api#4542 — merged and live on production since 2026-07-31 16:47Z.** Verification there accepts both domain variants, trying the legacy one first, so software wallets are untouched. The API side is already deployed, so this PR no longer has a merge-order prerequisite.

(The original pair PR #4354 was closed unmerged and superseded by #4542.)

## Validated end-to-end on production

Run on 2026-07-31 with a real BitBox02 Nova (`bb02p-multi`, main firmware v9.26.4 — the build measured to refuse the chainId-less envelope) on an iPhone 17e, against `api.dfx.swiss`:

| hop | evidence |
|---|---|
| device signs over BLE | no "typed data has no chain ID" screen, no NACK |
| DFX accepts the extended domain | `[RealUnitService] RealUnit registration signature matched chainId 1 domain / …` at 16:54:28Z |
| forward to Aktionariat | `POST /v1/realunit/register/complete → 201`, no `Failed to forward RealUnit registration` |
| persisted | `aktionariat_registration` row → `status = Completed`, `active = true` |

This is the scenario the earlier review asked for real-firmware data on: the same device and firmware that produced the NACK now completes a registration end to end.

Note on scope of that evidence: `Completed` is written after Aktionariat's `/registerUser` returns 2xx. It proves their registration endpoint accepted the forwarded payload; it does not by itself prove which step re-verifies the EIP-712 signature on their side, so a later step exercising the signature is still worth watching.

## Tests

- new: BitBox path signs with `domain.chainId` + `chainId` member in EIP712Domain types
- existing golden signature (software wallet) unchanged → legacy path frozen
- wallet package + registration service suites: 83/83 green (62 + 21); `flutter analyze`: no issues

