### PR TITLE
0ec27bf7 - fix(kyc): forward KYC context on the primary-email-confirmation gate

### DIFF
--- a/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
+++ b/lib/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart
@@ -79,7 +79,10 @@ class BuyPaymentInfoCubit extends Cubit<BuyPaymentInfoState> {
           return const BuyPaymentInfoFailure(PaymentInfoError.primaryEmailRequired);
         }
         if (paymentInfo.error == _quoteErrorPrimaryEmailNotConfirmed) {
-          return const BuyPaymentInfoFailure(PaymentInfoError.primaryEmailNotConfirmed);
+          return const BuyPaymentInfoFailure(
+            PaymentInfoError.primaryEmailNotConfirmed,
+            context: 'RealunitBuy',
+          );
         }
         return const BuyPaymentInfoFailure(PaymentInfoError.unknown);
       }

--- a/lib/screens/buy/widgets/payment_action_button.dart
+++ b/lib/screens/buy/widgets/payment_action_button.dart
@@ -122,13 +122,13 @@ class PaymentActionButton extends StatelessWidget {
           if (paymentState.error == PaymentInfoError.primaryEmailNotConfirmed) {
             // The buyer has a primary email on record but has not yet confirmed it.
             // The KYC page auto-routes to its confirm-email step in this case, so
-            // route there (no `extra`) instead of to email capture, then re-fetch
+            // route there instead of to email capture, then re-fetch
             // the quote so a now-confirmed email surfaces the binding-buy CTA.
             return Padding(
               padding: const EdgeInsets.symmetric(vertical: 20),
               child: AppFilledButton(
                 onPressed: () async {
-                  await context.pushNamed(AppRoutes.kyc);
+                  await context.pushNamed(AppRoutes.kyc, extra: paymentState.context);
                   if (context.mounted) {
                     context.read<BuyPaymentInfoCubit>().getPaymentInfo(
                       amount: amountController.text,

--- a/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
+++ b/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
@@ -11,7 +11,8 @@ import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_
 import 'package:realunit_wallet/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart';
 import 'package:realunit_wallet/styles/currency.dart';
 
-class _MockBuyPaymentInfoService extends Mock implements RealUnitBuyPaymentInfoService {}
+class _MockBuyPaymentInfoService extends Mock
+    implements RealUnitBuyPaymentInfoService {}
 
 BuyPaymentInfo _info({
   bool isValid = true,
@@ -54,9 +55,8 @@ void main() {
     });
 
     test('happy path emits Success with the payment info from the API', () async {
-      when(
-        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
-      ).thenAnswer((_) async => _info());
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info());
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300');
@@ -65,36 +65,31 @@ void main() {
       verify(() => service.getPaymentInfo(300, currency: Currency.chf)).called(1);
     });
 
-    test(
-      'API isValid=false with error=AmountTooLow → MinAmountNotMetFailure with API limit',
-      () async {
-        when(
-          () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
-        ).thenAnswer((_) async => _info(isValid: false, error: 'AmountTooLow', minVolume: 100));
+    test('API isValid=false with error=AmountTooLow → MinAmountNotMetFailure with API limit', () async {
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info(isValid: false, error: 'AmountTooLow', minVolume: 100));
 
-        final cubit = build();
-        await cubit.getPaymentInfo(amount: '50');
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '50');
 
-        expect(cubit.state, isA<BuyPaymentInfoMinAmountNotMetFailure>());
-        final f = cubit.state as BuyPaymentInfoMinAmountNotMetFailure;
-        expect(f.error, PaymentInfoError.minAmountNotMet);
-        expect(f.minAmount, 100);
-        verify(() => service.getPaymentInfo(50, currency: Currency.chf)).called(1);
-      },
-    );
+      expect(cubit.state, isA<BuyPaymentInfoMinAmountNotMetFailure>());
+      final f = cubit.state as BuyPaymentInfoMinAmountNotMetFailure;
+      expect(f.error, PaymentInfoError.minAmountNotMet);
+      expect(f.minAmount, 100);
+      verify(() => service.getPaymentInfo(50, currency: Currency.chf)).called(1);
+    });
 
     test('EUR min is reported by the API as-is, not scaled in the app', () async {
       // For EUR the API returns its own currency-specific minVolume; the
       // app no longer multiplies a hardcoded CHF baseline by an exchange
       // rate locally — the rate lives server-side.
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
-        (_) async => _info(
-          isValid: false,
-          error: 'AmountTooLow',
-          minVolume: 92,
-          currency: Currency.eur,
-        ),
-      );
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info(
+            isValid: false,
+            error: 'AmountTooLow',
+            minVolume: 92,
+            currency: Currency.eur,
+          ));
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '50', currency: Currency.eur);
@@ -104,31 +99,28 @@ void main() {
       verify(() => service.getPaymentInfo(50, currency: Currency.eur)).called(1);
     });
 
-    test(
-      'API isValid=false with error=PrimaryEmailRequired → Failure(primaryEmailRequired)',
-      () async {
-        // The API pre-tells on the quote that the account has no primary
-        // email; the app gates the confirm before the tap instead of
-        // reacting to a post-submit 400.
-        when(
-          () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
-        ).thenAnswer((_) async => _info(isValid: false, error: 'PrimaryEmailRequired'));
+    test('API isValid=false with error=PrimaryEmailRequired → Failure(primaryEmailRequired)', () async {
+      // The API pre-tells on the quote that the account has no primary
+      // email; the app gates the confirm before the tap instead of
+      // reacting to a post-submit 400.
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info(isValid: false, error: 'PrimaryEmailRequired'));
 
-        final cubit = build();
-        await cubit.getPaymentInfo(amount: '300');
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '300');
 
-        expect(cubit.state, isA<BuyPaymentInfoFailure>());
-        expect((cubit.state as BuyPaymentInfoFailure).error, PaymentInfoError.primaryEmailRequired);
-      },
-    );
+      expect(cubit.state, isA<BuyPaymentInfoFailure>());
+      expect((cubit.state as BuyPaymentInfoFailure).error, PaymentInfoError.primaryEmailRequired);
+    });
 
     test('API isValid=false with error=PrimaryEmailNotConfirmed → '
         'Failure(primaryEmailNotConfirmed)', () async {
       // A registered-but-unconfirmed email routes to the confirmation flow
       // (via KYC) instead of a post-submit failure or the email-capture path.
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
-        (_) async => _info(isValid: false, error: 'PrimaryEmailNotConfirmed'),
-      );
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer(
+            (_) async => _info(isValid: false, error: 'PrimaryEmailNotConfirmed'),
+          );
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300');
@@ -142,9 +134,10 @@ void main() {
 
     test('API isValid=false with error=PrimaryEmailNotConfirmed → '
         'Failure carries context', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
-        (_) async => _info(isValid: false, error: 'PrimaryEmailNotConfirmed'),
-      );
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer(
+            (_) async => _info(isValid: false, error: 'PrimaryEmailNotConfirmed'),
+          );
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300');
@@ -154,9 +147,8 @@ void main() {
     });
 
     test('API isValid=false with unknown error → generic Failure', () async {
-      when(
-        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
-      ).thenAnswer((_) async => _info(isValid: false, error: 'AmountTooHigh', minVolume: 100));
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info(isValid: false, error: 'AmountTooHigh', minVolume: 100));
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '999999999');
@@ -166,9 +158,8 @@ void main() {
     });
 
     test('empty amount string is treated as 0 → still calls the API', () async {
-      when(
-        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
-      ).thenAnswer((_) async => _info(isValid: false, error: 'AmountTooLow', minVolume: 100));
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info(isValid: false, error: 'AmountTooLow', minVolume: 100));
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '');
@@ -178,9 +169,8 @@ void main() {
     });
 
     test('comma decimal separator is normalised to dot', () async {
-      when(
-        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
-      ).thenAnswer((_) async => _info());
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => _info());
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300,75');
@@ -190,7 +180,8 @@ void main() {
     });
 
     test('KycLevelRequiredException → Failure(kycRequired, requiredLevel)', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer(
         (_) async => throw const KycLevelRequiredException(
           statusCode: 403,
           code: 'KYC_REQUIRED',
@@ -209,7 +200,8 @@ void main() {
     });
 
     test('KycLevelRequiredException with context → Failure carries context', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer(
         (_) async => throw const KycLevelRequiredException(
           statusCode: 403,
           code: 'KYC_REQUIRED',
@@ -230,7 +222,8 @@ void main() {
     });
 
     test('RegistrationRequiredException → Failure(registrationRequired)', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer(
         (_) async => throw const RegistrationRequiredException(
           statusCode: 403,
           code: 'REGISTRATION_REQUIRED',
@@ -246,7 +239,8 @@ void main() {
     });
 
     test('RegistrationRequiredException with context → Failure carries context', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer(
         (_) async => throw const RegistrationRequiredException(
           statusCode: 403,
           code: 'REGISTRATION_REQUIRED',
@@ -264,9 +258,8 @@ void main() {
     });
 
     test('generic exception → Failure(unknown)', () async {
-      when(
-        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
-      ).thenAnswer((_) async => throw Exception('network'));
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => throw Exception('network'));
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300');
@@ -276,9 +269,8 @@ void main() {
     });
 
     test('BitboxNotConnectedException → Failure(bitboxDisconnected)', () async {
-      when(
-        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
-      ).thenAnswer((_) async => throw const BitboxNotConnectedException());
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) async => throw const BitboxNotConnectedException());
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300');
@@ -288,7 +280,8 @@ void main() {
     });
 
     test('ApiException 503 → Failure(priceSourceUnavailable)', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer(
         (_) async => throw const ApiException(
           statusCode: 503,
           code: 'PRICE_SOURCE_UNAVAILABLE',
@@ -302,29 +295,25 @@ void main() {
       expect((cubit.state as BuyPaymentInfoFailure).error, PaymentInfoError.priceSourceUnavailable);
     });
 
-    test(
-      'ApiException with code PRICE_SOURCE_UNAVAILABLE (non-503) → priceSourceUnavailable',
-      () async {
-        when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
-          (_) async => throw const ApiException(
-            statusCode: 500,
-            code: 'PRICE_SOURCE_UNAVAILABLE',
-            message: 'unavailable',
-          ),
-        );
+    test('ApiException with code PRICE_SOURCE_UNAVAILABLE (non-503) → priceSourceUnavailable', () async {
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer(
+        (_) async => throw const ApiException(
+          statusCode: 500,
+          code: 'PRICE_SOURCE_UNAVAILABLE',
+          message: 'unavailable',
+        ),
+      );
 
-        final cubit = build();
-        await cubit.getPaymentInfo(amount: '300');
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '300');
 
-        expect(
-          (cubit.state as BuyPaymentInfoFailure).error,
-          PaymentInfoError.priceSourceUnavailable,
-        );
-      },
-    );
+      expect((cubit.state as BuyPaymentInfoFailure).error, PaymentInfoError.priceSourceUnavailable);
+    });
 
     test('other ApiException (e.g. 400) → Failure(unknown)', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer(
         (_) async => throw const ApiException(statusCode: 400, code: 'BAD_REQUEST', message: 'bad'),
       );
 
@@ -336,9 +325,8 @@ void main() {
 
     test('does not emit after close', () async {
       final completer = Completer<BuyPaymentInfo>();
-      when(
-        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
-      ).thenAnswer((_) => completer.future);
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
+          .thenAnswer((_) => completer.future);
 
       final cubit = build();
       unawaited(cubit.getPaymentInfo(amount: '300'));

--- a/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
+++ b/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
@@ -11,8 +11,7 @@ import 'package:realunit_wallet/packages/service/dfx/real_unit_buy_payment_info_
 import 'package:realunit_wallet/screens/buy/cubits/buy_payment_info/buy_payment_info_cubit.dart';
 import 'package:realunit_wallet/styles/currency.dart';
 
-class _MockBuyPaymentInfoService extends Mock
-    implements RealUnitBuyPaymentInfoService {}
+class _MockBuyPaymentInfoService extends Mock implements RealUnitBuyPaymentInfoService {}
 
 BuyPaymentInfo _info({
   bool isValid = true,
@@ -55,8 +54,9 @@ void main() {
     });
 
     test('happy path emits Success with the payment info from the API', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => _info());
+      when(
+        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
+      ).thenAnswer((_) async => _info());
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300');
@@ -65,31 +65,36 @@ void main() {
       verify(() => service.getPaymentInfo(300, currency: Currency.chf)).called(1);
     });
 
-    test('API isValid=false with error=AmountTooLow → MinAmountNotMetFailure with API limit', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => _info(isValid: false, error: 'AmountTooLow', minVolume: 100));
+    test(
+      'API isValid=false with error=AmountTooLow → MinAmountNotMetFailure with API limit',
+      () async {
+        when(
+          () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
+        ).thenAnswer((_) async => _info(isValid: false, error: 'AmountTooLow', minVolume: 100));
 
-      final cubit = build();
-      await cubit.getPaymentInfo(amount: '50');
+        final cubit = build();
+        await cubit.getPaymentInfo(amount: '50');
 
-      expect(cubit.state, isA<BuyPaymentInfoMinAmountNotMetFailure>());
-      final f = cubit.state as BuyPaymentInfoMinAmountNotMetFailure;
-      expect(f.error, PaymentInfoError.minAmountNotMet);
-      expect(f.minAmount, 100);
-      verify(() => service.getPaymentInfo(50, currency: Currency.chf)).called(1);
-    });
+        expect(cubit.state, isA<BuyPaymentInfoMinAmountNotMetFailure>());
+        final f = cubit.state as BuyPaymentInfoMinAmountNotMetFailure;
+        expect(f.error, PaymentInfoError.minAmountNotMet);
+        expect(f.minAmount, 100);
+        verify(() => service.getPaymentInfo(50, currency: Currency.chf)).called(1);
+      },
+    );
 
     test('EUR min is reported by the API as-is, not scaled in the app', () async {
       // For EUR the API returns its own currency-specific minVolume; the
       // app no longer multiplies a hardcoded CHF baseline by an exchange
       // rate locally — the rate lives server-side.
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => _info(
-            isValid: false,
-            error: 'AmountTooLow',
-            minVolume: 92,
-            currency: Currency.eur,
-          ));
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
+        (_) async => _info(
+          isValid: false,
+          error: 'AmountTooLow',
+          minVolume: 92,
+          currency: Currency.eur,
+        ),
+      );
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '50', currency: Currency.eur);
@@ -99,28 +104,31 @@ void main() {
       verify(() => service.getPaymentInfo(50, currency: Currency.eur)).called(1);
     });
 
-    test('API isValid=false with error=PrimaryEmailRequired → Failure(primaryEmailRequired)', () async {
-      // The API pre-tells on the quote that the account has no primary
-      // email; the app gates the confirm before the tap instead of
-      // reacting to a post-submit 400.
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => _info(isValid: false, error: 'PrimaryEmailRequired'));
+    test(
+      'API isValid=false with error=PrimaryEmailRequired → Failure(primaryEmailRequired)',
+      () async {
+        // The API pre-tells on the quote that the account has no primary
+        // email; the app gates the confirm before the tap instead of
+        // reacting to a post-submit 400.
+        when(
+          () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
+        ).thenAnswer((_) async => _info(isValid: false, error: 'PrimaryEmailRequired'));
 
-      final cubit = build();
-      await cubit.getPaymentInfo(amount: '300');
+        final cubit = build();
+        await cubit.getPaymentInfo(amount: '300');
 
-      expect(cubit.state, isA<BuyPaymentInfoFailure>());
-      expect((cubit.state as BuyPaymentInfoFailure).error, PaymentInfoError.primaryEmailRequired);
-    });
+        expect(cubit.state, isA<BuyPaymentInfoFailure>());
+        expect((cubit.state as BuyPaymentInfoFailure).error, PaymentInfoError.primaryEmailRequired);
+      },
+    );
 
     test('API isValid=false with error=PrimaryEmailNotConfirmed → '
         'Failure(primaryEmailNotConfirmed)', () async {
       // A registered-but-unconfirmed email routes to the confirmation flow
       // (via KYC) instead of a post-submit failure or the email-capture path.
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer(
-            (_) async => _info(isValid: false, error: 'PrimaryEmailNotConfirmed'),
-          );
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
+        (_) async => _info(isValid: false, error: 'PrimaryEmailNotConfirmed'),
+      );
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300');
@@ -132,9 +140,23 @@ void main() {
       );
     });
 
+    test('API isValid=false with error=PrimaryEmailNotConfirmed → '
+        'Failure carries context', () async {
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
+        (_) async => _info(isValid: false, error: 'PrimaryEmailNotConfirmed'),
+      );
+
+      final cubit = build();
+      await cubit.getPaymentInfo(amount: '300');
+
+      expect(cubit.state, isA<BuyPaymentInfoFailure>());
+      expect((cubit.state as BuyPaymentInfoFailure).context, 'RealunitBuy');
+    });
+
     test('API isValid=false with unknown error → generic Failure', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => _info(isValid: false, error: 'AmountTooHigh', minVolume: 100));
+      when(
+        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
+      ).thenAnswer((_) async => _info(isValid: false, error: 'AmountTooHigh', minVolume: 100));
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '999999999');
@@ -144,8 +166,9 @@ void main() {
     });
 
     test('empty amount string is treated as 0 → still calls the API', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => _info(isValid: false, error: 'AmountTooLow', minVolume: 100));
+      when(
+        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
+      ).thenAnswer((_) async => _info(isValid: false, error: 'AmountTooLow', minVolume: 100));
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '');
@@ -155,8 +178,9 @@ void main() {
     });
 
     test('comma decimal separator is normalised to dot', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => _info());
+      when(
+        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
+      ).thenAnswer((_) async => _info());
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300,75');
@@ -166,8 +190,7 @@ void main() {
     });
 
     test('KycLevelRequiredException → Failure(kycRequired, requiredLevel)', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
         (_) async => throw const KycLevelRequiredException(
           statusCode: 403,
           code: 'KYC_REQUIRED',
@@ -186,8 +209,7 @@ void main() {
     });
 
     test('KycLevelRequiredException with context → Failure carries context', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
         (_) async => throw const KycLevelRequiredException(
           statusCode: 403,
           code: 'KYC_REQUIRED',
@@ -208,8 +230,7 @@ void main() {
     });
 
     test('RegistrationRequiredException → Failure(registrationRequired)', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
         (_) async => throw const RegistrationRequiredException(
           statusCode: 403,
           code: 'REGISTRATION_REQUIRED',
@@ -225,8 +246,7 @@ void main() {
     });
 
     test('RegistrationRequiredException with context → Failure carries context', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
         (_) async => throw const RegistrationRequiredException(
           statusCode: 403,
           code: 'REGISTRATION_REQUIRED',
@@ -244,8 +264,9 @@ void main() {
     });
 
     test('generic exception → Failure(unknown)', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => throw Exception('network'));
+      when(
+        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
+      ).thenAnswer((_) async => throw Exception('network'));
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300');
@@ -255,8 +276,9 @@ void main() {
     });
 
     test('BitboxNotConnectedException → Failure(bitboxDisconnected)', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) async => throw const BitboxNotConnectedException());
+      when(
+        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
+      ).thenAnswer((_) async => throw const BitboxNotConnectedException());
 
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300');
@@ -266,8 +288,7 @@ void main() {
     });
 
     test('ApiException 503 → Failure(priceSourceUnavailable)', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
         (_) async => throw const ApiException(
           statusCode: 503,
           code: 'PRICE_SOURCE_UNAVAILABLE',
@@ -281,25 +302,29 @@ void main() {
       expect((cubit.state as BuyPaymentInfoFailure).error, PaymentInfoError.priceSourceUnavailable);
     });
 
-    test('ApiException with code PRICE_SOURCE_UNAVAILABLE (non-503) → priceSourceUnavailable', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer(
-        (_) async => throw const ApiException(
-          statusCode: 500,
-          code: 'PRICE_SOURCE_UNAVAILABLE',
-          message: 'unavailable',
-        ),
-      );
+    test(
+      'ApiException with code PRICE_SOURCE_UNAVAILABLE (non-503) → priceSourceUnavailable',
+      () async {
+        when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
+          (_) async => throw const ApiException(
+            statusCode: 500,
+            code: 'PRICE_SOURCE_UNAVAILABLE',
+            message: 'unavailable',
+          ),
+        );
 
-      final cubit = build();
-      await cubit.getPaymentInfo(amount: '300');
+        final cubit = build();
+        await cubit.getPaymentInfo(amount: '300');
 
-      expect((cubit.state as BuyPaymentInfoFailure).error, PaymentInfoError.priceSourceUnavailable);
-    });
+        expect(
+          (cubit.state as BuyPaymentInfoFailure).error,
+          PaymentInfoError.priceSourceUnavailable,
+        );
+      },
+    );
 
     test('other ApiException (e.g. 400) → Failure(unknown)', () async {
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer(
+      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency'))).thenAnswer(
         (_) async => throw const ApiException(statusCode: 400, code: 'BAD_REQUEST', message: 'bad'),
       );
 
@@ -311,8 +336,9 @@ void main() {
 
     test('does not emit after close', () async {
       final completer = Completer<BuyPaymentInfo>();
-      when(() => service.getPaymentInfo(any(), currency: any(named: 'currency')))
-          .thenAnswer((_) => completer.future);
+      when(
+        () => service.getPaymentInfo(any(), currency: any(named: 'currency')),
+      ).thenAnswer((_) => completer.future);
 
       final cubit = build();
       unawaited(cubit.getPaymentInfo(amount: '300'));

--- a/test/screens/buy/widgets/payment_action_button_test.dart
+++ b/test/screens/buy/widgets/payment_action_button_test.dart
@@ -31,6 +31,7 @@ void main() {
   // value (mirrors the registration / KYC gates), so the re-fetch is
   // asserted on both paths.
   bool? emailCaptureResult;
+  String? kycExtra;
 
   setUpAll(() {
     registerFallbackValue(Currency.chf);
@@ -42,6 +43,7 @@ void main() {
     amountController = TextEditingController(text: '250');
     pushedRoutes = <String>[];
     emailCaptureResult = true;
+    kycExtra = null;
 
     when(() => converterCubit.state)
         .thenReturn(const BuyConverterState(currency: Currency.eur));
@@ -88,8 +90,9 @@ void main() {
         GoRoute(
           name: AppRoutes.kyc,
           path: '/kyc',
-          builder: (_, _) {
+          builder: (_, state) {
             pushedRoutes.add(AppRoutes.kyc);
+            kycExtra = state.extra as String?;
             return _EmailCaptureStub(
               onReady: (popContext) {
                 WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -183,7 +186,10 @@ void main() {
       'tap pushes kyc (never email capture) and re-fetches the quote',
       (tester) async {
         when(() => paymentInfoCubit.state).thenReturn(
-          const BuyPaymentInfoFailure(PaymentInfoError.primaryEmailNotConfirmed),
+          const BuyPaymentInfoFailure(
+            PaymentInfoError.primaryEmailNotConfirmed,
+            context: 'RealunitBuy',
+          ),
         );
 
         await pumpButton(tester);
@@ -193,6 +199,7 @@ void main() {
 
         // Routed to KYC confirm-email, not to email capture.
         expect(pushedRoutes, [AppRoutes.kyc]);
+        expect(kycExtra, 'RealunitBuy');
         // After the KYC flow returns, the quote is re-fetched with the
         // current amount + currency so a now-confirmed email surfaces the CTA.
         verify(


### PR DESCRIPTION
EN:
The buy-page CTA forwards the API's KYC context on the `registrationRequired` and `kycRequired` gates but not on the `primaryEmailNotConfirmed` one, so a re-check after confirming email was scored against the app's full KYC step set instead of the `RealunitBuy`-scoped subset. A buyer who already finished `Ident` could be reported `InProgress` for steps `RealunitBuy` deliberately excludes from the buy gate. This closes item 3 of DFXswiss/api#4556.

DE:
Der Buy-Seiten-CTA reicht den von der API gelieferten KYC-Kontext bei den Gates `registrationRequired` und `kycRequired` weiter, beim Gate `primaryEmailNotConfirmed` bisher jedoch nicht — dadurch wurde eine erneute Prüfung nach der E-Mail-Bestätigung gegen den vollständigen KYC-Schritt-Satz der App statt gegen die `RealunitBuy`-Teilmenge bewertet. Ein Käufer, der `Ident` bereits abgeschlossen hatte, konnte dadurch als `InProgress` gemeldet werden wegen Schritten, die `RealunitBuy` bewusst vom Buy-Gate ausschliesst. Schliesst Item 3 von DFXswiss/api#4556 ab.

<details>
<summary>Details</summary>

## Problem

`PaymentActionButton`'s `primaryEmailNotConfirmed` branch pushed `AppRoutes.kyc` with no `extra`, unlike its `registrationRequired`/`kycRequired` siblings a few lines above, which already pass `extra: paymentState.context`.

That alone wasn't the whole gap: `paymentState.context` was itself always `null` on this path. `BuyPaymentInfoFailure.context` is populated from a thrown exception's server-supplied field for the `kycRequired`/`registrationRequired` branches (`e.context`), but `primaryEmailNotConfirmed` is a `QuoteError` code embedded directly in the quote response body — a different shape with no context field to read.

Losing the context here means `KycInfoMapper.toDto` (API side) computes `processStatus` over the full `requiredKycSteps` set instead of the `RealunitBuy`-scoped subset. Concretely: a buyer who already finished `Ident` but hasn't confirmed their primary email hits this gate, taps through to KYC, confirms the email, and on the subsequent re-check could still be reported `InProgress` — not because anything buy-relevant is outstanding, but because `FinancialData`/`DfxApproval` (steps `RealunitBuy` context deliberately excludes from the buy gate) are unfinished.

## Change

Three parts:
1. `payment_action_button.dart` — forward `extra: paymentState.context` on the `primaryEmailNotConfirmed` push, mirroring the two branches above it.
2. `buy_payment_info_cubit.dart` — populate that context in the first place: the `primaryEmailNotConfirmed` `BuyPaymentInfoFailure` is now constructed with `context: 'RealunitBuy'`. Since this cubit is unconditionally the RealUnit buy flow, the value is a static call-site identifier rather than a server decision, hardcoded as the same literal already used for the sibling branches (`test/screens/buy/cubits/buy_payment_info_cubit_test.dart`'s existing `... with context` tests).
3. `payment_action_button_test.dart` — the mock KYC route builder previously discarded `GoRouterState` entirely, so the forwarding in (1) had no regression coverage; it now captures `state.extra` and the relevant test asserts it equals `'RealunitBuy'`.

The `primaryEmailRequired` branch (routes to email capture, never to `/kyc`) is untouched — it has nothing to scope.

## Verification

- `flutter analyze` — no issues.
- `flutter test test/screens/buy/cubits/buy_payment_info_cubit_test.dart test/screens/buy/widgets/payment_action_button_test.dart` — 24/24 passed.
- Mutation-tested the new widget assertion by temporarily reverting the `extra` forwarding in `payment_action_button.dart` and confirming the test goes red, then restored it.

</details>
