### PR TITLE
c23c74f4 - Render the handbook insider section single-column

### DIFF
--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -7973,7 +7973,10 @@
             nach einer einmaligen Freischaltung auf dem Gerät.
           </p>
 
-          <div class="tests cols-2">
+          <!-- Single column on purpose: the explainer block below carries a
+               three-image walkthrough that needs the full content width; the
+               half-width cols-2 grid would stack its images vertically. -->
+          <div class="tests">
             <div class="test" id="insider-unlock">
               <div class="head">
                 <a class="name permalink" href="#insider-unlock">insider-unlock</a>

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -7976,7 +7976,7 @@
           <!-- Single column on purpose: the explainer block below carries a
                three-image walkthrough that needs the full content width; the
                half-width cols-2 grid would stack its images vertically. -->
-          <div class="tests">
+          <div class="tests cols-1">
             <div class="test" id="insider-unlock">
               <div class="head">
                 <a class="name permalink" href="#insider-unlock">insider-unlock</a>


### PR DESCRIPTION
## Summary

Follow-up to #885: section 79 (insider unlock explainer) inherited the standard `cols-2` test grid, which squeezes the three-image walkthrough into a half-width column — the images stack vertically and the card grows very tall (see the deployed page). Switching the section to the base `.tests` class (an existing single-column grid) lets the explainer run full width with its three images side by side, and the `269-dashboard-insider-unlocked` catalog entry follows below.

One attribute change plus an HTML comment explaining the deliberate deviation from the otherwise uniform `cols-2` sections.