### PR TITLE
Wire Sentry into native release builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,7 @@ jobs:
     outputs:
       proceed: ${{ steps.check.outputs.proceed }}
       is_prerelease: ${{ steps.check.outputs.is_prerelease }}
+      sentry_environment: ${{ steps.check.outputs.sentry_environment }}
     steps:
       - name: Inspect tag
         id: check
@@ -48,19 +49,28 @@ jobs:
           # Strict shape: vX.Y.Z with all parts numeric, no suffix.
           if ! echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::notice::Tag $TAG is not a plain vX.Y.Z tag; skipping release."
-            echo "proceed=false" >> $GITHUB_OUTPUT
-            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            {
+              echo "proceed=false"
+              echo "is_prerelease=false"
+              echo "sentry_environment=internal"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
           PATCH=$(echo "$TAG" | cut -d. -f3)
           if [ "$PATCH" -eq 0 ]; then
             echo "::notice::Tag $TAG has PATCH=0; running production-candidate release."
-            echo "proceed=true" >> $GITHUB_OUTPUT
-            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+            {
+              echo "proceed=true"
+              echo "is_prerelease=false"
+              echo "sentry_environment=production"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "::notice::Tag $TAG has PATCH=$PATCH; running internal release."
-            echo "proceed=true" >> $GITHUB_OUTPUT
-            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            {
+              echo "proceed=true"
+              echo "is_prerelease=true"
+              echo "sentry_environment=internal"
+            } >> "$GITHUB_OUTPUT"
           fi
 
   store-metadata-preflight:
@@ -172,6 +182,9 @@ jobs:
         working-directory: android
         env:
           NEW_VERSION: ${{ github.ref_name }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: ${{ needs.guard.outputs.sentry_environment }}
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
@@ -269,6 +282,9 @@ jobs:
         working-directory: ios
         env:
           NEW_VERSION: ${{ github.ref_name }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: ${{ needs.guard.outputs.sentry_environment }}
 
       - name: Upload IPA artifact
         uses: actions/upload-artifact@v4

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -41,6 +41,16 @@ def upload_sentry_symbols(marketing_version:, version_code:, symbols_path:, dart
   ENV["SENTRY_RELEASE"] = "swiss.realunit.app@#{marketing_version}+#{version_code}"
   ENV["SENTRY_DIST"] = version_code.to_s
   Dir.chdir("../..") do
+    # The plugin only warns and continues on missing input, which would ship
+    # a release with degraded (or no) crash symbolication silently. Fail the
+    # build instead.
+    if Dir.glob("#{symbols_path}/**/*").select { |f| File.file?(f) }.empty?
+      UI.user_error!("Sentry upload: no native debug symbols found under #{symbols_path}")
+    end
+    unless File.exist?(dart_symbol_map_path)
+      UI.user_error!("Sentry upload: Dart obfuscation map not found at #{dart_symbol_map_path}")
+    end
+
     sh("dart", "run", "sentry_dart_plugin",
        "--sentry-define=symbols_path=#{symbols_path}",
        "--sentry-define=dart_symbol_map_path=#{dart_symbol_map_path}"

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -13,7 +13,40 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+require "json"
+require "tempfile"
+
 default_platform(:android)
+
+# Keeps the DSN out of the process arguments Fastlane prints. Flutter reads
+# both compile-time values from this short-lived, mode-0600 JSON file.
+def with_crash_reporting_defines
+  dsn = ENV.fetch("SENTRY_DSN", "")
+  UI.user_error!("SENTRY_DSN is required for store release builds") if dsn.empty?
+
+  environment = ENV.fetch("SENTRY_ENVIRONMENT", "production")
+  file = Tempfile.new(["sentry-defines", ".json"])
+  File.chmod(0o600, file.path)
+  file.write(JSON.generate({
+    "SENTRY_DSN" => dsn,
+    "SENTRY_ENVIRONMENT" => environment,
+  }))
+  file.flush
+  yield file.path
+ensure
+  file&.close!
+end
+
+def upload_sentry_symbols(marketing_version:, version_code:, symbols_path:, dart_symbol_map_path:)
+  ENV["SENTRY_RELEASE"] = "swiss.realunit.app@#{marketing_version}+#{version_code}"
+  ENV["SENTRY_DIST"] = version_code.to_s
+  Dir.chdir("../..") do
+    sh("dart", "run", "sentry_dart_plugin",
+       "--sentry-define=symbols_path=#{symbols_path}",
+       "--sentry-define=dart_symbol_map_path=#{dart_symbol_map_path}"
+    )
+  end
+end
 
 # Runs tool/generate_release_info.dart (single source of truth for tag →
 # marketing version + version code) and reads the values back from the
@@ -61,28 +94,47 @@ platform :android do
     marketing_version = info["marketing_version"]
     version_code = info["version_code"]
 
-    Dir.chdir("..") do
-      sh("flutter", "build", "appbundle",
-         "--release",
-         "--build-name=#{marketing_version}",
-         "--build-number=#{version_code}",
-         "--no-tree-shake-icons",
-         "--obfuscate",
-         "--split-debug-info=build/debug_info"
-      )
-      sh("flutter", "build", "apk",
-         "--release",
-         "--build-name=#{marketing_version}",
-         "--build-number=#{version_code}",
-         "--no-tree-shake-icons",
-         "--obfuscate",
-         "--split-debug-info=build/debug_info"
-      )
-      File.rename(
-        "../build/app/outputs/flutter-apk/app-release.apk",
-        "../build/app/outputs/flutter-apk/realunit-#{tag_name}.apk"
-      )
+    with_crash_reporting_defines do |defines_file|
+      Dir.chdir("..") do
+        sh("flutter", "build", "appbundle",
+           "--release",
+           "--build-name=#{marketing_version}",
+           "--build-number=#{version_code}",
+           "--dart-define-from-file=#{defines_file}",
+           "--no-tree-shake-icons",
+           "--obfuscate",
+           "--split-debug-info=build/debug_info/appbundle",
+           "--extra-gen-snapshot-options=--save-obfuscation-map=build/appbundle-obfuscation-map.json"
+        )
+        sh("flutter", "build", "apk",
+           "--release",
+           "--build-name=#{marketing_version}",
+           "--build-number=#{version_code}",
+           "--dart-define-from-file=#{defines_file}",
+           "--no-tree-shake-icons",
+           "--obfuscate",
+           "--split-debug-info=build/debug_info/apk",
+           "--extra-gen-snapshot-options=--save-obfuscation-map=build/apk-obfuscation-map.json"
+        )
+        File.rename(
+          "../build/app/outputs/flutter-apk/app-release.apk",
+          "../build/app/outputs/flutter-apk/realunit-#{tag_name}.apk"
+        )
+      end
     end
+
+    upload_sentry_symbols(
+      marketing_version: marketing_version,
+      version_code: version_code,
+      symbols_path: "build/debug_info/appbundle",
+      dart_symbol_map_path: "build/appbundle-obfuscation-map.json"
+    )
+    upload_sentry_symbols(
+      marketing_version: marketing_version,
+      version_code: version_code,
+      symbols_path: "build/debug_info/apk",
+      dart_symbol_map_path: "build/apk-obfuscation-map.json"
+    )
 
     # Upload the binary + changelog only. The changelog is tied to this
     # build's version code (taken from the AAB); the listing metadata and

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -13,7 +13,37 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+require "json"
+require "tempfile"
+
 default_platform(:ios)
+
+# Keeps the DSN out of the process arguments Fastlane prints. Flutter writes
+# the encoded defines into Generated.xcconfig before gym invokes xcodebuild.
+def with_crash_reporting_defines
+  dsn = ENV.fetch("SENTRY_DSN", "")
+  UI.user_error!("SENTRY_DSN is required for store release builds") if dsn.empty?
+
+  environment = ENV.fetch("SENTRY_ENVIRONMENT", "production")
+  file = Tempfile.new(["sentry-defines", ".json"])
+  File.chmod(0o600, file.path)
+  file.write(JSON.generate({
+    "SENTRY_DSN" => dsn,
+    "SENTRY_ENVIRONMENT" => environment,
+  }))
+  file.flush
+  yield file.path
+ensure
+  file&.close!
+end
+
+def upload_sentry_symbols(marketing_version:, version_code:)
+  ENV["SENTRY_RELEASE"] = "swiss.realunit.app@#{marketing_version}+#{version_code}"
+  ENV["SENTRY_DIST"] = version_code.to_s
+  Dir.chdir("../..") do
+    sh("dart", "run", "sentry_dart_plugin")
+  end
+end
 
 def get_api_key
   app_store_connect_api_key(
@@ -110,13 +140,29 @@ platform :ios do
       xcodeproj: "Runner.xcodeproj"
     )
 
-    gym(
-      workspace: "Runner.xcworkspace",
-      scheme: "Runner",
-      output_name: "realunit-#{tag_name}.ipa",
-      xcargs: "-verbose",
-      verbose: true
-    )
+    with_crash_reporting_defines do |defines_file|
+      Dir.chdir("../..") do
+        sh("flutter", "build", "ios",
+           "--config-only",
+           "--release",
+           "--build-name=#{marketing_version}",
+           "--build-number=#{version_code}",
+           "--dart-define-from-file=#{defines_file}"
+        )
+      end
+      gym(
+        workspace: "Runner.xcworkspace",
+        scheme: "Runner",
+        archive_path: File.expand_path("../../build/ios/archive/Runner.xcarchive", __dir__),
+        output_name: "realunit-#{tag_name}.ipa",
+        xcargs: "-verbose",
+        verbose: true
+      )
+      upload_sentry_symbols(
+        marketing_version: marketing_version,
+        version_code: version_code
+      )
+    end
 
     upload_to_testflight(
       api_key: get_api_key,

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -41,6 +41,13 @@ def upload_sentry_symbols(marketing_version:, version_code:)
   ENV["SENTRY_RELEASE"] = "swiss.realunit.app@#{marketing_version}+#{version_code}"
   ENV["SENTRY_DIST"] = version_code.to_s
   Dir.chdir("../..") do
+    # The plugin only warns and continues on missing input, which would ship
+    # a release with degraded (or no) crash symbolication silently. Fail the
+    # build instead.
+    if Dir.glob("build/ios/archive/**/*.dSYM").empty?
+      UI.user_error!("Sentry upload: no dSYMs found under build/ios/archive")
+    end
+
     sh("dart", "run", "sentry_dart_plugin")
   end
 end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -655,6 +655,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  globbing:
+    dependency: transitive
+    description:
+      name: globbing
+      sha256: "4f89cfaf6fa74c9c1740a96259da06bd45411ede56744e28017cc534a12b6e2d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   go_router:
     dependency: "direct main"
     description:
@@ -791,6 +799,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  injector:
+    dependency: transitive
+    description:
+      name: injector
+      sha256: ed389bed5b48a699d5b9561c985023d0d5cc88dd5ff2237aadcce5a5ab433e4e
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -1183,6 +1199,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
+  properties:
+    dependency: transitive
+    description:
+      name: properties
+      sha256: "333f427dd4ed07bdbe8c75b9ff864a1e70b5d7a8426a2e8bdd457b65ae5ac598"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   provider:
     dependency: transitive
     description:
@@ -1239,6 +1271,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  sentry_dart_plugin:
+    dependency: "direct dev"
+    description:
+      name: sentry_dart_plugin
+      sha256: da9c1d0b3c87a251bfc36301f16af090a88c2d59128fe9a6f908f5ac20340c97
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1412,6 +1452,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  system_info2:
+    dependency: transitive
+    description:
+      name: system_info2
+      sha256: b937736ecfa63c45b10dde1ceb6bb30e5c0c340e14c441df024150679d65ac43
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -100,6 +100,7 @@ dev_dependencies:
   # Used by test/packages/config/legal_documents_config_test.dart to swap in a
   # recording fake for url_launcher without touching the platform channel.
   plugin_platform_interface: ^2.1.8
+  sentry_dart_plugin: 3.4.0
   url_launcher_platform_interface: ^2.3.2
 
 dependency_overrides:
@@ -110,6 +111,17 @@ dependency_overrides:
     git:
       url: https://github.com/cake-tech/web3dart.git
       ref: aa3f932dbf54eda651b7bd01ad00204acf998bd0
+
+sentry:
+  upload_debug_symbols: true
+  upload_source_maps: false
+  upload_sources: false
+  project: realunitchapp
+  org: sentry
+  url: https://sentry.dfxserve.com/
+  wait_for_processing: true
+  log_level: error
+  commits: false
 
 hooks:
   user_defines:


### PR DESCRIPTION
## Summary

- inject the repository `SENTRY_DSN` into Android and iOS store builds with an explicit `production`/`internal` environment
- keep compile-time values out of Fastlane process arguments via a mode-0600 temporary define file and fail release builds when the DSN is missing
- upload Android split debug info, Dart obfuscation maps, and iOS archive symbols to the self-hosted Sentry project
- identify uploads with the native release name `swiss.realunit.app@<version>+<build>` and matching distribution

The Sentry project `realunitchapp` and the repository secrets `SENTRY_DSN` and `SENTRY_AUTH_TOKEN` have been provisioned. Runtime reporting activates together with #878. Related to DFXServer/server#958.

## Validation

- Ruby syntax checks for both Fastfiles
- workflow YAML parse and `git diff --check`
- `flutter analyze --no-fatal-infos`
- non-golden Flutter suite: 4,687 tests passed; the 16 subprocess cases initially failed only because local `dart` was absent from PATH and all 16 passed when rerun with the Flutter SDK path
- DFX PR precheck: 3 rounds, final conformity and logic reviews both at 0 findings

## Follow-up verification

The first tagged native release should confirm the uploaded debug files in Sentry and symbolicate one controlled test event.