### PR TITLE
01a02915 - Live RealUnit geo-filter table in the handbook

### DIFF
--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -64,6 +64,13 @@ Auch der Tier-3-GitHub-Workflow hat dafür einen `flows`-`workflow_dispatch`-Inp
 neu laufen lassen. (Die Screenshots zieht das Handbook aus den Goldens, nicht
 mehr aus diesen Maestro-Läufen.)
 
+## Live Geo-Filter-Tabelle
+
+Die Sektion **Aktientoken — Geo-Filter** (`#spec-geo`) lädt `GET /v1/country`
+zur Laufzeit. Länderzeilen gehören nicht ins Repo. Im Image proxied nginx
+`/v1/country` auf `https://api.dfx.swiss/v1/country`; eine lokale HTML-Vorschau
+fällt auf die öffentliche API zurück.
+
 ## Einen neuen Handbook-Eintrag hinzufügen
 
 1. **Page + Golden-Test**: `lib/screens/<feature>/<name>_page.dart` + zugehörigen

--- a/docs/handbook/de/geo-filter.js
+++ b/docs/handbook/de/geo-filter.js
@@ -1,0 +1,157 @@
+/**
+ * Live RealUnit share-token geo-filter table.
+ *
+ * Source of truth is GET /v1/country (same payload the wallet uses). Rows are
+ * never copied into this repo. Same-origin `/v1/country` is the handbook
+ * nginx proxy; the public API is the fallback for a local file preview.
+ */
+(function () {
+  var URLS = ['/v1/country', 'https://api.dfx.swiss/v1/country'];
+  var COLUMNS = [
+    { key: 'symbol', label: 'ISO' },
+    { key: 'name', label: 'Land' },
+    { key: 'residence', label: 'Wohnsitz' },
+    { key: 'nationality', label: 'Nationalität' },
+    { key: 'residenceExisting', label: 'Wohnsitz Bestand' },
+    { key: 'nationalityExisting', label: 'Nationalität Bestand' },
+    { key: 'ipEnable', label: 'IP neu' },
+    { key: 'ipExisting', label: 'IP Bestand' },
+    { key: 'taxEnable', label: 'Steuer neu' },
+    { key: 'taxExisting', label: 'Steuer Bestand' },
+  ];
+
+  function $(id) {
+    return document.getElementById(id);
+  }
+
+  function cell(value) {
+    if (value === true) return 'ja';
+    if (value === false) return 'nein';
+    if (value == null || value === '') return '—';
+    return String(value);
+  }
+
+  function tone(field, value) {
+    if (value == null || value === '') return 'muted';
+    if (field === 'residence') {
+      if (value === 'Allowed') return 'ok';
+      if (value === 'Sanction') return 'bad';
+      if (value === 'Restricted') return 'warn';
+      return 'muted';
+    }
+    if (field === 'nationality') {
+      if (value === 'Ok') return 'ok';
+      if (value === 'Blocked') return 'bad';
+      if (value === 'Exception') return 'warn';
+      return 'muted';
+    }
+    if (value === true) return 'ok';
+    if (value === false) return 'bad';
+    return 'muted';
+  }
+
+  function rowView(country) {
+    var geo = country.realunit || {};
+    return {
+      symbol: country.symbol,
+      name: country.foreignName || country.name,
+      residence: geo.residence,
+      nationality: geo.nationality,
+      residenceExisting: geo.residenceExisting,
+      nationalityExisting: geo.nationalityExisting,
+      ipEnable: geo.ipEnable,
+      ipExisting: geo.ipExisting,
+      taxEnable: geo.taxEnable,
+      taxExisting: geo.taxExisting,
+    };
+  }
+
+  function load(urls) {
+    var url = urls[0];
+    return fetch(url, { credentials: 'same-origin' }).then(function (res) {
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      return res.json().then(function (body) {
+        if (!Array.isArray(body)) throw new Error('unexpected payload');
+        return { body: body, url: url };
+      });
+    }).catch(function (err) {
+      if (urls.length > 1) return load(urls.slice(1));
+      throw err;
+    });
+  }
+
+  function render(state) {
+    var tbody = $('geo-filter-body');
+    var status = $('geo-filter-status');
+    var missing = $('geo-filter-missing');
+    if (!tbody) return;
+
+    var q = ($('geo-filter-search') || {}).value || '';
+    q = q.trim().toLowerCase();
+    var residence = ($('geo-filter-residence') || {}).value || '';
+    var nationality = ($('geo-filter-nationality') || {}).value || '';
+
+    var rows = state.rows.filter(function (row) {
+      if (q && (row.symbol || '').toLowerCase().indexOf(q) < 0 && (row.name || '').toLowerCase().indexOf(q) < 0) {
+        return false;
+      }
+      if (residence && row.residence !== residence) return false;
+      if (nationality && row.nationality !== nationality) return false;
+      return true;
+    });
+
+    tbody.textContent = '';
+    rows.forEach(function (row) {
+      var tr = document.createElement('tr');
+      COLUMNS.forEach(function (col) {
+        var td = document.createElement('td');
+        td.textContent = cell(row[col.key]);
+        td.className = 'geo-tone-' + tone(col.key, row[col.key]);
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+
+    if (status) {
+      status.textContent =
+        rows.length + ' von ' + state.rows.length + ' Ländern · Quelle ' + state.url;
+    }
+    if (missing) {
+      missing.hidden = state.hasRealunit;
+    }
+  }
+
+  function init() {
+    var root = $('geo-filter-live');
+    if (!root) return;
+    var status = $('geo-filter-status');
+    if (status) status.textContent = 'Lade GET /v1/country …';
+
+    load(URLS)
+      .then(function (result) {
+        var rows = result.body.map(rowView);
+        var hasRealunit = result.body.some(function (country) {
+          return country && country.realunit != null;
+        });
+        var state = { rows: rows, url: result.url, hasRealunit: hasRealunit };
+        ['geo-filter-search', 'geo-filter-residence', 'geo-filter-nationality'].forEach(function (id) {
+          var el = $(id);
+          if (el) el.addEventListener('input', function () { render(state); });
+          if (el) el.addEventListener('change', function () { render(state); });
+        });
+        render(state);
+      })
+      .catch(function (err) {
+        if (status) {
+          status.textContent =
+            'Tabelle konnte nicht geladen werden (' + (err && err.message ? err.message : err) + ').';
+        }
+      });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -724,6 +724,70 @@
         border-radius: 8px;
         padding: 14px 16px;
       }
+      #geo-filter-live .geo-toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 0 0 12px 0;
+        align-items: center;
+      }
+      #geo-filter-live .geo-toolbar input,
+      #geo-filter-live .geo-toolbar select {
+        font: inherit;
+        padding: 6px 8px;
+        border: 1px solid var(--line-2);
+        border-radius: 4px;
+        background: var(--surface);
+        color: var(--ink);
+      }
+      #geo-filter-live .geo-toolbar input {
+        min-width: 180px;
+        flex: 1;
+      }
+      #geo-filter-status {
+        margin: 0 0 10px 0;
+        font-size: 12.5px;
+        color: var(--ink-3);
+      }
+      #geo-filter-scroller {
+        overflow-x: auto;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--surface);
+      }
+      #geo-filter-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12.5px;
+      }
+      #geo-filter-table th,
+      #geo-filter-table td {
+        padding: 6px 8px;
+        border-bottom: 1px solid var(--line);
+        text-align: left;
+        white-space: nowrap;
+      }
+      #geo-filter-table thead th {
+        background: var(--surface-2);
+        font-weight: 600;
+        position: sticky;
+        top: 0;
+      }
+      #geo-filter-table tbody tr:hover {
+        background: var(--surface-2);
+      }
+      .geo-tone-ok {
+        color: #0f7a3d;
+      }
+      .geo-tone-warn {
+        color: #9a6b12;
+      }
+      .geo-tone-bad {
+        color: #b42318;
+      }
+      .geo-tone-muted {
+        color: var(--ink-3);
+      }
       /* Downloads section (#spec-downloads) — static, hand-maintained list of
          the three public tester/download links. Reuses the .test card chrome
          (border + :target highlight) and the .copy-link button; the body adds a
@@ -773,6 +837,7 @@
         word-break: break-all;
       }
     </style>
+    <script src="geo-filter.js" defer></script>
   </head>
   <body>
     <div class="wrap">
@@ -1032,6 +1097,9 @@
             </li>
             <li>
               <a href="#spec-79"><span class="spec-num">79</span>Insider-Freischaltung — Bezahlen &amp; Senden</a>
+            </li>
+            <li>
+              <a href="#spec-geo"><span class="spec-num">G</span>Aktientoken — Geo-Filter</a>
             </li>
             <li>
               <a href="#spec-web"><span class="spec-num">W</span>Web · realunit.app</a>
@@ -8980,6 +9048,77 @@
                 <a class="dl-btn" href="../balance/vermoegensuebersicht-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../balance/vermoegensuebersicht-en.pdf" download>PDF</a>
               </div>
+            </div>
+          </div>
+        </details>
+
+        <details id="spec-geo" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">G</span>Aktientoken — Geo-Filter</h2>
+                <div class="file">GET /v1/country · country.realunit*</div>
+              </div>
+              <div class="rhs">
+                <b>Live aus der API</b>
+                <div class="links">
+                  <a href="https://api.dfx.swiss/v1/country">GET /v1/country ↗</a>
+                </div>
+              </div>
+            </div>
+          </summary>
+          <p class="spec-intro">
+            Wohnsitz- und Nationalitäts-Filter für den RealUnit-Aktientoken, direkt
+            aus <code>GET /v1/country</code>. Die Tabelle kopiert keine Zeilen ins
+            Repo — Single Source of Truth bleibt die DFX-country-Tabelle
+            (<code>realunitResidence</code> / <code>realunitNationality</code> plus
+            nullable Existing/IP/Tax-Spalten). Onboarding prüft nur Residence und
+            Nationality; IP, Steueransässigkeit und Grandfathering bleiben leer,
+            bis Legal sie füllt.
+          </p>
+          <div id="geo-filter-live">
+            <div class="geo-toolbar">
+              <input id="geo-filter-search" type="search" placeholder="Land oder ISO suchen" autocomplete="off" />
+              <select id="geo-filter-residence" aria-label="Wohnsitz">
+                <option value="">Wohnsitz: alle</option>
+                <option value="Allowed">Allowed</option>
+                <option value="Sanction">Sanction</option>
+                <option value="Restricted">Restricted</option>
+                <option value="Other">Other</option>
+              </select>
+              <select id="geo-filter-nationality" aria-label="Nationalität">
+                <option value="">Nationalität: alle</option>
+                <option value="Ok">Ok</option>
+                <option value="Blocked">Blocked</option>
+                <option value="Exception">Exception</option>
+              </select>
+            </div>
+            <p id="geo-filter-status">Lade GET /v1/country …</p>
+            <div class="callout warn" id="geo-filter-missing" hidden>
+              <p>
+                <b>API ohne <code>realunit</code>-Objekt.</b> Die Geo-Spalten bleiben
+                leer, bis DFXswiss/backend mit dem Country-DTO auf dieser Umgebung
+                deployed ist.
+              </p>
+            </div>
+            <div id="geo-filter-scroller">
+              <table id="geo-filter-table">
+                <thead>
+                  <tr>
+                    <th>ISO</th>
+                    <th>Land</th>
+                    <th>Wohnsitz</th>
+                    <th>Nationalität</th>
+                    <th>Wohnsitz Bestand</th>
+                    <th>Nationalität Bestand</th>
+                    <th>IP neu</th>
+                    <th>IP Bestand</th>
+                    <th>Steuer neu</th>
+                    <th>Steuer Bestand</th>
+                  </tr>
+                </thead>
+                <tbody id="geo-filter-body"></tbody>
+              </table>
             </div>
           </div>
         </details>

--- a/docs/handbook/de/index.html
+++ b/docs/handbook/de/index.html
@@ -8128,6 +8128,81 @@
 
         <hr class="sep" />
 
+        <details id="spec-geo" class="spec" open>
+          <summary>
+            <div class="spec-head">
+              <div class="lhs">
+                <h2><span class="num">G</span>Aktientoken — Geo-Filter</h2>
+                <div class="file">GET /v1/country · realunit.*</div>
+              </div>
+              <div class="rhs">
+                <b>Live aus der API</b>
+                <div class="links">
+                  <a href="https://api.dfx.swiss/v1/country">GET /v1/country ↗</a>
+                </div>
+              </div>
+            </div>
+          </summary>
+          <p class="spec-intro">
+            Wohnsitz- und Nationalitäts-Filter für den RealUnit-Aktientoken, direkt
+            aus <code>GET /v1/country</code>. Die JSON-Felder sind
+            <code>realunit.residence</code> und <code>realunit.nationality</code>
+            (plus nullable Existing/IP/Tax unter demselben <code>realunit</code>-Objekt);
+            auf der country-Tabelle heissen die Spalten
+            <code>realunitResidence</code> / <code>realunitNationality</code>.
+            Die Tabelle kopiert keine Zeilen ins Repo. Onboarding prüft nur Residence
+            und Nationality; IP, Steueransässigkeit und Grandfathering bleiben leer,
+            bis Legal sie füllt.
+          </p>
+          <div id="geo-filter-live">
+            <div class="geo-toolbar">
+              <input id="geo-filter-search" type="search" placeholder="Land oder ISO suchen" autocomplete="off" />
+              <select id="geo-filter-residence" aria-label="Wohnsitz">
+                <option value="">Wohnsitz: alle</option>
+                <option value="Allowed">Allowed</option>
+                <option value="Sanction">Sanction</option>
+                <option value="Restricted">Restricted</option>
+                <option value="Other">Other</option>
+              </select>
+              <select id="geo-filter-nationality" aria-label="Nationalität">
+                <option value="">Nationalität: alle</option>
+                <option value="Ok">Ok</option>
+                <option value="Blocked">Blocked</option>
+                <option value="Exception">Exception</option>
+              </select>
+            </div>
+            <p id="geo-filter-status">Lade GET /v1/country …</p>
+            <div class="callout warn" id="geo-filter-missing" hidden>
+              <p>
+                <b>API ohne <code>realunit</code>-Objekt.</b> Die Geo-Spalten bleiben
+                leer, bis DFXswiss/backend mit dem Country-DTO auf dieser Umgebung
+                deployed ist.
+              </p>
+            </div>
+            <div id="geo-filter-scroller">
+              <table id="geo-filter-table">
+                <thead>
+                  <tr>
+                    <th>ISO</th>
+                    <th>Land</th>
+                    <th>Wohnsitz</th>
+                    <th>Nationalität</th>
+                    <th>Wohnsitz Bestand</th>
+                    <th>Nationalität Bestand</th>
+                    <th>IP neu</th>
+                    <th>IP Bestand</th>
+                    <th>Steuer neu</th>
+                    <th>Steuer Bestand</th>
+                  </tr>
+                </thead>
+                <tbody id="geo-filter-body"></tbody>
+              </table>
+            </div>
+          </div>
+        </details>
+
+        <hr class="sep" />
+
         <details id="spec-web" class="spec" open>
           <summary>
             <div class="spec-head">
@@ -9048,77 +9123,6 @@
                 <a class="dl-btn" href="../balance/vermoegensuebersicht-en.pdf" target="_blank" rel="noopener">Ansehen ↗</a>
                 <a class="dl-btn" href="../balance/vermoegensuebersicht-en.pdf" download>PDF</a>
               </div>
-            </div>
-          </div>
-        </details>
-
-        <details id="spec-geo" class="spec" open>
-          <summary>
-            <div class="spec-head">
-              <div class="lhs">
-                <h2><span class="num">G</span>Aktientoken — Geo-Filter</h2>
-                <div class="file">GET /v1/country · country.realunit*</div>
-              </div>
-              <div class="rhs">
-                <b>Live aus der API</b>
-                <div class="links">
-                  <a href="https://api.dfx.swiss/v1/country">GET /v1/country ↗</a>
-                </div>
-              </div>
-            </div>
-          </summary>
-          <p class="spec-intro">
-            Wohnsitz- und Nationalitäts-Filter für den RealUnit-Aktientoken, direkt
-            aus <code>GET /v1/country</code>. Die Tabelle kopiert keine Zeilen ins
-            Repo — Single Source of Truth bleibt die DFX-country-Tabelle
-            (<code>realunitResidence</code> / <code>realunitNationality</code> plus
-            nullable Existing/IP/Tax-Spalten). Onboarding prüft nur Residence und
-            Nationality; IP, Steueransässigkeit und Grandfathering bleiben leer,
-            bis Legal sie füllt.
-          </p>
-          <div id="geo-filter-live">
-            <div class="geo-toolbar">
-              <input id="geo-filter-search" type="search" placeholder="Land oder ISO suchen" autocomplete="off" />
-              <select id="geo-filter-residence" aria-label="Wohnsitz">
-                <option value="">Wohnsitz: alle</option>
-                <option value="Allowed">Allowed</option>
-                <option value="Sanction">Sanction</option>
-                <option value="Restricted">Restricted</option>
-                <option value="Other">Other</option>
-              </select>
-              <select id="geo-filter-nationality" aria-label="Nationalität">
-                <option value="">Nationalität: alle</option>
-                <option value="Ok">Ok</option>
-                <option value="Blocked">Blocked</option>
-                <option value="Exception">Exception</option>
-              </select>
-            </div>
-            <p id="geo-filter-status">Lade GET /v1/country …</p>
-            <div class="callout warn" id="geo-filter-missing" hidden>
-              <p>
-                <b>API ohne <code>realunit</code>-Objekt.</b> Die Geo-Spalten bleiben
-                leer, bis DFXswiss/backend mit dem Country-DTO auf dieser Umgebung
-                deployed ist.
-              </p>
-            </div>
-            <div id="geo-filter-scroller">
-              <table id="geo-filter-table">
-                <thead>
-                  <tr>
-                    <th>ISO</th>
-                    <th>Land</th>
-                    <th>Wohnsitz</th>
-                    <th>Nationalität</th>
-                    <th>Wohnsitz Bestand</th>
-                    <th>Nationalität Bestand</th>
-                    <th>IP neu</th>
-                    <th>IP Bestand</th>
-                    <th>Steuer neu</th>
-                    <th>Steuer Bestand</th>
-                  </tr>
-                </thead>
-                <tbody id="geo-filter-body"></tbody>
-              </table>
             </div>
           </div>
         </details>

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -64,6 +64,25 @@ server {
     # here; otherwise defining add_header inside the block would silently
     # drop them. Cache-Control is "no-store" so a healthcheck answer is
     # never cached by intermediaries while the container is actually down.
+    # Public country list used by the live geo-filter table. Same payload as
+    # api.dfx.swiss/v1/country; kept behind Basic Auth with the rest of the
+    # handbook. Variable proxy_pass needs a resolver so nginx looks the
+    # host up at request time (the image has no baked IP).
+    resolver 1.1.1.1 ipv6=off valid=300s;
+    location = /v1/country {
+        set $dfx_country_upstream https://api.dfx.swiss/v1/country;
+        proxy_pass $dfx_country_upstream;
+        proxy_ssl_server_name on;
+        proxy_ssl_name api.dfx.swiss;
+        proxy_set_header Host api.dfx.swiss;
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 20s;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Cache-Control "private, no-store" always;
+    }
+
     location = /healthz {
         auth_basic off;
         add_header X-Content-Type-Options "nosniff" always;

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -75,6 +75,8 @@ server {
         proxy_ssl_server_name on;
         proxy_ssl_name api.dfx.swiss;
         proxy_set_header Host api.dfx.swiss;
+        # Country list is public. Do not forward handbook Basic Auth to the API.
+        proxy_set_header Authorization "";
         proxy_connect_timeout 10s;
         proxy_read_timeout 20s;
         add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
EN:
Adds a live RealUnit share-token geo-filter table to the handbook.
handbook.realunit.app loads GET /v1/country at runtime and does not copy country rows into the repo.
Until DFXswiss/backend is deployed, the realunit columns stay empty and the page says so.

DE:
Ergänzt die Live-Tabelle des RealUnit-Aktientoken-Geo-Filters im Handbook.
handbook.realunit.app lädt GET /v1/country zur Laufzeit und kopiert keine Länderzeilen ins Repo.
Solange DFXswiss/backend nicht deployed ist, bleiben die realunit-Spalten leer; die Seite weist darauf hin.

<details>
<summary>Details</summary>

Section `#spec-geo` in `docs/handbook/de/index.html`. Client `docs/handbook/de/geo-filter.js` tries same-origin `/v1/country` (nginx proxy in `handbook.nginx.conf`) then `https://api.dfx.swiss/v1/country`. Screenshot count is unchanged. No Dart/UI change, no goldens.

The geo-filter columns only appear after the merged backend `CountryDto.realunit` is live on that API.

</details>
