### PR TITLE
01a0234b - fix(buy): show and send exact CHF with rappen

### DIFF
--- a/lib/packages/service/dfx/models/payment/buy/buy_payment_info.dart
+++ b/lib/packages/service/dfx/models/payment/buy/buy_payment_info.dart
@@ -18,7 +18,7 @@ class BuyPaymentInfo extends Equatable {
   // authority on whether the quote is valid for trading and what the
   // current min/max limits are for the user+currency combination.
   final bool isValid;
-  // The whole-currency amount this quote charges, echoed by the API — the
+  // The amount this quote charges (Rappen-exact), echoed by the API — the
   // Details page must render this, never re-derive it from keystrokes.
   final double amount;
   final double? minVolume;

--- a/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
+++ b/lib/packages/service/dfx/real_unit_buy_payment_info_service.dart
@@ -15,7 +15,7 @@ class RealUnitBuyPaymentInfoService extends DFXAuthService {
 
   RealUnitBuyPaymentInfoService(super.appStore, super.walletService);
 
-  Future<BuyPaymentInfo> getPaymentInfo(int amount, {Currency currency = Currency.chf}) async {
+  Future<BuyPaymentInfo> getPaymentInfo(num amount, {Currency currency = Currency.chf}) async {
     final buyDto = RealUnitBuyDto(amount: amount, currency: currency);
 
     final uri = buildUri(host, _buyPaymentInfoPath);

--- a/lib/packages/utils/fiat_amount.dart
+++ b/lib/packages/utils/fiat_amount.dart
@@ -7,10 +7,10 @@ double? tryParseFiatAmount(String input) {
   return double.tryParse(input.replaceAll(',', '.'));
 }
 
-/// The whole-currency integer the backend charges for the raw [input] the user
-/// typed (e.g. `300,75` → `301`); empty input counts as zero.
-int chargedFiatAmount(String input) {
+/// Rappen-snapped major units the backend is asked to quote (e.g. `300,75` →
+/// `300.75`). Never rounds to whole currency. Empty input counts as zero.
+double chargedFiatAmount(String input) {
   final amount = tryParseFiatAmount(input.isEmpty ? '0' : input);
   if (amount == null) throw FormatException('Invalid fiat amount', input);
-  return amount.round();
+  return (amount * 100).round() / 100;
 }

--- a/lib/screens/buy/cubits/buy_converter/buy_converter_cubit.dart
+++ b/lib/screens/buy/cubits/buy_converter/buy_converter_cubit.dart
@@ -39,9 +39,12 @@ class BuyConverterCubit extends Cubit<BuyConverterState> {
       try {
         final result = await _brokerbotService.getBuyShares(value, state.currency);
         if (isClosed || mySeq != _seq) return;
+        final priceMinor = (result.pricePerShare * 100).round();
+        final payable = result.shares * priceMinor / 100;
         emit(
           state.copyWith(
             sharesText: result.shares.toString(),
+            fiatText: payable.toStringAsFixed(2),
             loading: false,
           ),
         );
@@ -90,9 +93,12 @@ class BuyConverterCubit extends Cubit<BuyConverterState> {
     try {
       final result = await _brokerbotService.getBuyShares(state.fiatText, currency);
       if (isClosed || mySeq != _seq) return;
+      final priceMinor = (result.pricePerShare * 100).round();
+      final payable = result.shares * priceMinor / 100;
       emit(
         state.copyWith(
           sharesText: result.shares.toString(),
+          fiatText: payable.toStringAsFixed(2),
           loading: false,
         ),
       );

--- a/lib/screens/buy/widgets/buy_confirm_button.dart
+++ b/lib/screens/buy/widgets/buy_confirm_button.dart
@@ -54,7 +54,7 @@ class BuyConfirmButtonView extends StatelessWidget {
             extra: BuyPaymentDetailsParams(
               buyPaymentInfo: buyPaymentInfo,
               // The charged amount comes from the quote itself, never keystrokes.
-              amount: '${buyPaymentInfo.amount.round()}',
+              amount: buyPaymentInfo.amount.toStringAsFixed(2),
               // Backward compatible: prefer the API-designated purpose once it
               // ships; until then `reference` (always returned) is the value.
               purposeOfPayment: state.remittanceInfo ?? state.reference,

--- a/lib/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart
+++ b/lib/screens/sell/cubits/sell_payment_info/sell_payment_info_cubit.dart
@@ -42,7 +42,7 @@ class SellPaymentInfoCubit extends Cubit<SellPaymentInfoState> {
       emit(const SellPaymentInfoLoading());
 
       final paymentInfo = await _sellPaymentInfoService.getPaymentInfo(
-        chargedFiatAmount(amount),
+        chargedFiatAmount(amount).round(),
         iban,
         currency: currency,
       );

--- a/test/packages/utils/fiat_amount_test.dart
+++ b/test/packages/utils/fiat_amount_test.dart
@@ -3,14 +3,13 @@ import 'package:realunit_wallet/packages/utils/fiat_amount.dart';
 
 void main() {
   group('chargedFiatAmount', () {
-    // The quote is always requested with this rounded integer, so the SEPA
-    // transfer / QR the API builds encodes it.
-    test('rounds a dot decimal to the charged integer (300.75 → 301)', () {
-      expect(chargedFiatAmount('300.75'), 301);
+    // Quote requests snap to Rappen, never to whole francs.
+    test('keeps a dot decimal at Rappen precision (300.75 → 300.75)', () {
+      expect(chargedFiatAmount('300.75'), 300.75);
     });
 
-    test('normalises a comma decimal (300,75 → 301)', () {
-      expect(chargedFiatAmount('300,75'), 301);
+    test('normalises a comma decimal (300,75 → 300.75)', () {
+      expect(chargedFiatAmount('300,75'), 300.75);
     });
 
     test('leaves a whole amount unchanged (300 → 300)', () {
@@ -21,9 +20,13 @@ void main() {
       expect(chargedFiatAmount(''), 0);
     });
 
-    test('rounds half away from zero and down below the half (0.5 → 1, 1.49 → 1)', () {
-      expect(chargedFiatAmount('0.5'), 1);
-      expect(chargedFiatAmount('1.49'), 1);
+    test('keeps half-franc and sub-franc amounts (0.5 → 0.5, 1.49 → 1.49)', () {
+      expect(chargedFiatAmount('0.5'), 0.5);
+      expect(chargedFiatAmount('1.49'), 1.49);
+    });
+
+    test('does not round leftover Rappen up to the next franc (9999.63 → 9999.63)', () {
+      expect(chargedFiatAmount('9999.63'), 9999.63);
     });
 
     test('throws on structurally invalid input instead of guessing', () {

--- a/test/screens/buy/cubits/buy_converter_cubit_test.dart
+++ b/test/screens/buy/cubits/buy_converter_cubit_test.dart
@@ -45,10 +45,27 @@ void main() {
       // Past the 100ms debounce.
       await Future<void>.delayed(const Duration(milliseconds: 250));
 
-      expect(cubit.state.fiatText, '100');
+      expect(cubit.state.fiatText, '87.50');
       expect(cubit.state.sharesText, '7');
       expect(cubit.state.loading, isFalse);
       verify(() => service.getBuyShares('100', Currency.chf)).called(1);
+    });
+
+    test('onFiatChanged snaps CHF to shares × list in Rappen (10000 → 7299 × 1.37 = 9999.63)', () async {
+      when(() => service.getBuyShares(any(), any())).thenAnswer(
+        (_) async => BrokerbotBuySharesDto(
+          shares: 7299,
+          pricePerShare: 1.37,
+          availableShares: 50000,
+        ),
+      );
+
+      final cubit = BuyConverterCubit(service);
+      await cubit.onFiatChanged('10000');
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+
+      expect(cubit.state.sharesText, '7299');
+      expect(cubit.state.fiatText, '9999.63');
     });
 
     test('onFiatChanged debounces — only the latest value reaches the service', () async {

--- a/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
+++ b/test/screens/buy/cubits/buy_payment_info_cubit_test.dart
@@ -175,8 +175,7 @@ void main() {
       final cubit = build();
       await cubit.getPaymentInfo(amount: '300,75');
 
-      // 300.75 rounded to 301.
-      verify(() => service.getPaymentInfo(301, currency: Currency.chf)).called(1);
+      verify(() => service.getPaymentInfo(300.75, currency: Currency.chf)).called(1);
     });
 
     test('KycLevelRequiredException → Failure(kycRequired, requiredLevel)', () async {

--- a/test/screens/buy/widgets/buy_confirm_button_test.dart
+++ b/test/screens/buy/widgets/buy_confirm_button_test.dart
@@ -33,7 +33,7 @@ const _info = BuyPaymentInfo(
   currency: Currency.chf,
 );
 
-// The quote echoes the charged amount; a fractional echo must render rounded.
+// The quote echoes the charged amount; rappen must render, not round to francs.
 const _quotedFractional = BuyPaymentInfo(
   amount: 300.75,
   id: 42,
@@ -200,7 +200,7 @@ void main() {
     });
 
     testWidgets('shows the charged amount echoed by the quote on the details '
-        'page, rounded (300.75 → 301) — never derived from keystrokes', (tester) async {
+        'page with rappen (300.75, not 301) — never derived from keystrokes', (tester) async {
       whenListen(
         cubit,
         Stream.fromIterable([
@@ -218,8 +218,8 @@ void main() {
 
       // The details amount is the quote's own echoed charge, so it can never
       // disagree with the SEPA transfer / QR the backend built for the quote.
-      expect(find.text('301'), findsOneWidget);
-      expect(find.text('300.75'), findsNothing);
+      expect(find.text('300.75'), findsOneWidget);
+      expect(find.text('301'), findsNothing);
     });
 
     testWidgets('forward path: remittanceInfo + paymentRequest drive the '


### PR DESCRIPTION
EN:
The buy flow now shows and quotes exact CHF with rappen instead of rounding to whole francs.

DE:
Der Kauf zeigt und quotet exakte CHF mit Rappen, statt auf ganze Franken zu runden.

<details>
<summary>Details</summary>

Typing 10000 CHF for REALU at 1.37 yields 7299 shares. The field now snaps to 9999.63 (shares times list in Rappen), the quote request keeps that amount, and payment details render two decimal places.

`chargedFiatAmount` snaps to Rappen only. Sell still sends an integer share count.

</details>