### PR TITLE
01a01ecf - Stage the fourteen account-merge web baselines (22 → 36)

### DIFF
--- a/.github/workflows/handbook.yaml
+++ b/.github/workflows/handbook.yaml
@@ -328,13 +328,13 @@ jobs:
       - name: Stage web e2e baselines from web repo
         env:
           WEB_DIR: _web-checkout
-          # RealUnitCH/web commits 22 Playwright visual baselines under
+          # RealUnitCH/web commits 36 Playwright visual baselines under
           # tests/__screenshots__/{desktop-chromium,tablet-chromium,mobile-safari}/.
           # `-ne` below fails the build on ANY drift (add OR remove) so a change
           # to the committed set upstream requires an explicit bump here AND a
           # matching card edit in docs/handbook/de/index.html (#spec-web) in the
           # SAME change — same guard rationale as the api steps above.
-          EXPECTED_WEB_BASELINE_COUNT: 22
+          EXPECTED_WEB_BASELINE_COUNT: 36
         run: |
           set -euo pipefail
 

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -225,7 +225,7 @@ eigenen `EXPECTED_PDF_COUNT`-Guard des balance-Steps — dann die Zahl in
 
 Die Sektion **W — Web / realunit.app** (`#spec-web`) zeigt die
 Visual-Regression-Baselines der öffentlichen Website `realunit.app`
-(Landingpage + Aktionariat-Adressbestätigungs-Flow). Sie sind das Web-Pendant
+(Landingpage + Aktionariat-Adressbestätigungs-Flow + Adresse-hinzufügen-Flow unter `/account-merge/`). Sie sind das Web-Pendant
 zu den Golden-Screenshots der App: Jedes Bild ist eine **Playwright-Baseline**,
 die im `RealUnitCH/web`-Repo unter `tests/__screenshots__/` committet und von
 dessen Visual-Regression-CI abgesichert ist — driftet das Seitenrendering, wird

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -8079,7 +8079,8 @@
           <p class="spec-intro">
             Die öffentliche Website <a href="https://realunit.app">realunit.app</a>
             (Landingpage plus der Aktionariat-Adressbestätigungs-Flow unter
-            <code>/confirm-aktionariat</code>) hat ihre eigene Visual-Regression-Suite.
+            <code>/confirm-aktionariat</code> und der Adresse-hinzufügen-Flow unter
+            <code>/account-merge/</code>) hat ihre eigene Visual-Regression-Suite.
             Jedes Bild hier ist eine <b>Playwright-Baseline</b> aus dem
             <a href="https://github.com/RealUnitCH/web">RealUnitCH/web</a>-Repo
             (<code>tests/__screenshots__/</code>), aufgenommen im gepinnten
@@ -8416,6 +8417,252 @@
                 <img
                   src="../web/mobile-safari/confirm-unavailable.png"
                   alt="Dienst nicht verfügbar — Mobile"
+                />
+              </div>
+              <div class="desc">
+                Derselbe Zustand in der Mobile-Ansicht.
+              </div>
+            </div>
+          </div>
+
+          <h3>Adresse hinzufügen — bestätigt <a class="src" href="https://github.com/RealUnitCH/web/tree/develop/tests/__screenshots__" title="Quelle: tests/__screenshots__/">↗</a></h3>
+          <div class="tests cols-2">
+            <div class="test" id="web-merge-confirmed-desktop-de">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-confirmed-desktop-de">web-merge-confirmed-desktop-de</a>
+                <button class="copy-link" type="button" data-target="web-merge-confirmed-desktop-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">desktop-chromium/merge-confirmed.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/desktop-chromium/merge-confirmed.png"
+                  alt="Adresse hinzugefügt — Desktop (DE)"
+                />
+              </div>
+              <div class="desc">
+                Erfolgs-Zustand von <code>/account-merge/</code> nach gültigem
+                Link: die Wallet-Adresse ist dem Konto hinzugefügt. Desktop sagt,
+                auf dem Smartphone zur App zurückzukehren. Desktop, Deutsch.
+              </div>
+            </div>
+            <div class="test" id="web-merge-confirmed-desktop-en">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-confirmed-desktop-en">web-merge-confirmed-desktop-en</a>
+                <button class="copy-link" type="button" data-target="web-merge-confirmed-desktop-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">desktop-chromium/merge-confirmed-en.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/desktop-chromium/merge-confirmed-en.png"
+                  alt="Address added — Desktop (EN)"
+                />
+              </div>
+              <div class="desc">
+                Derselbe Erfolgs-Zustand auf Englisch (<code>?lang=en</code>).
+              </div>
+            </div>
+            <div class="test" id="web-merge-confirmed-tablet">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-confirmed-tablet">web-merge-confirmed-tablet</a>
+                <button class="copy-link" type="button" data-target="web-merge-confirmed-tablet" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">tablet-chromium/merge-confirmed.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/tablet-chromium/merge-confirmed.png"
+                  alt="Adresse hinzugefügt — Tablet"
+                />
+              </div>
+              <div class="desc">
+                Erfolgs-Zustand im Tablet-Layout.
+              </div>
+            </div>
+            <div class="test" id="web-merge-confirmed-mobile">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-confirmed-mobile">web-merge-confirmed-mobile</a>
+                <button class="copy-link" type="button" data-target="web-merge-confirmed-mobile" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">mobile-safari/merge-confirmed-mobile.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/mobile-safari/merge-confirmed-mobile.png"
+                  alt="Adresse hinzugefügt — Mobile"
+                />
+              </div>
+              <div class="desc">
+                Erfolgs-Zustand in der Mobile-Ansicht; CTA «Zurück zur App».
+              </div>
+            </div>
+          </div>
+
+          <h3>Adresse hinzufügen — ungültiger Link <a class="src" href="https://github.com/RealUnitCH/web/tree/develop/tests/__screenshots__" title="Quelle: tests/__screenshots__/">↗</a></h3>
+          <div class="tests cols-2">
+            <div class="test" id="web-merge-invalid-desktop-de">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-invalid-desktop-de">web-merge-invalid-desktop-de</a>
+                <button class="copy-link" type="button" data-target="web-merge-invalid-desktop-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">desktop-chromium/merge-invalid.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/desktop-chromium/merge-invalid.png"
+                  alt="Ungültiger Adresse-hinzufügen-Link — Desktop (DE)"
+                />
+              </div>
+              <div class="desc">
+                Fehler-Zustand bei ungültigem oder abgelaufenem Link, Desktop,
+                Deutsch. Nutzer soll in der App eine neue Bestätigung anfordern.
+              </div>
+            </div>
+            <div class="test" id="web-merge-invalid-desktop-en">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-invalid-desktop-en">web-merge-invalid-desktop-en</a>
+                <button class="copy-link" type="button" data-target="web-merge-invalid-desktop-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">desktop-chromium/merge-invalid-en.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/desktop-chromium/merge-invalid-en.png"
+                  alt="Invalid add-address link — Desktop (EN)"
+                />
+              </div>
+              <div class="desc">
+                Derselbe Fehler-Zustand auf Englisch.
+              </div>
+            </div>
+            <div class="test" id="web-merge-invalid-tablet">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-invalid-tablet">web-merge-invalid-tablet</a>
+                <button class="copy-link" type="button" data-target="web-merge-invalid-tablet" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">tablet-chromium/merge-invalid.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/tablet-chromium/merge-invalid.png"
+                  alt="Ungültiger Adresse-hinzufügen-Link — Tablet"
+                />
+              </div>
+              <div class="desc">
+                Fehler-Zustand im Tablet-Layout.
+              </div>
+            </div>
+            <div class="test" id="web-merge-invalid-mobile">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-invalid-mobile">web-merge-invalid-mobile</a>
+                <button class="copy-link" type="button" data-target="web-merge-invalid-mobile" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">mobile-safari/merge-invalid.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/mobile-safari/merge-invalid.png"
+                  alt="Ungültiger Adresse-hinzufügen-Link — Mobile"
+                />
+              </div>
+              <div class="desc">
+                Fehler-Zustand in der Mobile-Ansicht.
+              </div>
+            </div>
+          </div>
+
+          <h3>Adresse hinzufügen — bereits hinzugefügt <a class="src" href="https://github.com/RealUnitCH/web/tree/develop/tests/__screenshots__" title="Quelle: tests/__screenshots__/">↗</a></h3>
+          <div class="tests cols-2">
+            <div class="test" id="web-merge-already-completed-desktop-de">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-already-completed-desktop-de">web-merge-already-completed-desktop-de</a>
+                <button class="copy-link" type="button" data-target="web-merge-already-completed-desktop-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">desktop-chromium/merge-already-completed.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/desktop-chromium/merge-already-completed.png"
+                  alt="Adresse bereits hinzugefügt — Desktop (DE)"
+                />
+              </div>
+              <div class="desc">
+                Zustand, wenn die Wallet-Adresse dem Konto schon zugeordnet ist
+                (HTTP 409). Desktop sagt, auf dem Smartphone zur App
+                zurückzukehren. Desktop, Deutsch.
+              </div>
+            </div>
+            <div class="test" id="web-merge-already-completed-desktop-en">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-already-completed-desktop-en">web-merge-already-completed-desktop-en</a>
+                <button class="copy-link" type="button" data-target="web-merge-already-completed-desktop-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">desktop-chromium/merge-already-completed-en.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/desktop-chromium/merge-already-completed-en.png"
+                  alt="Address already added — Desktop (EN)"
+                />
+              </div>
+              <div class="desc">
+                Derselbe Zustand auf Englisch.
+              </div>
+            </div>
+            <div class="test" id="web-merge-already-completed-mobile">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-already-completed-mobile">web-merge-already-completed-mobile</a>
+                <button class="copy-link" type="button" data-target="web-merge-already-completed-mobile" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">mobile-safari/merge-already-completed.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/mobile-safari/merge-already-completed.png"
+                  alt="Adresse bereits hinzugefügt — Mobile"
+                />
+              </div>
+              <div class="desc">
+                Derselbe Zustand in der Mobile-Ansicht; CTA «Zurück zur App».
+              </div>
+            </div>
+          </div>
+
+          <h3>Adresse hinzufügen — Dienst nicht verfügbar <a class="src" href="https://github.com/RealUnitCH/web/tree/develop/tests/__screenshots__" title="Quelle: tests/__screenshots__/">↗</a></h3>
+          <div class="tests cols-2">
+            <div class="test" id="web-merge-unavailable-desktop-de">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-unavailable-desktop-de">web-merge-unavailable-desktop-de</a>
+                <button class="copy-link" type="button" data-target="web-merge-unavailable-desktop-de" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">desktop-chromium/merge-unavailable.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/desktop-chromium/merge-unavailable.png"
+                  alt="Dienst nicht erreichbar — Desktop (DE)"
+                />
+              </div>
+              <div class="desc">
+                Zustand, wenn die Adresse gerade nicht hinzugefügt werden konnte,
+                mit Retry-Button. Desktop, Deutsch.
+              </div>
+            </div>
+            <div class="test" id="web-merge-unavailable-desktop-en">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-unavailable-desktop-en">web-merge-unavailable-desktop-en</a>
+                <button class="copy-link" type="button" data-target="web-merge-unavailable-desktop-en" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">desktop-chromium/merge-unavailable-en.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/desktop-chromium/merge-unavailable-en.png"
+                  alt="Service temporarily unavailable — Desktop (EN)"
+                />
+              </div>
+              <div class="desc">
+                Derselbe Zustand auf Englisch.
+              </div>
+            </div>
+            <div class="test" id="web-merge-unavailable-mobile">
+              <div class="head">
+                <a class="name permalink" href="#web-merge-unavailable-mobile">web-merge-unavailable-mobile</a>
+                <button class="copy-link" type="button" data-target="web-merge-unavailable-mobile" title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">🔗 Link</button>
+                <span class="src">mobile-safari/merge-unavailable.png</span>
+              </div>
+              <div class="img">
+                <img
+                  src="../web/mobile-safari/merge-unavailable.png"
+                  alt="Dienst nicht erreichbar — Mobile"
                 />
               </div>
               <div class="desc">


### PR DESCRIPTION
EN:
The handbook production deploy failed because the web-baseline guard still expected 22 Playwright PNGs after RealUnitCH/web added 14 for `/account-merge/`.
This change raises `EXPECTED_WEB_BASELINE_COUNT` to 36 and adds matching cards in `#spec-web`.
The cards describe adding a wallet address, not merging two accounts.
After this lands on staging, the staging-to-develop promotion can run that deploy again.

DE:
Der Handbook-Produktions-Deploy ist fehlgeschlagen, weil der Web-Baseline-Guard noch 22 Playwright-PNGs erwartet hat, nachdem RealUnitCH/web 14 für `/account-merge/` ergänzt hat.
Diese Änderung setzt `EXPECTED_WEB_BASELINE_COUNT` auf 36 und ergänzt die passenden Karten in `#spec-web`.
Die Karten beschreiben das Hinzufügen einer Wallet-Adresse, nicht das Zusammenführen zweier Konten.
Sobald das auf staging liegt, kann der Promote staging→develop den Deploy erneut fahren.

<details>
<summary>Details</summary>

The auto-promotion PR RealUnitCH/app#904 (`Promote: staging -> develop`) is red on `deploy-prd / Build and deploy to PRD` only:

```
Expected exactly 22 web baseline PNGs in _web-checkout/tests/__screenshots__, got 36.
```

Analyze & Test, Visual Regression, Coverage Floor Gate, and the PR-only Handbook Build Check stayed green: that last job does not clone RealUnitCH/web, so it never sees the count.

Cause: RealUnitCH/web#25 committed 14 new Playwright baselines for `/account-merge/` (add a wallet address to an existing account). The previous handbook update of this guard was #862 (18 → 22, no-registration confirm states). There was no open PR covering 22 → 36.

New files (14):

| Viewport | Files |
|---|---|
| desktop-chromium | merge-confirmed(.png + -en.png), merge-invalid(.png + -en.png), merge-already-completed(.png + -en.png), merge-unavailable(.png + -en.png) |
| tablet-chromium | merge-confirmed.png, merge-invalid.png (no tablet shots exist for already-completed / unavailable) |
| mobile-safari | merge-confirmed-mobile.png, merge-invalid.png, merge-already-completed.png, merge-unavailable.png |

Same markup as the existing confirm cards in `#spec-web`. Intro and `docs/handbook/README.md` now name `/account-merge/` next to `/confirm-aktionariat`.

No Dart, no golden regeneration, no other workflow files.

</details>