### PR TITLE
fix(ci): run the iOS config-only build outside the bundler environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,15 @@ coverage/
 !android/Gemfile.lock
 !ios/Gemfile.lock
 
+# Gem bundle installed when running a store lane with the CI's bundler
+# configuration (`path vendor/bundle`, `deployment true`, as ruby/setup-ruby's
+# bundler-cache does). Mirrors the paths CI uses so a `git status` after a local
+# repro stays clean.
+android/.bundle/
+android/vendor/
+ios/.bundle/
+ios/vendor/
+
 # Symbolication related
 app.*.symbols
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,8 @@ coverage/
 
 # Gem bundle installed when running a store lane with the bundler configuration
 # CI uses (`path vendor/bundle`, `deployment true` — see the "Set up Ruby" steps
-# in .github/workflows/release.yaml). Mirrors the paths CI produces so a
-# `git status` after a local repro stays clean.
+# in .github/workflows/release.yaml). Mirrors the paths CI produces so the gem
+# bundle from a local repro does not show up in `git status`.
 android/.bundle/
 android/vendor/bundle/
 ios/.bundle/

--- a/.gitignore
+++ b/.gitignore
@@ -40,14 +40,14 @@ coverage/
 !android/Gemfile.lock
 !ios/Gemfile.lock
 
-# Gem bundle installed when running a store lane with the CI's bundler
-# configuration (`path vendor/bundle`, `deployment true`, as ruby/setup-ruby's
-# bundler-cache does). Mirrors the paths CI uses so a `git status` after a local
-# repro stays clean.
+# Gem bundle installed when running a store lane with the bundler configuration
+# CI uses (`path vendor/bundle`, `deployment true` — see the "Set up Ruby" steps
+# in .github/workflows/release.yaml). Mirrors the paths CI produces so a
+# `git status` after a local repro stays clean.
 android/.bundle/
-android/vendor/
+android/vendor/bundle/
 ios/.bundle/
-ios/vendor/
+ios/vendor/bundle/
 
 # Symbolication related
 app.*.symbols

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -155,8 +155,7 @@ platform :ios do
       # "cocoapods is not currently included in the bundle" and Flutter fails
       # the build with "CocoaPods not installed or not in valid state".
       # Only the Flutter call is unbundled — it is the one step that shells out
-      # to pod. The xcodebuild gym runs never does; its [CP] phases only diff
-      # Podfile.lock against Manifest.lock.
+      # to pod; the xcodebuild gym runs never does.
       Bundler.with_unbundled_env do
         Dir.chdir("../..") do
           sh("flutter", "build", "ios",

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -13,6 +13,7 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+require "bundler"
 require "json"
 require "tempfile"
 
@@ -148,14 +149,21 @@ platform :ios do
     )
 
     with_crash_reporting_defines do |defines_file|
-      Dir.chdir("../..") do
-        sh("flutter", "build", "ios",
-           "--config-only",
-           "--release",
-           "--build-name=#{marketing_version}",
-           "--build-number=#{version_code}",
-           "--dart-define-from-file=#{defines_file}"
-        )
+      # Fastlane runs under `bundle exec`, and Bundler exports its environment
+      # (RUBYOPT=-rbundler/setup) to every child process. CocoaPods is not in
+      # this Gemfile, so the `pod` Flutter shells out to aborts with
+      # "cocoapods is not currently included in the bundle" and Flutter fails
+      # the build with "CocoaPods not installed or not in valid state".
+      Bundler.with_unbundled_env do
+        Dir.chdir("../..") do
+          sh("flutter", "build", "ios",
+             "--config-only",
+             "--release",
+             "--build-name=#{marketing_version}",
+             "--build-number=#{version_code}",
+             "--dart-define-from-file=#{defines_file}"
+          )
+        end
       end
       gym(
         workspace: "Runner.xcworkspace",

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -154,8 +154,9 @@ platform :ios do
       # this Gemfile, so the `pod` Flutter shells out to aborts with
       # "cocoapods is not currently included in the bundle" and Flutter fails
       # the build with "CocoaPods not installed or not in valid state".
-      # Only the Flutter call is unbundled — gym stays in the bundle, where it
-      # needs the bundled xcpretty binstub, and xcodebuild never invokes pod.
+      # Only the Flutter call is unbundled — it is the one step that shells out
+      # to pod. The xcodebuild gym runs never does; its [CP] phases only diff
+      # Podfile.lock against Manifest.lock.
       Bundler.with_unbundled_env do
         Dir.chdir("../..") do
           sh("flutter", "build", "ios",

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -154,6 +154,8 @@ platform :ios do
       # this Gemfile, so the `pod` Flutter shells out to aborts with
       # "cocoapods is not currently included in the bundle" and Flutter fails
       # the build with "CocoaPods not installed or not in valid state".
+      # Only the Flutter call is unbundled — gym stays in the bundle, where it
+      # needs the bundled xcpretty binstub, and xcodebuild never invokes pod.
       Bundler.with_unbundled_env do
         Dir.chdir("../..") do
           sh("flutter", "build", "ios",


### PR DESCRIPTION
## Problem

The v1.2.4 release job failed in `ios-deploy` at the `Upload to TestFlight` step ([run 30658246443](https://github.com/RealUnitCH/app/actions/runs/30658246443/job/91248015830)). Android shipped, iOS did not, and `github-release` was skipped.

```
Warning: CocoaPods is installed but broken. Skipping pod install.
CocoaPods not installed or not in valid state.
Exit status of command 'flutter build ios --config-only --release ...' was 1
```

## Root cause

The Sentry DSN injection added a `flutter build ios --config-only` call inside the `beta` lane. Fastlane runs under `bundle exec`, and Bundler exports its environment (`RUBYOPT=-rbundler/setup`) to every child process. CocoaPods is not part of `ios/Gemfile`, so the `pod` that Flutter shells out to aborts with `cocoapods is not currently included in the bundle`, and Flutter fails the build.

The workflow's own `Setup Pods` step is unaffected — it runs outside `bundle exec`, which is why it succeeds 19 seconds earlier in the same job on the same machine.

## Fix

Wrap only the Flutter call in `Bundler.with_unbundled_env`. `gym` keeps running inside the bundle: the `xcodebuild` it runs never invokes `pod`, and that path has been shipping releases unchanged.

Also ignores `android/{.bundle,vendor/bundle}/` and `ios/{.bundle,vendor/bundle}/` — the gem bundle a local lane repro installs with the configuration CI uses (`ruby/setup-ruby` with `bundler-cache: true` → `path vendor/bundle`, `deployment true`), which otherwise leaves the working tree dirty.

## Verification

Reproduced and fixed locally against the failing commit (`2d0d454`), Flutter 3.41.6, with the bundle installed using CI's own configuration:

| Case | Result |
| --- | --- |
| `flutter build ios --config-only` outside bundler (control) | passes — `Running pod install... 952ms` |
| `bundle exec pod --version` | fails — `cocoapods is not currently included in the bundle` |
| the same wrapped in `Bundler.with_unbundled_env` | passes — `1.17.0` |
| real `bundle exec fastlane` running the shipped code | fails exactly as CI does |
| the same with this patch | passes — `fastlane.tools finished successfully` |

The reproduction requires CI's step order: after a standalone `pod install`, Flutter still considers the Pods stale and runs its CocoaPods check, which is where it aborts.

`Generated.xcconfig` was checked after the patched run — `FLUTTER_BUILD_NAME`, `FLUTTER_BUILD_NUMBER` and the base64 `DART_DEFINES` for `SENTRY_DSN` / `SENTRY_ENVIRONMENT` are all present, so the DSN injection still does what it was added for.

Not covered locally: `gym`, the archive and the TestFlight upload need signing material. The next tagged release is the real confirmation.
